### PR TITLE
Phase 39a — Locale fixes, OpenAI Compatible translate, search pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ web/static/css/tailwind.css
 # Playwright MCP
 .playwright-mcp/
 
+# Codex
+.codex
+
 # Node (package install artifacts)
 node_modules/
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2026-04-09
+
+### Added
+
+#### 🔌 OpenAI Compatible 翻譯 Provider (Phase 39a-T2)
+- 新增 OpenAI Compatible 翻譯 Provider — 支援任意 OpenAI 相容 API 端點（Perplexity Pro、OpenRouter、本地 LLM 等）
+- Settings 頁新增 OpenAI Compatible 設定區塊（Base URL + API Key + Model 選擇）
+
+#### 🔍 搜尋改善 (Phase 39a-T4)
+- Grid 模式底部新增「載入更多」按鈕
+- Lightbox 最後一張按 Next 自動觸發載入更多
+
+#### ⚙️ Gemini 精簡 (Phase 39a-T3)
+- Gemini model 下拉精簡為 4 個推薦 model（allowlist 取代動態過濾）
+
+### Changed
+- locale 劇照用詞統一：「Sample Image」→「Stills」、「樣品圖」→「劇照」
+- README_EN 用詞同步對齊
+
+### Fixed
+
+#### 🐛 關鍵修復
+- DMM 分頁 offset 寫死 0 — 搜尋第二頁以後結果重複 (T5)
+- OpenAI Settings UI：select 切換 + 錯誤細化 + auto-fetch + custom model 持久化
+- XSS 修正 + ja locale short-circuit
+- loadMore() shared state desync — Lightbox/Grid/Detail currentIndex 不再被靜默修改
+- Gemini model fallback — 舊 model 不在 allowlist 時自動選第一個
+
 ## [0.6.4] - 2026-04-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### 🔌 OpenAI Compatible 翻譯 Provider (Phase 39a-T2)
-- 新增 OpenAI Compatible 翻譯 Provider — 支援任意 OpenAI 相容 API 端點（Perplexity Pro、OpenRouter、本地 LLM 等）
+- 新增 OpenAI Compatible 翻譯 Provider — 支援任意 OpenAI 相容 API 端點（OpenRouter、本地 LLM 等）
 - Settings 頁新增 OpenAI Compatible 設定區塊（Base URL + API Key + Model 選擇）
 
 #### 🔍 搜尋改善 (Phase 39a-T4)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ irm https://raw.githubusercontent.com/slive777/OpenAver/main/install.ps1 | iex
 
 ### 🌐 AI 翻譯
 - 日文標題一鍵翻譯為你的 UI 語系（繁中 / 简中 / 英文），日文模式跳過翻譯。
-- 支援 **Ollama**（本地 GPU，免費無限制）和 **Gemini Flash**（Google 雲端，有免費額度）。
+- 支援 **Ollama**（本地 GPU，免費無限制）、**Gemini Flash**（Google 雲端，有免費額度）和 **OpenAI API Compatible**（OpenRouter、任意相容端點）。
 
 ### ⚙️ Settings (設定)
 - **Dark Mode**: 全站深色模式，自動同步至生成的展示列表。
@@ -185,7 +185,7 @@ OpenAver/
 │   ├── organizer.py    # 檔案整理 + fallback 空值防護
 │   ├── path_utils.py   # 跨平台路徑處理 (file:// URI)
 │   ├── i18n.py         # 多語系翻譯核心 (t() / fallback chain)
-│   └── translate_service.py  # AI 翻譯 (Ollama/Gemini)
+│   └── translate_service.py  # AI 翻譯 (Ollama/Gemini/OpenAI Compatible)
 ├── locales/            # 四語系 JSON (zh_TW/zh_CN/ja/en)
 ├── tests/              # 測試代碼 (Pytest)
 └── windows/            # Windows 啟動器 (PyWebView)

--- a/README_EN.md
+++ b/README_EN.md
@@ -93,7 +93,7 @@ On first launch, a built-in setup wizard walks you through folder configuration 
 
 ### 🌐 AI Translation
 Most metadata fields (actress, maker, label, tags) are already in English from the source — but titles remain in Japanese. AI translation fills that gap automatically.
-- Supports **Ollama** (local GPU, free & unlimited) and **Gemini Flash** (Google cloud, free tier available).
+- Supports **Ollama** (local GPU, free & unlimited), **Gemini Flash** (Google cloud, free tier available), and **OpenAI API Compatible** (OpenRouter, any compatible endpoint).
 - Translation language follows your UI locale (English, Traditional Chinese, Simplified Chinese). Japanese locale skips translation since titles are already in Japanese.
 
 ### ⚙️ Settings
@@ -186,7 +186,7 @@ OpenAver/
 │   ├── organizer.py    # File organizer + null-value fallback guards
 │   ├── path_utils.py   # Cross-platform path handling (file:// URI)
 │   ├── i18n.py         # i18n core (t() / fallback chain)
-│   └── translate_service.py  # AI translation (Ollama/Gemini)
+│   └── translate_service.py  # AI translation (Ollama/Gemini/OpenAI Compatible)
 ├── locales/            # 4-locale JSON (zh_TW/zh_CN/ja/en)
 ├── tests/              # Test suite (Pytest)
 └── windows/            # Windows launcher (PyWebView)

--- a/README_EN.md
+++ b/README_EN.md
@@ -76,12 +76,12 @@ On first launch, a built-in setup wizard walks you through folder configuration 
 
 ### 🔍 Spotlight Search
 - **Multi-Source Aggregation**: One query simultaneously searches JavBus, JavDB, Jav321, DMM, D2Pass, and HEYZO.
-- **Detail View**: Cover, sample images, actress, tags — all in one place, no tab-hopping.
+- **Detail View**: Cover, stills, actress, tags — all in one place, no tab-hopping.
 - **Smart Search**: Search by ID, actress name, series, or maker — results are matched against your local library and marked if already in your collection.
 - **Version Detection**: Automatically identifies UC/LEAK/4K variants — no manual renaming needed.
 - **Actress Gallery Mode (Beta)**: When an actress search returns 10+ titles, the view switches to a gallery layout with a full profile Hero Card.
-- **Sample Gallery**: Browse full sample images directly from search results.
-- **Local Batch Search**: Drag in video files or folders — automatically extracts IDs and batch-searches for metadata, covers, and sample images.
+- **Sample Gallery**: Browse full stills directly from search results.
+- **Local Batch Search**: Drag in video files or folders — automatically extracts IDs and batch-searches for metadata, covers, and stills.
 
 ### 📝 Scanner
 - **Showcase Pages**: Scan a local video folder and generate beautiful, interactive showcase pages (smooth animations + frosted-glass effects + Lightbox gallery).

--- a/core/config.py
+++ b/core/config.py
@@ -76,14 +76,22 @@ class GeminiConfig(BaseModel):
     model: str = "gemini-flash-lite-latest"  # 預設使用 latest 別名（自動路由可用版本）
 
 
+class OpenAIConfig(BaseModel):
+    """串接結構：OpenAI Compatible 配置"""
+    base_url: str = ""   # e.g. "https://api.openai.com/v1"
+    api_key: str = ""    # 可為空（本地 LLM 不需要）
+    model: str = "gpt-4o-mini"
+
+
 class TranslateConfig(BaseModel):
     enabled: bool = False
-    provider: str = "ollama"  # "ollama" | "gemini"
+    provider: str = "ollama"  # "ollama" | "gemini" | "openai"
     batch_size: int = 10  # 批次翻譯大小
 
     # 嵌套結構
     ollama: OllamaConfig = OllamaConfig()
     gemini: GeminiConfig = GeminiConfig()
+    openai: OpenAIConfig = OpenAIConfig()
 
     # 舊字段（保留向後兼容）
     ollama_url: Optional[str] = None
@@ -215,6 +223,16 @@ def load_config() -> dict:
                 }
                 need_save = True
                 logger.info("[Config] 遷移配置：添加 Gemini 支持")
+
+            # Task T2：確保 openai 嵌套存在（OpenAI Compatible 支援遷移）
+            if 'openai' not in t:
+                t['openai'] = {
+                    'base_url': '',
+                    'api_key': '',
+                    'model': 'gpt-4o-mini'
+                }
+                need_save = True
+                logger.info("[Config] 遷移配置：添加 OpenAI Compatible 支持")
 
         # Migration: folder_format → folder_layers（舊版只存 folder_format）
         s = raw_config.get('scraper', {})

--- a/core/scraper.py
+++ b/core/scraper.py
@@ -400,13 +400,14 @@ def _dmm_keyword_search_progressive(
     limit: int,
     status_callback,
     result_callback,
+    offset: int = 0,
 ) -> Optional[List[Dict[str, Any]]]:
     """DMM keyword search with progressive enrichment (mirrors JavBus pattern).
 
     Returns a list of result dicts on success, or None if DMM returned nothing
     (caller should fall through to JavBus).
     """
-    pairs = dmm_scraper.search_by_keyword_with_ids(query, limit=limit)
+    pairs = dmm_scraper.search_by_keyword_with_ids(query, limit=limit, offset=offset)
     if not pairs:
         return None
 
@@ -451,7 +452,7 @@ def search_actress(name: str, limit: int = 20, offset: int = 0, status_callback:
         dmm_config = ScraperConfig(proxy_url=_dmm_proxy_url(proxy_url))
         dmm_scraper = DMMScraper(dmm_config)
         dmm_results = _dmm_keyword_search_progressive(
-            dmm_scraper, name, limit, status_callback, result_callback
+            dmm_scraper, name, limit, status_callback, result_callback, offset=offset
         )
         if dmm_results is not None:
             return dmm_results
@@ -746,7 +747,7 @@ def smart_search(query: str, limit: int = 20, offset: int = 0, status_callback: 
             dmm_config = ScraperConfig(proxy_url=_dmm_proxy_url(proxy_url))
             dmm_scraper = DMMScraper(dmm_config)
             dmm_results = _dmm_keyword_search_progressive(
-                dmm_scraper, query, limit, status_callback, result_callback
+                dmm_scraper, query, limit, status_callback, result_callback, offset=offset
             )
             if dmm_results is not None:
                 for r in dmm_results:

--- a/core/scrapers/dmm.py
+++ b/core/scrapers/dmm.py
@@ -582,7 +582,7 @@ class DMMScraper(BaseScraper):
         # 4. 完全失敗
         return None
 
-    def search_by_keyword_with_ids(self, keyword: str, limit: int = 20) -> list[tuple[str, Video]]:
+    def search_by_keyword_with_ids(self, keyword: str, limit: int = 20, offset: int = 0) -> list[tuple[str, Video]]:
         """
         關鍵字搜尋（輕量版）— 回傳 (content_id, shallow_Video) tuples。
         供 facade 層 ThreadPoolExecutor enrichment 使用。
@@ -593,7 +593,7 @@ class DMMScraper(BaseScraper):
                 'query': self.SEARCH_LIST_QUERY,
                 'variables': {
                     'limit': limit,
-                    'offset': 0,
+                    'offset': offset,
                     'sort': 'RELEASE_DATE',
                     'queryWord': keyword,
                 }
@@ -641,14 +641,14 @@ class DMMScraper(BaseScraper):
         except Exception:
             return []
 
-    def search_by_keyword(self, keyword: str, limit: int = 20) -> list[Video]:
+    def search_by_keyword(self, keyword: str, limit: int = 20, offset: int = 0) -> list[Video]:
         """關鍵字搜尋（女優名、片商名等日文關鍵字）"""
         try:
             payload = {
                 'query': self.SEARCH_LIST_QUERY,
                 'variables': {
                     'limit': limit,
-                    'offset': 0,
+                    'offset': offset,
                     'sort': 'RELEASE_DATE',
                     'queryWord': keyword,
                 }

--- a/core/translate_service.py
+++ b/core/translate_service.py
@@ -378,6 +378,97 @@ class GeminiTranslateService(TranslateService):
         return translations
 
 
+class OpenAICompatibleTranslateService(TranslateService):
+    """OpenAI Compatible API 翻譯服務實現（支援 OpenAI、Perplexity、OpenRouter、本地 LLM 等）"""
+
+    def __init__(self, config: Dict, target_language: str = "zh-TW"):
+        """
+        初始化 OpenAI Compatible 服務
+
+        Args:
+            config: OpenAI Compatible 配置字典
+                {
+                    "base_url": "https://api.openai.com/v1",
+                    "api_key": "sk-xxx",  # 可為空（本地 LLM 不需要）
+                    "model": "gpt-4o-mini"
+                }
+            target_language: 目標語言代碼（zh-TW / zh-CN / en / ja）
+        """
+        self.base_url = (config.get("base_url") or "").rstrip("/")
+        self.api_key = config.get("api_key", "")
+        self.model = config.get("model") or "gpt-4o-mini"
+        self.target_language = target_language
+
+    async def translate_single(self, title: str, context: Optional[Dict] = None) -> str:
+        """
+        單片翻譯
+
+        使用 OpenAI Chat Completions API 格式
+        """
+        # ja 短路：不呼叫 API，直接回傳原文
+        if self.target_language == "ja":
+            return title
+
+        lang_data = LANGUAGE_PROMPTS.get(self.target_language, LANGUAGE_PROMPTS["zh-TW"])
+        instruction = lang_data["gemini_instruction"]
+        rules = lang_data["gemini_rules"]
+
+        prompt = f"""你是專業的影視資料庫管理員與翻譯引擎。這是既有日文文字的逐字翻譯任務，{instruction}。
+
+原文：
+{title}
+
+翻譯要求：
+{rules}
+"""
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.3,
+            "max_tokens": 100
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(
+                    f"{self.base_url}/chat/completions",
+                    headers=headers,
+                    json=payload
+                )
+                resp.raise_for_status()
+
+            data = resp.json()
+            choices = data.get("choices")
+            if not choices:
+                logger.error("[OpenAI] Response missing 'choices': %s", data)
+                return ""
+            result = choices[0]["message"]["content"].strip()
+            return result
+
+        except Exception as e:
+            logger.error("[OpenAI] Single translation failed: %s", e)
+            return ""
+
+    async def translate_batch(self, titles: List[str], context: Optional[Dict] = None) -> List[str]:
+        """
+        批次翻譯 - 逐片翻譯確保穩定性
+        """
+        if not titles:
+            return []
+
+        results = []
+        for title in titles:
+            result = await self.translate_single(title, context)
+            results.append(result)
+
+        return results
+
+
 def create_translate_service(config: Dict, target_language: str = "zh-TW") -> TranslateService:
     """
     創建翻譯服務實例（工廠函數）
@@ -385,9 +476,10 @@ def create_translate_service(config: Dict, target_language: str = "zh-TW") -> Tr
     Args:
         config: translate 配置字典
             {
-                "provider": "ollama" | "gemini",
+                "provider": "ollama" | "gemini" | "openai",
                 "ollama": {...},
-                "gemini": {...}
+                "gemini": {...},
+                "openai": {...}
             }
         target_language: 目標語言代碼（zh-TW / zh-CN / en / ja），預設 zh-TW
 
@@ -406,6 +498,10 @@ def create_translate_service(config: Dict, target_language: str = "zh-TW") -> Tr
     elif provider == "gemini":
         gemini_config = config.get("gemini", {})
         return GeminiTranslateService(gemini_config, target_language)
+
+    elif provider == "openai":
+        openai_config = config.get("openai", {})
+        return OpenAICompatibleTranslateService(openai_config, target_language)
 
     else:
         raise ValueError(f"Unknown translate provider: {provider}")

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/en.json
+++ b/locales/en.json
@@ -113,7 +113,8 @@
       "search_range": "Search {start}-{end} / {total}",
       "translating_progress": "Translating ({processed}/{total})",
       "translate_all_count": "Translate All ({count})",
-      "searching": "Searching..."
+      "searching": "Searching...",
+      "load_more": "Load more"
     },
     "mode": {
       "exact": "Exact ID Search",

--- a/locales/en.json
+++ b/locales/en.json
@@ -292,7 +292,16 @@
       "gemini_n_flash_models": "Found {count} Flash models",
       "test_failed": "Test failed: {msg}",
       "testing_translation": "Testing translation...",
-      "translation_success": "Translation test passed! ({translation})"
+      "translation_success": "Translation test passed! ({translation})",
+      "openai_connection_failed": "Connection failed",
+      "openai_http_error": "HTTP request failed",
+      "openai_missing_base_url": "Please enter Base URL",
+      "openai_missing_model": "Please enter model name",
+      "openai_connection_timeout": "Connection timeout",
+      "openai_api_error": "API returned an error",
+      "openai_translate_failed": "Translation test failed",
+      "openai_unknown_response_format": "Unknown response format",
+      "ja_skip": "Japanese mode: translation skipped"
     }
   },
   "scanner": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -195,7 +195,8 @@
       "openai_compatible": "OpenAI Compatible",
       "openai_api_key_placeholder": "Leave blank = no Authorization header",
       "openai_api_key_hint": "Local LLMs can leave empty; cloud services require an API Key",
-      "openai_model_placeholder": "e.g. gpt-4o-mini"
+      "openai_model_placeholder": "e.g. gpt-4o-mini",
+      "openai_custom_model": "Custom..."
     },
     "scraper": {
       "suffix_keywords_label": "Version Tags",
@@ -295,6 +296,10 @@
       "translation_success": "Translation test passed! ({translation})",
       "openai_connection_failed": "Connection failed",
       "openai_http_error": "HTTP request failed",
+      "openai_auth_failed": "Authentication failed, check API Key",
+      "openai_forbidden": "Access forbidden",
+      "openai_not_found": "API endpoint not found, check Base URL",
+      "openai_rate_limited": "Rate limit exceeded, try again later",
       "openai_missing_base_url": "Please enter Base URL",
       "openai_missing_model": "Please enter model name",
       "openai_connection_timeout": "Connection timeout",

--- a/locales/en.json
+++ b/locales/en.json
@@ -191,7 +191,11 @@
       "security_item1": "API Key is stored in plain text in config.json",
       "security_item2": "Do not share config.json with others",
       "security_item3_prefix": "To revoke, go to",
-      "security_item3_suffix": "to regenerate"
+      "security_item3_suffix": "to regenerate",
+      "openai_compatible": "OpenAI Compatible",
+      "openai_api_key_placeholder": "Leave blank = no Authorization header",
+      "openai_api_key_hint": "Local LLMs can leave empty; cloud services require an API Key",
+      "openai_model_placeholder": "e.g. gpt-4o-mini"
     },
     "scraper": {
       "suffix_keywords_label": "Version Tags",
@@ -679,7 +683,8 @@
       "dmm_proxy": "DMM requires a Japanese IP; enter a Japanese proxy in the <strong>Settings page</strong> → Proxy field",
       "dmm_direct": "If you are already on a VPN or Japan network, you can also enter <code>direct</code> in the Proxy field to enable it without a proxy address.",
       "translate_ollama": "<strong>Ollama</strong>: Confirm the Ollama application is running (Windows requires manual launch)",
-      "translate_gemini": "<strong>Gemini</strong>: Confirm the API Key is correctly set on the <strong>Settings page</strong>"
+      "translate_gemini": "<strong>Gemini</strong>: Confirm the API Key is correctly set on the <strong>Settings page</strong>",
+      "translate_openai": "<strong>OpenAI Compatible</strong>: Check that the Base URL and model name are correct"
     },
     "js": {
       "version_load_failed": "Failed to load",

--- a/locales/en.json
+++ b/locales/en.json
@@ -89,10 +89,10 @@
     "gallery": {
       "prev": "Previous (←)",
       "next": "Next (→)",
-      "sample_prefix": "Sample"
+      "sample_prefix": "Stills"
     },
     "grid": {
-      "sample_prefix": "Sample Image",
+      "sample_prefix": "Stills",
       "thumb_prefix": "Thumbnail",
       "detail_title": "View Detail",
       "unknown_actor": "Unknown",
@@ -215,8 +215,8 @@
       "video_extensions_hint": "Comma-separated",
       "jellyfin_mode_label": "Jellyfin Image Mode",
       "jellyfin_mode_hint": "Auto-generate {stem}-poster.jpg + {stem}-fanart.jpg (for Jellyfin library)",
-      "download_sample_images_label": "Download Sample Images (extrafanart)",
-      "download_sample_images_hint": "Download screenshots to extrafanart/ during organize (requires Create Folder enabled)"
+      "download_sample_images_label": "Download Stills (extrafanart)",
+      "download_sample_images_hint": "Download stills to extrafanart/ during organize (requires Create Folder enabled)"
     },
     "gallery": {
       "output_dir_label": "Output Directory",
@@ -460,8 +460,8 @@
     "gallery": {
       "prev": "Previous (←)",
       "next": "Next (→)",
-      "sample_prefix": "Sample",
-      "sample_alt": "Sample Image",
+      "sample_prefix": "Stills",
+      "sample_alt": "Stills",
       "thumb_alt": "Thumbnail"
     },
     "shortcut": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -195,7 +195,8 @@
       "openai_compatible": "OpenAI 互換",
       "openai_api_key_placeholder": "空白 = Authorization ヘッダーなし",
       "openai_api_key_hint": "ローカル LLM は空白可、クラウドサービスは API Key が必要",
-      "openai_model_placeholder": "例: gpt-4o-mini"
+      "openai_model_placeholder": "例: gpt-4o-mini",
+      "openai_custom_model": "カスタム..."
     },
     "scraper": {
       "suffix_keywords_label": "バージョンマーク",
@@ -295,6 +296,10 @@
       "translation_success": "翻訳テスト成功！ ({translation})",
       "openai_connection_failed": "接続失敗",
       "openai_http_error": "HTTPリクエスト失敗",
+      "openai_auth_failed": "認証失敗、API Key を確認してください",
+      "openai_forbidden": "アクセス権限がありません",
+      "openai_not_found": "APIエンドポイントが見つかりません、Base URL を確認してください",
+      "openai_rate_limited": "レート制限超過、後でもう一度お試しください",
       "openai_missing_base_url": "Base URL を入力してください",
       "openai_missing_model": "モデル名を入力してください",
       "openai_connection_timeout": "接続タイムアウト",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -292,7 +292,16 @@
       "gemini_n_flash_models": "{count} 個の Flash モデル",
       "test_failed": "テスト失敗: {msg}",
       "testing_translation": "翻訳テスト中...",
-      "translation_success": "翻訳テスト成功！ ({translation})"
+      "translation_success": "翻訳テスト成功！ ({translation})",
+      "openai_connection_failed": "接続失敗",
+      "openai_http_error": "HTTPリクエスト失敗",
+      "openai_missing_base_url": "Base URL を入力してください",
+      "openai_missing_model": "モデル名を入力してください",
+      "openai_connection_timeout": "接続タイムアウト",
+      "openai_api_error": "API エラー",
+      "openai_translate_failed": "翻訳テスト失敗",
+      "openai_unknown_response_format": "不明なレスポンス形式",
+      "ja_skip": "日本語モード：翻訳スキップ"
     }
   },
   "scanner": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -191,7 +191,11 @@
       "security_item1": "API Key は config.json に平文で保存されます",
       "security_item2": "config.json を他人に共有しないでください",
       "security_item3_prefix": "取り消す場合は",
-      "security_item3_suffix": "で再生成してください"
+      "security_item3_suffix": "で再生成してください",
+      "openai_compatible": "OpenAI 互換",
+      "openai_api_key_placeholder": "空白 = Authorization ヘッダーなし",
+      "openai_api_key_hint": "ローカル LLM は空白可、クラウドサービスは API Key が必要",
+      "openai_model_placeholder": "例: gpt-4o-mini"
     },
     "scraper": {
       "suffix_keywords_label": "バージョンマーク",
@@ -679,7 +683,8 @@
       "dmm_proxy": "DMM には日本 IP が必要です。<strong>設定ページ</strong> → Proxy フィールドに日本のプロキシを入力してください",
       "dmm_direct": "VPN や日本のネットワークに接続済みの場合、Proxy フィールドに <code>direct</code> と入力するだけで有効化できます。Proxy アドレスは不要です。",
       "translate_ollama": "<strong>Ollama</strong>：Ollama アプリが起動していることを確認してください（Windows では手動起動が必要）",
-      "translate_gemini": "<strong>Gemini</strong>：<strong>設定ページ</strong>で API Key が正しく設定されていることを確認"
+      "translate_gemini": "<strong>Gemini</strong>：<strong>設定ページ</strong>で API Key が正しく設定されていることを確認",
+      "translate_openai": "<strong>OpenAI Compatible</strong>：Base URL とモデル名が正しいか確認してください"
     },
     "js": {
       "version_load_failed": "読み込み失敗",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -113,7 +113,8 @@
       "search_range": "検索 {start}-{end} / {total}",
       "translating_progress": "翻訳中 ({processed}/{total})",
       "translate_all_count": "すべて翻訳 ({count})",
-      "searching": "検索中..."
+      "searching": "検索中...",
+      "load_more": "もっと読み込む"
     },
     "mode": {
       "exact": "完全品番検索",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -195,7 +195,8 @@
       "openai_compatible": "OpenAI 兼容",
       "openai_api_key_placeholder": "留空 = 不送 Authorization header",
       "openai_api_key_hint": "本地 LLM 可留空，云端服务需填入 API Key",
-      "openai_model_placeholder": "e.g. gpt-4o-mini"
+      "openai_model_placeholder": "e.g. gpt-4o-mini",
+      "openai_custom_model": "自定义..."
     },
     "scraper": {
       "suffix_keywords_label": "版本标记",
@@ -295,6 +296,10 @@
       "translation_success": "翻译测试成功！ ({translation})",
       "openai_connection_failed": "连接失败",
       "openai_http_error": "HTTP 请求失败",
+      "openai_auth_failed": "认证失败，请检查 API Key",
+      "openai_forbidden": "无访问权限",
+      "openai_not_found": "API 端点不存在，请确认 Base URL",
+      "openai_rate_limited": "请求频率超限，请稍后再试",
       "openai_missing_base_url": "请输入 Base URL",
       "openai_missing_model": "请输入模型名称",
       "openai_connection_timeout": "连接超时",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -191,7 +191,11 @@
       "security_item1": "API Key 将以明文存储在 config.json",
       "security_item2": "请勿将 config.json 分享给他人",
       "security_item3_prefix": "如需撤销，请前往",
-      "security_item3_suffix": "重新生成"
+      "security_item3_suffix": "重新生成",
+      "openai_compatible": "OpenAI 兼容",
+      "openai_api_key_placeholder": "留空 = 不送 Authorization header",
+      "openai_api_key_hint": "本地 LLM 可留空，云端服务需填入 API Key",
+      "openai_model_placeholder": "e.g. gpt-4o-mini"
     },
     "scraper": {
       "suffix_keywords_label": "版本标记",
@@ -679,7 +683,8 @@
       "dmm_proxy": "DMM 需要日本 IP，请在<strong>设置页</strong> → Proxy 栏填入日本 IP 代理",
       "dmm_direct": "若已连接 VPN 或日本网络，也可以在 Proxy 栏输入 <code>direct</code> 直接启用，不需要填写 Proxy 地址。",
       "translate_ollama": "<strong>Ollama</strong>：确认 Ollama 应用程序已启动（Windows 需手动开启）",
-      "translate_gemini": "<strong>Gemini</strong>：确认 API Key 已在<strong>设置页</strong>正确设置"
+      "translate_gemini": "<strong>Gemini</strong>：确认 API Key 已在<strong>设置页</strong>正确设置",
+      "translate_openai": "<strong>OpenAI Compatible</strong>：确认 Base URL 和模型名称正确"
     },
     "js": {
       "version_load_failed": "无法载入",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -113,7 +113,8 @@
       "search_range": "搜索 {start}-{end} / {total}",
       "translating_progress": "翻译中 ({processed}/{total})",
       "translate_all_count": "翻译全部 ({count})",
-      "searching": "搜索中..."
+      "searching": "搜索中...",
+      "load_more": "载入更多"
     },
     "mode": {
       "exact": "完整番号搜索",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -292,7 +292,16 @@
       "gemini_n_flash_models": "找到 {count} 个 Flash 模型",
       "test_failed": "测试失败: {msg}",
       "testing_translation": "测试翻译中...",
-      "translation_success": "翻译测试成功！ ({translation})"
+      "translation_success": "翻译测试成功！ ({translation})",
+      "openai_connection_failed": "连接失败",
+      "openai_http_error": "HTTP 请求失败",
+      "openai_missing_base_url": "请输入 Base URL",
+      "openai_missing_model": "请输入模型名称",
+      "openai_connection_timeout": "连接超时",
+      "openai_api_error": "API 返回错误",
+      "openai_translate_failed": "翻译测试失败",
+      "openai_unknown_response_format": "未知的响应格式",
+      "ja_skip": "日文模式：跳过翻译"
     }
   },
   "scanner": {

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -92,7 +92,7 @@
       "sample_prefix": "剧照"
     },
     "grid": {
-      "sample_prefix": "样品图",
+      "sample_prefix": "剧照",
       "thumb_prefix": "缩图",
       "detail_title": "查看详情",
       "unknown_actor": "未知",
@@ -461,7 +461,7 @@
       "prev": "上一张 (←)",
       "next": "下一张 (→)",
       "sample_prefix": "剧照",
-      "sample_alt": "样品图",
+      "sample_alt": "剧照",
       "thumb_alt": "缩图"
     },
     "shortcut": {

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -292,7 +292,16 @@
       "select_model": "請先選擇模型",
       "network_error": "✗ 網路錯誤，請稍後再試",
       "translation_success": "翻譯測試成功！ ({translation})",
-      "test_failed": "測試失敗: {msg}"
+      "test_failed": "測試失敗: {msg}",
+      "openai_connection_failed": "連線失敗",
+      "openai_http_error": "HTTP 請求失敗",
+      "openai_missing_base_url": "請輸入 Base URL",
+      "openai_missing_model": "請輸入模型名稱",
+      "openai_connection_timeout": "連線逾時",
+      "openai_api_error": "API 回傳錯誤",
+      "openai_translate_failed": "翻譯測試失敗",
+      "openai_unknown_response_format": "未知的回應格式",
+      "ja_skip": "日文模式：跳過翻譯"
     }
   },
   "scanner": {

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -195,7 +195,8 @@
       "openai_compatible": "OpenAI 相容",
       "openai_api_key_placeholder": "留空 = 不送 Authorization header",
       "openai_api_key_hint": "本地 LLM 可留空，雲端服務需填入 API Key",
-      "openai_model_placeholder": "e.g. gpt-4o-mini"
+      "openai_model_placeholder": "e.g. gpt-4o-mini",
+      "openai_custom_model": "自訂..."
     },
     "scraper": {
       "suffix_keywords_label": "版本標記",
@@ -295,6 +296,10 @@
       "test_failed": "測試失敗: {msg}",
       "openai_connection_failed": "連線失敗",
       "openai_http_error": "HTTP 請求失敗",
+      "openai_auth_failed": "認證失敗，請檢查 API Key",
+      "openai_forbidden": "無存取權限",
+      "openai_not_found": "API 端點不存在，請確認 Base URL",
+      "openai_rate_limited": "請求頻率超限，請稍後再試",
       "openai_missing_base_url": "請輸入 Base URL",
       "openai_missing_model": "請輸入模型名稱",
       "openai_connection_timeout": "連線逾時",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -113,7 +113,8 @@
       "search_range": "搜尋 {start}-{end} / {total}",
       "translating_progress": "翻譯中 ({processed}/{total})",
       "translate_all_count": "翻譯全部 ({count})",
-      "searching": "搜尋中..."
+      "searching": "搜尋中...",
+      "load_more": "載入更多"
     },
     "mode": {
       "exact": "完整番號搜尋",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -191,7 +191,11 @@
       "security_item1": "API Key 將以明文存儲在 config.json",
       "security_item2": "請勿將 config.json 分享給他人",
       "security_item3_prefix": "如需撤銷，請前往",
-      "security_item3_suffix": "重新生成"
+      "security_item3_suffix": "重新生成",
+      "openai_compatible": "OpenAI 相容",
+      "openai_api_key_placeholder": "留空 = 不送 Authorization header",
+      "openai_api_key_hint": "本地 LLM 可留空，雲端服務需填入 API Key",
+      "openai_model_placeholder": "e.g. gpt-4o-mini"
     },
     "scraper": {
       "suffix_keywords_label": "版本標記",
@@ -679,7 +683,8 @@
       "dmm_proxy": "DMM 需要日本 IP，請在<strong>設定頁</strong> → Proxy 欄位填入日本 IP 代理",
       "dmm_direct": "若已連接 VPN 或日本網路，也可以在 Proxy 欄位輸入 <code>direct</code> 直接啟用，不需要填寫 Proxy 位址。",
       "translate_ollama": "<strong>Ollama</strong>：確認 Ollama 應用程式已啟動（Windows 需手動開啟）",
-      "translate_gemini": "<strong>Gemini</strong>：確認 API Key 已在<strong>設定頁</strong>正確設定"
+      "translate_gemini": "<strong>Gemini</strong>：確認 API Key 已在<strong>設定頁</strong>正確設定",
+      "translate_openai": "<strong>OpenAI Compatible</strong>：確認 Base URL 和模型名稱正確"
     },
     "js": {
       "version_load_failed": "無法載入",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -92,7 +92,7 @@
       "sample_prefix": "劇照"
     },
     "grid": {
-      "sample_prefix": "樣品圖",
+      "sample_prefix": "劇照",
       "thumb_prefix": "縮圖",
       "detail_title": "查看詳情",
       "unknown_actor": "未知",
@@ -461,7 +461,7 @@
       "prev": "上一張 (←)",
       "next": "下一張 (→)",
       "sample_prefix": "劇照",
-      "sample_alt": "樣品圖",
+      "sample_alt": "劇照",
       "thumb_alt": "縮圖"
     },
     "shortcut": {

--- a/tests/integration/test_api_config.py
+++ b/tests/integration/test_api_config.py
@@ -90,3 +90,30 @@ class TestTranslateConfigRoundTrip:
         updated = response.json()["data"]
         assert updated["translate"]["enabled"] is True
         assert updated["translate"]["provider"] == "gemini"
+
+    def test_openai_config_roundtrip(self, client, temp_config_path):
+        """translate.openai 設定在 round-trip 後應完整保留"""
+        response = client.get("/api/config")
+        assert response.status_code == 200
+        config_data = response.json()["data"]
+
+        config_data["translate"]["provider"] = "openai"
+        config_data["translate"]["openai"] = {
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test-roundtrip",
+            "model": "gpt-4o"
+        }
+
+        response = client.put("/api/config", json=config_data)
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        response = client.get("/api/config")
+        assert response.status_code == 200
+        updated = response.json()["data"]
+
+        assert updated["translate"]["provider"] == "openai"
+        openai_cfg = updated["translate"]["openai"]
+        assert openai_cfg["base_url"] == "https://api.openai.com/v1"
+        assert openai_cfg["api_key"] == "sk-test-roundtrip"
+        assert openai_cfg["model"] == "gpt-4o"

--- a/tests/integration/test_api_openai_translate.py
+++ b/tests/integration/test_api_openai_translate.py
@@ -93,7 +93,7 @@ class TestOpenAIModels:
         assert data["error"] == "missing_base_url"
 
     def test_models_http_error(self):
-        """HTTP 403 from upstream → success=False, error is fixed key (no status code leak)."""
+        """HTTP 403 from upstream → success=False, error key is 'forbidden'."""
         resp = _make_http_response(403)
         mock_cm = _make_mock_client(get_response=resp)
 
@@ -106,7 +106,55 @@ class TestOpenAIModels:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
-        assert data["error"] == "http_error"
+        assert data["error"] == "forbidden"
+
+    def test_models_auth_failed(self):
+        """HTTP 401 → success=False, error='auth_failed'."""
+        resp = _make_http_response(401)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "bad-key"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "auth_failed"
+
+    def test_models_not_found(self):
+        """HTTP 404 → success=False, error='not_found'."""
+        resp = _make_http_response(404)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://localhost:8080",
+                "api_key": ""
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "not_found"
+
+    def test_models_rate_limited(self):
+        """HTTP 429 → success=False, error='rate_limited'."""
+        resp = _make_http_response(429)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "test-key"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "rate_limited"
 
     def test_models_timeout(self):
         """Timeout → success=False, error is a fixed string (no exception text)."""
@@ -172,7 +220,7 @@ class TestOpenAITranslate:
         assert data["translation"]  # non-empty
 
     def test_translate_http_error(self):
-        """HTTP 401 → success=False, error is fixed key (no status code leak)."""
+        """HTTP 401 → success=False, error='auth_failed'."""
         resp = _make_http_response(401)
         mock_cm = _make_mock_client(post_response=resp)
 
@@ -181,6 +229,78 @@ class TestOpenAITranslate:
             response = client.post("/api/openai/test", json={
                 "base_url": "http://localhost:8080",
                 "api_key": "bad",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "auth_failed"
+
+    def test_translate_forbidden(self):
+        """HTTP 403 → success=False, error='forbidden'."""
+        resp = _make_http_response(403)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "bad",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "forbidden"
+
+    def test_translate_not_found(self):
+        """HTTP 404 → success=False, error='not_found'."""
+        resp = _make_http_response(404)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "not_found"
+
+    def test_translate_rate_limited(self):
+        """HTTP 429 → success=False, error='rate_limited'."""
+        resp = _make_http_response(429)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "test-key",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "rate_limited"
+
+    def test_translate_server_error(self):
+        """HTTP 500 → success=False, error='http_error' (generic fallback)."""
+        resp = _make_http_response(500)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
                 "model": "my-model"
             })
 

--- a/tests/integration/test_api_openai_translate.py
+++ b/tests/integration/test_api_openai_translate.py
@@ -1,0 +1,294 @@
+"""
+OpenAI Compatible API router integration tests.
+
+Covers /api/openai/models and /api/openai/test endpoints.
+Uses TestClient + mock httpx.AsyncClient (no real HTTP connections).
+"""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, AsyncMock, MagicMock
+import httpx
+
+from web.app import app
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_client(get_response=None, post_response=None, raise_on_get=None, raise_on_post=None):
+    """Build a mock httpx.AsyncClient context-manager with configurable responses."""
+    mock_client = AsyncMock()
+
+    if raise_on_get is not None:
+        mock_client.get = AsyncMock(side_effect=raise_on_get)
+    elif get_response is not None:
+        mock_client.get = AsyncMock(return_value=get_response)
+
+    if raise_on_post is not None:
+        mock_client.post = AsyncMock(side_effect=raise_on_post)
+    elif post_response is not None:
+        mock_client.post = AsyncMock(return_value=post_response)
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _make_http_response(status_code: int, json_body: dict | None = None):
+    """Build a minimal mock httpx.Response."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = status_code
+    if json_body is not None:
+        mock_resp.json = MagicMock(return_value=json_body)
+    # Simulate raise_for_status for 4xx/5xx
+    if status_code >= 400:
+        request = MagicMock()
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                message=f"HTTP {status_code}",
+                request=request,
+                response=mock_resp,
+            )
+        )
+    else:
+        mock_resp.raise_for_status = MagicMock(return_value=None)
+    return mock_resp
+
+
+# ===========================================================================
+# /api/openai/models
+# ===========================================================================
+
+class TestOpenAIModels:
+
+    def test_models_success(self):
+        """GET /models returns sorted model id list."""
+        resp = _make_http_response(200, {"data": [{"id": "model-b"}, {"id": "model-a"}]})
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "test-key"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["models"] == ["model-a", "model-b"]
+
+    def test_models_empty_base_url(self):
+        """Empty base_url → success=False, fixed error key."""
+        response = client.post("/api/openai/models", json={
+            "base_url": "",
+            "api_key": ""
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "missing_base_url"
+
+    def test_models_http_error(self):
+        """HTTP 403 from upstream → success=False, error is fixed key (no status code leak)."""
+        resp = _make_http_response(403)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "bad-key"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "http_error"
+
+    def test_models_timeout(self):
+        """Timeout → success=False, error is a fixed string (no exception text)."""
+        mock_cm = _make_mock_client(raise_on_get=httpx.TimeoutException("timed out"))
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://localhost:8080",
+                "api_key": ""
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        # error must be a fixed key matching locale
+        assert data["error"] == "connection_timeout"
+
+    def test_models_connection_error(self):
+        """Generic exception (DNS failure etc.) → success=False, error is fixed string."""
+        mock_cm = _make_mock_client(raise_on_get=Exception("DNS resolution failed"))
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/openai/models", json={
+                "base_url": "http://nonexistent.invalid",
+                "api_key": ""
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        # Negative assertion: must NOT contain raw exception text
+        assert "DNS resolution failed" not in data["error"]
+        assert data["error"]  # non-empty
+
+
+# ===========================================================================
+# /api/openai/test
+# ===========================================================================
+
+class TestOpenAITranslate:
+
+    def test_translate_success(self):
+        """Valid chat completions response → success=True, non-empty translation."""
+        api_resp = {
+            "choices": [
+                {"message": {"content": "新人女演員出道"}}
+            ]
+        }
+        resp = _make_http_response(200, api_resp)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["translation"]  # non-empty
+
+    def test_translate_http_error(self):
+        """HTTP 401 → success=False, error is fixed key (no status code leak)."""
+        resp = _make_http_response(401)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "bad",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "http_error"
+
+    def test_translate_api_error_response(self):
+        """Upstream returns error field with XSS payload → fixed error string, no raw message."""
+        api_resp = {"error": {"message": "Model not found <script>alert(1)</script>"}}
+        resp = _make_http_response(200, api_resp)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        # Negative assertions: must NOT leak the upstream error message
+        assert "script" not in data["error"]
+        assert "alert" not in data["error"]
+        assert "Model not found" not in data["error"]
+        assert data["error"]  # non-empty fixed string
+
+    def test_translate_unknown_format(self):
+        """Response with no 'choices' and no 'error' → success=False, fixed error string."""
+        api_resp = {"unexpected": "format"}
+        resp = _make_http_response(200, api_resp)
+        mock_cm = _make_mock_client(post_response=resp)
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"]  # non-empty fixed string
+
+    def test_translate_ja_locale(self):
+        """ja locale short-circuits without any HTTP call → success=True, translation='ja_skip'."""
+        mock_cm = _make_mock_client()  # no side-effects configured
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm) as mock_client_cls, \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "ja"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
+                "model": "my-model"
+            })
+            # httpx.AsyncClient should never be instantiated
+            mock_client_cls.assert_not_called()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["translation"] == "ja_skip"
+
+    def test_translate_empty_base_url(self):
+        """Empty base_url → success=False, fixed error key."""
+        response = client.post("/api/openai/test", json={
+            "base_url": "",
+            "api_key": "",
+            "model": "my-model"
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "missing_base_url"
+
+    def test_translate_empty_model(self):
+        """Empty model → success=False, fixed error key."""
+        response = client.post("/api/openai/test", json={
+            "base_url": "http://localhost:8080",
+            "api_key": "",
+            "model": ""
+        })
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "missing_model"
+
+    def test_translate_general_exception(self):
+        """Generic exception → success=False, error does NOT leak exception details."""
+        mock_cm = _make_mock_client(raise_on_post=Exception("Internal error details"))
+
+        with patch("web.routers.openai_translate.httpx.AsyncClient", return_value=mock_cm), \
+             patch("web.routers.openai_translate.load_config", return_value={"general": {"locale": "zh-TW"}}):
+            response = client.post("/api/openai/test", json={
+                "base_url": "http://localhost:8080",
+                "api_key": "",
+                "model": "my-model"
+            })
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        # Negative assertion: must NOT contain raw exception text
+        assert "Internal error details" not in data["error"]
+        assert data["error"]  # non-empty fixed string

--- a/tests/integration/test_gemini_router.py
+++ b/tests/integration/test_gemini_router.py
@@ -67,8 +67,8 @@ def _make_api_models(*names: str) -> dict:
 
 
 ALLOWLIST = [
-    "gemini-2.0-flash-lite-latest",
-    "gemini-2.0-flash-latest",
+    "gemini-flash-lite-latest",
+    "gemini-flash-latest",
     "gemma-4-26b-a4b-it",
     "gemma-4-31b-it",
 ]
@@ -107,7 +107,7 @@ class TestGeminiAllowlist:
         """BC2: API 回傳缺少部分 allowlist model → response 只含有回傳的 model，不補假資料。"""
         # Only 2 of the 4 are returned
         body = _make_api_models(
-            "gemini-2.0-flash-lite-latest",
+            "gemini-flash-lite-latest",
             "gemma-4-31b-it",
         )
         resp = _make_http_response(200, body)
@@ -121,9 +121,9 @@ class TestGeminiAllowlist:
         assert data["success"] is True
         assert data["count"] == 2
         names = [m["name"] for m in data["models"]]
-        assert "gemini-2.0-flash-lite-latest" in names
+        assert "gemini-flash-lite-latest" in names
         assert "gemma-4-31b-it" in names
-        assert "gemini-2.0-flash-latest" not in names
+        assert "gemini-flash-latest" not in names
         assert "gemma-4-26b-a4b-it" not in names
 
     def test_non_allowlist_models_filtered_out(self):
@@ -203,8 +203,8 @@ class TestGeminiAllowlist:
         body = {
             "models": [
                 {
-                    "name": "models/gemini-2.0-flash-lite-latest",
-                    "displayName": "Gemini 2.0 Flash Lite Latest",
+                    "name": "models/gemini-flash-lite-latest",
+                    "displayName": "Gemini Flash Lite Latest",
                     "description": "",
                 }
             ]
@@ -219,4 +219,4 @@ class TestGeminiAllowlist:
         data = response.json()
         assert data["success"] is True
         assert data["count"] == 1
-        assert data["models"][0]["name"] == "gemini-2.0-flash-lite-latest"
+        assert data["models"][0]["name"] == "gemini-flash-lite-latest"

--- a/tests/integration/test_gemini_router.py
+++ b/tests/integration/test_gemini_router.py
@@ -161,7 +161,7 @@ class TestGeminiAllowlist:
         assert data["models"] == []
 
     def test_invalid_api_key_400(self):
-        """BC5: API Key 無效 (HTTP 400) → success=False, error='Invalid API Key'。"""
+        """BC5: API Key 無效 (HTTP 400) → success=False + error 非空。"""
         resp = _make_http_response(400)
         mock_cm = _make_mock_client(get_response=resp)
 
@@ -171,10 +171,10 @@ class TestGeminiAllowlist:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
-        assert data["error"] == "Invalid API Key"
+        assert data["error"]  # 非空即可，不鎖定具體文案
 
     def test_forbidden_api_key_403(self):
-        """BC5: API Key 無效 (HTTP 403) → success=False, error='API Key permission denied'。"""
+        """BC5: API Key 無效 (HTTP 403) → success=False + error 非空。"""
         resp = _make_http_response(403)
         mock_cm = _make_mock_client(get_response=resp)
 
@@ -184,10 +184,10 @@ class TestGeminiAllowlist:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
-        assert data["error"] == "API Key permission denied"
+        assert data["error"]  # 非空即可，不鎖定具體文案
 
     def test_connection_timeout(self):
-        """BC6: API 超時 → success=False, error='Connection timeout'。"""
+        """BC6: API 超時 → success=False + error 非空。"""
         mock_cm = _make_mock_client(raise_on_get=httpx.TimeoutException("timed out"))
 
         with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
@@ -196,7 +196,7 @@ class TestGeminiAllowlist:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
-        assert data["error"] == "Connection timeout"
+        assert data["error"]  # 非空即可，不鎖定具體文案
 
     def test_model_name_strip_prefix(self):
         """BC7: API 回傳帶 'models/' prefix 的 name → strip 後正確比對 allowlist。"""

--- a/tests/integration/test_gemini_router.py
+++ b/tests/integration/test_gemini_router.py
@@ -1,0 +1,222 @@
+"""
+Gemini API router integration tests — TDD-lite for allowlist filtering.
+
+Covers POST /api/gemini/test endpoint.
+Uses TestClient + mock httpx.AsyncClient (no real HTTP connections).
+"""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, AsyncMock, MagicMock
+import httpx
+
+from web.app import app
+
+client = TestClient(app)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_client(get_response=None, raise_on_get=None):
+    """Build a mock httpx.AsyncClient context-manager with configurable responses."""
+    mock_client = AsyncMock()
+
+    if raise_on_get is not None:
+        mock_client.get = AsyncMock(side_effect=raise_on_get)
+    elif get_response is not None:
+        mock_client.get = AsyncMock(return_value=get_response)
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=mock_client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _make_http_response(status_code: int, json_body: dict | None = None):
+    """Build a minimal mock httpx.Response."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.status_code = status_code
+    if json_body is not None:
+        mock_resp.json = MagicMock(return_value=json_body)
+    if status_code >= 400:
+        request = MagicMock()
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                message=f"HTTP {status_code}",
+                request=request,
+                response=mock_resp,
+            )
+        )
+    else:
+        mock_resp.raise_for_status = MagicMock(return_value=None)
+    return mock_resp
+
+
+def _make_api_models(*names: str) -> dict:
+    """Build a Gemini-style API response dict with the given model short-names."""
+    return {
+        "models": [
+            {
+                "name": f"models/{n}",
+                "displayName": n.replace("-", " ").title(),
+                "description": f"Model {n}",
+            }
+            for n in names
+        ]
+    }
+
+
+ALLOWLIST = [
+    "gemini-2.0-flash-lite-latest",
+    "gemini-2.0-flash-latest",
+    "gemma-4-26b-a4b-it",
+    "gemma-4-31b-it",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGeminiAllowlist:
+
+    def test_all_four_allowlist_models_returned_in_order(self):
+        """BC1: API 回傳全部 4 個 allowlist model → response models 長度 4，順序依 allowlist。"""
+        body = _make_api_models(*ALLOWLIST)
+        # Include some extra noise so filtering is exercised
+        body["models"].append({
+            "name": "models/gemini-1.5-flash",
+            "displayName": "Gemini 1.5 Flash",
+            "description": "Old model",
+        })
+        resp = _make_http_response(200, body)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "valid-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 4
+        assert len(data["models"]) == 4
+        names = [m["name"] for m in data["models"]]
+        assert names == ALLOWLIST
+
+    def test_missing_allowlist_model_not_injected(self):
+        """BC2: API 回傳缺少部分 allowlist model → response 只含有回傳的 model，不補假資料。"""
+        # Only 2 of the 4 are returned
+        body = _make_api_models(
+            "gemini-2.0-flash-lite-latest",
+            "gemma-4-31b-it",
+        )
+        resp = _make_http_response(200, body)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "valid-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 2
+        names = [m["name"] for m in data["models"]]
+        assert "gemini-2.0-flash-lite-latest" in names
+        assert "gemma-4-31b-it" in names
+        assert "gemini-2.0-flash-latest" not in names
+        assert "gemma-4-26b-a4b-it" not in names
+
+    def test_non_allowlist_models_filtered_out(self):
+        """BC3: API 回傳非 allowlist model → 被過濾掉，不出現在 response。"""
+        body = _make_api_models(
+            "gemini-pro",
+            "gemini-1.5-flash",
+            "gemini-1.5-flash-8b",
+            "gemini-embedding-exp",
+        )
+        resp = _make_http_response(200, body)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "valid-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 0
+        assert data["models"] == []
+
+    def test_empty_models_list_from_api(self):
+        """BC4: API 回傳 models 為空列表 → success=True, models=[], count=0。"""
+        resp = _make_http_response(200, {"models": []})
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "valid-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 0
+        assert data["models"] == []
+
+    def test_invalid_api_key_400(self):
+        """BC5: API Key 無效 (HTTP 400) → success=False, error='Invalid API Key'。"""
+        resp = _make_http_response(400)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "bad-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "Invalid API Key"
+
+    def test_forbidden_api_key_403(self):
+        """BC5: API Key 無效 (HTTP 403) → success=False, error='API Key permission denied'。"""
+        resp = _make_http_response(403)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "forbidden-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "API Key permission denied"
+
+    def test_connection_timeout(self):
+        """BC6: API 超時 → success=False, error='Connection timeout'。"""
+        mock_cm = _make_mock_client(raise_on_get=httpx.TimeoutException("timed out"))
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "valid-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error"] == "Connection timeout"
+
+    def test_model_name_strip_prefix(self):
+        """BC7: API 回傳帶 'models/' prefix 的 name → strip 後正確比對 allowlist。"""
+        body = {
+            "models": [
+                {
+                    "name": "models/gemini-2.0-flash-lite-latest",
+                    "displayName": "Gemini 2.0 Flash Lite Latest",
+                    "description": "",
+                }
+            ]
+        }
+        resp = _make_http_response(200, body)
+        mock_cm = _make_mock_client(get_response=resp)
+
+        with patch("web.routers.gemini.httpx.AsyncClient", return_value=mock_cm):
+            response = client.post("/api/gemini/test", json={"api_key": "valid-key"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["count"] == 1
+        assert data["models"][0]["name"] == "gemini-2.0-flash-lite-latest"

--- a/tests/unit/test_core_config.py
+++ b/tests/unit/test_core_config.py
@@ -485,3 +485,54 @@ class TestMigrationPrimarySource:
         result = load_config()
 
         assert result["search"]["primary_source"] == "javbus"
+
+
+# ============ test_migration_openai ============
+
+class TestMigrationOpenAI:
+    """openai 嵌套補齊 migration（Task T2）"""
+
+    def test_translate_openai_migration(self, tmp_path, monkeypatch):
+        """舊設定無 openai 區段 → migration 後自動補齊預設值"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {
+            "translate": {
+                "enabled": False,
+                "ollama": {"url": "http://localhost:11434", "model": "qwen3:8b"},
+                "gemini": {"api_key": "", "model": "gemini-flash-lite-latest"},
+            }
+        })
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert "openai" in result["translate"]
+        openai = result["translate"]["openai"]
+        assert openai["base_url"] == ""
+        assert openai["api_key"] == ""
+        assert openai["model"] == "gpt-4o-mini"
+
+    def test_translate_openai_not_overwrite_existing(self, tmp_path, monkeypatch):
+        """openai 嵌套已存在 → 不覆蓋用戶設定"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {
+            "translate": {
+                "enabled": True,
+                "provider": "openai",
+                "openai": {
+                    "base_url": "https://api.openai.com/v1",
+                    "api_key": "sk-test",
+                    "model": "gpt-4o"
+                }
+            }
+        })
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        openai = result["translate"]["openai"]
+        assert openai["base_url"] == "https://api.openai.com/v1"
+        assert openai["api_key"] == "sk-test"
+        assert openai["model"] == "gpt-4o"

--- a/tests/unit/test_dmm_keyword.py
+++ b/tests/unit/test_dmm_keyword.py
@@ -358,3 +358,32 @@ class TestDMMSearchByKeyword:
              patch('core.scrapers.dmm.rate_limit'):
             dmm_scraper.search_by_keyword_with_ids("test")
         mock_fetch.assert_not_called()
+
+    # ============================================================
+    # T5: offset 參數傳遞測試
+    # ============================================================
+
+    def test_keyword_with_ids_offset_passed(self, dmm_scraper):
+        """search_by_keyword_with_ids(offset=40) → GraphQL variables.offset == 40"""
+        mock_resp = _make_mock_resp(status_code=200, json_data=DMM_SEARCH_LIST_RESPONSE)
+
+        with patch.object(dmm_scraper._session, 'post', return_value=mock_resp) as mock_post, \
+             patch('core.scrapers.dmm.rate_limit'):
+            dmm_scraper.search_by_keyword_with_ids("未歩なな", limit=20, offset=40)
+
+        call_kwargs = mock_post.call_args_list[0][1]
+        payload = call_kwargs.get('json', {})
+        assert payload['variables']['offset'] == 40
+
+    def test_keyword_offset_passed(self, dmm_scraper):
+        """search_by_keyword(offset=40) → GraphQL variables.offset == 40"""
+        mock_resp = _make_mock_resp(status_code=200, json_data=DMM_SEARCH_LIST_RESPONSE)
+
+        with patch.object(dmm_scraper._session, 'post', return_value=mock_resp) as mock_post, \
+             patch.object(dmm_scraper, '_fetch_by_id', return_value=None), \
+             patch('core.scrapers.dmm.rate_limit'):
+            dmm_scraper.search_by_keyword("未歩なな", limit=20, offset=40)
+
+        call_kwargs = mock_post.call_args_list[0][1]
+        payload = call_kwargs.get('json', {})
+        assert payload['variables']['offset'] == 40

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -652,3 +652,76 @@ class TestGeminiLocaleKeyGuard:
         js = self._js()
         assert "gemini_n_flash_models" not in js, \
             "settings.js 仍含 gemini_n_flash_models，應改為 connected_n_models"
+
+
+GRID_MODE_JS = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "search" / "state" / "grid-mode.js"
+
+
+class TestLoadMoreButton:
+    """39a-T4: 守衛 Grid Load More 按鈕 + hasVisibleNext + nextLightboxVideo loadMore 觸發"""
+
+    def _html(self):
+        return SEARCH_HTML.read_text(encoding="utf-8")
+
+    def _base(self):
+        return BASE_JS.read_text(encoding="utf-8")
+
+    def _grid_mode(self):
+        return GRID_MODE_JS.read_text(encoding="utf-8")
+
+    def _locale(self, name):
+        return json.loads((LOCALES_ROOT / name).read_text(encoding="utf-8"))
+
+    def _get_nested(self, d, dotted_key):
+        keys = dotted_key.split(".")
+        cur = d
+        for k in keys:
+            if not isinstance(cur, dict) or k not in cur:
+                return None
+            cur = cur[k]
+        return cur
+
+    # --- search.html ---
+
+    def test_html_load_more_click_binding(self):
+        """search.html grid-staging-wrapper 內含 loadMore() 的 @click 綁定"""
+        html = self._html()
+        assert '@click="loadMore()"' in html, \
+            'search.html 缺少 @click="loadMore()" 綁定（Load More 按鈕）'
+
+    def test_html_load_more_i18n_ref(self):
+        """search.html 含 t('search.button.load_more') 引用"""
+        html = self._html()
+        assert "t('search.button.load_more')" in html, \
+            "search.html 缺少 t('search.button.load_more') i18n 引用"
+
+    def test_html_load_more_xshow_condition(self):
+        """search.html Load More 按鈕 x-show 含 hasMoreResults && !isLoadingMore && displayMode === 'grid'"""
+        html = self._html()
+        assert "hasMoreResults && !isLoadingMore && displayMode === 'grid'" in html, \
+            "search.html Load More 按鈕缺少正確的 x-show 條件（hasMoreResults && !isLoadingMore && displayMode === 'grid'）"
+
+    # --- base.js ---
+
+    def test_base_has_visible_next_checks_has_more_results(self):
+        """base.js hasVisibleNext() 含 hasMoreResults 判斷"""
+        js = self._base()
+        assert "hasMoreResults" in js, \
+            "base.js hasVisibleNext() 缺少 hasMoreResults 判斷"
+
+    # --- grid-mode.js ---
+
+    def test_grid_mode_next_lightbox_video_calls_load_more(self):
+        """grid-mode.js nextLightboxVideo() 含 loadMore() 呼叫"""
+        js = self._grid_mode()
+        assert "this.loadMore()" in js, \
+            "grid-mode.js nextLightboxVideo() 缺少 this.loadMore() 呼叫"
+
+    # --- locale files ---
+
+    def test_all_locales_have_load_more_key(self):
+        """四個 locale 檔案均含 search.button.load_more key"""
+        for locale_file in ["zh_TW.json", "zh_CN.json", "en.json", "ja.json"]:
+            data = self._locale(locale_file)
+            val = self._get_nested(data, "search.button.load_more")
+            assert val, f"{locale_file} 缺少 search.button.load_more key"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -765,3 +765,57 @@ class TestCodexFixes:
         assert "modelNames.includes(this.form.geminiModel)" in js or \
                "includes(this.form.geminiModel)" in js, \
             "settings.js testGeminiConnection() 成功後應含 includes(this.form.geminiModel) allowlist 檢查"
+
+
+class TestOpenAIErrorI18nGuard:
+    """39a-PR-fix P1: 守衛 fetchOpenAIModels/testOpenAITranslation error 使用 window.t(errorKey) 翻譯"""
+
+    def _js(self):
+        return SETTINGS_JS.read_text(encoding="utf-8")
+
+    def test_fetch_models_error_uses_i18n(self):
+        """fetchOpenAIModels() error 分支使用 settings.status.openai_ 動態 errorKey 拼接"""
+        js = self._js()
+        # 截取 fetchOpenAIModels 函數體
+        start = js.find("async fetchOpenAIModels()")
+        assert start != -1, "settings.js 找不到 async fetchOpenAIModels() 函數"
+        # 截取到下一個 async 函數起點（保守估計）
+        next_async = js.find("async ", start + 1)
+        func_body = js[start:next_async] if next_async != -1 else js[start:]
+        assert "settings.status.openai_" in func_body, \
+            "settings.js fetchOpenAIModels() error 分支應包含 settings.status.openai_ 動態 key 拼接"
+
+    def test_translate_error_uses_i18n(self):
+        """testOpenAITranslation() error 分支使用 settings.status.openai_ 動態 errorKey 拼接"""
+        js = self._js()
+        start = js.find("async testOpenAITranslation()")
+        assert start != -1, "settings.js 找不到 async testOpenAITranslation() 函數"
+        next_async = js.find("async ", start + 1)
+        func_body = js[start:next_async] if next_async != -1 else js[start:]
+        assert "settings.status.openai_" in func_body, \
+            "settings.js testOpenAITranslation() error 分支應包含 settings.status.openai_ 動態 key 拼接"
+
+    def test_fetch_catch_uses_i18n(self):
+        """fetchOpenAIModels() catch 分支使用 window.t('settings.status.openai_connection_failed')"""
+        js = self._js()
+        assert "window.t('settings.status.openai_connection_failed')" in js, \
+            "settings.js fetchOpenAIModels() catch 分支應使用 window.t('settings.status.openai_connection_failed')，不顯示裸 error.message"
+
+
+class TestAutoFetchDirtyStateGuard:
+    """39a-PR-fix P2: 守衛 auto-fallback 後同步 savedState，防止誤觸 dirty state"""
+
+    def _js(self):
+        return SETTINGS_JS.read_text(encoding="utf-8")
+
+    def test_gemini_fallback_syncs_saved_state(self):
+        """testGeminiConnection() auto-fallback 後同步 savedState.geminiModel"""
+        js = self._js()
+        assert "this.savedState.geminiModel" in js, \
+            "settings.js testGeminiConnection() auto-fallback 後應同步 this.savedState.geminiModel，否則 isDirty 誤判"
+
+    def test_openai_fallback_syncs_saved_state(self):
+        """fetchOpenAIModels() auto-assign 後同步 savedState.openaiModel"""
+        js = self._js()
+        assert "this.savedState.openaiModel" in js, \
+            "settings.js fetchOpenAIModels() auto-assign 後應同步 this.savedState.openaiModel，否則 isDirty 誤判"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -639,3 +639,16 @@ class TestShowcaseKeyboardGuard:
         block = self._extract_block(content, '// 5. Lightbox 開啟時的快捷鍵')
         assert 'e.preventDefault()' in block, \
             "lightbox keyboard 分支缺少 e.preventDefault()"
+
+
+class TestGeminiLocaleKeyGuard:
+    """39a-T3: 守衛 settings.js 不再使用 gemini_n_flash_models locale key"""
+
+    def _js(self):
+        return SETTINGS_JS.read_text(encoding="utf-8")
+
+    def test_settings_js_no_gemini_n_flash_models(self):
+        """settings.js 不應出現 gemini_n_flash_models（已替換為 connected_n_models）"""
+        js = self._js()
+        assert "gemini_n_flash_models" not in js, \
+            "settings.js 仍含 gemini_n_flash_models，應改為 connected_n_models"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -725,3 +725,43 @@ class TestLoadMoreButton:
             data = self._locale(locale_file)
             val = self._get_nested(data, "search.button.load_more")
             assert val, f"{locale_file} 缺少 search.button.load_more key"
+
+
+NAVIGATION_JS = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "search" / "state" / "navigation.js"
+
+
+class TestCodexFixes:
+    """39a Codex review 修正守衛"""
+
+    def _navigation_js(self):
+        return NAVIGATION_JS.read_text(encoding="utf-8")
+
+    def _settings_js(self):
+        return SETTINGS_JS.read_text(encoding="utf-8")
+
+    def test_loadmore_no_currentindex_assignment(self):
+        """F1：loadMore() 成功分支不含 this.currentIndex = 賦值"""
+        js = self._navigation_js()
+        # 找到 loadMore 函數體，截取到 finally 區塊結束
+        start = js.find("async loadMore()")
+        assert start != -1, "navigation.js 找不到 async loadMore() 函數"
+        # 截取 loadMore 函數體（到函數結尾）
+        func_body = js[start:]
+        # 找到 finally { ... } 後的第一個右大括號（函數結束）
+        finally_pos = func_body.find("finally {")
+        if finally_pos != -1:
+            # 截取 loadMore 函數範圍：從函數開始到 finally 區塊後的 } 結尾
+            end_pos = func_body.find("}", finally_pos + len("finally {"))
+            # 再找外層函數的 }
+            end_pos = func_body.find("},", end_pos + 1)
+            func_body = func_body[:end_pos] if end_pos != -1 else func_body
+        # 確認函數體內不含 this.currentIndex = 賦值（有空格的賦值語句）
+        assert "this.currentIndex =" not in func_body, \
+            "navigation.js loadMore() 成功分支不應含 this.currentIndex = 賦值（破壞 shared state contract）"
+
+    def test_gemini_model_fallback_includes_check(self):
+        """F2：testGeminiConnection() 成功後包含 includes() 檢查舊 model 是否在 allowlist"""
+        js = self._settings_js()
+        assert "modelNames.includes(this.form.geminiModel)" in js or \
+               "includes(this.form.geminiModel)" in js, \
+            "settings.js testGeminiConnection() 成功後應含 includes(this.form.geminiModel) allowlist 檢查"

--- a/tests/unit/test_translate_service.py
+++ b/tests/unit/test_translate_service.py
@@ -17,6 +17,7 @@ from core.translate_service import (
     TranslateService,
     OllamaTranslateService,
     GeminiTranslateService,
+    OpenAICompatibleTranslateService,
     create_translate_service
 )
 
@@ -206,3 +207,277 @@ class TestTranslateSingleJaShortCircuit:
             mock_client.assert_not_called()
 
         assert result == original_title
+
+
+# ============ OpenAICompatibleTranslateService 測試 ============
+
+class TestOpenAICompatibleTranslateService:
+    """測試 OpenAI Compatible 翻譯服務"""
+
+    def test_trailing_slash_removed(self):
+        """base_url 尾斜線自動移除"""
+        service = OpenAICompatibleTranslateService({"base_url": "http://host/v1/"})
+        assert service.base_url == "http://host/v1"
+
+    def test_trailing_slash_removed_multiple(self):
+        """多重尾斜線自動移除"""
+        service = OpenAICompatibleTranslateService({"base_url": "http://host/v1///"})
+        assert service.base_url == "http://host/v1"
+
+    def test_default_model(self):
+        """預設 model 為 gpt-4o-mini"""
+        service = OpenAICompatibleTranslateService({})
+        assert service.model == "gpt-4o-mini"
+
+    def test_custom_model(self):
+        """自定義 model 正確設置"""
+        service = OpenAICompatibleTranslateService({"model": "llama3"})
+        assert service.model == "llama3"
+
+    def test_api_key_empty_by_default(self):
+        """api_key 預設為空字串"""
+        service = OpenAICompatibleTranslateService({})
+        assert service.api_key == ""
+
+    @pytest.mark.asyncio
+    async def test_ja_short_circuit(self):
+        """target=ja 時不呼叫 HTTP，直接回傳原文"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "model": "m"},
+            "ja"
+        )
+        original_title = "テスト"
+
+        with patch("httpx.AsyncClient") as mock_client:
+            result = await service.translate_single(original_title)
+            mock_client.assert_not_called()
+
+        assert result == original_title
+
+    @pytest.mark.asyncio
+    async def test_api_key_empty_no_auth_header(self):
+        """api_key 為空時不送 Authorization header"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "api_key": "", "model": "m"},
+            "zh-TW"
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "新人女演員出道"}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        captured_headers = {}
+
+        async def mock_post(url, headers=None, json=None):
+            captured_headers.update(headers or {})
+            return mock_response
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(side_effect=mock_post)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.translate_service.httpx.AsyncClient", return_value=mock_client_instance):
+            result = await service.translate_single("新人女優デビュー")
+
+        assert "Authorization" not in captured_headers
+        assert result == "新人女演員出道"
+
+    @pytest.mark.asyncio
+    async def test_api_key_present_auth_header(self):
+        """api_key 有值時送 Authorization: Bearer xxx"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "api_key": "sk-test123", "model": "m"},
+            "zh-TW"
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "新人女演員出道"}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        captured_headers = {}
+
+        async def mock_post(url, headers=None, json=None):
+            captured_headers.update(headers or {})
+            return mock_response
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(side_effect=mock_post)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.translate_service.httpx.AsyncClient", return_value=mock_client_instance):
+            await service.translate_single("新人女優デビュー")
+
+        assert captured_headers.get("Authorization") == "Bearer sk-test123"
+
+    @pytest.mark.asyncio
+    async def test_translate_single_url_no_double_slash(self):
+        """POST URL 無雙斜線（base_url 無尾斜線後拼接 /chat/completions）"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://host/v1/", "model": "m"},
+            "zh-TW"
+        )
+
+        captured_url = {}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "test"}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        async def mock_post(url, headers=None, json=None):
+            captured_url["url"] = url
+            return mock_response
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(side_effect=mock_post)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.translate_service.httpx.AsyncClient", return_value=mock_client_instance):
+            await service.translate_single("テスト")
+
+        assert captured_url["url"] == "http://host/v1/chat/completions"
+        assert "//" not in captured_url["url"].replace("://", "")
+
+    @pytest.mark.asyncio
+    async def test_translate_single_success(self):
+        """mock 200 + OpenAI format → 回翻譯結果"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "model": "gpt-4o-mini"},
+            "zh-TW"
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "  新人女演員出道  "}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.translate_service.httpx.AsyncClient", return_value=mock_client_instance):
+            result = await service.translate_single("新人女優デビュー")
+
+        assert result == "新人女演員出道"
+
+    @pytest.mark.asyncio
+    async def test_translate_single_http_error(self):
+        """mock 401 → 回 ''，不拋例外"""
+        import httpx as _httpx
+
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "model": "m"},
+            "zh-TW"
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        http_error = _httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=MagicMock(),
+            response=mock_response
+        )
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(side_effect=http_error)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.translate_service.httpx.AsyncClient", return_value=mock_client_instance):
+            result = await service.translate_single("テスト")
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_translate_single_bad_response(self):
+        """mock 200 + {error: ...}（無 choices）→ 回 ''"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "model": "m"},
+            "zh-TW"
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"error": "model not found"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("core.translate_service.httpx.AsyncClient", return_value=mock_client_instance):
+            result = await service.translate_single("テスト")
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_translate_batch(self):
+        """mock translate_single → batch 循環正確"""
+        service = OpenAICompatibleTranslateService(
+            {"base_url": "http://localhost/v1", "model": "m"},
+            "zh-TW"
+        )
+
+        call_count = 0
+        side_effects = ["翻譯A", "翻譯B"]
+
+        async def mock_translate_single(title, context=None):
+            nonlocal call_count
+            result = side_effects[call_count]
+            call_count += 1
+            return result
+
+        service.translate_single = mock_translate_single
+
+        results = await service.translate_batch(["タイトルA", "タイトルB"])
+
+        assert len(results) == 2
+        assert results[0] == "翻譯A"
+        assert results[1] == "翻譯B"
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_translate_batch_empty(self):
+        """空列表 → 回空列表"""
+        service = OpenAICompatibleTranslateService({}, "zh-TW")
+        results = await service.translate_batch([])
+        assert results == []
+
+
+class TestFactoryOpenAI:
+    """測試 factory openai branch"""
+
+    def test_factory_openai(self):
+        """create_translate_service 回傳 OpenAICompatibleTranslateService"""
+        config = {
+            "provider": "openai",
+            "openai": {"base_url": "http://localhost/v1", "model": "gpt-4o-mini"}
+        }
+        service = create_translate_service(config)
+        assert isinstance(service, OpenAICompatibleTranslateService)
+
+    def test_factory_openai_inherits_translate_service(self):
+        """OpenAICompatibleTranslateService 是 TranslateService 子類"""
+        assert issubclass(OpenAICompatibleTranslateService, TranslateService)
+
+    def test_factory_openai_empty_base_url_no_error(self):
+        """base_url 為空時 factory 層不拋錯（讓 translate_single 在 HTTP 階段失敗）"""
+        config = {"provider": "openai", "openai": {"base_url": "", "model": "m"}}
+        service = create_translate_service(config)
+        assert isinstance(service, OpenAICompatibleTranslateService)
+        assert service.base_url == ""

--- a/web/app.py
+++ b/web/app.py
@@ -44,6 +44,7 @@ from web.routers import scraper as scraper_router
 from web.routers import translate as translate_router
 from web.routers import scanner as scanner_router
 from web.routers import gemini as gemini_router
+from web.routers import openai_translate as openai_translate_router
 from web.routers import filename as filename_router
 from web.routers import showcase as showcase_router
 from web.routers import motion_lab as motion_lab_router
@@ -55,6 +56,7 @@ app.include_router(scraper_router.router)
 app.include_router(translate_router.router)
 app.include_router(scanner_router.router)
 app.include_router(gemini_router.router)
+app.include_router(openai_translate_router.router)
 app.include_router(filename_router.router)
 app.include_router(showcase_router.router)
 app.include_router(motion_lab_router.router)

--- a/web/routers/gemini.py
+++ b/web/routers/gemini.py
@@ -19,8 +19,8 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/api/gemini", tags=["gemini"])
 
 ALLOWED_GEMINI_MODELS = [
-    "gemini-2.0-flash-lite-latest",
-    "gemini-2.0-flash-latest",
+    "gemini-flash-lite-latest",
+    "gemini-flash-latest",
     "gemma-4-26b-a4b-it",
     "gemma-4-31b-it",
 ]

--- a/web/routers/gemini.py
+++ b/web/routers/gemini.py
@@ -18,6 +18,13 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/gemini", tags=["gemini"])
 
+ALLOWED_GEMINI_MODELS = [
+    "gemini-2.0-flash-lite-latest",
+    "gemini-2.0-flash-latest",
+    "gemma-4-26b-a4b-it",
+    "gemma-4-31b-it",
+]
+
 
 class TestRequest(BaseModel):
     """測試 Gemini API Key 請求"""
@@ -59,9 +66,8 @@ async def test_gemini_connection(request: TestRequest):
 
     測試流程：
     1. 調用 Gemini API 獲取模型列表
-    2. 過濾出 Flash 系列模型
-    3. 排序（latest 優先）
-    4. 返回模型列表
+    2. 以 ALLOWED_GEMINI_MODELS allowlist 過濾（保持 allowlist 定義順序）
+    3. 返回模型列表
 
     Args:
         request: 包含 API Key 的請求
@@ -83,29 +89,26 @@ async def test_gemini_connection(request: TestRequest):
 
         data = response.json()
 
-        # 過濾 Flash 系列模型
-        flash_models = []
+        # 以 allowlist 過濾並保持 allowlist 順序
+        api_models = {}
         for model in data.get("models", []):
             name = model.get("name", "").replace("models/", "")
+            api_models[name] = model
 
-            # 只保留 flash 系列，排除 pro 和 embedding
-            if is_flash_model(name):
-                flash_models.append(ModelInfo(
-                    name=name,
-                    display_name=model.get("displayName", name),
+        allowed_models = []
+        for allowed_name in ALLOWED_GEMINI_MODELS:
+            if allowed_name in api_models:
+                model = api_models[allowed_name]
+                allowed_models.append(ModelInfo(
+                    name=allowed_name,
+                    display_name=model.get("displayName", allowed_name),
                     description=model.get("description", "")[:100]  # 限制長度
                 ))
 
-        # 排序：lite-latest 優先（最推薦），其他 latest 次之
-        flash_models.sort(key=lambda m: (
-            0 if "lite-latest" in m.name else (1 if "latest" in m.name else 2),
-            m.name
-        ))
-
         return TestResponse(
             success=True,
-            models=flash_models,
-            count=len(flash_models)
+            models=allowed_models,
+            count=len(allowed_models)
         )
 
     except httpx.HTTPStatusError as e:
@@ -138,37 +141,6 @@ async def test_gemini_connection(request: TestRequest):
             error="測試 Gemini 連線失敗"
         )
 
-
-def is_flash_model(model_name: str) -> bool:
-    """
-    判斷是否為 flash 系列模型
-
-    過濾規則：
-    - 必須包含 "flash"
-    - 排除 "pro" 系列
-    - 排除 "embedding" 模型
-
-    Args:
-        model_name: 模型名稱
-
-    Returns:
-        bool: 是否為 flash 系列
-    """
-    name_lower = model_name.lower()
-
-    # 必須包含 flash
-    if "flash" not in name_lower:
-        return False
-
-    # 排除 pro 系列
-    if "pro" in name_lower:
-        return False
-
-    # 排除 embedding 模型
-    if "embedding" in name_lower:
-        return False
-
-    return True
 
 
 @router.post("/test-translate", response_model=TestTranslateResponse)

--- a/web/routers/openai_translate.py
+++ b/web/routers/openai_translate.py
@@ -82,8 +82,19 @@ async def fetch_openai_models(request: ModelsRequest):
         return ModelsResponse(success=True, models=models)
 
     except httpx.HTTPStatusError as e:
-        logger.warning("[OpenAI] 查詢模型列表失敗: HTTP %s", e.response.status_code)
-        return ModelsResponse(success=False, error="http_error")
+        sc = e.response.status_code
+        if sc == 401:
+            error_key = "auth_failed"
+        elif sc == 403:
+            error_key = "forbidden"
+        elif sc == 404:
+            error_key = "not_found"
+        elif sc == 429:
+            error_key = "rate_limited"
+        else:
+            error_key = "http_error"
+        logger.warning("[OpenAI] 請求失敗: HTTP %s", sc)
+        return ModelsResponse(success=False, error=error_key)
 
     except httpx.TimeoutException:
         logger.warning("[OpenAI] 查詢模型列表逾時")
@@ -175,8 +186,19 @@ async def test_openai_translate(request: TestTranslateRequest):
             return TestTranslateResponse(success=False, error="unknown_response_format")
 
     except httpx.HTTPStatusError as e:
-        logger.warning("[OpenAI] 測試翻譯失敗: HTTP %s", e.response.status_code)
-        return TestTranslateResponse(success=False, error="http_error")
+        sc = e.response.status_code
+        if sc == 401:
+            error_key = "auth_failed"
+        elif sc == 403:
+            error_key = "forbidden"
+        elif sc == 404:
+            error_key = "not_found"
+        elif sc == 429:
+            error_key = "rate_limited"
+        else:
+            error_key = "http_error"
+        logger.warning("[OpenAI] 請求失敗: HTTP %s", sc)
+        return TestTranslateResponse(success=False, error=error_key)
 
     except httpx.TimeoutException:
         logger.warning("[OpenAI] 測試翻譯逾時")

--- a/web/routers/openai_translate.py
+++ b/web/routers/openai_translate.py
@@ -1,0 +1,187 @@
+"""
+OpenAI Compatible API 路由 - 提供模型查詢和翻譯測試功能
+
+端點：
+- POST /api/openai/models - 查詢可用模型列表
+- POST /api/openai/test   - 翻譯測試
+"""
+
+from core.logger import get_logger
+from core.config import load_config
+from core.translate_service import LANGUAGE_PROMPTS
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import httpx
+from typing import List, Optional
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/openai", tags=["openai"])
+
+
+class ModelsRequest(BaseModel):
+    """查詢模型列表請求"""
+    base_url: str
+    api_key: str = ""
+
+
+class ModelsResponse(BaseModel):
+    """模型列表響應"""
+    success: bool
+    models: List[str] = []
+    error: str = ""
+
+
+class TestTranslateRequest(BaseModel):
+    """翻譯測試請求"""
+    base_url: str
+    api_key: str = ""
+    model: str
+
+
+class TestTranslateResponse(BaseModel):
+    """翻譯測試響應"""
+    success: bool
+    translation: str = ""
+    error: str = ""
+
+
+@router.post("/models", response_model=ModelsResponse)
+async def fetch_openai_models(request: ModelsRequest):
+    """
+    查詢 OpenAI Compatible API 可用模型列表
+
+    1. GET {base_url}/models
+    2. 取 data[].id 回傳模型 ID 列表
+    3. 失敗時 graceful fallback（不拋 HTTPException），回 success=False
+
+    Args:
+        request: 包含 base_url 和 api_key 的請求
+
+    Returns:
+        ModelsResponse: 包含成功狀態和模型列表
+    """
+    if not request.base_url.strip():
+        raise HTTPException(status_code=400, detail="base_url is required")
+
+    base_url = request.base_url.rstrip("/")
+    headers = {}
+    if request.api_key:
+        headers["Authorization"] = f"Bearer {request.api_key}"
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"{base_url}/models", headers=headers)
+            response.raise_for_status()
+
+        data = response.json()
+        models = [item["id"] for item in data.get("data", []) if "id" in item]
+        models.sort()
+
+        return ModelsResponse(success=True, models=models)
+
+    except httpx.HTTPStatusError as e:
+        error_msg = f"HTTP {e.response.status_code}"
+        logger.warning("[OpenAI] 查詢模型列表失敗: %s", error_msg)
+        return ModelsResponse(success=False, error=error_msg)
+
+    except httpx.TimeoutException:
+        logger.warning("[OpenAI] 查詢模型列表逾時")
+        return ModelsResponse(success=False, error="Connection timeout")
+
+    except Exception as e:
+        logger.warning("[OpenAI] 查詢模型列表失敗: %s", e)
+        return ModelsResponse(success=False, error=str(e))
+
+
+@router.post("/test", response_model=TestTranslateResponse)
+async def test_openai_translate(request: TestTranslateRequest):
+    """
+    測試 OpenAI Compatible API 翻譯功能
+
+    使用安全的測試標題驗證翻譯能力
+
+    Args:
+        request: 包含 base_url、api_key 和 model 的請求
+
+    Returns:
+        TestTranslateResponse: 包含翻譯結果或錯誤訊息
+    """
+    if not request.base_url.strip():
+        raise HTTPException(status_code=400, detail="base_url is required")
+
+    if not request.model.strip():
+        raise HTTPException(status_code=400, detail="model is required")
+
+    # 使用安全的測試標題（與 gemini.py 行 191 相同）
+    test_title = "新人女優デビュー"
+
+    config = load_config()
+    locale = config.get("general", {}).get("locale", "zh-TW")
+    lang_data = LANGUAGE_PROMPTS.get(locale, LANGUAGE_PROMPTS["zh-TW"])
+    instruction = lang_data["gemini_instruction"]
+    rules = lang_data["gemini_rules"]
+
+    prompt = f"""你是專業的影視資料庫管理員與翻譯引擎。這是既有日文文字的逐字翻譯任務，{instruction}。
+
+原文：
+{test_title}
+
+翻譯要求：
+{rules}
+"""
+
+    base_url = request.base_url.rstrip("/")
+    headers = {"Content-Type": "application/json"}
+    if request.api_key:
+        headers["Authorization"] = f"Bearer {request.api_key}"
+
+    payload = {
+        "model": request.model,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.3,
+        "max_tokens": 100
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(
+                f"{base_url}/chat/completions",
+                headers=headers,
+                json=payload
+            )
+            response.raise_for_status()
+
+        data = response.json()
+
+        choices = data.get("choices")
+        if choices and len(choices) > 0:
+            translation = choices[0]["message"]["content"].strip()
+            return TestTranslateResponse(success=True, translation=translation)
+
+        elif "error" in data:
+            error_msg = data["error"].get("message", "Unknown error") if isinstance(data["error"], dict) else str(data["error"])
+            return TestTranslateResponse(success=False, error=error_msg)
+
+        else:
+            return TestTranslateResponse(success=False, error="未知的響應格式")
+
+    except httpx.HTTPStatusError as e:
+        try:
+            error_data = e.response.json()
+            if isinstance(error_data.get("error"), dict):
+                error_msg = error_data["error"].get("message", f"HTTP {e.response.status_code}")
+            else:
+                error_msg = str(error_data.get("error", f"HTTP {e.response.status_code}"))
+        except Exception:
+            error_msg = f"HTTP {e.response.status_code}"
+
+        return TestTranslateResponse(success=False, error=error_msg)
+
+    except httpx.TimeoutException:
+        return TestTranslateResponse(success=False, error="連接超時（15秒）")
+
+    except Exception as e:
+        logger.error("[OpenAI] 測試翻譯失敗: %s", e)
+        return TestTranslateResponse(success=False, error=str(e))

--- a/web/routers/openai_translate.py
+++ b/web/routers/openai_translate.py
@@ -10,7 +10,7 @@ from core.logger import get_logger
 from core.config import load_config
 from core.translate_service import LANGUAGE_PROMPTS
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from pydantic import BaseModel
 import httpx
 from typing import List, Optional
@@ -63,7 +63,7 @@ async def fetch_openai_models(request: ModelsRequest):
         ModelsResponse: 包含成功狀態和模型列表
     """
     if not request.base_url.strip():
-        raise HTTPException(status_code=400, detail="base_url is required")
+        return ModelsResponse(success=False, error="missing_base_url")
 
     base_url = request.base_url.rstrip("/")
     headers = {}
@@ -82,17 +82,16 @@ async def fetch_openai_models(request: ModelsRequest):
         return ModelsResponse(success=True, models=models)
 
     except httpx.HTTPStatusError as e:
-        error_msg = f"HTTP {e.response.status_code}"
-        logger.warning("[OpenAI] 查詢模型列表失敗: %s", error_msg)
-        return ModelsResponse(success=False, error=error_msg)
+        logger.warning("[OpenAI] 查詢模型列表失敗: HTTP %s", e.response.status_code)
+        return ModelsResponse(success=False, error="http_error")
 
     except httpx.TimeoutException:
         logger.warning("[OpenAI] 查詢模型列表逾時")
-        return ModelsResponse(success=False, error="Connection timeout")
+        return ModelsResponse(success=False, error="connection_timeout")
 
     except Exception as e:
         logger.warning("[OpenAI] 查詢模型列表失敗: %s", e)
-        return ModelsResponse(success=False, error=str(e))
+        return ModelsResponse(success=False, error="connection_failed")
 
 
 @router.post("/test", response_model=TestTranslateResponse)
@@ -109,16 +108,24 @@ async def test_openai_translate(request: TestTranslateRequest):
         TestTranslateResponse: 包含翻譯結果或錯誤訊息
     """
     if not request.base_url.strip():
-        raise HTTPException(status_code=400, detail="base_url is required")
+        return TestTranslateResponse(success=False, error="missing_base_url")
 
     if not request.model.strip():
-        raise HTTPException(status_code=400, detail="model is required")
+        return TestTranslateResponse(success=False, error="missing_model")
 
     # 使用安全的測試標題（與 gemini.py 行 191 相同）
     test_title = "新人女優デビュー"
 
     config = load_config()
     locale = config.get("general", {}).get("locale", "zh-TW")
+
+    # F2: ja short-circuit — 與 translate_service.py 的行為保持一致
+    if locale == "ja":
+        return TestTranslateResponse(
+            success=True,
+            translation="ja_skip"
+        )
+
     lang_data = LANGUAGE_PROMPTS.get(locale, LANGUAGE_PROMPTS["zh-TW"])
     instruction = lang_data["gemini_instruction"]
     rules = lang_data["gemini_rules"]
@@ -161,27 +168,20 @@ async def test_openai_translate(request: TestTranslateRequest):
             return TestTranslateResponse(success=True, translation=translation)
 
         elif "error" in data:
-            error_msg = data["error"].get("message", "Unknown error") if isinstance(data["error"], dict) else str(data["error"])
-            return TestTranslateResponse(success=False, error=error_msg)
+            logger.warning("[OpenAI] 測試翻譯 API 回傳錯誤: %s", data["error"])
+            return TestTranslateResponse(success=False, error="api_error")
 
         else:
-            return TestTranslateResponse(success=False, error="未知的響應格式")
+            return TestTranslateResponse(success=False, error="unknown_response_format")
 
     except httpx.HTTPStatusError as e:
-        try:
-            error_data = e.response.json()
-            if isinstance(error_data.get("error"), dict):
-                error_msg = error_data["error"].get("message", f"HTTP {e.response.status_code}")
-            else:
-                error_msg = str(error_data.get("error", f"HTTP {e.response.status_code}"))
-        except Exception:
-            error_msg = f"HTTP {e.response.status_code}"
-
-        return TestTranslateResponse(success=False, error=error_msg)
+        logger.warning("[OpenAI] 測試翻譯失敗: HTTP %s", e.response.status_code)
+        return TestTranslateResponse(success=False, error="http_error")
 
     except httpx.TimeoutException:
-        return TestTranslateResponse(success=False, error="連接超時（15秒）")
+        logger.warning("[OpenAI] 測試翻譯逾時")
+        return TestTranslateResponse(success=False, error="connection_timeout")
 
     except Exception as e:
         logger.error("[OpenAI] 測試翻譯失敗: %s", e)
-        return TestTranslateResponse(success=False, error=str(e))
+        return TestTranslateResponse(success=False, error="translate_failed")

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -200,7 +200,7 @@ window.SearchStateMixin_Base = function () {
                 // 從 actress photo 看有沒有可見 item
                 return this.searchResults.some(r => !r._failed);
             }
-            return this.searchResults.slice(this.lightboxIndex + 1).some(r => !r._failed);
+            return this.searchResults.slice(this.lightboxIndex + 1).some(r => !r._failed) || this.hasMoreResults;
         },
 
         showNavigation() {

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -252,8 +252,12 @@ window.SearchStateMixin_GridMode = {
             while (newIdx < this.searchResults.length && this.searchResults[newIdx]._failed) {
                 newIdx++;
             }
-            if (newIdx >= this.searchResults.length) return;  // no more valid items → don't move
+            if (newIdx >= this.searchResults.length) {
+                if (this.hasMoreResults && !this.isLoadingMore) this.loadMore();
+                return;
+            }
         } else {
+            if (this.hasMoreResults && !this.isLoadingMore) this.loadMore();
             return;  // at last item → don't move
         }
 

--- a/web/static/js/pages/search/state/navigation.js
+++ b/web/static/js/pages/search/state/navigation.js
@@ -86,14 +86,14 @@ window.SearchStateMixin_Navigation = {
             const data = await response.json();
 
             if (response.ok && data.success && data.data && data.data.length > 0) {
+                const newBatchStart = this.searchResults.length;
                 this.searchResults = this.searchResults.concat(data.data);
                 this.currentOffset = newOffset;
                 this.hasMoreResults = data.has_more;
-                this.currentIndex = this.searchResults.length - data.data.length;
                 this._resetCoverState();
 
                 if (window.SearchUI?.preloadImages) {
-                    window.SearchUI.preloadImages(this.currentIndex + 1, 5);
+                    window.SearchUI.preloadImages(newBatchStart + 1, 5);
                 }
 
                 // T4: Load more 後查詢本地狀態

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -17,6 +17,9 @@ function settingsPage() {
             ollamaModel: '',
             geminiApiKey: '',
             geminiModel: '',
+            openaiBaseUrl: '',
+            openaiApiKey: '',
+            openaiModel: 'gpt-4o-mini',
 
             // Scraper
             createFolder: true,
@@ -60,6 +63,11 @@ function settingsPage() {
         geminiModelStatus: '',
         ollamaModels: [],
         geminiModels: [],
+        openaiStatus: '',
+        openaiModelStatus: '',
+        openaiModels: [],
+        fetchingOpenaiModels: false,
+        testingOpenaiTranslate: false,
         // Toast state
         _toast: { message: '', type: 'success', visible: false },
         _toastTimer: null,
@@ -296,6 +304,11 @@ function settingsPage() {
                         this.form.geminiModel = config.translate.gemini.model;
                     }
 
+                    // OpenAI Compatible
+                    this.form.openaiBaseUrl = config.translate.openai?.base_url || '';
+                    this.form.openaiApiKey = config.translate.openai?.api_key || '';
+                    this.form.openaiModel = config.translate.openai?.model || 'gpt-4o-mini';
+
                     // 自動測試 Gemini（如果有 API Key 且是 gemini provider）
                     if (config.translate.gemini?.api_key && config.translate.provider === 'gemini') {
                         setTimeout(() => this.testGeminiConnection(), 100);
@@ -415,6 +428,11 @@ function settingsPage() {
                     gemini: {
                         api_key: this.form.geminiApiKey,
                         model: this.form.geminiModel || 'gemini-flash-lite-latest'
+                    },
+                    openai: {
+                        base_url: this.form.openaiBaseUrl.trim(),
+                        api_key: this.form.openaiApiKey,
+                        model: this.form.openaiModel.trim() || 'gpt-4o-mini'
                     }
                 };
 
@@ -672,6 +690,91 @@ function settingsPage() {
                 this.geminiModelStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.test_failed', {msg: error.message})}</span>`;
             } finally {
                 this.testGeminiTranslateLoading = false;
+            }
+        },
+
+        async fetchOpenAIModels() {
+            const baseUrl = this.form.openaiBaseUrl.trim();
+
+            if (!baseUrl) {
+                this.openaiStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.enter_url')}</span>`;
+                return;
+            }
+
+            this.fetchingOpenaiModels = true;
+            this.openaiStatus = `<span class="text-base-content/50">${window.t('settings.status.connecting')}</span>`;
+
+            try {
+                const response = await fetch('/api/openai/models', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        base_url: baseUrl,
+                        api_key: this.form.openaiApiKey
+                    })
+                });
+
+                const data = await response.json();
+
+                if (data.success && data.models && data.models.length > 0) {
+                    this.openaiModels = data.models;
+                    this.openaiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.connected_n_models', {count: data.models.length})}</span>`;
+
+                    // 如果目前模型不在列表中，設為第一個
+                    if (!this.openaiModels.includes(this.form.openaiModel)) {
+                        this.form.openaiModel = this.openaiModels[0];
+                    }
+                } else {
+                    this.openaiModels = [];
+                    this.openaiStatus = `<span class="text-warning"><i class="bi bi-exclamation-circle"></i> ${data.error || window.t('settings.status.connection_failed')}</span>`;
+                }
+            } catch (error) {
+                this.openaiModels = [];
+                this.openaiStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${error.message}</span>`;
+            } finally {
+                this.fetchingOpenaiModels = false;
+            }
+        },
+
+        async testOpenAITranslation() {
+            const baseUrl = this.form.openaiBaseUrl.trim();
+            const model = this.form.openaiModel.trim();
+
+            if (!baseUrl) {
+                this.openaiModelStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.enter_url')}</span>`;
+                return;
+            }
+
+            if (!model) {
+                this.openaiModelStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.select_model')}</span>`;
+                return;
+            }
+
+            this.testingOpenaiTranslate = true;
+            this.openaiModelStatus = `<span class="text-base-content/50">${window.t('settings.status.testing_translation')}</span>`;
+
+            try {
+                const response = await fetch('/api/openai/test', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        base_url: baseUrl,
+                        api_key: this.form.openaiApiKey,
+                        model: model
+                    })
+                });
+
+                const data = await response.json();
+
+                if (data.success) {
+                    this.openaiModelStatus = `<span class="text-success"><i class="bi bi-check-circle-fill"></i> ${window.t('settings.status.translation_success', {translation: data.translation})}</span>`;
+                } else {
+                    this.openaiModelStatus = `<span class="text-error"><i class="bi bi-exclamation-triangle-fill"></i> ${data.error}</span>`;
+                }
+            } catch (error) {
+                this.openaiModelStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.test_failed', {msg: error.message})}</span>`;
+            } finally {
+                this.testingOpenaiTranslate = false;
             }
         },
 

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -66,6 +66,7 @@ function settingsPage() {
         openaiStatus: '',
         openaiModelStatus: '',
         openaiModels: [],
+        openaiUseCustomModel: false,
         fetchingOpenaiModels: false,
         testingOpenaiTranslate: false,
         // Toast state
@@ -312,6 +313,11 @@ function settingsPage() {
                     // 自動測試 Gemini（如果有 API Key 且是 gemini provider）
                     if (config.translate.gemini?.api_key && config.translate.provider === 'gemini') {
                         setTimeout(() => this.testGeminiConnection(), 100);
+                    }
+
+                    // 自動 fetch OpenAI models（如果有 base_url 且是 openai provider）
+                    if (config.translate.openai?.base_url && config.translate.provider === 'openai') {
+                        setTimeout(() => this.fetchOpenAIModels(), 100);
                     }
 
                     // Scraper
@@ -720,17 +726,17 @@ function settingsPage() {
                     this.openaiModels = data.models;
                     this.openaiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.connected_n_models', {count: data.models.length})}</span>`;
 
-                    // 如果目前模型不在列表中，清空讓用戶從 datalist 選
-                    if (!this.openaiModels.includes(this.form.openaiModel)) {
-                        this.form.openaiModel = '';
+                    // 若目前是自訂模式，保持不動；否則若 model 不在清單中，選第一個
+                    if (!this.openaiUseCustomModel && !this.openaiModels.includes(this.form.openaiModel)) {
+                        this.form.openaiModel = this.openaiModels[0];
                     }
                 } else {
-                    this.openaiModels = [];
+                    // 不清空 openaiModels — 保留舊清單
                     const errorKey = `settings.status.openai_${data.error || 'connection_failed'}`;
                     this.openaiStatus = `<span class="text-warning"><i class="bi bi-exclamation-circle"></i> ${window.t(errorKey)}</span>`;
                 }
             } catch (error) {
-                this.openaiModels = [];
+                // 不清空 openaiModels — 保留舊清單
                 this.openaiStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.openai_connection_failed')}</span>`;
             } finally {
                 this.fetchingOpenaiModels = false;

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -726,11 +726,12 @@ function settingsPage() {
                     }
                 } else {
                     this.openaiModels = [];
-                    this.openaiStatus = `<span class="text-warning"><i class="bi bi-exclamation-circle"></i> ${data.error || window.t('settings.status.connection_failed')}</span>`;
+                    const errorKey = `settings.status.openai_${data.error || 'connection_failed'}`;
+                    this.openaiStatus = `<span class="text-warning"><i class="bi bi-exclamation-circle"></i> ${window.t(errorKey)}</span>`;
                 }
             } catch (error) {
                 this.openaiModels = [];
-                this.openaiStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${error.message}</span>`;
+                this.openaiStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.openai_connection_failed')}</span>`;
             } finally {
                 this.fetchingOpenaiModels = false;
             }
@@ -767,12 +768,22 @@ function settingsPage() {
                 const data = await response.json();
 
                 if (data.success) {
-                    this.openaiModelStatus = `<span class="text-success"><i class="bi bi-check-circle-fill"></i> ${window.t('settings.status.translation_success', {translation: data.translation})}</span>`;
+                    const escapeHtml = (text) => {
+                        const div = document.createElement('div');
+                        div.textContent = text;
+                        return div.innerHTML;
+                    };
+                    if (data.translation === 'ja_skip') {
+                        this.openaiModelStatus = `<span class="text-info"><i class="bi bi-info-circle"></i> ${window.t('settings.status.ja_skip')}</span>`;
+                    } else {
+                        this.openaiModelStatus = `<span class="text-success"><i class="bi bi-check-circle-fill"></i> ${escapeHtml(data.translation)}</span>`;
+                    }
                 } else {
-                    this.openaiModelStatus = `<span class="text-error"><i class="bi bi-exclamation-triangle-fill"></i> ${data.error}</span>`;
+                    const errorKey = `settings.status.openai_${data.error || 'translate_failed'}`;
+                    this.openaiModelStatus = `<span class="text-error"><i class="bi bi-exclamation-triangle-fill"></i> ${window.t(errorKey)}</span>`;
                 }
             } catch (error) {
-                this.openaiModelStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.test_failed', {msg: error.message})}</span>`;
+                this.openaiModelStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${window.t('settings.status.openai_translate_failed')}</span>`;
             } finally {
                 this.testingOpenaiTranslate = false;
             }

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -646,6 +646,8 @@ function settingsPage() {
                     const modelNames = data.models.map(m => m.name);
                     if (data.models.length > 0 && !modelNames.includes(this.form.geminiModel)) {
                         this.form.geminiModel = data.models[0].name;
+                        // auto-fallback 不算用戶修改，同步快照避免 isDirty 誤判
+                        if (this.savedState) this.savedState.geminiModel = this.form.geminiModel;
                     }
                 } else {
                     this.geminiStatus = `<span class="text-error"><i class="bi bi-x-circle"></i> ${data.error || window.t('settings.status.connect_failed')}</span>`;
@@ -733,6 +735,8 @@ function settingsPage() {
                             this.openaiUseCustomModel = true;
                         } else {
                             this.form.openaiModel = this.openaiModels[0];
+                            // auto-assign 不算用戶修改，同步快照避免 isDirty 誤判
+                            if (this.savedState) this.savedState.openaiModel = this.form.openaiModel;
                         }
                     }
                 } else {

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -726,9 +726,13 @@ function settingsPage() {
                     this.openaiModels = data.models;
                     this.openaiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.connected_n_models', {count: data.models.length})}</span>`;
 
-                    // 若目前是自訂模式，保持不動；否則若 model 不在清單中，選第一個
-                    if (!this.openaiUseCustomModel && !this.openaiModels.includes(this.form.openaiModel)) {
-                        this.form.openaiModel = this.openaiModels[0];
+                    // model 不在清單中 → 切換到自訂模式（保留用戶的 custom model）
+                    if (!this.openaiModels.includes(this.form.openaiModel)) {
+                        if (this.form.openaiModel) {
+                            this.openaiUseCustomModel = true;
+                        } else {
+                            this.form.openaiModel = this.openaiModels[0];
+                        }
                     }
                 } else {
                     // 不清空 openaiModels — 保留舊清單

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -642,8 +642,9 @@ function settingsPage() {
                     this.geminiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.connected_n_models', {count: data.count})}</span>`;
                     this.geminiModels = data.models;
 
-                    // Set first model as default if none selected
-                    if (!this.form.geminiModel && data.models.length > 0) {
+                    // 如果當前 model 不在 allowlist，自動選第一個
+                    const modelNames = data.models.map(m => m.name);
+                    if (data.models.length > 0 && !modelNames.includes(this.form.geminiModel)) {
                         this.form.geminiModel = data.models[0].name;
                     }
                 } else {

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -720,9 +720,9 @@ function settingsPage() {
                     this.openaiModels = data.models;
                     this.openaiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.connected_n_models', {count: data.models.length})}</span>`;
 
-                    // 如果目前模型不在列表中，設為第一個
+                    // 如果目前模型不在列表中，清空讓用戶從 datalist 選
                     if (!this.openaiModels.includes(this.form.openaiModel)) {
-                        this.form.openaiModel = this.openaiModels[0];
+                        this.form.openaiModel = '';
                     }
                 } else {
                     this.openaiModels = [];

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -639,7 +639,7 @@ function settingsPage() {
                 const data = await response.json();
 
                 if (data.success) {
-                    this.geminiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.gemini_n_flash_models', {count: data.count})}</span>`;
+                    this.geminiStatus = `<span class="text-success"><i class="bi bi-check-circle"></i> ${window.t('settings.status.connected_n_models', {count: data.count})}</span>`;
                     this.geminiModels = data.models;
 
                     // Set first model as default if none selected

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -496,6 +496,7 @@
             <ul>
                 <li>{{ t('help.troubleshooting.translate_ollama') | safe }}</li>
                 <li>{{ t('help.troubleshooting.translate_gemini') | safe }}</li>
+                <li>{{ t('help.troubleshooting.translate_openai') | safe }}</li>
             </ul>
         </div>
     </div>

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -624,6 +624,14 @@
                     </div>
                 </template>
             </div>
+            <!-- Load More 按鈕 -->
+            <div class="text-center py-4"
+                 x-show="hasMoreResults && !isLoadingMore && displayMode === 'grid'"
+                 x-cloak>
+                <button class="btn btn-outline btn-sm" @click="loadMore()">
+                    <span x-text="t('search.button.load_more')"></span>
+                </button>
+            </div>
             </div><!-- /.grid-staging-wrapper -->
 
             <!-- 檔案列表（卡片外，下方獨立） -->

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -182,6 +182,7 @@
                             :disabled="!form.translateEnabled">
                             <option value="ollama">Ollama{{ t('settings.translate.ollama_local') }}</option>
                             <option value="gemini">Gemini{{ t('settings.translate.gemini_cloud') }}</option>
+                            <option value="openai" x-text="t('settings.translate.openai_compatible')">OpenAI Compatible</option>
                         </select>
                     </div>
 
@@ -297,6 +298,73 @@
                                     </button>
                                 </div>
                                 <small class="settings-hint" x-html="geminiModelStatus"></small>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- OpenAI Compatible 設定 -->
+                    <div id="openaiFields" x-show="form.translateProvider === 'openai'" x-cloak>
+                        <!-- Base URL + Test Connection -->
+                        <div class="settings-form-row">
+                            <label class="row-label" x-text="'Base URL'"></label>
+                            <div class="flex-1 flex flex-col gap-1">
+                                <div class="variable-input-group">
+                                    <input type="text" class="input input-bordered input-sm flex-1"
+                                        x-model="form.openaiBaseUrl"
+                                        placeholder="https://api.openai.com/v1"
+                                        :disabled="!form.translateEnabled">
+                                    <button class="btn btn-sm btn-outline" type="button"
+                                        @click="fetchOpenAIModels()"
+                                        :disabled="!form.translateEnabled || fetchingOpenaiModels">
+                                        <span x-show="fetchingOpenaiModels" class="loading loading-spinner loading-sm"></span>
+                                        <template x-if="!fetchingOpenaiModels">
+                                            <i class="bi bi-plug"></i>
+                                        </template>
+                                        <span x-text="fetchingOpenaiModels ? '' : ' ' + window.t('settings.action.test')"></span>
+                                    </button>
+                                </div>
+                                <small class="settings-hint" x-html="openaiStatus"></small>
+                            </div>
+                        </div>
+
+                        <!-- API Key -->
+                        <div class="settings-form-row">
+                            <label class="row-label">API Key</label>
+                            <div class="flex-1 flex flex-col gap-1">
+                                <input type="password" class="input input-bordered input-sm"
+                                    x-model="form.openaiApiKey"
+                                    :placeholder="window.t('settings.translate.openai_api_key_placeholder')"
+                                    :disabled="!form.translateEnabled">
+                                <small class="settings-hint" x-text="window.t('settings.translate.openai_api_key_hint')"></small>
+                            </div>
+                        </div>
+
+                        <!-- Model (datalist) + Test Translate -->
+                        <div class="settings-form-row">
+                            <label class="row-label" x-text="window.t('settings.translate.model_label')"></label>
+                            <div class="flex-1 flex flex-col gap-1">
+                                <div class="variable-input-group">
+                                    <input type="text" class="input input-bordered input-sm flex-1"
+                                        list="openaiModelList"
+                                        x-model="form.openaiModel"
+                                        :placeholder="window.t('settings.translate.openai_model_placeholder')"
+                                        :disabled="!form.translateEnabled">
+                                    <datalist id="openaiModelList">
+                                        <template x-for="m in openaiModels" :key="m">
+                                            <option :value="m"></option>
+                                        </template>
+                                    </datalist>
+                                    <button class="btn btn-sm btn-outline" type="button"
+                                        @click="testOpenAITranslation()"
+                                        :disabled="!form.translateEnabled || testingOpenaiTranslate || !form.openaiBaseUrl.trim() || !form.openaiModel.trim()">
+                                        <span x-show="testingOpenaiTranslate" class="loading loading-spinner loading-sm"></span>
+                                        <template x-if="!testingOpenaiTranslate">
+                                            <i class="bi bi-chat-dots"></i>
+                                        </template>
+                                        <span x-text="testingOpenaiTranslate ? '' : ' ' + window.t('settings.action.test')"></span>
+                                    </button>
+                                </div>
+                                <small class="settings-hint" x-html="openaiModelStatus"></small>
                             </div>
                         </div>
                     </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -339,21 +339,38 @@
                             </div>
                         </div>
 
-                        <!-- Model (datalist) + Test Translate -->
+                        <!-- Model (select/input dual mode) + Test Translate -->
                         <div class="settings-form-row">
                             <label class="row-label" x-text="window.t('settings.translate.model_label')"></label>
                             <div class="flex-1 flex flex-col gap-1">
                                 <div class="variable-input-group">
-                                    <input type="text" class="input input-bordered input-sm flex-1"
-                                        list="openaiModelList"
-                                        x-model="form.openaiModel"
-                                        :placeholder="window.t('settings.translate.openai_model_placeholder')"
-                                        :disabled="!form.translateEnabled">
-                                    <datalist id="openaiModelList">
-                                        <template x-for="m in openaiModels" :key="m">
-                                            <option :value="m"></option>
-                                        </template>
-                                    </datalist>
+                                    <!-- select 模式：有 models 且非自訂模式 -->
+                                    <template x-if="openaiModels.length > 0 && !openaiUseCustomModel">
+                                        <select class="select select-bordered select-sm flex-1"
+                                            x-model="form.openaiModel"
+                                            @change="if ($event.target.value === '__custom__') { openaiUseCustomModel = true; form.openaiModel = ''; }"
+                                            :disabled="!form.translateEnabled">
+                                            <template x-for="m in openaiModels" :key="m">
+                                                <option :value="m" x-text="m"></option>
+                                            </template>
+                                            <option value="__custom__" x-text="window.t('settings.translate.openai_custom_model') || 'Custom...'"></option>
+                                        </select>
+                                    </template>
+                                    <!-- input 模式：無 models 或自訂模式 -->
+                                    <template x-if="openaiModels.length === 0 || openaiUseCustomModel">
+                                        <div class="flex gap-1 items-center flex-1">
+                                            <input type="text" class="input input-bordered input-sm flex-1"
+                                                x-model="form.openaiModel"
+                                                :placeholder="window.t('settings.translate.openai_model_placeholder')"
+                                                :disabled="!form.translateEnabled">
+                                            <button x-show="openaiUseCustomModel && openaiModels.length > 0"
+                                                class="btn btn-xs btn-ghost"
+                                                type="button"
+                                                @click="openaiUseCustomModel = false; form.openaiModel = openaiModels[0] || '';">
+                                                <i class="bi bi-list-ul"></i>
+                                            </button>
+                                        </div>
+                                    </template>
                                     <button class="btn btn-sm btn-outline" type="button"
                                         @click="testOpenAITranslation()"
                                         :disabled="!form.translateEnabled || testingOpenaiTranslate || !form.openaiBaseUrl.trim() || !form.openaiModel.trim()">


### PR DESCRIPTION
## Summary
- **OpenAI Compatible 翻譯 Provider** — 支援任意 OpenAI 相容 API 端點（OpenRouter、本地 LLM 等）
- **Gemini model allowlist** — 精簡為 4 個推薦 model（取代動態 is_flash_model 過濾）
- **Grid "Load More" 按鈕** — Grid 模式底部載入更多 + Lightbox 最後一張自動觸發
- **DMM 分頁 offset 修正** — GraphQL variables 不再寫死 0，第二頁以後不再重複
- **Locale 劇照用詞統一** — "Sample Image" → "Stills"、"樣品圖" → "劇照"
- **Codex review 修正** — loadMore state desync、Gemini model fallback、error contract

## Test plan
- [x] 全套測試 1766 passed (89s)
- [x] 敏感資訊掃描 PASS
- [x] 打包完整性檢查 PASS
- [x] 測試增量審計 PASS (204 新測試)
- [x] 手動驗證：OpenAI Compatible 翻譯設定 + 測試
- [x] 手動驗證：Gemini Test → 4 個 model
- [x] 手動驗證：Grid Load More + Lightbox 自動載入
- [x] 手動驗證：DMM 搜尋分頁不重複

🤖 Generated with [Claude Code](https://claude.com/claude-code)