### PR TITLE
feat: Phase 30 — State / Lifecycle 技術債收斂

### DIFF
--- a/core/gallery_scanner.py
+++ b/core/gallery_scanner.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 from core.logger import get_logger
+from core.nfo_utils import sanitize_nfo_bytes
 from core.path_utils import to_file_uri
 
 logger = get_logger(__name__)
@@ -285,8 +286,9 @@ class VideoScanner:
     def parse_nfo(self, nfo_path: str) -> Optional[VideoInfo]:
         """讀取 NFO 檔案"""
         try:
-            tree = ET.parse(nfo_path)
-            root = tree.getroot()
+            raw = Path(nfo_path).read_bytes()
+            raw = sanitize_nfo_bytes(raw)
+            root = ET.fromstring(raw)
 
             info = VideoInfo()
 

--- a/core/nfo_updater.py
+++ b/core/nfo_updater.py
@@ -9,8 +9,12 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Generator
 
-from core.scraper import search_jav
+from core.logger import get_logger
+from core.nfo_utils import sanitize_nfo_bytes
 from core.path_utils import normalize_path, uri_to_fs_path
+from core.scraper import search_jav
+
+logger = get_logger(__name__)
 
 
 def needs_update(info: dict, has_nfo: bool = True) -> Tuple[bool, List[str]]:
@@ -116,10 +120,13 @@ def get_nfo_path_from_video(video_path: str) -> Optional[str]:
 def parse_nfo(nfo_path: str) -> Tuple[Optional[ET.ElementTree], Optional[ET.Element]]:
     """解析 NFO 檔案"""
     try:
-        tree = ET.parse(nfo_path)
-        root = tree.getroot()
+        raw = Path(nfo_path).read_bytes()
+        raw = sanitize_nfo_bytes(raw)
+        root = ET.fromstring(raw)
+        tree = ET.ElementTree(root)
         return tree, root
-    except Exception:
+    except Exception as e:
+        logger.warning(f"NFO 解析失敗: {nfo_path} - {e}")
         return None, None
 
 

--- a/core/nfo_utils.py
+++ b/core/nfo_utils.py
@@ -1,0 +1,36 @@
+"""NFO 檔案工具函數"""
+
+import re
+
+# CDATA 區塊 pattern（用於先拆出 CDATA 再對非 CDATA 部分 sanitize）
+_CDATA_RE = re.compile(rb'<!\[CDATA\[.*?\]\]>', re.DOTALL)
+# bare & pattern：只保留 XML 規範允許的 5 個 predefined entity + numeric reference
+_BARE_AMP_RE = re.compile(rb'&(?!(?:amp|lt|gt|quot|apos);|#(?:\d+|x[0-9a-fA-F]+);)')
+
+
+def sanitize_nfo_bytes(raw: bytes) -> bytes:
+    """
+    修正非法 bare '&'，讓 malformed XML 可被解析。
+    在 bytes 層級操作，不破壞原始編碼。
+
+    只對 CDATA 以外的區域做替換：
+    - 保留：&amp; &lt; &gt; &quot; &apos; &#123; &#xAB;
+    - 保留：CDATA 區塊內容原封不動（CDATA 內的 & 是合法的）
+    - 替換：其餘 bare &（&t=、&nbsp;、&hellip; 等）→ &amp;
+    """
+    # 無 CDATA 的快速路徑（NFO 幾乎不會有 CDATA）
+    if b'<![CDATA[' not in raw:
+        return _BARE_AMP_RE.sub(b'&amp;', raw)
+
+    # 有 CDATA：逐段處理，CDATA 區塊原封不動
+    result = []
+    last_end = 0
+    for m in _CDATA_RE.finditer(raw):
+        # CDATA 前的普通區域：sanitize
+        result.append(_BARE_AMP_RE.sub(b'&amp;', raw[last_end:m.start()]))
+        # CDATA 區塊：原封不動
+        result.append(m.group())
+        last_end = m.end()
+    # 最後一段普通區域
+    result.append(_BARE_AMP_RE.sub(b'&amp;', raw[last_end:]))
+    return b''.join(result)

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -670,3 +670,35 @@ class TestScannerClearCache:
         html = (PROJECT_ROOT / 'web/templates/scanner.html').read_text(encoding='utf-8')
         assert "/api/gallery/cache" in html
         assert "DELETE" in html
+
+
+class TestPageLifecycleGuard:
+    """page-lifecycle.js 存在性守衛 — 確保 script tag 及三頁 __registerPage 呼叫不被移除"""
+
+    def test_base_html_loads_page_lifecycle(self):
+        """base.html 必須引用 page-lifecycle.js"""
+        base_html = PROJECT_ROOT / "web" / "templates" / "base.html"
+        content = base_html.read_text(encoding='utf-8')
+        assert 'page-lifecycle.js' in content, \
+            "base.html 缺少 page-lifecycle.js script tag — 刪除會導致三頁 __registerPage 呼叫靜默失敗"
+
+    def test_settings_js_calls_register_page(self):
+        """settings.js 必須呼叫 __registerPage"""
+        js_file = PROJECT_ROOT / "web" / "static" / "js" / "pages" / "settings.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '__registerPage' in content, \
+            "settings.js 缺少 __registerPage 呼叫 — dirty-check lifecycle 會失效"
+
+    def test_search_state_index_calls_register_page(self):
+        """search/state/index.js 必須呼叫 __registerPage"""
+        js_file = PROJECT_ROOT / "web" / "static" / "js" / "pages" / "search" / "state" / "index.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '__registerPage' in content, \
+            "search/state/index.js 缺少 __registerPage 呼叫 — Search 離頁 save/cleanup 會失效"
+
+    def test_showcase_core_calls_register_page(self):
+        """showcase/core.js 必須呼叫 __registerPage"""
+        js_file = PROJECT_ROOT / "web" / "static" / "js" / "pages" / "showcase" / "core.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '__registerPage' in content, \
+            "showcase/core.js 缺少 __registerPage 呼叫 — Showcase lightbox cleanup lifecycle 會失效"

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -961,3 +961,69 @@ class TestWindowGlobalCleanup:
         assert len(found) == 0, (
             f"init.js 仍包含 {len(found)} 個防呆 fallback（bridge 移除後不再需要）: {found}"
         )
+
+
+class TestFetchAbortController:
+    """T4.3 守衛 — fetch 可取消化（AbortController per-key）"""
+    BASE_JS = PROJECT_ROOT / "web/static/js/pages/search/state/base.js"
+    SEARCH_FLOW_JS = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+    NAVIGATION_JS = PROJECT_ROOT / "web/static/js/pages/search/state/navigation.js"
+    BATCH_JS = PROJECT_ROOT / "web/static/js/pages/search/state/batch.js"
+    FILE_LIST_JS = PROJECT_ROOT / "web/static/js/pages/search/state/file-list.js"
+
+    def test_base_has_abort_controllers(self):
+        """base.js 必須有 _abortControllers: {} 初始值"""
+        content = self.BASE_JS.read_text(encoding='utf-8')
+        assert '_abortControllers: {}' in content
+
+    def test_search_flow_has_get_abort_signal(self):
+        """search-flow.js 必須定義 _getAbortSignal method"""
+        content = self.SEARCH_FLOW_JS.read_text(encoding='utf-8')
+        assert '_getAbortSignal(' in content
+
+    def test_search_flow_has_abort_all_fetches(self):
+        """search-flow.js 必須定義 _abortAllFetches method"""
+        content = self.SEARCH_FLOW_JS.read_text(encoding='utf-8')
+        assert '_abortAllFetches(' in content
+
+    def test_cleanup_calls_abort_all_fetches(self):
+        """cleanupForNavigation() 必須呼叫 _abortAllFetches()"""
+        content = self.SEARCH_FLOW_JS.read_text(encoding='utf-8')
+        assert '_abortAllFetches()' in content
+
+    def test_load_more_uses_abort_signal(self):
+        """loadMore() 的 fetch 必須傳 signal"""
+        content = self.NAVIGATION_JS.read_text(encoding='utf-8')
+        assert "_getAbortSignal('loadMore')" in content
+
+    def test_load_more_handles_abort_error(self):
+        """loadMore() 的 catch 必須處理 AbortError"""
+        content = self.NAVIGATION_JS.read_text(encoding='utf-8')
+        assert 'AbortError' in content
+
+    def test_translate_all_uses_abort_signal(self):
+        """translateAll() 的 fetch 必須傳 signal"""
+        content = self.BATCH_JS.read_text(encoding='utf-8')
+        assert "_getAbortSignal('translateAll')" in content
+
+    def test_translate_all_handles_abort_error(self):
+        """translateAll() 的 catch 必須處理 AbortError"""
+        content = self.BATCH_JS.read_text(encoding='utf-8')
+        assert 'AbortError' in content
+
+    def test_set_file_list_uses_abort_signal(self):
+        """setFileList() 的 filter-files fetch 必須傳 signal"""
+        content = self.FILE_LIST_JS.read_text(encoding='utf-8')
+        assert "_getAbortSignal('setFileList')" in content
+
+    def test_set_file_list_handles_abort_error(self):
+        """setFileList() 的 filter-files catch 必須處理 AbortError"""
+        # 確認 file-list.js 的 filter-files catch 有 AbortError guard
+        # 用 content 中 AbortError 出現至少 2 次（setFileList + loadFavorite）
+        content = self.FILE_LIST_JS.read_text(encoding='utf-8')
+        assert content.count('AbortError') >= 2
+
+    def test_load_favorite_uses_abort_signal(self):
+        """loadFavorite() 的 fetch 必須傳 signal"""
+        content = self.FILE_LIST_JS.read_text(encoding='utf-8')
+        assert "_getAbortSignal('loadFavorite')" in content

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -735,3 +735,92 @@ class TestPageLifecycleGuard:
         content = js_file.read_text(encoding='utf-8')
         assert '__registerPage' in content, \
             "showcase/core.js 缺少 __registerPage 呼叫 — Showcase lightbox cleanup lifecycle 會失效"
+
+
+class TestWindowGlobalCleanup:
+    """T3.3 守衛 — bridge.js 不再設定多餘的 window.xxx 全域函數"""
+
+    BRIDGE_JS = PROJECT_ROOT / "web/static/js/pages/search/state/bridge.js"
+    FILE_LIST_JS = PROJECT_ROOT / "web/static/js/pages/search/state/file-list.js"
+    PERSISTENCE_JS = PROJECT_ROOT / "web/static/js/pages/search/state/persistence.js"
+    SEARCH_FLOW_JS = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+    INIT_JS = PROJECT_ROOT / "web/static/js/pages/search/init.js"
+
+    def test_bridge_no_window_edit_tag_functions(self):
+        """bridge.js 不應設定 translateWithAI / startEditTitle / confirmEditTitle 等 11 個全域函數"""
+        content = self.BRIDGE_JS.read_text(encoding='utf-8')
+        forbidden = [
+            'window.translateWithAI',
+            'window.startEditTitle',
+            'window.confirmEditTitle',
+            'window.cancelEditTitle',
+            'window.startEditChineseTitle',
+            'window.confirmEditChineseTitle',
+            'window.cancelEditChineseTitle',
+            'window.showAddTagInput',
+            'window.confirmAddTag',
+            'window.cancelAddTag',
+            'window.removeUserTag',
+        ]
+        found = [f for f in forbidden if f in content]
+        assert len(found) == 0, (
+            f"bridge.js 仍設定 {len(found)} 個多餘全域函數（HTML 已用 Alpine @click）: {found}"
+        )
+
+    def test_bridge_no_window_searchcore_progress_bridge(self):
+        """bridge.js 不應設定 window.SearchCore.initProgress / updateLog / handleSearchStatus"""
+        content = self.BRIDGE_JS.read_text(encoding='utf-8')
+        forbidden = [
+            'window.SearchCore.initProgress',
+            'window.SearchCore.updateLog',
+            'window.SearchCore.handleSearchStatus',
+        ]
+        found = [f for f in forbidden if f in content]
+        assert len(found) == 0, (
+            f"bridge.js 仍設定 {len(found)} 個 SearchCore bridge（應由 file-list.js 直接呼叫 Alpine method）: {found}"
+        )
+
+    def test_file_list_calls_this_progress_methods(self):
+        """file-list.js 的 searchForFile() 應直接呼叫 this.initProgress / this.updateLog / this.handleSearchStatus"""
+        content = self.FILE_LIST_JS.read_text(encoding='utf-8')
+        assert 'this.initProgress(' in content, \
+            "file-list.js 缺少 this.initProgress() — 應直接呼叫 Alpine method，不透過 window.SearchCore"
+        assert 'this.updateLog(' in content, \
+            "file-list.js 缺少 this.updateLog() — 應直接呼叫 Alpine method，不透過 window.SearchCore"
+        assert 'this.handleSearchStatus(' in content, \
+            "file-list.js 缺少 this.handleSearchStatus() — 應直接呼叫 Alpine method，不透過 window.SearchCore"
+
+    def test_file_list_no_searchcore_progress_calls(self):
+        """file-list.js 不應再透過 window.SearchCore 呼叫進度函數"""
+        content = self.FILE_LIST_JS.read_text(encoding='utf-8')
+        forbidden = [
+            'window.SearchCore.initProgress',
+            'window.SearchCore.updateLog',
+            'window.SearchCore.handleSearchStatus',
+        ]
+        found = [f for f in forbidden if f in content]
+        assert len(found) == 0, (
+            f"file-list.js 仍透過 window.SearchCore 呼叫 {len(found)} 個進度函數: {found}"
+        )
+
+    def test_no_window_searchcore_update_clear_button(self):
+        """Alpine mixins 不應再呼叫 window.SearchCore.updateClearButton()"""
+        targets = [self.FILE_LIST_JS, self.PERSISTENCE_JS, self.SEARCH_FLOW_JS]
+        violations = []
+        for js_file in targets:
+            content = js_file.read_text(encoding='utf-8')
+            if 'window.SearchCore.updateClearButton' in content:
+                violations.append(js_file.name)
+        assert len(violations) == 0, (
+            f"以下檔案仍呼叫 window.SearchCore.updateClearButton()（應改為 this.hasContent = ...）: {violations}"
+        )
+
+    def test_init_no_progress_fallback(self):
+        """init.js 不應再包含 initProgress / updateLog / handleSearchStatus 的防呆 fallback"""
+        content = self.INIT_JS.read_text(encoding='utf-8')
+        forbidden = ['window.SearchCore.initProgress =', 'window.SearchCore.updateLog =',
+                     'window.SearchCore.handleSearchStatus =']
+        found = [f for f in forbidden if f in content]
+        assert len(found) == 0, (
+            f"init.js 仍包含 {len(found)} 個防呆 fallback（bridge 移除後不再需要）: {found}"
+        )

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1077,3 +1077,85 @@ class TestScannerDeadCodeGuard:
         content = self.SCANNER_HTML.read_text(encoding='utf-8')
         assert 'window.isGenerating' not in content, \
             "scanner.html 仍含 window.isGenerating — T5.2 應已移除所有死碼賦值"
+
+
+class TestSearchMigrationDeadCode:
+    """T5.3 守衛 — Search 遷移殘留清除（T5.3a + T5.3b）"""
+
+    CORE_JS = PROJECT_ROOT / "web/static/js/pages/search/core.js"
+    BRIDGE_JS = PROJECT_ROOT / "web/static/js/pages/search/state/bridge.js"
+    FILE_JS = PROJECT_ROOT / "web/static/js/pages/search/file.js"
+
+    # ===== T5.3a 守衛 =====
+
+    def test_core_no_savestate_stub(self):
+        """core.js 不含 saveState / restoreState 空殼函數定義"""
+        content = self.CORE_JS.read_text(encoding='utf-8')
+        assert 'function saveState()' not in content, \
+            "core.js 仍含 function saveState() 空殼 — T5.3a 應已刪除"
+        assert 'function restoreState()' not in content, \
+            "core.js 仍含 function restoreState() 空殼 — T5.3a 應已刪除"
+        assert 'T3.2: dead code' not in content, \
+            "core.js 仍含 T3.2 dead code 註解 — T5.3a 應已刪除"
+
+    def test_core_no_null_progress_slots(self):
+        """core.js 不含 initProgress / updateLog / handleSearchStatus null slot"""
+        content = self.CORE_JS.read_text(encoding='utf-8')
+        assert 'initProgress: null' not in content, \
+            "core.js 仍含 initProgress: null slot — T5.3a 應已刪除"
+        assert 'updateLog: null' not in content, \
+            "core.js 仍含 updateLog: null slot — T5.3a 應已刪除"
+        assert 'handleSearchStatus: null' not in content, \
+            "core.js 仍含 handleSearchStatus: null slot — T5.3a 應已刪除"
+
+    def test_bridge_no_render_noop(self):
+        """bridge.js 不含 renderFileList / renderSearchResultsList no-op 覆寫"""
+        content = self.BRIDGE_JS.read_text(encoding='utf-8')
+        assert 'renderFileList' not in content, \
+            "bridge.js 仍含 renderFileList no-op 覆寫 — T5.3a 應已刪除"
+        assert 'renderSearchResultsList' not in content, \
+            "bridge.js 仍含 renderSearchResultsList no-op 覆寫 — T5.3a 應已刪除"
+
+    def test_file_no_render_stubs(self):
+        """file.js 不含 renderFileList / renderSearchResultsList 空函數定義"""
+        content = self.FILE_JS.read_text(encoding='utf-8')
+        assert 'renderFileList' not in content, \
+            "file.js 仍含 renderFileList 空函數定義 — T5.3a 應已刪除"
+        assert 'renderSearchResultsList' not in content, \
+            "file.js 仍含 renderSearchResultsList 空函數定義 — T5.3a 應已刪除"
+
+    # ===== T5.3b 守衛 =====
+
+    def test_core_no_dosearch_null_slot(self):
+        """core.js 不含 doSearch: null slot"""
+        content = self.CORE_JS.read_text(encoding='utf-8')
+        assert 'doSearch: null' not in content, \
+            "core.js 仍含 doSearch: null slot — T5.3b 應已刪除"
+
+    def test_bridge_no_searchfile_stubs(self):
+        """bridge.js 不含 SearchFile bridge stub 轉發"""
+        content = self.BRIDGE_JS.read_text(encoding='utf-8')
+        assert 'window.SearchFile.switchToFile' not in content, \
+            "bridge.js 仍含 window.SearchFile.switchToFile — T5.3b 應已刪除"
+        assert 'window.SearchFile.searchAll' not in content, \
+            "bridge.js 仍含 window.SearchFile.searchAll — T5.3b 應已刪除"
+        assert 'window.SearchFile.scrapeAll' not in content, \
+            "bridge.js 仍含 window.SearchFile.scrapeAll — T5.3b 應已刪除"
+        assert 'window.SearchFile.setFileList' not in content, \
+            "bridge.js 仍含 window.SearchFile.setFileList — T5.3b 應已刪除"
+        assert 'window.SearchFile.handleFileDrop' not in content, \
+            "bridge.js 仍含 window.SearchFile.handleFileDrop — T5.3b 應已刪除"
+
+    def test_file_no_bridge_stubs(self):
+        """file.js 不含 bridge stub 空函數定義"""
+        content = self.FILE_JS.read_text(encoding='utf-8')
+        assert 'switchToFile: function()' not in content, \
+            "file.js 仍含 switchToFile: function() 空函數 — T5.3b 應已刪除"
+        assert 'searchAll: function()' not in content, \
+            "file.js 仍含 searchAll: function() 空函數 — T5.3b 應已刪除"
+        assert 'scrapeAll: function()' not in content, \
+            "file.js 仍含 scrapeAll: function() 空函數 — T5.3b 應已刪除"
+        assert 'setFileList: function()' not in content, \
+            "file.js 仍含 setFileList: function() 空函數 — T5.3b 應已刪除"
+        assert 'handleFileDrop: function()' not in content, \
+            "file.js 仍含 handleFileDrop: function() 空函數 — T5.3b 應已刪除"

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -672,6 +672,39 @@ class TestScannerClearCache:
         assert "DELETE" in html
 
 
+class TestSearchCoreFacade:
+    """T3.2 守衛 — SearchCore.state 已降級為只讀 Alpine proxy façade"""
+
+    def test_search_core_state_uses_alpine_proxy(self):
+        """core.js 的 window.SearchCore.state getter 必須使用 Alpine.$data 代理"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/core.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert 'Alpine.$data' in content, (
+            "core.js 的 SearchCore.state getter 未使用 Alpine.$data — "
+            "T3.2 Step 1 應已將 state getter 改為代理 Alpine proxy"
+        )
+
+    def test_sync_to_core_is_noop(self):
+        """bridge.js 不含 coreState.xxx = 賦值（_syncToCore 已是 no-op）"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/bridge.js"
+        content = js_file.read_text(encoding='utf-8')
+        # 匹配 coreState.xxx = （非 ?.、非 == 的賦值）
+        violations = re.findall(r'coreState\.\w+\s*=(?!=)', content)
+        assert len(violations) == 0, (
+            f"bridge.js 的 _syncToCore 仍含 {len(violations)} 個 coreState 賦值 "
+            f"（應已改為 no-op）: {violations}"
+        )
+
+    def test_persistence_no_corestate_fallback(self):
+        """persistence.js 的 saveState() 不含 coreState?. fallback（已改為直接用 Alpine state）"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/persistence.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert 'coreState?.' not in content, (
+            "persistence.js 仍含 coreState?. fallback — "
+            "T3.2 Step 3 應已移除，直接使用 Alpine this.xxx"
+        )
+
+
 class TestPageLifecycleGuard:
     """page-lifecycle.js 存在性守衛 — 確保 script tag 及三頁 __registerPage 呼叫不被移除"""
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -749,6 +749,62 @@ class TestPageLifecycleGuard:
             "showcase/core.js 缺少 __registerPage 呼叫 — Showcase lightbox cleanup lifecycle 會失效"
 
 
+class TestEventSourceTracking:
+    """T4.1 守衛 — 所有 EventSource 建立都透過 _trackConnection 包裝"""
+
+    def test_base_has_active_connections(self):
+        """base.js 必須有 _activeConnections: [] 初始值"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/base.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_activeConnections' in content, \
+            "base.js 缺少 _activeConnections 初始值 — T4.1 集中追蹤 EventSource"
+
+    def test_search_flow_has_track_methods(self):
+        """search-flow.js 必須定義 _trackConnection / _untrackConnection / _closeAllConnections"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+        content = js_file.read_text(encoding='utf-8')
+        for method in ('_trackConnection', '_untrackConnection', '_closeAllConnections'):
+            assert method in content, \
+                f"search-flow.js 缺少 {method} — T4.1 連線追蹤方法"
+
+    def test_do_search_uses_track_connection(self):
+        """doSearch() 的 new EventSource 必須包在 _trackConnection(...) 內"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+        content = js_file.read_text(encoding='utf-8')
+        # 確認有 _trackConnection(new EventSource( 的用法
+        assert '_trackConnection(new EventSource(' in content, \
+            "search-flow.js 的 doSearch() 未使用 _trackConnection 包裝 EventSource"
+
+    def test_file_list_uses_track_connection(self):
+        """searchForFile() 的 new EventSource 必須包在 _trackConnection(...) 內"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/file-list.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_trackConnection(' in content, \
+            "file-list.js 的 searchForFile() 未使用 _trackConnection 包裝 EventSource"
+
+    def test_cleanup_calls_close_all_connections(self):
+        """cleanupForNavigation() 必須呼叫 _closeAllConnections()"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_closeAllConnections()' in content, \
+            "search-flow.js 的 cleanupForNavigation() 未呼叫 _closeAllConnections()"
+
+    def test_no_bare_new_event_source_in_search_state(self):
+        """search/state/ 下所有 JS 的 new EventSource 都應在 _trackConnection 內"""
+        state_dir = PROJECT_ROOT / "web/static/js/pages/search/state"
+        violations = []
+        for js_file in state_dir.glob("*.js"):
+            content = js_file.read_text(encoding='utf-8')
+            # 找 new EventSource( 但不在 _trackConnection 同行
+            for i, line in enumerate(content.splitlines(), 1):
+                if 'new EventSource(' in line and '_trackConnection' not in line:
+                    violations.append(f"{js_file.name}:{i} — {line.strip()[:80]}")
+        assert len(violations) == 0, (
+            f"發現 {len(violations)} 個 bare new EventSource（未包在 _trackConnection 內）:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+
 class TestWindowGlobalCleanup:
     """T3.3 守衛 — bridge.js 不再設定多餘的 window.xxx 全域函數"""
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -1065,3 +1065,15 @@ class TestFetchAbortController:
         """loadFavorite() 的 fetch 必須傳 signal"""
         content = self.FILE_LIST_JS.read_text(encoding='utf-8')
         assert "_getAbortSignal('loadFavorite')" in content
+
+
+class TestScannerDeadCodeGuard:
+    """T5.2 守衛 — Scanner 已移除 window.isGenerating 死碼"""
+
+    SCANNER_HTML = PROJECT_ROOT / "web" / "templates" / "scanner.html"
+
+    def test_scanner_no_window_is_generating(self):
+        """scanner.html 不含 window.isGenerating（Alpine getter 已完全取代）"""
+        content = self.SCANNER_HTML.read_text(encoding='utf-8')
+        assert 'window.isGenerating' not in content, \
+            "scanner.html 仍含 window.isGenerating — T5.2 應已移除所有死碼賦值"

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -748,6 +748,44 @@ class TestPageLifecycleGuard:
         assert '__registerPage' in content, \
             "showcase/core.js 缺少 __registerPage 呼叫 — Showcase lightbox cleanup lifecycle 會失效"
 
+    def test_scanner_html_calls_register_page(self):
+        """scanner.html 必須呼叫 __registerPage"""
+        html_file = PROJECT_ROOT / "web" / "templates" / "scanner.html"
+        content = html_file.read_text(encoding='utf-8')
+        assert '__registerPage' in content, \
+            "scanner.html 缺少 __registerPage 呼叫 — Scanner lifecycle 未接入統一機制"
+
+
+class TestScannerLifecycleGuard:
+    """T5.1 守衛 — Scanner 已接入 __registerPage，不再使用舊 shim"""
+
+    SCANNER_HTML = PROJECT_ROOT / "web" / "templates" / "scanner.html"
+    PAGE_LIFECYCLE_JS = PROJECT_ROOT / "web" / "static" / "js" / "components" / "page-lifecycle.js"
+
+    def test_scanner_no_confirm_leaving_scanner(self):
+        """scanner.html 不含 confirmLeavingScanner（舊 shim 已刪除）"""
+        content = self.SCANNER_HTML.read_text(encoding='utf-8')
+        assert 'confirmLeavingScanner' not in content, \
+            "scanner.html 仍含 confirmLeavingScanner — T5.1 應已刪除舊離頁 shim"
+
+    def test_scanner_no_self_added_beforeunload(self):
+        """scanner.html 不自掛 addEventListener('beforeunload'（由 page-lifecycle.js 統一管理）"""
+        content = self.SCANNER_HTML.read_text(encoding='utf-8')
+        assert "addEventListener('beforeunload'" not in content, \
+            "scanner.html 仍自掛 beforeunload listener — T5.1 應刪除，改由 onBeforeUnload hook 處理"
+
+    def test_scanner_no_skip_before_unload(self):
+        """scanner.html 不含 _skipBeforeUnload（隨舊 shim 一起刪除）"""
+        content = self.SCANNER_HTML.read_text(encoding='utf-8')
+        assert '_skipBeforeUnload' not in content, \
+            "scanner.html 仍含 _skipBeforeUnload — T5.1 應已隨舊 shim 一起刪除"
+
+    def test_page_lifecycle_no_confirm_leaving_scanner_shim(self):
+        """page-lifecycle.js 不含 confirmLeavingScanner compatibility shim"""
+        content = self.PAGE_LIFECYCLE_JS.read_text(encoding='utf-8')
+        assert 'confirmLeavingScanner' not in content, \
+            "page-lifecycle.js 仍含 confirmLeavingScanner shim — T5.1 Scanner 接入後應刪除"
+
 
 class TestEventSourceTracking:
     """T4.1 守衛 — 所有 EventSource 建立都透過 _trackConnection 包裝"""

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -704,6 +704,18 @@ class TestSearchCoreFacade:
             "T3.2 Step 3 應已移除，直接使用 Alpine this.xxx"
         )
 
+    def test_search_core_has_legacy_state_fallback(self):
+        """core.js 的 window.SearchCore 必須包含 _legacyState fallback（Alpine 未 boot 時的安全預設值）"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/core.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_legacyState' in content, (
+            "core.js 缺少 _legacyState — SearchCore.state getter 在 Alpine 未 boot 時"
+            "必須回傳有穩定形狀的物件（含 searchResults: [], fileList: [] 等）"
+        )
+        # 確認 _legacyState 包含關鍵欄位
+        assert 'searchResults: []' in content, "_legacyState 缺少 searchResults: []"
+        assert 'fileList: []' in content, "_legacyState 缺少 fileList: []"
+
 
 class TestPageLifecycleGuard:
     """page-lifecycle.js 存在性守衛 — 確保 script tag 及三頁 __registerPage 呼叫不被移除"""

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -805,6 +805,75 @@ class TestEventSourceTracking:
         )
 
 
+class TestTimerTracking:
+    """T4.2 守衛 — 所有 setTimeout 都透過 _timers registry 管理"""
+
+    def test_base_has_timers_registry(self):
+        """base.js 必須有 _timers: {} 初始值"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/base.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_timers: {}' in content, \
+            "base.js 缺少 _timers: {} — T4.2 集中追蹤 setTimeout"
+
+    def test_base_no_toast_timer(self):
+        """base.js 不再有 _toastTimer: null 宣告（已由 _timers registry 取代）"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/base.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_toastTimer: null' not in content, \
+            "base.js 仍含 _toastTimer: null — T4.2 應已移除，改用 _timers registry"
+
+    def test_search_flow_has_set_timer(self):
+        """search-flow.js 必須定義 _setTimer method"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_setTimer(' in content, \
+            "search-flow.js 缺少 _setTimer method — T4.2 timer registry"
+
+    def test_search_flow_has_clear_all_timers(self):
+        """search-flow.js 必須定義 _clearAllTimers method"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_clearAllTimers(' in content, \
+            "search-flow.js 缺少 _clearAllTimers method — T4.2 timer registry"
+
+    def test_cleanup_calls_clear_all_timers(self):
+        """cleanupForNavigation() 必須呼叫 _clearAllTimers()"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/search-flow.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_clearAllTimers()' in content, \
+            "search-flow.js 的 cleanupForNavigation() 未呼叫 _clearAllTimers()"
+
+    def test_result_card_no_manual_toast_timer(self):
+        """result-card.js 不再有 _toastTimer = 手動賦值（改用 _setTimer）"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/result-card.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert '_toastTimer =' not in content, \
+            "result-card.js 仍含 _toastTimer = 手動賦值 — T4.2 應改用 _setTimer('toast', ...)"
+
+    def test_result_card_uses_set_timer(self):
+        """result-card.js 的 showToast() 必須使用 _setTimer"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/result-card.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert "_setTimer('toast'" in content, \
+            "result-card.js 的 showToast() 未使用 _setTimer('toast', ...) — T4.2"
+
+    def test_persistence_uses_set_timer(self):
+        """persistence.js 的 setupAutoSave() 必須使用 _setTimer（不再用 saveTimeout local variable）"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/persistence.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert "_setTimer('autosave'" in content, \
+            "persistence.js 的 setupAutoSave() 未使用 _setTimer('autosave', ...) — T4.2"
+        assert 'saveTimeout' not in content, \
+            "persistence.js 仍含 saveTimeout local variable — T4.2 應已移除"
+
+    def test_file_list_uses_set_timer(self):
+        """file-list.js 的 loadFavorite() 必須使用 _setTimer"""
+        js_file = PROJECT_ROOT / "web/static/js/pages/search/state/file-list.js"
+        content = js_file.read_text(encoding='utf-8')
+        assert "_setTimer('loadFavorite'" in content, \
+            "file-list.js 的 loadFavorite() 未使用 _setTimer('loadFavorite', ...) — T4.2"
+
+
 class TestWindowGlobalCleanup:
     """T3.3 守衛 — bridge.js 不再設定多餘的 window.xxx 全域函數"""
 

--- a/tests/unit/test_actress_alias_api.py
+++ b/tests/unit/test_actress_alias_api.py
@@ -404,3 +404,26 @@ class TestNfoUpdaterActressFunctions:
 
         assert updated is False
         assert "無法解析" in msg
+
+    def test_replace_actress_in_nfo_with_bare_ampersand(self, tmp_path):
+        """含 bare & 的 NFO 應可解析、正確替換、回寫後仍是合法 XML"""
+        import xml.etree.ElementTree as ET
+        from core.nfo_updater import replace_actress_in_nfo
+
+        nfo_content = '<?xml version="1.0" encoding="UTF-8"?>\n<movie>\n  <actor><name>舊名</name></actor>\n  <trailer>https://example.com/video?sign=abc&t=123</trailer>\n</movie>'
+        nfo_path = tmp_path / "test.nfo"
+        nfo_path.write_text(nfo_content, encoding='utf-8')
+
+        updated, msg = replace_actress_in_nfo(str(nfo_path), "舊名", "新名")
+        assert updated is True
+
+        # 驗證回寫後文字替換正確
+        result = nfo_path.read_text(encoding='utf-8')
+        assert '新名' in result
+        assert '舊名' not in result
+
+        # 驗證回寫後是合法 XML（用標準 ET.parse，不經過 sanitizer）
+        tree = ET.parse(str(nfo_path))
+        root = tree.getroot()
+        actor_elem = root.find('.//actor/name')
+        assert actor_elem is not None and actor_elem.text == '新名'

--- a/tests/unit/test_scanner_sqlite.py
+++ b/tests/unit/test_scanner_sqlite.py
@@ -294,6 +294,24 @@ class TestScanToSqlite:
 
         assert result['inserted'] == 1
 
+    def test_scan_nfo_with_bare_ampersand(self, temp_db, temp_video_dir):
+        """含 bare & 的 NFO 應可解析，actor 和 genre 正確讀取"""
+        video_path = create_video_file(temp_video_dir, "test.mp4")
+        nfo_content = '<?xml version="1.0" encoding="UTF-8"?>\n<movie>\n  <title>測試影片</title>\n  <num>ADN-700</num>\n  <maker>片商</maker>\n  <actor><name>女優A</name></actor>\n  <genre>劇情</genre>\n  <trailer>https://example.com/video?sign=abc&t=123</trailer>\n</movie>'
+        nfo_path = video_path.with_suffix('.nfo')
+        nfo_path.write_text(nfo_content, encoding='utf-8')
+
+        scanner = VideoScanner()
+        result = scanner.scan_to_sqlite(str(temp_video_dir), temp_db)
+
+        assert result['inserted'] == 1
+        repo = VideoRepository(temp_db)
+        videos = repo.get_all()
+        assert len(videos) == 1
+        assert videos[0].title == "測試影片"
+        assert "女優A" in videos[0].actresses
+        assert "劇情" in videos[0].tags
+
 
 class TestScanToSqliteIntegration:
     """scan_to_sqlite 整合測試"""

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -398,3 +398,11 @@
     gap: 2px;
     align-items: center;
 }
+
+/* ==================== Form Loading State ==================== */
+
+/* 載入期間視覺提示：半透明 + wait cursor */
+#settingsForm[inert] {
+    opacity: 0.6;
+    cursor: wait;
+}

--- a/web/static/js/components/page-lifecycle.js
+++ b/web/static/js/components/page-lifecycle.js
@@ -1,0 +1,95 @@
+/**
+ * Page Lifecycle Manager
+ * web/static/js/components/page-lifecycle.js
+ *
+ * 契約：
+ *   beforeLeave(href) → boolean   sidebar 導航時呼叫。gate + save，不釋放資源。
+ *   onBeforeUnload() → string|null  tab 關閉/reload 時呼叫。save + 回傳 non-null 觸發原生提示。
+ *   cleanup()                       釋放資源（關 SSE、清 timer、abort fetch），不做保存。
+ *
+ * 兩條離頁路徑：
+ *   路徑 A（sidebar）：beforeLeave → cleanup → 頁面卸載
+ *   路徑 B（tab close）：onBeforeUnload → [原生提示] → unload 事件 → cleanup
+ */
+(function () {
+    var _handlers = { beforeLeave: null, onBeforeUnload: null, cleanup: null };
+    var _cleanedUp = false;
+
+    // beforeunload：只做 save + 原生提示，不做 cleanup
+    // （使用者可能按「留下」→ 頁面不卸載 → hooks 必須保持完整）
+    window.addEventListener('beforeunload', function (e) {
+        if (_handlers.onBeforeUnload) {
+            var msg = _handlers.onBeforeUnload();
+            if (msg) {
+                e.preventDefault();
+                e.returnValue = msg;
+            }
+        }
+    });
+
+    // unload：頁面確定要卸載了，best-effort cleanup
+    window.addEventListener('unload', function () {
+        _doCleanup();
+    });
+
+    function registerPage(handlers) {
+        _cleanedUp = false;
+        _handlers = {
+            beforeLeave: handlers.beforeLeave || null,
+            onBeforeUnload: handlers.onBeforeUnload || null,
+            cleanup: handlers.cleanup || null,
+        };
+    }
+
+    /**
+     * sidebar 導航入口（路徑 A）
+     * @param {string} href - 目的地 URL
+     * @returns {boolean} 是否允許離開（false = 阻止導航）
+     */
+    function leavePage(href) {
+        // 若有頁面已 registerPage，走新路徑
+        if (_handlers.beforeLeave !== null || _handlers.onBeforeUnload !== null || _handlers.cleanup !== null) {
+            if (_handlers.beforeLeave) {
+                try {
+                    var allowed = _handlers.beforeLeave(href);
+                    if (!allowed) return false;
+                } catch (e) {
+                    console.error('[page-lifecycle] beforeLeave error:', e);
+                    // 例外不阻止導航
+                }
+            }
+            _doCleanup();
+            return true;
+        }
+
+        // Compatibility shim：尚未 registerPage 的頁面走舊路徑
+        // （T2.2/T2.3/T2.4 完成後移除）
+        if (typeof window.cleanupSearchBeforeLeave === 'function') {
+            window.cleanupSearchBeforeLeave();
+        }
+        if (typeof window.confirmLeavingSettings === 'function' && !window.confirmLeavingSettings(href)) {
+            return false;
+        }
+        if (typeof window.confirmLeavingScanner === 'function' && !window.confirmLeavingScanner(href)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * cleanup one-shot wrapper
+     */
+    function _doCleanup() {
+        if (_cleanedUp) return;
+        _cleanedUp = true;
+        try {
+            if (_handlers.cleanup) _handlers.cleanup();
+        } catch (e) {
+            console.error('[page-lifecycle] cleanup error:', e);
+        }
+        _handlers = { beforeLeave: null, onBeforeUnload: null, cleanup: null };
+    }
+
+    window.__registerPage = registerPage;
+    window.__leavePage = leavePage;
+})();

--- a/web/static/js/components/page-lifecycle.js
+++ b/web/static/js/components/page-lifecycle.js
@@ -19,10 +19,14 @@
     // （使用者可能按「留下」→ 頁面不卸載 → hooks 必須保持完整）
     window.addEventListener('beforeunload', function (e) {
         if (_handlers.onBeforeUnload) {
-            var msg = _handlers.onBeforeUnload();
-            if (msg) {
-                e.preventDefault();
-                e.returnValue = msg;
+            try {
+                var msg = _handlers.onBeforeUnload();
+                if (msg) {
+                    e.preventDefault();
+                    e.returnValue = msg;
+                }
+            } catch (err) {
+                console.error('[page-lifecycle] onBeforeUnload error:', err);
             }
         }
     });

--- a/web/static/js/components/page-lifecycle.js
+++ b/web/static/js/components/page-lifecycle.js
@@ -62,14 +62,8 @@
             return true;
         }
 
-        // Compatibility shim：尚未 registerPage 的頁面走舊路徑
-        // （T2.2/T2.3/T2.4 完成後移除）
-        if (typeof window.cleanupSearchBeforeLeave === 'function') {
-            window.cleanupSearchBeforeLeave();
-        }
-        if (typeof window.confirmLeavingSettings === 'function' && !window.confirmLeavingSettings(href)) {
-            return false;
-        }
+        // Compatibility shim：Scanner 尚未 registerPage，走舊路徑
+        // （Scanner 接入 lifecycle 後移除整個 shim）
         if (typeof window.confirmLeavingScanner === 'function' && !window.confirmLeavingScanner(href)) {
             return false;
         }

--- a/web/static/js/components/page-lifecycle.js
+++ b/web/static/js/components/page-lifecycle.js
@@ -65,12 +65,6 @@
             _doCleanup();
             return true;
         }
-
-        // Compatibility shim：Scanner 尚未 registerPage，走舊路徑
-        // （Scanner 接入 lifecycle 後移除整個 shim）
-        if (typeof window.confirmLeavingScanner === 'function' && !window.confirmLeavingScanner(href)) {
-            return false;
-        }
         return true;
     }
 

--- a/web/static/js/pages/search/core.js
+++ b/web/static/js/pages/search/core.js
@@ -151,7 +151,7 @@ async function _translateWithAI() {
                 }
                 // T1c: Alpine reactive will update UI automatically
                 console.log(`[Gemini] 翻譯完成: ${result.result}`);
-                saveState();
+                window.SearchCore.saveState();
             } else {
                 throw new Error(result.error || '翻譯失敗');
             }
@@ -217,7 +217,7 @@ async function _translateWithAI() {
             });
 
             console.log(`[Ollama Batch] 完成 ${translations.filter(t => t).length} 片翻譯`);
-            saveState();
+            window.SearchCore.saveState();
         }
 
         if (state.listMode !== 'file') {
@@ -234,20 +234,6 @@ async function _translateWithAI() {
         // T1c: isTranslating cleanup handled by Alpine wrapper
         // T1c: UI updates handled by Alpine reactive
     }
-}
-
-// === 狀態保存/還原 ===
-
-function saveState() {
-    // T3.2: dead code — bridge.js 已覆寫此函數，Alpine persistence.js 接管
-}
-
-function restoreState() {
-    // T3.2: dead code — bridge.js 已覆寫此函數，Alpine persistence.js 接管
-}
-
-function clearState() {
-    sessionStorage.removeItem(STATE_KEY);
 }
 
 function clearAll() {
@@ -269,7 +255,7 @@ function clearAll() {
 
     window.SearchUI.showState('empty');
     updateClearButton();
-    clearState();
+    sessionStorage.removeItem(STATE_KEY);
 }
 
 function updateClearButton() {
@@ -420,16 +406,8 @@ window.SearchCore = {
     initDOM,
     // 函數
     loadAppConfig,
-    saveState,
-    restoreState,
-    clearState,
     clearAll,
     updateClearButton,
-    // T1b: 這些函數已遷移到 Alpine，保留 bridge 指向（在 state.js setupBridgeLayer() 設定）
-    doSearch: null,
-    initProgress: null,      // bridge 在 state.js 設定
-    updateLog: null,         // bridge 在 state.js 設定
-    handleSearchStatus: null, // bridge 在 state.js 設定
     hasJapanese,
     translateWithOllama,
     // T1c: Internal translate function (called by Alpine wrapper)

--- a/web/static/js/pages/search/core.js
+++ b/web/static/js/pages/search/core.js
@@ -4,38 +4,13 @@
  */
 
 // === 狀態變數 ===
-let searchResults = [];
-let currentIndex = 0;
-
-// 分頁相關
-let currentQuery = '';
-let currentOffset = 0;
-let hasMoreResults = false;
-let isLoadingMore = false;
-let isSearchingFile = false;
+// T3.2 Step 4: 14 個 module vars 已刪除（searchResults, currentIndex, currentQuery,
+// currentOffset, hasMoreResults, isLoadingMore, isSearchingFile, fileList,
+// currentFileIndex, listMode, batchState, appConfig, isTranslating, currentMode）
+// 狀態現由 Alpine reactive proxy 管理（透過 SearchCore.state getter 存取）
 const PAGE_SIZE = 20;
 
-// 多檔案列表狀態
-let fileList = [];
-let currentFileIndex = 0;
-let listMode = null;  // 'file' | 'search' | null
-
-// 批次搜尋狀態
-let batchState = {
-    batchSize: 20,        // 每批數量
-    isProcessing: false,  // 是否正在處理批次
-    isPaused: false,      // 是否暫停（Phase 9.4 使用）
-    total: 0,             // 本批實際總數
-    processed: 0,         // 本批已處理數量
-    success: 0,           // 本批成功數量
-    failed: 0             // 本批失敗數量
-};
-
-// 翻譯功能
-let appConfig = null;
-let isTranslating = false;
-
-// 🆕 追蹤正在批次翻譯的片索引
+// 🆕 追蹤正在批次翻譯的片索引（T3.3 再處理）
 const batchTranslatingIndices = new Set();
 
 // 狀態保存 Key
@@ -86,15 +61,16 @@ function initDOM() {
 
 // === 載入應用設定 ===
 async function loadAppConfig() {
+    const state = window.SearchCore.state;
     try {
         const resp = await fetch('/api/config');
         const data = await resp.json();
         if (data.success) {
-            appConfig = data.data;
+            state.appConfig = data.data;
 
             // 更新我的最愛按鈕 tooltip
             if (dom.btnFavorite) {
-                const favoriteFolder = appConfig?.search?.favorite_folder || '系統下載資料夾';
+                const favoriteFolder = state.appConfig?.search?.favorite_folder || '系統下載資料夾';
                 dom.btnFavorite.title = `載入：${favoriteFolder}`;
             }
         }
@@ -143,17 +119,18 @@ async function translateWithOllama(text, mode, metadata = {}) {
  * NOTE: isTranslating state is managed by Alpine wrapper in state.js
  */
 async function _translateWithAI() {
+    const state = window.SearchCore.state;
     // T1c: isTranslating now managed by Alpine wrapper
     try {
         // === Gemini 模式：只翻譯當前片 ===
-        if (appConfig?.translate?.provider === 'gemini') {
+        if (state.appConfig?.translate?.provider === 'gemini') {
             let currentResult = null;
 
-            if (listMode === 'file' && fileList[currentFileIndex]) {
-                const results = fileList[currentFileIndex].searchResults || [];
-                currentResult = results[currentIndex];
+            if (state.listMode === 'file' && state.fileList[state.currentFileIndex]) {
+                const results = state.fileList[state.currentFileIndex].searchResults || [];
+                currentResult = results[state.currentIndex];
             } else {
-                currentResult = searchResults[currentIndex];
+                currentResult = state.searchResults[state.currentIndex];
             }
 
             if (!currentResult || !currentResult.title || !hasJapanese(currentResult.title)) {
@@ -167,10 +144,10 @@ async function _translateWithAI() {
 
             if (result.success && result.result) {
                 // 更新翻譯結果
-                if (listMode === 'file') {
-                    fileList[currentFileIndex].searchResults[currentIndex].translated_title = result.result;
+                if (state.listMode === 'file') {
+                    state.fileList[state.currentFileIndex].searchResults[state.currentIndex].translated_title = result.result;
                 } else {
-                    searchResults[currentIndex].translated_title = result.result;
+                    state.searchResults[state.currentIndex].translated_title = result.result;
                 }
                 // T1c: Alpine reactive will update UI automatically
                 console.log(`[Gemini] 翻譯完成: ${result.result}`);
@@ -186,9 +163,9 @@ async function _translateWithAI() {
         const batch = [];
         const batchMeta = [];
 
-        if (listMode === 'file') {
-            for (let fi = currentFileIndex; fi < fileList.length && batch.length < 1; fi++) {
-                const file = fileList[fi];
+        if (state.listMode === 'file') {
+            for (let fi = state.currentFileIndex; fi < state.fileList.length && batch.length < 1; fi++) {
+                const file = state.fileList[fi];
                 const results = file.searchResults || [];
 
                 for (let ri = 0; ri < results.length && batch.length < 1; ri++) {
@@ -200,8 +177,8 @@ async function _translateWithAI() {
                 }
             }
         } else {
-            for (let i = currentIndex; i < searchResults.length && batch.length < 1; i++) {
-                const result = searchResults[i];
+            for (let i = state.currentIndex; i < state.searchResults.length && batch.length < 1; i++) {
+                const result = state.searchResults[i];
                 if (result.title && hasJapanese(result.title) && !result.translated_title) {
                     batch.push(result);
                     batchMeta.push({ resultIndex: i });
@@ -215,7 +192,7 @@ async function _translateWithAI() {
 
         console.log(`[Ollama Batch] 批次翻譯 ${batch.length} 片`);
 
-        if (listMode !== 'file') {
+        if (state.listMode !== 'file') {
             batchMeta.forEach(meta => {
                 batchTranslatingIndices.add(meta.resultIndex);
             });
@@ -229,11 +206,11 @@ async function _translateWithAI() {
                 if (!trans) return;
                 const meta = batchMeta[i];
 
-                if (listMode === 'file') {
-                    fileList[meta.fileIndex].searchResults[meta.resultIndex].translated_title = trans;
+                if (state.listMode === 'file') {
+                    state.fileList[meta.fileIndex].searchResults[meta.resultIndex].translated_title = trans;
                     // T1c: Alpine reactive will update UI automatically
                 } else {
-                    searchResults[meta.resultIndex].translated_title = trans;
+                    state.searchResults[meta.resultIndex].translated_title = trans;
                     batchTranslatingIndices.delete(meta.resultIndex);
                     // T1c: Alpine reactive will update UI automatically
                 }
@@ -243,7 +220,7 @@ async function _translateWithAI() {
             saveState();
         }
 
-        if (listMode !== 'file') {
+        if (state.listMode !== 'file') {
             batchMeta.forEach(meta => {
                 batchTranslatingIndices.delete(meta.resultIndex);
             });
@@ -262,69 +239,11 @@ async function _translateWithAI() {
 // === 狀態保存/還原 ===
 
 function saveState() {
-    const state = {
-        searchResults,
-        currentIndex,
-        currentQuery,
-        currentOffset,
-        hasMoreResults,
-        fileList,
-        currentFileIndex,
-        listMode,
-        queryValue: dom.queryInput ? dom.queryInput.value : ''
-    };
-    sessionStorage.setItem(STATE_KEY, JSON.stringify(state));
+    // T3.2: dead code — bridge.js 已覆寫此函數，Alpine persistence.js 接管
 }
 
 function restoreState() {
-    const saved = sessionStorage.getItem(STATE_KEY);
-    if (!saved) return false;
-
-    try {
-        const state = JSON.parse(saved);
-        searchResults = state.searchResults || [];
-        currentIndex = state.currentIndex || 0;
-        currentQuery = state.currentQuery || '';
-        currentOffset = state.currentOffset || 0;
-        hasMoreResults = state.hasMoreResults || false;
-        fileList = state.fileList || [];
-        currentFileIndex = state.currentFileIndex || 0;
-        listMode = state.listMode || null;
-        if (dom.queryInput) {
-            dom.queryInput.value = state.queryValue || '';
-        }
-
-        // 有內容才還原顯示
-        if (searchResults.length > 0) {
-            window.SearchUI.displayResult?.(searchResults[currentIndex]);
-            window.SearchUI.updateNavigation?.();
-            window.SearchUI.showState('result');
-
-            if (listMode === 'search') {
-                window.SearchFile?.renderSearchResultsList?.();
-            } else if (listMode === 'file') {
-                window.SearchFile?.renderFileList?.();
-            }
-            updateClearButton();
-            return true;
-        } else if (fileList.length > 0 && listMode === 'file') {
-            window.SearchFile?.renderFileList?.();
-            updateClearButton();
-            const currentFile = fileList[currentFileIndex];
-            if (currentFile && currentFile.searchResults && currentFile.searchResults.length > 0) {
-                searchResults = currentFile.searchResults;
-                hasMoreResults = currentFile.hasMoreResults || false;
-                window.SearchUI.displayResult?.(searchResults[currentIndex]);
-                window.SearchUI.updateNavigation?.();
-                window.SearchUI.showState('result');
-                return true;
-            }
-        }
-    } catch (e) {
-        console.error('還原狀態失敗:', e);
-        sessionStorage.removeItem(STATE_KEY);
-    }
-    return false;
+    // T3.2: dead code — bridge.js 已覆寫此函數，Alpine persistence.js 接管
 }
 
 function clearState() {
@@ -332,16 +251,17 @@ function clearState() {
 }
 
 function clearAll() {
-    searchResults = [];
-    currentIndex = 0;
-    currentQuery = '';
-    currentOffset = 0;
-    hasMoreResults = false;
-    fileList = [];
-    currentFileIndex = 0;
-    listMode = null;
+    const state = window.SearchCore.state;
+    state.searchResults = [];
+    state.currentIndex = 0;
+    state.currentQuery = '';
+    state.currentOffset = 0;
+    state.hasMoreResults = false;
+    state.fileList = [];
+    state.currentFileIndex = 0;
+    state.listMode = null;
     if (dom.queryInput) dom.queryInput.value = '';
-    isSearchingFile = false;
+    state.isSearchingFile = false;
 
     // 確保導航按鈕圖示正確
     if (dom.btnPrev) dom.btnPrev.innerHTML = '<i class="bi bi-chevron-left"></i>';
@@ -353,7 +273,8 @@ function clearAll() {
 }
 
 function updateClearButton() {
-    const hasContent = searchResults.length > 0 || fileList.length > 0;
+    const state = window.SearchCore.state;
+    const hasContent = state.searchResults.length > 0 || state.fileList.length > 0;
     // Alpine x-show 控制顯示/隱藏（classList 操作已移除）
     const el = document.querySelector('.search-container[x-data]');
     if (el && el._x_dataStack) {
@@ -373,11 +294,10 @@ const MODE_TEXT = {
     'uncensored': '無碼搜尋'
 };
 
-let currentMode = '';
+// T3.2 Step 4: let currentMode = '' 已刪除（改由 Alpine state 管理）
 
 // === 搜尋邏輯 ===
 // T1b: doSearch, fallbackSearch 已遷移到 Alpine state.js
-// 保留 module-level vars 供舊 JS 讀取
 
 // === 本地狀態查詢 ===
 
@@ -467,38 +387,14 @@ async function translateBatch(titles) {
 
 // === 暴露介面 ===
 window.SearchCore = {
-    // 狀態（供其他模組讀寫）
+    // 狀態（供其他模組讀寫）— T3.2: 代理 Alpine reactive proxy
     get state() {
-        return {
-            get searchResults() { return searchResults; },
-            set searchResults(v) { searchResults = v; },
-            get currentIndex() { return currentIndex; },
-            set currentIndex(v) { currentIndex = v; },
-            get currentQuery() { return currentQuery; },
-            set currentQuery(v) { currentQuery = v; },
-            get currentOffset() { return currentOffset; },
-            set currentOffset(v) { currentOffset = v; },
-            get hasMoreResults() { return hasMoreResults; },
-            set hasMoreResults(v) { hasMoreResults = v; },
-            get isLoadingMore() { return isLoadingMore; },
-            set isLoadingMore(v) { isLoadingMore = v; },
-            get isSearchingFile() { return isSearchingFile; },
-            set isSearchingFile(v) { isSearchingFile = v; },
-            get fileList() { return fileList; },
-            set fileList(v) { fileList = v; },
-            get currentFileIndex() { return currentFileIndex; },
-            set currentFileIndex(v) { currentFileIndex = v; },
-            get listMode() { return listMode; },
-            set listMode(v) { listMode = v; },
-            get appConfig() { return appConfig; },
-            get isTranslating() { return isTranslating; },
-            set isTranslating(v) { isTranslating = v; },
-            get currentMode() { return currentMode; },
-            set currentMode(v) { currentMode = v; },
-            get batchState() { return batchState; },
-            set batchState(v) { batchState = v; },
-            PAGE_SIZE
-        };
+        const el = document.querySelector('.search-container[x-data]');
+        if (el && el._x_dataStack) {
+            return Alpine.$data(el);  // 直接回傳 Alpine reactive proxy
+        }
+        // Alpine 未 boot 時回傳空物件（不應在正常使用情境發生）
+        return {};
     },
     // DOM 引用
     get dom() { return dom; },

--- a/web/static/js/pages/search/core.js
+++ b/web/static/js/pages/search/core.js
@@ -387,14 +387,32 @@ async function translateBatch(titles) {
 
 // === 暴露介面 ===
 window.SearchCore = {
+    // Alpine 未 boot 時的安全 fallback（穩定形狀，避免 TypeError）
+    _legacyState: {
+        searchResults: [],
+        currentIndex: 0,
+        currentQuery: '',
+        currentOffset: 0,
+        hasMoreResults: false,
+        isLoadingMore: false,
+        isSearchingFile: false,
+        fileList: [],
+        currentFileIndex: 0,
+        listMode: null,
+        appConfig: null,
+        isTranslating: false,
+        currentMode: '',
+        batchState: {},
+        PAGE_SIZE: 20
+    },
     // 狀態（供其他模組讀寫）— T3.2: 代理 Alpine reactive proxy
     get state() {
         const el = document.querySelector('.search-container[x-data]');
         if (el && el._x_dataStack) {
             return Alpine.$data(el);  // 直接回傳 Alpine reactive proxy
         }
-        // Alpine 未 boot 時回傳空物件（不應在正常使用情境發生）
-        return {};
+        // Alpine 未 boot 時回傳 _legacyState（穩定形狀，不報錯）
+        return this._legacyState;
     },
     // DOM 引用
     get dom() { return dom; },

--- a/web/static/js/pages/search/file.js
+++ b/web/static/js/pages/search/file.js
@@ -221,12 +221,4 @@ window.SearchFile = {
     parseFilenames,
     scrapeFile,
     detectSuffixes,
-    // Bridge stubs (overwritten by Alpine setupBridgeLayer)
-    switchToFile: function() {},
-    searchAll: function() {},
-    scrapeAll: function() {},
-    setFileList: function() {},
-    handleFileDrop: function() {},
-    renderFileList: function() {},
-    renderSearchResultsList: function() {}
 };

--- a/web/static/js/pages/search/init.js
+++ b/web/static/js/pages/search/init.js
@@ -13,23 +13,6 @@ document.addEventListener('DOMContentLoaded', function () {
         window.SearchCore.initDOM();
     }
 
-    // Fix 4b: 如果 Alpine bridge 未建立，補上 no-op 防止 file.js 呼叫時拋錯
-    if (!window.SearchCore.initProgress) {
-        window.SearchCore.initProgress = (query) => {
-            console.warn('[Init] initProgress called without Alpine bridge');
-        };
-    }
-    if (!window.SearchCore.updateLog) {
-        window.SearchCore.updateLog = (msg) => {
-            console.warn('[Init] updateLog called without Alpine bridge');
-        };
-    }
-    if (!window.SearchCore.handleSearchStatus) {
-        window.SearchCore.handleSearchStatus = (source, status) => {
-            console.warn('[Init] handleSearchStatus called without Alpine bridge');
-        };
-    }
-
     const { state, dom } = window.SearchCore;
 
     // T1b: 表單提交、導航按鈕、鍵盤導航已遷移到 Alpine（@submit.prevent, @click, @keydown.window）

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -70,6 +70,7 @@ window.SearchStateMixin_Base = function() {
             visible: false
         },
         _timers: {},  // Timer registry：{ [key: string]: number }（setTimeout ID）
+        _abortControllers: {},  // Fetch AbortController registry：{ [key: string]: AbortController }（T4.3）
 
         // ===== T1d: File List State =====
         dragActive: false,

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -90,6 +90,7 @@ window.SearchStateMixin_Base = function() {
         // ===== Search State Machine =====
         requestId: 0,              // 搜尋請求計數器（防競態）
         activeEventSource: null,   // 當前 SSE 連線
+        _activeConnections: [],    // Array<EventSource> — 追蹤所有進行中的 SSE 連線
         _searchSnapshot: null,     // cancelSearch 用的狀態快照
 
         // ===== T2a: Display Mode State =====

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -69,7 +69,7 @@ window.SearchStateMixin_Base = function() {
             type: 'success',  // 'success' | 'error' | 'warning' | 'info'
             visible: false
         },
-        _toastTimer: null,  // setTimeout ID for auto-hide
+        _timers: {},  // Timer registry：{ [key: string]: number }（setTimeout ID）
 
         // ===== T1d: File List State =====
         dragActive: false,

--- a/web/static/js/pages/search/state/batch.js
+++ b/web/static/js/pages/search/state/batch.js
@@ -118,6 +118,7 @@ window.SearchStateMixin_Batch = {
         ts.failed = 0;
 
         const isGemini = this.appConfig?.translate?.provider === 'gemini';
+        let aborted = false;
 
         for (const result of translatableResults) {
             if (ts.isPaused) {
@@ -140,7 +141,8 @@ window.SearchStateMixin_Batch = {
                         mode: 'translate',
                         actors: result.actors,
                         number: result.number
-                    })
+                    }),
+                    signal: this._getAbortSignal('translateAll')  // T4.3
                 });
                 const data = await response.json();
                 if (data.success && data.result && !data.skipped) {
@@ -150,6 +152,7 @@ window.SearchStateMixin_Batch = {
                     ts.failed++;
                 }
             } catch (err) {
+                if (err.name === 'AbortError') { aborted = true; break; }  // T4.3: 離頁 abort → 結束 loop
                 ts.failed++;
             }
 
@@ -160,9 +163,12 @@ window.SearchStateMixin_Batch = {
             }
         }
 
+        this._clearAbort('translateAll');  // T4.3: 清除 registry（與其他 fetch 的 finally 一致）
         ts.isProcessing = false;
         ts.isPaused = false;
-        this.showToast(`翻譯完成：成功 ${ts.success}，失敗 ${ts.failed}`, ts.failed > 0 ? 'warning' : 'success');
+        if (!aborted) {  // T4.3: abort 時不顯示 toast（DOM 可能已不可用）
+            this.showToast(`翻譯完成：成功 ${ts.success}，失敗 ${ts.failed}`, ts.failed > 0 ? 'warning' : 'success');
+        }
         ts.total = 0;
     },
 

--- a/web/static/js/pages/search/state/batch.js
+++ b/web/static/js/pages/search/state/batch.js
@@ -77,7 +77,6 @@ window.SearchStateMixin_Batch = {
 
         // 批次處理完成
         this.isSearchingFile = false;
-        this._syncToCore();
         batch.isProcessing = false;
         batch.isPaused = false;
 
@@ -190,7 +189,6 @@ window.SearchStateMixin_Batch = {
             this.searchResults = file.searchResults;
             this.currentIndex = 0;
             this.coverError = '';
-            this._syncToCore({ skipFileList: true });  // scrape 迴圈中，fileList 不變
 
             const metadata = { ...file.searchResults[0] };
 

--- a/web/static/js/pages/search/state/batch.js
+++ b/web/static/js/pages/search/state/batch.js
@@ -45,6 +45,7 @@ window.SearchStateMixin_Batch = {
 
         // 並行處理，一次 2 個
         const concurrency = 2;
+        let aborted = false;
         for (let i = 0; i < currentBatch.length; i += concurrency) {
             // 支援暫停
             if (batch.isPaused) {
@@ -57,6 +58,8 @@ window.SearchStateMixin_Batch = {
                     }, 100);
                 });
             }
+            // cleanup 已設 isProcessing=false → 中斷 loop，不繼續發新工作
+            if (!batch.isProcessing) { aborted = true; break; }
 
             const chunk = currentBatch.slice(i, Math.min(i + concurrency, currentBatch.length));
 
@@ -73,6 +76,8 @@ window.SearchStateMixin_Batch = {
 
                 batch.processed++;
             }));
+            // cleanup 在 chunk 執行中發生 → SSE 被關掉，Promise.all resolve 後檢查
+            if (!batch.isProcessing) { aborted = true; break; }
         }
 
         // 批次處理完成
@@ -80,9 +85,10 @@ window.SearchStateMixin_Batch = {
         batch.isProcessing = false;
         batch.isPaused = false;
 
-        // 顯示完成統計
-        const totalProcessed = batch.success + batch.failed;
-        alert(`批次搜尋完成！\n成功: ${batch.success}\n失敗: ${batch.failed}`);
+        // 顯示完成統計（cleanup 中斷時不顯示）
+        if (!aborted) {
+            alert(`批次搜尋完成！\n成功: ${batch.success}\n失敗: ${batch.failed}`);
+        }
 
         // 重置 total
         batch.total = 0;
@@ -131,6 +137,8 @@ window.SearchStateMixin_Batch = {
                     }, 100);
                 });
             }
+            // cleanup 已設 isProcessing=false → 中斷 loop，不繼續發新 fetch
+            if (!ts.isProcessing) { aborted = true; break; }
 
             try {
                 const response = await fetch('/api/translate', {

--- a/web/static/js/pages/search/state/bridge.js
+++ b/web/static/js/pages/search/state/bridge.js
@@ -16,25 +16,8 @@ window.SearchStateMixin_Bridge = {
             window.SearchCore.clearState = () => this.clearState();
         }
 
-        // T1b: 新增搜尋流程 bridge
-        // 讓舊 JS 可以觸發 Alpine 搜尋
-        if (window.SearchCore) {
-            window.SearchCore.doSearch = (query) => this.doSearch(query);
-        }
         if (window.SearchUI) {
             window.SearchUI.navigateResult = (delta) => this.navigate(delta);
-        }
-
-        // T1d: file.js functions now in Alpine
-        if (window.SearchFile) {
-            window.SearchFile.switchToFile = (index, position, showFullLoading) =>
-                this.switchToFile(index, position, showFullLoading);
-            window.SearchFile.searchAll = () => this.searchAll();
-            window.SearchFile.scrapeAll = () => this.scrapeAll();
-            window.SearchFile.setFileList = (paths) => this.setFileList(paths);
-            window.SearchFile.handleFileDrop = (files) => this.handleFileDrop(files);
-            window.SearchFile.renderFileList = () => {}; // no-op
-            window.SearchFile.renderSearchResultsList = () => {}; // no-op
         }
 
         // T6b: Toast bridge（供外部 JS 如 ui.js 的 showSourceToast 使用）

--- a/web/static/js/pages/search/state/bridge.js
+++ b/web/static/js/pages/search/state/bridge.js
@@ -25,36 +25,6 @@ window.SearchStateMixin_Bridge = {
             window.SearchUI.navigateResult = (delta) => this.navigate(delta);
         }
 
-        // Fix 1: 新增 file.js 需要的進度函數 bridge
-        if (window.SearchCore) {
-            window.SearchCore.initProgress = (query) => {
-                this.progressLog = '搜尋中...';
-                this.currentMode = '';
-                this.detailDone = 0;
-                this.detailTotal = 0;
-                this.currentQuery = query;
-            };
-            window.SearchCore.updateLog = (msg) => {
-                this.progressLog = msg;
-            };
-            window.SearchCore.handleSearchStatus = (source, status) => {
-                this.handleSearchStatus(source, status);
-            };
-        }
-
-        // T1c: 覆寫全域函數，指向 Alpine methods
-        window.translateWithAI = () => this.translateWithAI();
-        window.startEditTitle = () => this.startEditTitle();
-        window.confirmEditTitle = () => this.confirmEditTitle();
-        window.cancelEditTitle = () => this.cancelEditTitle();
-        window.startEditChineseTitle = () => this.startEditChineseTitle();
-        window.confirmEditChineseTitle = () => this.confirmEditChineseTitle();
-        window.cancelEditChineseTitle = () => this.cancelEditChineseTitle();
-        window.showAddTagInput = () => this.showAddTagInput();
-        window.confirmAddTag = () => this.confirmAddTag();
-        window.cancelAddTag = () => this.cancelAddTag();
-        window.removeUserTag = (tag) => this.removeUserTag(tag);
-
         // T1d: file.js functions now in Alpine
         if (window.SearchFile) {
             window.SearchFile.switchToFile = (index, position, showFullLoading) =>

--- a/web/static/js/pages/search/state/bridge.js
+++ b/web/static/js/pages/search/state/bridge.js
@@ -3,43 +3,6 @@
  * 包含：舊 JS 與 Alpine 的橋接層（setupBridgeLayer）
  */
 window.SearchStateMixin_Bridge = {
-    /**
-     * 同步 Alpine state 到 core.js module vars
-     *
-     * 集中式 state sync helper，取代散落在各 mixin 的手動 coreState 賦值。
-     *
-     * @param {Object} options - 可選配置
-     * @param {boolean} options.skipFileList - 跳過 fileList 陣列同步（效能優化，僅同步索引）
-     */
-    _syncToCore(options = {}) {
-        const coreState = window.SearchCore?.state;
-        if (!coreState) {
-            console.warn('[Alpine] _syncToCore: window.SearchCore.state not available');
-            return;
-        }
-
-        // === 核心搜尋狀態（永遠同步） ===
-        coreState.searchResults = this.searchResults;
-        coreState.currentIndex = this.currentIndex;
-        coreState.currentQuery = this.currentQuery;
-        coreState.currentOffset = this.currentOffset;
-        coreState.hasMoreResults = this.hasMoreResults;
-        coreState.isLoadingMore = this.isLoadingMore;
-        coreState.listMode = this.listMode;
-
-        // === 檔案列表狀態（可選同步） ===
-        if (!options.skipFileList) {
-            coreState.fileList = this.fileList;
-            coreState.currentFileIndex = this.currentFileIndex;
-        } else {
-            // skipFileList: 只同步索引（輕量，適用於純導航操作）
-            coreState.currentFileIndex = this.currentFileIndex;
-        }
-
-        // === 內部狀態標記 ===
-        coreState.isSearchingFile = this.isSearchingFile;
-    },
-
     // ===== Bridge Layer =====
     // 修正 2: 簡化 Bridge Layer（不覆寫 window.SearchCore.state）
     setupBridgeLayer() {

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -192,7 +192,8 @@ window.SearchStateMixin_FileList = {
             const resp = await fetch('/api/search/filter-files', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ paths })
+                body: JSON.stringify({ paths }),
+                signal: this._getAbortSignal('setFileList')  // T4.3
             });
             const result = await resp.json();
 
@@ -212,7 +213,10 @@ window.SearchStateMixin_FileList = {
                 paths = result.files;
             }
         } catch (err) {
+            if (err.name === 'AbortError') return;  // T4.3: 新搜尋取代，靜默退出
             console.error('Filter API error:', err);
+        } finally {
+            this._clearAbort('setFileList');  // T4.3: 操作完成清除 registry
         }
 
         // 使用後端 API 批次解析所有檔名
@@ -338,7 +342,9 @@ window.SearchStateMixin_FileList = {
     async loadFavorite() {
         this.isLoadingFavorite = true;
         try {
-            const resp = await fetch('/api/search/favorite-files');
+            const resp = await fetch('/api/search/favorite-files', {
+                signal: this._getAbortSignal('loadFavorite')  // T4.3
+            });
             const result = await resp.json();
 
             if (!result.success) {
@@ -357,9 +363,11 @@ window.SearchStateMixin_FileList = {
             }, 100);
 
         } catch (err) {
+            if (err.name === 'AbortError') return;  // T4.3: 靜默忽略取消
             alert('載入失敗：' + err.message);
         } finally {
             this.isLoadingFavorite = false;
+            this._clearAbort('loadFavorite');  // T4.3: 操作完成清除 registry
         }
     }
 };

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -10,14 +10,12 @@ window.SearchStateMixin_FileList = {
 
         this.currentFileIndex = index;
         const file = this.fileList[index];
-        this._syncToCore({ skipFileList: true });  // 只切換索引
 
         if (!file.number) {
             this.searchResults = [];
             this.hasMoreResults = false;
             this.currentIndex = 0;
             this.coverError = `無法識別番號: ${file.filename}`;
-            this._syncToCore({ skipFileList: true });
             window.SearchUI.showState('result');
             return;
         }
@@ -29,7 +27,6 @@ window.SearchStateMixin_FileList = {
             this.hasMoreResults = file.hasMoreResults || false;
             this.currentIndex = position === 'last' ? this.searchResults.length - 1 : 0;
             this.coverError = '';
-            this._syncToCore({ skipFileList: true });
 
             window.SearchUI.showState('result');
         } else {
@@ -37,14 +34,12 @@ window.SearchStateMixin_FileList = {
             this.hasMoreResults = false;
             this.currentIndex = 0;
             this.coverError = `找不到 ${file.number} 的資料`;
-            this._syncToCore({ skipFileList: true });
             window.SearchUI.showState('result');
         }
     },
 
     async searchForFile(file, position = 'first', showFullLoading = false) {
         this.isSearchingFile = true;
-        this._syncToCore({ skipFileList: true });
 
         if (showFullLoading) {
             window.SearchUI.showState('loading');
@@ -84,7 +79,6 @@ window.SearchStateMixin_FileList = {
                             this.hasMoreResults = file.hasMoreResults;
                             this.currentIndex = position === 'last' ? this.searchResults.length - 1 : 0;
                             this.coverError = '';
-                            this._syncToCore();
 
                             // T4: File search 後查詢本地狀態
                             if (window.SearchCore?.checkLocalStatus) {
@@ -101,7 +95,6 @@ window.SearchStateMixin_FileList = {
                             this.searchResults = [];
                             this.hasMoreResults = false;
                             this.currentIndex = 0;
-                            this._syncToCore();
 
                             window.SearchUI.showState('result');
                         }
@@ -118,7 +111,6 @@ window.SearchStateMixin_FileList = {
                         this.searchResults = [];
                         this.hasMoreResults = false;
                         this.currentIndex = 0;
-                        this._syncToCore();
 
                         window.SearchUI.showState('result');
                         resolve();
@@ -139,7 +131,6 @@ window.SearchStateMixin_FileList = {
                 this.searchResults = [];
                 this.hasMoreResults = false;
                 this.currentIndex = 0;
-                this._syncToCore();
 
                 window.SearchUI.showState('result');
                 resolve();
@@ -150,7 +141,6 @@ window.SearchStateMixin_FileList = {
     switchToSearchResult(index) {
         if (index < 0 || index >= this.searchResults.length) return;
         this.currentIndex = index;
-        this._syncToCore({ skipFileList: true });
 
         // Reset cover error on switch
         this.coverError = '';
@@ -186,7 +176,6 @@ window.SearchStateMixin_FileList = {
         } else if (this.currentFileIndex > index) {
             this.currentFileIndex--;
         }
-        this._syncToCore();
 
         if (this.fileList.length > 0) {
             this.switchToFile(this.currentFileIndex, 'first', false);
@@ -275,7 +264,6 @@ window.SearchStateMixin_FileList = {
         this.currentFileIndex = 0;
         this.listMode = 'file';
         this.displayMode = 'detail';
-        this._syncToCore();
 
         // 重置批次狀態
         const batch = this.batchState;

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -43,7 +43,7 @@ window.SearchStateMixin_FileList = {
 
         if (showFullLoading) {
             window.SearchUI.showState('loading');
-            window.SearchCore.initProgress(file.number);
+            this.initProgress(file.number);
         } else {
             this.isSearchingFile = true;
             this.searchingFileDirection = position === 'first' ? 'next' : 'prev';
@@ -57,11 +57,11 @@ window.SearchStateMixin_FileList = {
                     const data = JSON.parse(event.data);
 
                     if (data.type === 'mode') {
-                        window.SearchCore.state.currentMode = data.mode;
-                        window.SearchCore.updateLog(`${window.SearchCore.MODE_TEXT[data.mode] || '搜尋'}...`);
+                        this.currentMode = data.mode;
+                        this.updateLog(`${window.SearchCore.MODE_TEXT[data.mode] || '搜尋'}...`);
                     }
                     else if (data.type === 'status') {
-                        window.SearchCore.handleSearchStatus(data.source, data.status);
+                        this.handleSearchStatus(data.source, data.status);
                     }
                     else if (data.type === 'result') {
                         eventSource.close();
@@ -274,7 +274,7 @@ window.SearchStateMixin_FileList = {
         batch.success = 0;
         batch.failed = 0;
 
-        window.SearchCore.updateClearButton();
+        this.hasContent = this.searchResults.length > 0 || this.fileList.length > 0;
 
         if (this.fileList.length > 0) {
             if (this.fileList[0].number) {

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -50,7 +50,7 @@ window.SearchStateMixin_FileList = {
         }
 
         return new Promise((resolve) => {
-            const eventSource = new EventSource(`/api/search/stream?q=${encodeURIComponent(file.number)}`);
+            const eventSource = this._trackConnection(new EventSource(`/api/search/stream?q=${encodeURIComponent(file.number)}`));
 
             eventSource.onmessage = (event) => {
                 try {
@@ -65,6 +65,7 @@ window.SearchStateMixin_FileList = {
                     }
                     else if (data.type === 'result') {
                         eventSource.close();
+                        this._untrackConnection(eventSource);
                         this.isSearchingFile = false;
                         this.searchingFileDirection = null;
                         this.listMode = 'file';
@@ -102,6 +103,7 @@ window.SearchStateMixin_FileList = {
                     }
                     else if (data.type === 'error') {
                         eventSource.close();
+                        this._untrackConnection(eventSource);
                         this.isSearchingFile = false;
                         this.searchingFileDirection = null;
                         file.searched = true;
@@ -122,6 +124,7 @@ window.SearchStateMixin_FileList = {
 
             eventSource.onerror = () => {
                 eventSource.close();
+                this._untrackConnection(eventSource);
                 this.isSearchingFile = false;
                 this.searchingFileDirection = null;
                 file.searched = true;

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -188,12 +188,13 @@ window.SearchStateMixin_FileList = {
 
     async setFileList(paths) {
         // 呼叫過濾 API
+        const setFileListSignal = this._getAbortSignal('setFileList');  // T4.3
         try {
             const resp = await fetch('/api/search/filter-files', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ paths }),
-                signal: this._getAbortSignal('setFileList')  // T4.3
+                signal: setFileListSignal
             });
             const result = await resp.json();
 
@@ -216,7 +217,7 @@ window.SearchStateMixin_FileList = {
             if (err.name === 'AbortError') return;  // T4.3: 新搜尋取代，靜默退出
             console.error('Filter API error:', err);
         } finally {
-            this._clearAbort('setFileList');  // T4.3: 操作完成清除 registry
+            this._clearAbort('setFileList', setFileListSignal);  // T4.3: 操作完成清除 registry（比對 signal 避免刪掉新請求）
         }
 
         // 使用後端 API 批次解析所有檔名
@@ -341,9 +342,10 @@ window.SearchStateMixin_FileList = {
 
     async loadFavorite() {
         this.isLoadingFavorite = true;
+        const loadFavoriteSignal = this._getAbortSignal('loadFavorite');  // T4.3
         try {
             const resp = await fetch('/api/search/favorite-files', {
-                signal: this._getAbortSignal('loadFavorite')  // T4.3
+                signal: loadFavoriteSignal
             });
             const result = await resp.json();
 
@@ -367,7 +369,7 @@ window.SearchStateMixin_FileList = {
             alert('載入失敗：' + err.message);
         } finally {
             this.isLoadingFavorite = false;
-            this._clearAbort('loadFavorite');  // T4.3: 操作完成清除 registry
+            this._clearAbort('loadFavorite', loadFavoriteSignal);  // T4.3: 操作完成清除 registry（比對 signal 避免刪掉新請求）
         }
     }
 };

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -348,8 +348,8 @@ window.SearchStateMixin_FileList = {
 
             await this.setFileList(result.files);
 
-            // 自動開始搜尋
-            setTimeout(() => {
+            // 自動開始搜尋（T4.2: 改用 _setTimer，離頁時可統一清除）
+            this._setTimer('loadFavorite', () => {
                 const searchableFiles = this.fileList.filter(f => f.number && !f.searched);
                 if (searchableFiles.length > 0) {
                     this.searchAll();

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -25,7 +25,6 @@ window.SearchStateMixin_GridMode = {
         this.lightboxOpen = true;
         // 同步 currentIndex（讓 Detail 與 Grid 保持一致）
         this.currentIndex = index;
-        this._syncToCore({ skipFileList: true });
     },
 
     /**
@@ -59,7 +58,6 @@ window.SearchStateMixin_GridMode = {
         if (this.lightboxIndex > 0) {
             this.lightboxIndex--;
             this.currentIndex = this.lightboxIndex;
-            this._syncToCore({ skipFileList: true });
         }
     },
 
@@ -71,13 +69,11 @@ window.SearchStateMixin_GridMode = {
             // At actress photo → go to first cover
             this.lightboxIndex = 0;
             this.currentIndex = 0;
-            this._syncToCore({ skipFileList: true });
             return;
         }
         if (this.lightboxIndex < this.searchResults.length - 1) {
             this.lightboxIndex++;
             this.currentIndex = this.lightboxIndex;
-            this._syncToCore({ skipFileList: true });
         }
     },
 
@@ -128,7 +124,6 @@ window.SearchStateMixin_GridMode = {
     switchToDetail(index) {
         this.displayMode = 'detail';
         this.currentIndex = index;
-        this._syncToCore({ skipFileList: true });
         this.saveState();
     },
 

--- a/web/static/js/pages/search/state/index.js
+++ b/web/static/js/pages/search/state/index.js
@@ -49,19 +49,21 @@ function searchPage() {
             this.setupAutoSave();
 
             // 7. 接入 page lifecycle（取代 cleanupSearchBeforeLeave + beforeunload）
-            window.__registerPage({
-                beforeLeave: () => {
-                    this.saveState();
-                    return true;  // search 不阻止導航，只做保存
-                },
-                onBeforeUnload: () => {
-                    this.saveState();
-                    return null;  // search 不觸發原生提示
-                },
-                cleanup: () => {
-                    this.cleanupForNavigation();  // 關 SSE + abort fallback + requestId++
-                }
-            });
+            if (window.__registerPage) {
+                window.__registerPage({
+                    beforeLeave: () => {
+                        this.saveState();
+                        return true;  // search 不阻止導航，只做保存
+                    },
+                    onBeforeUnload: () => {
+                        this.saveState();
+                        return null;  // search 不觸發原生提示
+                    },
+                    cleanup: () => {
+                        this.cleanupForNavigation();  // 關 SSE + abort fallback + requestId++
+                    }
+                });
+            }
 
             // 8. T1d: 監聽 pywebview-files 事件
             window.addEventListener('pywebview-files', async (e) => {

--- a/web/static/js/pages/search/state/index.js
+++ b/web/static/js/pages/search/state/index.js
@@ -24,6 +24,8 @@ function searchPage() {
         ...window.SearchStateMixin_Bridge,
         ...window.SearchStateMixin_GridMode,
 
+        _navStateSaved: false,
+
         // ===== Lifecycle =====
         async init() {
             // 1. 初始化舊 JS 的 DOM references（必須在 DOM ready 後）
@@ -48,13 +50,30 @@ function searchPage() {
             // 6. Watch state 變化並自動儲存
             this.setupAutoSave();
 
-            // 7. 監聽離開前儲存
-            window.addEventListener('beforeunload', () => this.saveState());
+            // 7. 監聽離開前儲存（安全網 — sidebar 沒攔到時兜底）
+            window.addEventListener('beforeunload', () => this._saveAndCleanupForNav());
+
+            // 暴露全域清理函數（供 base.html sidebar 使用）
+            window.cleanupSearchBeforeLeave = () => {
+                this._saveAndCleanupForNav();
+            };
 
             // 8. T1d: 監聽 pywebview-files 事件
             window.addEventListener('pywebview-files', async (e) => {
                 await this.setFileList(e.detail.paths);
             });
+        },
+
+        /**
+         * 導航前保存 + 清理（one-shot：只執行一次）
+         * sidebar click 先呼叫，beforeunload 再呼叫時跳過。
+         */
+        _saveAndCleanupForNav() {
+            if (this._navStateSaved) return;  // 已保存過，跳過
+            this._navStateSaved = true;
+
+            this.saveState();               // 先存（activeEventSource 仍在 → pageState=loading → 走 snapshot）
+            this.cleanupForNavigation();    // 再關 SSE + requestId++
         }
     };
 }

--- a/web/static/js/pages/search/state/index.js
+++ b/web/static/js/pages/search/state/index.js
@@ -24,8 +24,6 @@ function searchPage() {
         ...window.SearchStateMixin_Bridge,
         ...window.SearchStateMixin_GridMode,
 
-        _navStateSaved: false,
-
         // ===== Lifecycle =====
         async init() {
             // 1. 初始化舊 JS 的 DOM references（必須在 DOM ready 後）
@@ -50,13 +48,20 @@ function searchPage() {
             // 6. Watch state 變化並自動儲存
             this.setupAutoSave();
 
-            // 7. 監聽離開前儲存（安全網 — sidebar 沒攔到時兜底）
-            window.addEventListener('beforeunload', () => this._saveAndCleanupForNav());
-
-            // 暴露全域清理函數（供 base.html sidebar 使用）
-            window.cleanupSearchBeforeLeave = () => {
-                this._saveAndCleanupForNav();
-            };
+            // 7. 接入 page lifecycle（取代 cleanupSearchBeforeLeave + beforeunload）
+            window.__registerPage({
+                beforeLeave: () => {
+                    this.saveState();
+                    return true;  // search 不阻止導航，只做保存
+                },
+                onBeforeUnload: () => {
+                    this.saveState();
+                    return null;  // search 不觸發原生提示
+                },
+                cleanup: () => {
+                    this.cleanupForNavigation();  // 關 SSE + abort fallback + requestId++
+                }
+            });
 
             // 8. T1d: 監聽 pywebview-files 事件
             window.addEventListener('pywebview-files', async (e) => {
@@ -64,16 +69,5 @@ function searchPage() {
             });
         },
 
-        /**
-         * 導航前保存 + 清理（one-shot：只執行一次）
-         * sidebar click 先呼叫，beforeunload 再呼叫時跳過。
-         */
-        _saveAndCleanupForNav() {
-            if (this._navStateSaved) return;  // 已保存過，跳過
-            this._navStateSaved = true;
-
-            this.saveState();               // 先存（activeEventSource 仍在 → pageState=loading → 走 snapshot）
-            this.cleanupForNavigation();    // 再關 SSE + requestId++
-        }
     };
 }

--- a/web/static/js/pages/search/state/navigation.js
+++ b/web/static/js/pages/search/state/navigation.js
@@ -58,7 +58,8 @@ window.SearchStateMixin_Navigation = {
 
         try {
             const response = await fetch(
-                `/api/search?q=${encodeURIComponent(this.currentQuery)}&offset=${newOffset}&limit=${this.PAGE_SIZE}`
+                `/api/search?q=${encodeURIComponent(this.currentQuery)}&offset=${newOffset}&limit=${this.PAGE_SIZE}`,
+                { signal: this._getAbortSignal('loadMore') }
             );
             const data = await response.json();
 
@@ -80,9 +81,11 @@ window.SearchStateMixin_Navigation = {
                 this.hasMoreResults = false;
             }
         } catch (err) {
+            if (err.name === 'AbortError') return;  // T4.3: 靜默忽略取消
             console.error('載入更多失敗:', err);
         } finally {
             this.isLoadingMore = false;
+            this._clearAbort('loadMore');  // T4.3: 操作完成清除 registry
         }
     },
 

--- a/web/static/js/pages/search/state/navigation.js
+++ b/web/static/js/pages/search/state/navigation.js
@@ -36,7 +36,6 @@ window.SearchStateMixin_Navigation = {
         // 正常範圍內導航
         if (newIndex >= 0 && newIndex < this.searchResults.length) {
             this.currentIndex = newIndex;
-            this._syncToCore({ skipFileList: true });  // 導航頻繁，跳過 fileList
 
             // Reset cover error on navigation
             this.coverError = '';
@@ -68,7 +67,6 @@ window.SearchStateMixin_Navigation = {
                 this.currentOffset = newOffset;
                 this.hasMoreResults = data.has_more;
                 this.currentIndex = this.searchResults.length - data.data.length;
-                this._syncToCore({ skipFileList: true });  // load more 不涉及 fileList
 
                 if (window.SearchUI?.preloadImages) {
                     window.SearchUI.preloadImages(this.currentIndex + 1, 5);
@@ -85,7 +83,6 @@ window.SearchStateMixin_Navigation = {
             console.error('載入更多失敗:', err);
         } finally {
             this.isLoadingMore = false;
-            this._syncToCore({ skipFileList: true });
         }
     },
 

--- a/web/static/js/pages/search/state/navigation.js
+++ b/web/static/js/pages/search/state/navigation.js
@@ -55,11 +55,12 @@ window.SearchStateMixin_Navigation = {
 
         this.isLoadingMore = true;
         const newOffset = this.currentOffset + this.PAGE_SIZE;
+        const loadMoreSignal = this._getAbortSignal('loadMore');
 
         try {
             const response = await fetch(
                 `/api/search?q=${encodeURIComponent(this.currentQuery)}&offset=${newOffset}&limit=${this.PAGE_SIZE}`,
-                { signal: this._getAbortSignal('loadMore') }
+                { signal: loadMoreSignal }
             );
             const data = await response.json();
 
@@ -85,7 +86,7 @@ window.SearchStateMixin_Navigation = {
             console.error('載入更多失敗:', err);
         } finally {
             this.isLoadingMore = false;
-            this._clearAbort('loadMore');  // T4.3: 操作完成清除 registry
+            this._clearAbort('loadMore', loadMoreSignal);  // T4.3: 操作完成清除 registry（比對 signal 避免刪掉新請求）
         }
     },
 

--- a/web/static/js/pages/search/state/persistence.js
+++ b/web/static/js/pages/search/state/persistence.js
@@ -26,7 +26,6 @@ window.SearchStateMixin_Persistence = {
             if (this.appConfig?.search?.gallery_mode_enabled === false) {
                 this.displayMode = 'detail';
             }
-            this._syncToCore();
 
             // 還原搜尋框輸入值
             if (state.queryValue) {
@@ -45,7 +44,6 @@ window.SearchStateMixin_Persistence = {
                 if (currentFile?.searchResults?.length > 0) {
                     this.searchResults = currentFile.searchResults;
                     this.hasMoreResults = currentFile.hasMoreResults || false;
-                    this._syncToCore();
                     window.SearchUI.showState('result');
                 }
             }
@@ -83,19 +81,16 @@ window.SearchStateMixin_Persistence = {
             return;
         }
 
-        // 正常路徑：現有邏輯不變
-        // T1a: 從 core.js module vars 讀取（它們是 source of truth）
-        // Alpine state 可能是 stale（core.js 函數直接改 module vars，不經過 Alpine）
-        const coreState = window.SearchCore?.state;
+        // T3.2 Step 3: SearchCore.state 已代理 Alpine，直接用 Alpine state
         const state = {
-            searchResults: coreState?.searchResults ?? this.searchResults,
-            currentIndex: coreState?.currentIndex ?? this.currentIndex,
-            currentQuery: coreState?.currentQuery ?? this.currentQuery,
-            currentOffset: coreState?.currentOffset ?? this.currentOffset,
-            hasMoreResults: coreState?.hasMoreResults ?? this.hasMoreResults,
-            fileList: coreState?.fileList ?? this.fileList,
-            currentFileIndex: coreState?.currentFileIndex ?? this.currentFileIndex,
-            listMode: coreState?.listMode ?? this.listMode,
+            searchResults: this.searchResults,
+            currentIndex: this.currentIndex,
+            currentQuery: this.currentQuery,
+            currentOffset: this.currentOffset,
+            hasMoreResults: this.hasMoreResults,
+            fileList: this.fileList,
+            currentFileIndex: this.currentFileIndex,
+            listMode: this.listMode,
             queryValue: this.searchQuery,
             displayMode: this.displayMode,
             currentMode: this.currentMode,  // T3 fix: 持久化搜尋模式

--- a/web/static/js/pages/search/state/persistence.js
+++ b/web/static/js/pages/search/state/persistence.js
@@ -48,8 +48,8 @@ window.SearchStateMixin_Persistence = {
                 }
             }
 
-            // 同步 clear button（.hidden toggling + Alpine hasContent）
-            window.SearchCore.updateClearButton();
+            // 同步 clear button（直接計算 hasContent）
+            this.hasContent = this.searchResults.length > 0 || this.fileList.length > 0;
 
             console.log('[Alpine] State restored from sessionStorage');
         } catch (e) {

--- a/web/static/js/pages/search/state/persistence.js
+++ b/web/static/js/pages/search/state/persistence.js
@@ -61,6 +61,29 @@ window.SearchStateMixin_Persistence = {
     },
 
     saveState() {
+        // 搜尋進行中：用 _searchSnapshot 保存（上一輪完整一致狀態）
+        // 條件：snapshot 存在 + pageState 仍是 loading（覆蓋 SSE 和 REST fallback 兩條路徑）
+        if (this._searchSnapshot && this.pageState === 'loading') {
+            const snap = this._searchSnapshot;
+            const state = {
+                searchResults: snap.searchResults,
+                currentIndex: snap.currentIndex,
+                currentQuery: snap.currentQuery,
+                currentOffset: snap.currentOffset,
+                hasMoreResults: snap.hasMoreResults,
+                fileList: snap.fileList,
+                currentFileIndex: snap.currentFileIndex,
+                listMode: snap.listMode,
+                queryValue: snap.currentQuery,    // 上一輪的 query
+                displayMode: snap.displayMode,
+                currentMode: snap.currentMode,
+                actressProfile: snap.actressProfile
+            };
+            sessionStorage.setItem(this.STATE_KEY, JSON.stringify(state));
+            return;
+        }
+
+        // 正常路徑：現有邏輯不變
         // T1a: 從 core.js module vars 讀取（它們是 source of truth）
         // Alpine state 可能是 stale（core.js 函數直接改 module vars，不經過 Alpine）
         const coreState = window.SearchCore?.state;

--- a/web/static/js/pages/search/state/persistence.js
+++ b/web/static/js/pages/search/state/persistence.js
@@ -105,10 +105,9 @@ window.SearchStateMixin_Persistence = {
 
     setupAutoSave() {
         // Watch 主要狀態變化並自動儲存（debounce 100ms）
-        let saveTimeout;
+        // T4.2: 改用 _setTimer 取代 local debounce variable，支援離頁統一清除
         const debouncedSave = () => {
-            clearTimeout(saveTimeout);
-            saveTimeout = setTimeout(() => this.saveState(), 100);
+            this._setTimer('autosave', () => this.saveState(), 100);
         };
 
         this.$watch('searchResults', debouncedSave);

--- a/web/static/js/pages/search/state/result-card.js
+++ b/web/static/js/pages/search/state/result-card.js
@@ -231,16 +231,8 @@ window.SearchStateMixin_ResultCard = {
         this._toast.type = type;
         this._toast.visible = true;
 
-        // 清除舊的 timer
-        if (this._toastTimer) {
-            clearTimeout(this._toastTimer);
-        }
-
-        // 設定自動隱藏
-        this._toastTimer = setTimeout(() => {
-            this._toast.visible = false;
-            this._toastTimer = null;
-        }, duration);
+        // T4.2: 使用 _setTimer 管理（自動取代舊 timer，離頁時可統一清除）
+        this._setTimer('toast', () => { this._toast.visible = false; }, duration);
     },
 
     // ===== T1c: Cover Error =====

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -129,7 +129,6 @@ window.SearchStateMixin_SearchFlow = {
                         this.hasMoreResults = data.has_more || false;
                         this.actressProfile = data.actress_profile || null;  // T2d: 寫入女優資料
                         this.listMode = 'search';
-                        this._syncToCore();
 
                         // 查詢本地狀態（非同步）
                         if (window.SearchCore?.checkLocalStatus) {
@@ -217,7 +216,6 @@ window.SearchStateMixin_SearchFlow = {
                 this.hasMoreResults = data.has_more || false;
                 this.actressProfile = data.actress_profile || null;  // T2d: 寫入女優資料
                 this.listMode = 'search';
-                this._syncToCore();
 
                 // 查詢本地狀態
                 if (window.SearchCore?.checkLocalStatus) {
@@ -289,7 +287,6 @@ window.SearchStateMixin_SearchFlow = {
             this.displayMode = snap.displayMode || 'detail';
             this.currentMode = snap.currentMode || '';
             this.errorText = snap.errorText || '';
-            this._syncToCore();
 
             // 還原顯示
             window.SearchUI.showState(snap.pageState);

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -288,6 +288,18 @@ window.SearchStateMixin_SearchFlow = {
     },
 
     /**
+     * 離頁前清理 SSE（不還原 snapshot，因為離頁時會另外 saveState）
+     */
+    cleanupForNavigation() {
+        if (this.activeEventSource) {
+            this.activeEventSource.close();
+            this.activeEventSource = null;
+        }
+        this.requestId++;  // 讓進行中的 onmessage/onerror callback 失效
+        // 也讓進行中的 fallbackSearch() 的 savedRequestId check 失效
+    },
+
+    /**
      * 處理 SSE 狀態更新（T3b: 豐富化進度文字，顯示來源名稱）
      * @param {string} source - 來源（javbus/jav321/javdb/fc2/avsox/mode/done）
      * @param {string} status - 狀態字串

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -319,6 +319,9 @@ window.SearchStateMixin_SearchFlow = {
         // T4.2: 清除所有 setTimeout timer
         this._clearAllTimers();
 
+        // T4.3: 取消所有 fetch（loadMore / translateAll / setFileList / loadFavorite）
+        this._abortAllFetches();
+
         // T4.2: 讓 batch/translate 的 checkInterval 自清（setPaused=false 讓條件成立）
         this.batchState.isProcessing = false;
         this.batchState.isPaused = false;
@@ -380,6 +383,35 @@ window.SearchStateMixin_SearchFlow = {
     _clearAllTimers() {
         Object.values(this._timers).forEach(clearTimeout);
         this._timers = {};
+    },
+
+    // ===== T4.3: Fetch AbortController 集中追蹤方法 =====
+
+    /**
+     * 取得指定 key 的 AbortSignal（自動 abort 並取代同 key 的舊 controller）
+     * @param {string} key - fetch 識別碼（如 'loadMore', 'translateAll', 'setFileList', 'loadFavorite'）
+     * @returns {AbortSignal}
+     */
+    _getAbortSignal(key) {
+        if (this._abortControllers[key]) this._abortControllers[key].abort();
+        this._abortControllers[key] = new AbortController();
+        return this._abortControllers[key].signal;
+    },
+
+    /**
+     * 從 registry 移除指定 key 的 AbortController（fetch 完成後呼叫）
+     * @param {string} key - fetch 識別碼
+     */
+    _clearAbort(key) {
+        delete this._abortControllers[key];
+    },
+
+    /**
+     * 取消並清空所有 registry 中的 fetch（離頁時呼叫）
+     */
+    _abortAllFetches() {
+        Object.values(this._abortControllers).forEach(c => c.abort());
+        this._abortControllers = {};
     },
 
     /**

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -195,8 +195,13 @@ window.SearchStateMixin_SearchFlow = {
         // T4: 重置 rotating border 動畫追蹤
         this._localBorderPlayed = {};
 
+        // 建立 AbortController（離頁時可取消）
+        this._fallbackAbortController = new AbortController();
+
         try {
-            const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+            const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`, {
+                signal: this._fallbackAbortController.signal
+            });
             const data = await response.json();
 
             // Fix 3: 檢查是否已被新搜尋取代
@@ -244,6 +249,8 @@ window.SearchStateMixin_SearchFlow = {
                 window.SearchUI.showState('error');
             }
         } catch (err) {
+            // AbortError：離頁或新搜尋取消，靜默忽略
+            if (err.name === 'AbortError') return;
             // Fix 3: 舊請求失敗不覆蓋新搜尋畫面
             if (savedRequestId !== this.requestId) return;
             this._searchSnapshot = null;
@@ -261,6 +268,11 @@ window.SearchStateMixin_SearchFlow = {
             this.activeEventSource = null;
         }
         this.requestId++;
+        // 取消進行中的 REST fallback fetch
+        if (this._fallbackAbortController) {
+            this._fallbackAbortController.abort();
+            this._fallbackAbortController = null;
+        }
 
         // 還原到搜尋前的狀態
         const snap = this._searchSnapshot;
@@ -294,6 +306,11 @@ window.SearchStateMixin_SearchFlow = {
         if (this.activeEventSource) {
             this.activeEventSource.close();
             this.activeEventSource = null;
+        }
+        // 取消進行中的 REST fallback fetch
+        if (this._fallbackAbortController) {
+            this._fallbackAbortController.abort();
+            this._fallbackAbortController = null;
         }
         this.requestId++;  // 讓進行中的 onmessage/onerror callback 失效
         // 也讓進行中的 fallbackSearch() 的 savedRequestId check 失效

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -146,8 +146,7 @@ window.SearchStateMixin_SearchFlow = {
                             window.SearchUI.preloadImages(1, 5);
                         }
                         this.listMode = 'search';
-                        this.hasContent = true;
-                        window.SearchCore.updateClearButton();
+                        this.hasContent = this.searchResults.length > 0 || this.fileList.length > 0;
                         this._searchSnapshot = null; // Fix 2: 清空 snapshot（搜尋成功）
                         // Reset edit states
                         this.coverError = '';
@@ -233,8 +232,7 @@ window.SearchStateMixin_SearchFlow = {
                     window.SearchUI.preloadImages(1, 5);
                 }
                 this.listMode = 'search';
-                this.hasContent = true;
-                window.SearchCore.updateClearButton();
+                this.hasContent = this.searchResults.length > 0 || this.fileList.length > 0;
                 this._searchSnapshot = null; // Fix 2: 清空 snapshot（搜尋成功）
                 // Reset edit states
                 this.coverError = '';
@@ -311,6 +309,26 @@ window.SearchStateMixin_SearchFlow = {
         }
         this.requestId++;  // 讓進行中的 onmessage/onerror callback 失效
         // 也讓進行中的 fallbackSearch() 的 savedRequestId check 失效
+    },
+
+    /**
+     * 初始化搜尋進度顯示（T3.3: 從 bridge.js 搬移）
+     * @param {string} query - 搜尋番號
+     */
+    initProgress(query) {
+        this.progressLog = '搜尋中...';
+        this.currentMode = '';
+        this.detailDone = 0;
+        this.detailTotal = 0;
+        this.currentQuery = query;
+    },
+
+    /**
+     * 更新進度記錄文字（T3.3: 從 bridge.js 搬移）
+     * @param {string} msg - 進度訊息
+     */
+    updateLog(msg) {
+        this.progressLog = msg;
     },
 
     /**

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -315,6 +315,15 @@ window.SearchStateMixin_SearchFlow = {
         }
         this.requestId++;  // 讓進行中的 onmessage/onerror callback 失效
         // 也讓進行中的 fallbackSearch() 的 savedRequestId check 失效
+
+        // T4.2: 清除所有 setTimeout timer
+        this._clearAllTimers();
+
+        // T4.2: 讓 batch/translate 的 checkInterval 自清（setPaused=false 讓條件成立）
+        this.batchState.isProcessing = false;
+        this.batchState.isPaused = false;
+        this.translateState.isProcessing = false;
+        this.translateState.isPaused = false;
     },
 
     // ===== T4.1: EventSource 集中追蹤方法 =====
@@ -347,6 +356,30 @@ window.SearchStateMixin_SearchFlow = {
             }
         });
         this._activeConnections = [];
+    },
+
+    // ===== T4.2: Timer 集中追蹤方法 =====
+
+    /**
+     * 設定具名 timer（自動取代同 key 的舊 timer）
+     * @param {string} key - timer 識別碼（如 'toast', 'autosave', 'loadFavorite'）
+     * @param {Function} fn - 回調函數
+     * @param {number} delay - 延遲毫秒
+     */
+    _setTimer(key, fn, delay) {
+        if (this._timers[key]) clearTimeout(this._timers[key]);
+        this._timers[key] = setTimeout(() => {
+            delete this._timers[key];
+            fn();
+        }, delay);
+    },
+
+    /**
+     * 清除所有 registry 中的 timer（離頁時呼叫）
+     */
+    _clearAllTimers() {
+        Object.values(this._timers).forEach(clearTimeout);
+        this._timers = {};
     },
 
     /**

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -400,10 +400,14 @@ window.SearchStateMixin_SearchFlow = {
 
     /**
      * 從 registry 移除指定 key 的 AbortController（fetch 完成後呼叫）
+     * 只清除持有指定 signal 的 controller，避免刪掉新請求的 controller
      * @param {string} key - fetch 識別碼
+     * @param {AbortSignal} [signal] - 呼叫 _getAbortSignal 時取得的 signal；若省略則無條件刪除
      */
-    _clearAbort(key) {
-        delete this._abortControllers[key];
+    _clearAbort(key, signal) {
+        if (!signal || (this._abortControllers[key] && this._abortControllers[key].signal === signal)) {
+            delete this._abortControllers[key];
+        }
     },
 
     /**

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -97,14 +97,15 @@ window.SearchStateMixin_SearchFlow = {
 
         // 檔案列表由 x-show 自動隱藏（listMode=null, fileList=[]）
 
-        // 6. 建立 SSE 連線
-        this.activeEventSource = new EventSource(`/api/search/stream?q=${encodeURIComponent(query)}`);
+        // 6. 建立 SSE 連線並追蹤
+        this.activeEventSource = this._trackConnection(new EventSource(`/api/search/stream?q=${encodeURIComponent(query)}`));
         const eventSource = this.activeEventSource;
 
         eventSource.onmessage = (event) => {
             // 檢查是否已被取消
             if (currentRequestId !== this.requestId) {
                 eventSource.close();
+                this._untrackConnection(eventSource);
                 return;
             }
 
@@ -120,6 +121,7 @@ window.SearchStateMixin_SearchFlow = {
                 }
                 else if (data.type === 'result') {
                     eventSource.close();
+                    this._untrackConnection(eventSource);
                     this.activeEventSource = null;
 
                     if (data.success && data.data && data.data.length > 0) {
@@ -161,6 +163,7 @@ window.SearchStateMixin_SearchFlow = {
                 }
                 else if (data.type === 'error') {
                     eventSource.close();
+                    this._untrackConnection(eventSource);
                     this.activeEventSource = null;
                     this._searchSnapshot = null; // Fix 2: 清空 snapshot（搜尋錯誤）
                     this.errorText = data.message || '搜尋失敗';  // T6c: Alpine state
@@ -175,10 +178,12 @@ window.SearchStateMixin_SearchFlow = {
             // 檢查是否已被取消
             if (currentRequestId !== this.requestId) {
                 eventSource.close();
+                this._untrackConnection(eventSource);
                 return;
             }
 
             eventSource.close();
+            this._untrackConnection(eventSource);
             this.activeEventSource = null;
             this.fallbackSearch(query, currentRequestId); // Fix 3: 傳入 requestId
         };
@@ -261,6 +266,7 @@ window.SearchStateMixin_SearchFlow = {
     cancelSearch() {
         if (this.activeEventSource) {
             this.activeEventSource.close();
+            this._untrackConnection(this.activeEventSource);
             this.activeEventSource = null;
         }
         this.requestId++;
@@ -298,10 +304,10 @@ window.SearchStateMixin_SearchFlow = {
      * 離頁前清理 SSE（不還原 snapshot，因為離頁時會另外 saveState）
      */
     cleanupForNavigation() {
-        if (this.activeEventSource) {
-            this.activeEventSource.close();
-            this.activeEventSource = null;
-        }
+        // _closeAllConnections() 包含 activeEventSource 和 searchForFile() 的 ES
+        this._closeAllConnections();
+        this.activeEventSource = null;   // 維持單一引用清零（語義清晰）
+
         // 取消進行中的 REST fallback fetch
         if (this._fallbackAbortController) {
             this._fallbackAbortController.abort();
@@ -309,6 +315,38 @@ window.SearchStateMixin_SearchFlow = {
         }
         this.requestId++;  // 讓進行中的 onmessage/onerror callback 失效
         // 也讓進行中的 fallbackSearch() 的 savedRequestId check 失效
+    },
+
+    // ===== T4.1: EventSource 集中追蹤方法 =====
+
+    /**
+     * 追蹤 EventSource 連線，加入 _activeConnections 陣列
+     * @param {EventSource} es - 要追蹤的 EventSource 實例
+     * @returns {EventSource} 回傳 es 本身，讓呼叫側可以鏈式賦值
+     */
+    _trackConnection(es) {
+        this._activeConnections.push(es);
+        return es;
+    },
+
+    /**
+     * 從 _activeConnections 移除 EventSource（不關閉連線）
+     * @param {EventSource} es - 要移除的 EventSource 實例
+     */
+    _untrackConnection(es) {
+        this._activeConnections = this._activeConnections.filter(c => c !== es);
+    },
+
+    /**
+     * 關閉並清空所有追蹤中的 EventSource 連線
+     */
+    _closeAllConnections() {
+        this._activeConnections.forEach(c => {
+            if (c.readyState !== EventSource.CLOSED) {
+                c.close();
+            }
+        });
+        this._activeConnections = [];
     },
 
     /**

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -209,15 +209,22 @@ function settingsPage() {
                 }
             });
 
-            // 暴露全域檢查函式（供 base.html sidebar 使用）
-            window.confirmLeavingSettings = (targetUrl) => {
-                if (this.isDirty) {
-                    this.pendingNavigationUrl = targetUrl;
+            // 接入 page lifecycle（取代 window.confirmLeavingSettings）
+            window.__registerPage({
+                beforeLeave: (href) => {
+                    if (!this.isDirty) return true;
+                    this.pendingNavigationUrl = href;
                     this.dirtyCheckModalOpen = true;
-                    return false;  // 阻止導航
+                    return false;
+                },
+                onBeforeUnload: () => {
+                    if (this.isDirty) return '您有未儲存的設定變更';
+                    return null;
+                },
+                cleanup: () => {
+                    if (this._toastTimer) clearTimeout(this._toastTimer);
                 }
-                return true;  // 允許導航
-            };
+            });
         },
 
         // ===== Methods =====

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -210,21 +210,23 @@ function settingsPage() {
             });
 
             // 接入 page lifecycle（取代 window.confirmLeavingSettings）
-            window.__registerPage({
-                beforeLeave: (href) => {
-                    if (!this.isDirty) return true;
-                    this.pendingNavigationUrl = href;
-                    this.dirtyCheckModalOpen = true;
-                    return false;
-                },
-                onBeforeUnload: () => {
-                    if (this.isDirty) return '您有未儲存的設定變更';
-                    return null;
-                },
-                cleanup: () => {
-                    if (this._toastTimer) clearTimeout(this._toastTimer);
-                }
-            });
+            if (window.__registerPage) {
+                window.__registerPage({
+                    beforeLeave: (href) => {
+                        if (!this.isDirty) return true;
+                        this.pendingNavigationUrl = href;
+                        this.dirtyCheckModalOpen = true;
+                        return false;
+                    },
+                    onBeforeUnload: () => {
+                        if (this.isDirty) return '您有未儲存的設定變更';
+                        return null;
+                    },
+                    cleanup: () => {
+                        if (this._toastTimer) clearTimeout(this._toastTimer);
+                    }
+                });
+            }
         },
 
         // ===== Methods =====

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -73,6 +73,7 @@ function settingsPage() {
         // ===== Dirty Check State =====
         savedState: null,
         pendingNavigationUrl: '',
+        _configLoading: true,  // 初始 true，loadConfig 完成後 false
 
         // ===== Constants =====
 
@@ -121,6 +122,7 @@ function settingsPage() {
 
         // ===== Computed Properties =====
         get isDirty() {
+            if (this._configLoading) return false;
             if (!this.savedState) return false;
             return JSON.stringify(this.form) !== JSON.stringify(this.savedState);
         },
@@ -220,6 +222,8 @@ function settingsPage() {
 
         // ===== Methods =====
         async loadConfig() {
+            // 鎖定表單（載入期間不可操作）
+            this._configLoading = true;
             // 清空快照（載入期間不判定 dirty）
             this.savedState = null;
 
@@ -303,6 +307,8 @@ function settingsPage() {
                 }
             } catch (e) {
                 console.error('載入設定失敗:', e);
+            } finally {
+                this._configLoading = false;
             }
         },
 

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -243,6 +243,7 @@ function settingsPage() {
                     this.form.translateEnabled = config.translate.enabled;
                     this.form.translateProvider = config.translate.provider || 'ollama';
                     this.form.ollamaUrl = config.translate.ollama?.url || config.translate.ollama_url || 'http://localhost:11434';
+                    this.form.ollamaModel = config.translate.ollama?.model || config.translate.ollama_model || '';
                     this.form.geminiApiKey = config.translate.gemini?.api_key || '';
 
                     // Gemini model 預設填入
@@ -295,15 +296,17 @@ function settingsPage() {
                     this.form.defaultPage = defaultPage;
                     // sidebar_collapsed 已移除（由 Alpine $persist + localStorage 驅動）
 
-                    // 自動載入 Ollama 模型列表
+                    // 建立初始快照（dirty check 基準）— 必須在解鎖前建立
+                    this.savedState = JSON.parse(JSON.stringify(this.form));
+                    // 解鎖表單（config hydrate 完成）
+                    this._configLoading = false;
+
+                    // 背景載入 Ollama 模型列表（不阻塞表單）
                     const ollamaUrl = config.translate.ollama?.url || config.translate.ollama_url;
                     const ollamaModel = config.translate.ollama?.model || config.translate.ollama_model;
                     if (ollamaUrl && config.translate.provider === 'ollama') {
-                        await this.loadOllamaModels(ollamaUrl, ollamaModel);
+                        this.loadOllamaModels(ollamaUrl, ollamaModel);  // 不 await
                     }
-
-                    // 建立初始快照（dirty check 基準）
-                    this.savedState = JSON.parse(JSON.stringify(this.form));
                 }
             } catch (e) {
                 console.error('載入設定失敗:', e);

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -53,13 +53,15 @@ function showcaseState() {
         // --- 生命週期 ---
         async init() {
             // 接入 page lifecycle：清理 lightbox timer 和 body class
-            window.__registerPage({
-                cleanup: () => {
-                    if (this.lightboxMoveTimer) clearTimeout(this.lightboxMoveTimer);
-                    if (this.toastTimer) clearTimeout(this.toastTimer);
-                    if (this.lightboxOpen) document.body.classList.remove('overflow-hidden');
-                }
-            });
+            if (window.__registerPage) {
+                window.__registerPage({
+                    cleanup: () => {
+                        if (this.lightboxMoveTimer) clearTimeout(this.lightboxMoveTimer);
+                        if (this.toastTimer) clearTimeout(this.toastTimer);
+                        if (this.lightboxOpen) document.body.classList.remove('overflow-hidden');
+                    }
+                });
+            }
 
             this.restoreState();        // M2c: 先恢復狀態
             const savedPage = this.page;

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -52,6 +52,15 @@ function showcaseState() {
 
         // --- 生命週期 ---
         async init() {
+            // 接入 page lifecycle：清理 lightbox timer 和 body class
+            window.__registerPage({
+                cleanup: () => {
+                    if (this.lightboxMoveTimer) clearTimeout(this.lightboxMoveTimer);
+                    if (this.toastTimer) clearTimeout(this.toastTimer);
+                    if (this.lightboxOpen) document.body.classList.remove('overflow-hidden');
+                }
+            });
+
             this.restoreState();        // M2c: 先恢復狀態
             const savedPage = this.page;
             await this.fetchVideos();

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -277,14 +277,7 @@
     handleNavClick(event, href) {
         // 開新分頁（Ctrl/Cmd-click, 中鍵）不觸發清理
         if (event.ctrlKey || event.metaKey || event.shiftKey || event.button !== 0) return;
-        // search: 清理 SSE 連線（不阻止導航，只做 cleanup）
-        if (typeof window.cleanupSearchBeforeLeave === 'function') {
-            window.cleanupSearchBeforeLeave();
-        }
-        // settings: dirty-check（可能阻止導航）
-        if (typeof window.confirmLeavingSettings === 'function' && !window.confirmLeavingSettings(href)) {
-            event.preventDefault();
-        } else if (typeof window.confirmLeavingScanner === 'function' && !window.confirmLeavingScanner(href)) {
+        if (window.__leavePage && !window.__leavePage(href)) {
             event.preventDefault();
         }
     }
@@ -461,6 +454,8 @@
     <script defer src="/static/js/components/motion-prefs.js"></script>
     <!-- Motion Adapter — shared GSAP wrappers (T5) -->
     <script defer src="/static/js/components/motion-adapter.js"></script>
+    <!-- Page Lifecycle Manager (T2.1) -->
+    <script defer src="/static/js/components/page-lifecycle.js"></script>
 
     <!-- Alpine Plugins (must load before Alpine Core) -->
     <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js"></script>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -275,6 +275,11 @@
     sidebarCollapsed: {{ sidebar_collapsed|default(false)|tojson }},
     mobileMenuOpen: false,
     handleNavClick(event, href) {
+        // search: 清理 SSE 連線（不阻止導航，只做 cleanup）
+        if (typeof window.cleanupSearchBeforeLeave === 'function') {
+            window.cleanupSearchBeforeLeave();
+        }
+        // settings: dirty-check（可能阻止導航）
         if (typeof window.confirmLeavingSettings === 'function' && !window.confirmLeavingSettings(href)) {
             event.preventDefault();
         } else if (typeof window.confirmLeavingScanner === 'function' && !window.confirmLeavingScanner(href)) {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -275,6 +275,8 @@
     sidebarCollapsed: {{ sidebar_collapsed|default(false)|tojson }},
     mobileMenuOpen: false,
     handleNavClick(event, href) {
+        // 開新分頁（Ctrl/Cmd-click, 中鍵）不觸發清理
+        if (event.ctrlKey || event.metaKey || event.shiftKey || event.button !== 0) return;
         // search: 清理 SSE 連線（不阻止導航，只做 cleanup）
         if (typeof window.cleanupSearchBeforeLeave === 'function') {
             window.cleanupSearchBeforeLeave();

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -978,9 +978,6 @@ function scannerPage() {
         // 設置 localStorage 標記
         localStorage.setItem('avlist_generating', 'true');
 
-        // 同步全域變數（過渡期）
-        window.isGenerating = true;
-
         try {
             this.eventSource = new EventSource('/api/gallery/generate');
 
@@ -1005,8 +1002,6 @@ function scannerPage() {
                     localStorage.setItem('avlist_generating', 'false');
                     localStorage.setItem('avlist_last_status', '完成');
                     localStorage.removeItem('avlist_state');  // 清除 viewer 狀態
-
-                    window.isGenerating = false;
 
                     // 處理 NFO 更新提示
                     if (data.session_update && data.session_update.count > 0) {
@@ -1035,7 +1030,6 @@ function scannerPage() {
                     this.addLog('error', '錯誤: ' + data.message);
                     this.flushLogs();
                     localStorage.setItem('avlist_generating', 'false');
-                    window.isGenerating = false;
                 }
             };
 
@@ -1047,12 +1041,10 @@ function scannerPage() {
                 this.addLog('error', '連線中斷');
                 this.flushLogs();
                 localStorage.setItem('avlist_generating', 'false');
-                window.isGenerating = false;
             };
         } catch (e) {
             this.state = 'error';
             localStorage.setItem('avlist_generating', 'false');
-            window.isGenerating = false;
             alert('發生錯誤: ' + e.message);
         }
     },
@@ -1075,7 +1067,6 @@ function scannerPage() {
         this.clearLogs();
 
         localStorage.setItem('avlist_generating', 'true');
-        window.isGenerating = true;
 
         try {
             this.eventSource = new EventSource('/api/gallery/update');
@@ -1099,7 +1090,6 @@ function scannerPage() {
 
                     localStorage.setItem('avlist_generating', 'false');
                     localStorage.setItem('avlist_last_status', data.message || '完成');
-                    window.isGenerating = false;
 
                     this.showToast('補全完成！請重新產生列表以更新', 'success');
                     if (data.message) {
@@ -1117,7 +1107,6 @@ function scannerPage() {
                     this.addLog('error', '錯誤: ' + data.message);
                     this.flushLogs();
                     localStorage.setItem('avlist_generating', 'false');
-                    window.isGenerating = false;
                 }
             };
 
@@ -1129,12 +1118,10 @@ function scannerPage() {
                 this.addLog('error', '連線中斷');
                 this.flushLogs();
                 localStorage.setItem('avlist_generating', 'false');
-                window.isGenerating = false;
             };
         } catch (e) {
             this.state = 'error';
             localStorage.setItem('avlist_generating', 'false');
-            window.isGenerating = false;
             alert('發生錯誤: ' + e.message);
         }
     },
@@ -1155,7 +1142,6 @@ function scannerPage() {
         this.clearLogs();
 
         localStorage.setItem('avlist_generating', 'true');
-        window.isGenerating = true;
 
         try {
             this.eventSource = new EventSource('/api/gallery/jellyfin-update');
@@ -1179,7 +1165,6 @@ function scannerPage() {
 
                     localStorage.setItem('avlist_generating', 'false');
                     localStorage.setItem('avlist_last_status', data.message || '完成');
-                    window.isGenerating = false;
 
                     this.showToast('補齊完成！', 'success');
                     if (data.message) {
@@ -1196,7 +1181,6 @@ function scannerPage() {
                     this.addLog('error', '錯誤: ' + data.message);
                     this.flushLogs();
                     localStorage.setItem('avlist_generating', 'false');
-                    window.isGenerating = false;
                 }
             };
 
@@ -1208,12 +1192,10 @@ function scannerPage() {
                 this.addLog('error', '連線中斷');
                 this.flushLogs();
                 localStorage.setItem('avlist_generating', 'false');
-                window.isGenerating = false;
             };
         } catch (e) {
             this.state = 'error';
             localStorage.setItem('avlist_generating', 'false');
-            window.isGenerating = false;
             alert('發生錯誤: ' + e.message);
         }
     },

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -500,35 +500,35 @@ function scannerPage() {
         await this.$nextTick();
         this.restoreLogs();
 
-        // 暴露全域檢查函式
-        window.confirmLeavingScanner = (targetUrl) => {
-            const guard = this.shouldWarnBeforeLeave();
-            if (guard.shouldWarn) {
-                if (guard.useModal) {
-                    this.pendingNavigationUrl = targetUrl;
-                    this.dirtyCheckModalOpen = true;
-                    return false;
-                } else {
-                    const confirmed = confirm(guard.message + '確定要離開嗎？');
-                    if (confirmed) {
-                        this._skipBeforeUnload = true;
+        // T5.1: 接入統一 page lifecycle
+        if (window.__registerPage) {
+            window.__registerPage({
+                beforeLeave: (href) => {
+                    const guard = this.shouldWarnBeforeLeave();
+                    if (guard.shouldWarn) {
+                        if (guard.useModal) {
+                            this.pendingNavigationUrl = href;
+                            this.dirtyCheckModalOpen = true;
+                            return false;
+                        } else {
+                            return confirm(guard.message + '確定要離開嗎？');
+                        }
                     }
-                    return confirmed;
+                    return true;
+                },
+                onBeforeUnload: () => {
+                    const guard = this.shouldWarnBeforeLeave();
+                    if (guard.shouldWarn) return guard.message;
+                    return null;
+                },
+                cleanup: () => {
+                    if (this.eventSource) { this.eventSource.close(); this.eventSource = null; }
+                    clearTimeout(this._toastTimer);
+                    clearTimeout(this.logTimer);
+                    clearTimeout(this.previewDebounceTimer);
                 }
-            }
-            return true;
-        };
-
-        // beforeunload 警告
-        window.addEventListener('beforeunload', (e) => {
-            if (this._skipBeforeUnload) return;
-            const guard = this.shouldWarnBeforeLeave();
-            if (guard.shouldWarn) {
-                e.preventDefault();
-                e.returnValue = guard.message;
-                return e.returnValue;
-            }
-        });
+            });
+        }
     },
 
     // ===== Leave Guard =====

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -780,7 +780,13 @@ function scannerPage() {
         await this.loadConfig();
         this.dirtyCheckModalOpen = false;
         if (this.pendingNavigationUrl) {
-            window.location.href = this.pendingNavigationUrl;
+            const url = this.pendingNavigationUrl;
+            // dirty state cleared by loadConfig(); beforeLeave will now return true
+            // → __leavePage triggers _doCleanup (closes eventSource + clears timers)
+            if (window.__leavePage) {
+                window.__leavePage(url);
+            }
+            window.location.href = url;
         }
     },
 
@@ -789,7 +795,13 @@ function scannerPage() {
         if (saved) {
             this.dirtyCheckModalOpen = false;
             if (this.pendingNavigationUrl) {
-                window.location.href = this.pendingNavigationUrl;
+                const url = this.pendingNavigationUrl;
+                // dirty state cleared by saveConfig(); beforeLeave will now return true
+                // → __leavePage triggers _doCleanup (closes eventSource + clears timers)
+                if (window.__leavePage) {
+                    window.__leavePage(url);
+                }
+                window.location.href = url;
             }
         }
         // If save failed, modal stays open, user sees toast error

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -38,7 +38,9 @@
         </div>
     </div>
 
-    <form id="settingsForm" @submit.prevent="saveConfig">
+    <!-- 靜態 inert：HTML 渲染即生效，Alpine boot 前保護 -->
+    <!-- Alpine boot 後由 :inert binding 接管 -->
+    <form id="settingsForm" @submit.prevent="saveConfig" inert :inert="_configLoading">
         <!-- 1. 搜尋與刮削設定 (Search & Scraper) -->
         <div class="card mb-4">
             <div class="settings-card-header">


### PR DESCRIPTION
## Summary
- **Page Lifecycle 統一框架** — `page-lifecycle.js` 提供 `__registerPage` / `__leavePage` API，Search / Settings / Showcase / Scanner 四頁全部接入
- **Search 雙 Store 收斂** — SearchCore 降級為 Alpine 只讀 façade，消除 10+ 欄位重複同步
- **Async 資源集中管理** — EventSource / Timer / AbortController 集中追蹤 + 離頁一次釋放
- **遷移死碼清除** — Scanner `window.isGenerating` 14 處、Search 空殼函數 / null slot / bridge stub 全部清理
- **BUG 修復** — Settings dirty-check 競態、Search SSE 離頁凍結、NFO bare `&` sanitize

## Test plan
- [ ] `pytest tests/ -v --ignore=tests/smoke -m "not smoke"` 全通過（623 tests）
- [ ] 各頁面 sidebar 導航正常（無殘留 SSE / timer）
- [ ] Scanner SSE 進行中離頁有 confirm 警告
- [ ] Settings 未儲存離頁有 dirty-check modal
- [ ] Search 翻譯後刷頁可還原狀態
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)