### PR TITLE
feat(43): Actress Favorite + /search Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-04-12
+
+### Added
+
+#### 🎯 43 — Actress Favorite 系統 + /search 整合
+- **DB `actresses` 表 + ActressRepository CRUD**：`save`（ON CONFLICT DO UPDATE 保留 `created_at`）/ `get_by_name` / `delete_by_name` / `get_all` / `exists`
+- **照片下載模組 `core/actress_photo.py`**：Referer 設定（graphis/gfriends/wiki/minnano）、Content-Type 副檔名推斷、glob 刪舊檔覆蓋
+- **API Router `web/routers/actress.py`** 四端點：
+  - `POST /api/actresses/favorite` — cache 優先 + fallback orchestrator + 照片下載 + makers 前綴→片商名轉換
+  - `GET /api/actresses/{name}` — 已收藏女優查詢
+  - `DELETE /api/actresses/{name}` — DB + 本地照片刪除
+  - `GET /api/actresses/photo/{name}` — 本地照片 binary response
+- **Orchestrator `ProfileResult` namedtuple**：`get_actress_profile` 回傳 `(data, timed_out)` 結構化結果，區分 timeout vs not-found
+- **`get_cached_profile()` 公開 cache 讀取**：收藏流程 cache hit 時不打網路
+- **/search DB 優先查詢**：已收藏女優搜尋時完全本地回應（0 網路請求）+ `is_favorite` 旗標
+- **Hero Card footer 重設計**：左 name 右 age，hover 顯示 height · cup · 三圍
+- **愛心收藏 overlay**（`.av-card-preview-overlay` + `.btn-glass-circle`）：未收藏 hover 空心可點擊；已收藏常駐實心純指示（CD-10）
+- **Actress Lightbox 重建**：上圖下文 5 rows（名稱+愛心 / 核心 metadata / aliases chips / info chips / URL 連結）；chips 超過 N 個 +剩餘數 badge 可展開
+- **Source link icon**：lightbox cover-actions 位置，點擊開啟文字來源頁面（minnano / Wikipedia JP）；已收藏或無文字來源時不顯示
+- **i18n 四語系同步**：`search.actress.*` + `search.unit.age/cup` 共 7 keys × 4 語系
+- **Capabilities 三端點**：`favorite_actress` / `get_actress` / `unfavorite_actress`（含 side_effect + confirmation_required 安全標記）
+
+### Fixed
+- **aliases `[object Object]` bug**：minnano scraper 回傳 dict list，新增 `_flatten_aliases()` helper 在存入 DB 和前端回傳時 flatten 為純字串 list
+- **Race condition**：`addFavoriteActress()` 加 captured profile reference + await 後 stale-check（同 41d pattern）
+- **URL scheme XSS 防護**：新增 `_safeUrl()` http(s) 白名單 guard，blog_url / official_url 不再直接綁 `:href`
+- **422 validation response**：全域 `RequestValidationError` handler 回固定中文格式
+- **makers 精度**：番號前綴→片商名轉換（`load_prefix_mapping`），保序去重維持 gfriends probe 優先順序
+- **CSS hardcoded color**：`#ff4d6d` 改用 `--color-favorite` CSS 變數
+- **Hero card guard test**：搜尋範圍 800→1200 字元（適應 T5 overlay 偏移）
+
+### Tests
+- 全套 2129 → 2167 tests passed（+38 net）
+- 新增：`test_actress_repository.py`（13）、`test_actress_photo.py`（6）、`test_actress_aliases_flatten.py`（6）、`test_api_actress.py`（12）
+- 更新：orchestrator tests（ProfileResult 型別）、actress_profile tests（DB 優先查詢）、capabilities tests（+3 tools）
+
 ## [0.7.1] - 2026-04-11
 
 ### Added

--- a/core/actress_photo.py
+++ b/core/actress_photo.py
@@ -1,0 +1,129 @@
+"""
+actress_photo.py — 女優照片下載 / 儲存 / 讀取 / 刪除
+"""
+import requests
+from pathlib import Path
+from typing import Optional
+
+from core.logger import get_logger
+from core.organizer import sanitize_filename
+
+logger = get_logger(__name__)
+
+# 照片存放目錄
+GFRIENDS_DIR: Path = Path(__file__).parent.parent / "output" / "Gfriends"
+
+# HTTP 請求基本 headers
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+# Content-Type → 副檔名對應表
+CONTENT_TYPE_MAP: dict[str, str] = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/webp": ".webp",
+    "image/png": ".png",
+    "image/gif": ".gif",
+}
+
+# photo_source → Referer 對應表
+REFERER_MAP: dict[str, str] = {
+    "graphis": "https://www.graphis.ne.jp/",
+    "gfriends": "https://github.com/gfriends/gfriends",
+    "wiki": "https://ja.wikipedia.org/",
+    "minnano": "https://www.minnano-av.com/",
+}
+
+
+def download_actress_photo(name: str, photo_url: str, photo_source: str) -> bool:
+    """
+    下載女優照片並儲存到 GFRIENDS_DIR。
+
+    Args:
+        name: 女優姓名（會經 sanitize_filename 處理）
+        photo_url: 照片 URL
+        photo_source: 來源識別碼，用於設定 Referer header
+
+    Returns:
+        True 表示成功，False 表示任何失敗
+    """
+    if not photo_url:
+        return False
+
+    GFRIENDS_DIR.mkdir(parents=True, exist_ok=True)
+    safe_name = sanitize_filename(name)
+
+    # 刪除同名的舊檔（副檔名可能不同）
+    for old_file in GFRIENDS_DIR.glob(f"{safe_name}.*"):
+        try:
+            old_file.unlink()
+        except Exception as e:
+            logger.warning(f"[actress_photo] 刪除舊檔失敗 {old_file}: {e}")
+
+    try:
+        headers = _HEADERS.copy()
+        referer = REFERER_MAP.get(photo_source, "")
+        if referer:
+            headers["Referer"] = referer
+
+        resp = requests.get(photo_url, headers=headers, timeout=15)
+
+        if resp.status_code != 200:
+            logger.warning(
+                f"[actress_photo] 下載失敗，HTTP {resp.status_code}：{photo_url}"
+            )
+            return False
+
+        # 推斷副檔名
+        content_type = resp.headers.get("Content-Type", "").split(";")[0].strip().lower()
+        ext = CONTENT_TYPE_MAP.get(content_type)
+        if not ext:
+            # fallback：從 URL 路徑最後一段取副檔名
+            url_path = photo_url.split("?")[0]
+            suffix = Path(url_path).suffix.lower()
+            ext = suffix if suffix in {".jpg", ".jpeg", ".png", ".webp", ".gif"} else ".jpg"
+        if ext == ".jpeg":
+            ext = ".jpg"
+
+        save_path = GFRIENDS_DIR / f"{safe_name}{ext}"
+        save_path.write_bytes(resp.content)
+        logger.info(f"[actress_photo] 下載完成：{save_path}")
+        return True
+
+    except Exception as e:
+        logger.warning(f"[actress_photo] 下載例外 ({name}): {e}")
+        return False
+
+
+def get_local_photo_path(name: str) -> Optional[Path]:
+    """
+    取得女優本地照片路徑。
+
+    Returns:
+        找到回 Path，不存在回 None
+    """
+    safe_name = sanitize_filename(name)
+    matches = list(GFRIENDS_DIR.glob(f"{safe_name}.*"))
+    return matches[0] if matches else None
+
+
+def delete_local_photo(name: str) -> bool:
+    """
+    刪除女優的本地照片（idempotent）。
+
+    Returns:
+        True（含無檔案可刪），exception 時回 False
+    """
+    try:
+        safe_name = sanitize_filename(name)
+        for file in GFRIENDS_DIR.glob(f"{safe_name}.*"):
+            file.unlink()
+        return True
+    except Exception as e:
+        logger.warning(f"[actress_photo] 刪除失敗 ({name}): {e}")
+        return False

--- a/core/database.py
+++ b/core/database.py
@@ -91,6 +91,33 @@ def init_db(db_path: Path = None) -> None:
         CREATE INDEX IF NOT EXISTS idx_actress_aliases_new_name ON actress_aliases(new_name)
     """)
 
+    # 創建女優資料表
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS actresses (
+            name TEXT PRIMARY KEY,
+            name_en TEXT,
+            birth TEXT,
+            height TEXT,
+            cup TEXT,
+            bust INTEGER,
+            waist INTEGER,
+            hip INTEGER,
+            hometown TEXT,
+            hobby TEXT,
+            aliases TEXT DEFAULT '[]',
+            agency TEXT,
+            debut_work TEXT,
+            tags TEXT DEFAULT '[]',
+            nickname TEXT,
+            blog_url TEXT,
+            official_url TEXT,
+            photo_source TEXT,
+            primary_text_source TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
     # 插入種子資料（只在表格為空時插入，避免刪除後又重新插入）
     cursor.execute("SELECT COUNT(*) FROM actress_aliases")
     if cursor.fetchone()[0] == 0:
@@ -843,5 +870,180 @@ class ActressAliasRepository:
                 (count, id)
             )
             conn.commit()
+        finally:
+            conn.close()
+
+
+@dataclass
+class Actress:
+    """女優資料模型"""
+    name: str = ""
+    name_en: Optional[str] = None
+    birth: Optional[str] = None
+    height: Optional[str] = None
+    cup: Optional[str] = None
+    bust: Optional[int] = None
+    waist: Optional[int] = None
+    hip: Optional[int] = None
+    hometown: Optional[str] = None
+    hobby: Optional[str] = None
+    aliases: List[str] = field(default_factory=list)  # JSON
+    agency: Optional[str] = None
+    debut_work: Optional[str] = None
+    tags: List[str] = field(default_factory=list)  # JSON
+    nickname: Optional[str] = None
+    blog_url: Optional[str] = None
+    official_url: Optional[str] = None
+    photo_source: Optional[str] = None
+    primary_text_source: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def to_dict(self) -> dict:
+        """轉為字典（JSON 欄位序列化）"""
+        data = asdict(self)
+        data['aliases'] = json.dumps(self.aliases, ensure_ascii=False)
+        data['tags'] = json.dumps(self.tags, ensure_ascii=False)
+        if self.created_at:
+            data['created_at'] = self.created_at.isoformat()
+        if self.updated_at:
+            data['updated_at'] = self.updated_at.isoformat()
+        return data
+
+    @classmethod
+    def from_row(cls, row: tuple, columns: List[str]) -> 'Actress':
+        """從資料庫 row 建立"""
+        data = dict(zip(columns, row))
+
+        if 'aliases' in data and data['aliases']:
+            try:
+                data['aliases'] = json.loads(data['aliases'])
+            except json.JSONDecodeError:
+                data['aliases'] = []
+        else:
+            data['aliases'] = []
+
+        if 'tags' in data and data['tags']:
+            try:
+                data['tags'] = json.loads(data['tags'])
+            except json.JSONDecodeError:
+                data['tags'] = []
+        else:
+            data['tags'] = []
+
+        if 'created_at' in data and data['created_at']:
+            if isinstance(data['created_at'], str):
+                data['created_at'] = datetime.fromisoformat(data['created_at'])
+
+        if 'updated_at' in data and data['updated_at']:
+            if isinstance(data['updated_at'], str):
+                data['updated_at'] = datetime.fromisoformat(data['updated_at'])
+
+        return cls(**data)
+
+
+class ActressRepository:
+    """女優資料存取層"""
+
+    def __init__(self, db_path: Path = None):
+        self.db_path = db_path or get_db_path()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """取得資料庫連線"""
+        return get_connection(self.db_path)
+
+    def _get_columns(self) -> List[str]:
+        """取得欄位名稱列表"""
+        return [
+            'name', 'name_en', 'birth', 'height', 'cup',
+            'bust', 'waist', 'hip', 'hometown', 'hobby',
+            'aliases', 'agency', 'debut_work', 'tags', 'nickname',
+            'blog_url', 'official_url', 'photo_source', 'primary_text_source',
+            'created_at', 'updated_at',
+        ]
+
+    def save(self, actress: Actress) -> None:
+        """新增或更新女優（根據 name 判斷）"""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            actress_dict = actress.to_dict()
+            actress_dict.pop('created_at', None)
+            actress_dict.pop('updated_at', None)
+
+            columns = list(actress_dict.keys())
+            placeholders = ', '.join(['?'] * len(columns))
+            update_parts = [
+                f"{col} = excluded.{col}"
+                for col in columns
+                if col != 'name'
+            ]
+            update_clause = ', '.join(update_parts)
+
+            sql = f"""
+                INSERT INTO actresses ({', '.join(columns)})
+                VALUES ({placeholders})
+                ON CONFLICT(name) DO UPDATE SET
+                    {update_clause},
+                    updated_at = CURRENT_TIMESTAMP
+            """
+
+            cursor.execute(sql, list(actress_dict.values()))
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_by_name(self, name: str) -> Optional[Actress]:
+        """根據 name 查詢"""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute("SELECT * FROM actresses WHERE name = ?", (name,))
+            row = cursor.fetchone()
+            if row:
+                return Actress.from_row(row, self._get_columns())
+            return None
+        finally:
+            conn.close()
+
+    def delete_by_name(self, name: str) -> bool:
+        """刪除女優資料
+
+        Returns:
+            bool: 是否成功刪除（不存在則回 False）
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute("DELETE FROM actresses WHERE name = ?", (name,))
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def get_all(self) -> List[Actress]:
+        """取得所有女優"""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute("SELECT * FROM actresses ORDER BY name")
+            rows = cursor.fetchall()
+            return [Actress.from_row(row, self._get_columns()) for row in rows]
+        finally:
+            conn.close()
+
+    def exists(self, name: str) -> bool:
+        """檢查女優是否存在"""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute("SELECT COUNT(*) FROM actresses WHERE name = ?", (name,))
+            row = cursor.fetchone()
+            return bool(row and row[0] > 0)
         finally:
             conn.close()

--- a/core/scrapers/actress/__init__.py
+++ b/core/scrapers/actress/__init__.py
@@ -1,1 +1,1 @@
-from core.scrapers.actress.orchestrator import get_actress_profile
+from core.scrapers.actress.orchestrator import get_actress_profile, get_cached_profile, ProfileResult

--- a/core/scrapers/actress/orchestrator.py
+++ b/core/scrapers/actress/orchestrator.py
@@ -9,10 +9,13 @@ Routes:
     TD-1     : current_age computed from text.birth, never read from source
 """
 
+from collections import namedtuple
 from datetime import datetime
 from typing import Optional, Dict
 
 from core.logger import get_logger
+
+ProfileResult = namedtuple("ProfileResult", ["data", "timed_out"])
 
 logger = get_logger(__name__)
 
@@ -74,21 +77,34 @@ def _compute_age_from_birth(birth: Optional[str]) -> Optional[int]:
     return age
 
 
-def get_actress_profile(name: str, makers: list = None) -> Optional[Dict]:
+def get_cached_profile(name: str) -> Optional[dict]:
+    """公開 cache 讀取 — 回傳 cached profile dict 或 None（不觸發 scrape）"""
+    import time
+    key = _normalize_name(name)
+    entry = _cache.get(key)
+    if entry and (time.time() - entry["timestamp"]) < _CACHE_TTL:
+        return entry["data"]
+    return None
+
+
+def get_actress_profile(name: str, makers: list = None) -> ProfileResult:
     """
     取得女優完整資料（minnano + wiki + graphis + gfriends 四來源並行）
 
     Phase 42b T3: 4-route parallel with C1 cascade, C4 mixed return shape, TD-1 age fix.
+    Phase 43 T3: 回傳 ProfileResult namedtuple（data, timed_out）。
 
     Args:
         name: 女優名稱（日文）
         makers: 片商名稱列表（從搜尋結果統計，用於 gfriends 查表）
 
     Returns:
-        C4 mixed shape dict (nested new fields + legacy flat shortcuts), or None if all sources miss.
+        ProfileResult(data=dict, timed_out=False) 若有資料；
+        ProfileResult(data=None, timed_out=True) 若全部 timeout；
+        ProfileResult(data=None, timed_out=False) 若全部 miss（非 timeout）。
     """
     import time
-    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
     from core.scrapers.actress.minnano_av import scrape_minnano_av
     from core.scrapers.actress.wiki_ja import scrape_wiki_ja
     from core.scrapers.actress.graphis import scrape_graphis_photo
@@ -99,7 +115,7 @@ def get_actress_profile(name: str, makers: list = None) -> Optional[Dict]:
     if cache_key in _cache:
         cached = _cache[cache_key]
         if time.time() - cached['timestamp'] < _CACHE_TTL:
-            return cached['data']
+            return ProfileResult(data=cached['data'], timed_out=False)
         else:
             del _cache[cache_key]  # 過期清理
 
@@ -111,27 +127,40 @@ def get_actress_profile(name: str, makers: list = None) -> Optional[Dict]:
     gfriends_future = executor.submit(lookup_gfriends, name, makers)
 
     start = time.time()
+    any_timed_out = False
 
     try:
         minnano_result = minnano_future.result(timeout=5)
+    except FuturesTimeoutError:
+        minnano_result = None
+        any_timed_out = True
     except Exception:
         minnano_result = None
 
     remaining = max(0, 5 - (time.time() - start))
     try:
         wiki_result = wiki_future.result(timeout=remaining)
+    except FuturesTimeoutError:
+        wiki_result = None
+        any_timed_out = True
     except Exception:
         wiki_result = None
 
     remaining = max(0, 5 - (time.time() - start))
     try:
         graphis_result = graphis_future.result(timeout=remaining)
+    except FuturesTimeoutError:
+        graphis_result = None
+        any_timed_out = True
     except Exception:
         graphis_result = None
 
     remaining = max(0, 5 - (time.time() - start))
     try:
         gfriends_url = gfriends_future.result(timeout=remaining)
+    except FuturesTimeoutError:
+        gfriends_url = None
+        any_timed_out = True
     except Exception:
         gfriends_url = None
 
@@ -139,7 +168,7 @@ def get_actress_profile(name: str, makers: list = None) -> Optional[Dict]:
 
     # Edge case: all routes returned nothing
     if not any([minnano_result, wiki_result, graphis_result, gfriends_url]):
-        return None
+        return ProfileResult(data=None, timed_out=any_timed_out)
 
     # C1 — text primary source cascade: Minnano → Wikipedia → Graphis → None
     # Each source must have meaningful text fields to be eligible (not just name_ja shell)
@@ -215,4 +244,4 @@ def get_actress_profile(name: str, makers: list = None) -> Optional[Dict]:
         'timestamp': time.time()
     }
 
-    return result
+    return ProfileResult(data=result, timed_out=False)

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/en.json
+++ b/locales/en.json
@@ -78,7 +78,16 @@
       "chinese_title_ai": "AI Translated Title"
     },
     "unit": {
-      "minutes": "min"
+      "minutes": "min",
+      "age": " y/o",
+      "cup": " cup"
+    },
+    "actress": {
+      "add_favorite": "Add to favorites",
+      "favorited": "Favorited",
+      "favorite_success": "Added to favorites",
+      "favorite_error": "Failed to add, please try again",
+      "favorite_timeout": "Request timed out, please try again"
     },
     "badge": {
       "subtitle": "Chinese Subtitles"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -78,7 +78,16 @@
       "chinese_title_ai": "AI 翻訳タイトル"
     },
     "unit": {
-      "minutes": "分"
+      "minutes": "分",
+      "age": "歳",
+      "cup": "カップ"
+    },
+    "actress": {
+      "add_favorite": "お気に入りに追加",
+      "favorited": "お気に入り済み",
+      "favorite_success": "お気に入りに追加しました",
+      "favorite_error": "追加に失敗しました。後でもう一度お試しください",
+      "favorite_timeout": "タイムアウトしました。後でもう一度お試しください"
     },
     "badge": {
       "subtitle": "中国語字幕"

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -78,7 +78,16 @@
       "chinese_title_ai": "AI 翻译标题"
     },
     "unit": {
-      "minutes": "分钟"
+      "minutes": "分钟",
+      "age": "岁",
+      "cup": "罩杯"
+    },
+    "actress": {
+      "add_favorite": "收藏此女优",
+      "favorited": "已收藏",
+      "favorite_success": "已成功收藏",
+      "favorite_error": "收藏失败，请稍后再试",
+      "favorite_timeout": "收藏超时，请稍后再试"
     },
     "badge": {
       "subtitle": "中文字幕"

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -78,7 +78,16 @@
       "chinese_title_ai": "AI 翻譯標題"
     },
     "unit": {
-      "minutes": "分鐘"
+      "minutes": "分鐘",
+      "age": "歲",
+      "cup": "罩杯"
+    },
+    "actress": {
+      "add_favorite": "收藏此女優",
+      "favorited": "已收藏",
+      "favorite_success": "已成功收藏",
+      "favorite_error": "收藏失敗，請稍後再試",
+      "favorite_timeout": "收藏逾時，請稍後再試"
     },
     "badge": {
       "subtitle": "中文字幕"

--- a/tests/integration/test_actress_profile.py
+++ b/tests/integration/test_actress_profile.py
@@ -465,24 +465,28 @@ def mock_search_actress():
 
 @pytest.fixture
 def mock_actress_profile():
-    """Mock 女優資料"""
+    """Mock 女優資料（回傳 ProfileResult namedtuple，T3 後的型別）"""
+    from core.scrapers.actress.orchestrator import ProfileResult
+
     def mock_fn(name, **kwargs):
         if name == '桜空もも':
-            return {
+            data = {
                 'name': '桜空もも',
                 'img': 'https://graphis.ne.jp/prof.jpg',
                 'backdrop': 'https://graphis.ne.jp/model.jpg',
                 'birth': '1996-12-03',
                 'age': 29
             }
-        return None
+            return ProfileResult(data=data, timed_out=False)
+        return ProfileResult(data=None, timed_out=False)
     return mock_fn
 
 
 def test_search_api_actress_with_profile(client, mock_search_actress, mock_actress_profile):
     """測試女優搜尋 API（有 actress_profile）"""
     with patch('web.routers.search.search_actress', side_effect=mock_search_actress), \
-         patch('core.scrapers.actress.orchestrator.get_actress_profile', side_effect=mock_actress_profile):
+         patch('core.scrapers.actress.orchestrator.get_actress_profile', side_effect=mock_actress_profile), \
+         patch('core.database.ActressRepository.get_by_name', return_value=None):
 
         resp = client.get("/api/search?q=桜空もも&mode=actress")
         data = resp.json()
@@ -559,9 +563,13 @@ def test_search_api_few_results_no_profile(client):
 
 def test_search_api_graceful_failure(client, mock_search_actress):
     """測試雙來源失敗時不影響搜尋結果"""
-    # Mock 雙來源都失敗
+    from core.scrapers.actress.orchestrator import ProfileResult
+
+    # Mock 雙來源都失敗（orchestrator 回傳 ProfileResult(data=None)）
     with patch('web.routers.search.search_actress', side_effect=mock_search_actress), \
-         patch('core.scrapers.actress.orchestrator.get_actress_profile', return_value=None):
+         patch('core.scrapers.actress.orchestrator.get_actress_profile',
+               return_value=ProfileResult(data=None, timed_out=False)), \
+         patch('core.database.ActressRepository.get_by_name', return_value=None):
 
         resp = client.get("/api/search?q=桜空もも&mode=actress")
         data = resp.json()
@@ -965,6 +973,8 @@ def test_get_actress_profile_gfriends_only():
 
 def test_search_api_passes_makers_to_profile(client):
     """REST /api/search 路徑：_extract_top_makers 的結果應傳給 get_actress_profile"""
+    from core.scrapers.actress.orchestrator import ProfileResult
+
     def mock_smart_search(q, **kwargs):
         return [
             {'number': 'SONE-205', 'actors': ['桜空もも']},
@@ -972,15 +982,16 @@ def test_search_api_passes_makers_to_profile(client):
             {'number': 'SONE-162', 'actors': ['桜空もも']},
         ]
 
-    mock_profile = MagicMock(return_value={
+    mock_profile = MagicMock(return_value=ProfileResult(data={
         'name': '桜空もも',
         'img': 'https://graphis.ne.jp/prof.jpg',
         'backdrop': 'https://graphis.ne.jp/model.jpg',
-    })
+    }, timed_out=False))
 
     # Patch smart_search in the router's own namespace (it's imported at module load time)
     with patch('web.routers.search.smart_search', side_effect=mock_smart_search), \
-         patch('core.scrapers.actress.orchestrator.get_actress_profile', mock_profile):
+         patch('core.scrapers.actress.orchestrator.get_actress_profile', mock_profile), \
+         patch('core.database.ActressRepository.get_by_name', return_value=None):
 
         resp = client.get("/api/search?q=桜空もも")
         data = resp.json()
@@ -999,6 +1010,8 @@ def test_search_api_passes_makers_to_profile(client):
 
 def test_sse_passes_makers_to_profile(client):
     """SSE /api/search/stream 路徑：_extract_top_makers 的結果應傳給 get_actress_profile"""
+    from core.scrapers.actress.orchestrator import ProfileResult
+
     def mock_smart_search(q, **kwargs):
         return [
             {'number': 'SONE-205', 'actors': ['桜空もも']},
@@ -1006,14 +1019,15 @@ def test_sse_passes_makers_to_profile(client):
             {'number': 'SONE-162', 'actors': ['桜空もも']},
         ]
 
-    mock_profile = MagicMock(return_value={
+    mock_profile = MagicMock(return_value=ProfileResult(data={
         'name': '桜空もも',
         'img': 'https://graphis.ne.jp/prof.jpg',
         'backdrop': 'https://graphis.ne.jp/model.jpg',
-    })
+    }, timed_out=False))
 
     with patch('web.routers.search.smart_search', side_effect=mock_smart_search), \
-         patch('core.scrapers.actress.orchestrator.get_actress_profile', mock_profile):
+         patch('core.scrapers.actress.orchestrator.get_actress_profile', mock_profile), \
+         patch('core.database.ActressRepository.get_by_name', return_value=None):
 
         response = client.get('/api/search/stream?q=桜空もも')
 

--- a/tests/integration/test_actress_profile.py
+++ b/tests/integration/test_actress_profile.py
@@ -187,16 +187,17 @@ def test_get_actress_profile_both_sources():
 
         result = get_actress_profile("桜空もも")
 
-        assert result is not None
+        assert result.data is not None
         # Graphis 照片優先（gfriends 回傳 None）
-        assert result['img'] == 'https://graphis.ne.jp/prof.jpg'
-        assert result['backdrop'] == 'https://graphis.ne.jp/model.jpg'
+        assert result.data['img'] == 'https://graphis.ne.jp/prof.jpg'
+        assert result.data['backdrop'] == 'https://graphis.ne.jp/model.jpg'
 
         # graphis text wins cascade (minnano/wiki mocked None by T4.3)
-        assert result['birth'] == '1997-12-03'   # from graphis (via text cascade)
-        assert result['age'] == 28                # TD-1: from birth 1997-12-03 + frozen 2026-04-11
-        assert result['height'] == '160cm'
-        assert result['cup'] == 'G'
+        assert result.data['birth'] == '1997-12-03'   # from graphis (via text cascade)
+        assert result.data['age'] == 28                # TD-1: from birth 1997-12-03 + frozen 2026-04-11
+        assert result.data['height'] == '160cm'
+        assert result.data['cup'] == 'G'
+        assert result.timed_out is False
 
 
 
@@ -219,10 +220,11 @@ def test_get_actress_profile_graphis_only():
 
         result = get_actress_profile("桜空もも")
 
-        assert result is not None
-        assert result['name'] == '桜空もも'
-        assert result['img'] == 'https://graphis.ne.jp/prof.jpg'
-        assert result['backdrop'] == 'https://graphis.ne.jp/model.jpg'
+        assert result.data is not None
+        assert result.data['name'] == '桜空もも'
+        assert result.data['img'] == 'https://graphis.ne.jp/prof.jpg'
+        assert result.data['backdrop'] == 'https://graphis.ne.jp/model.jpg'
+        assert result.timed_out is False
 
 
 def test_get_actress_profile_both_fail():
@@ -235,7 +237,8 @@ def test_get_actress_profile_both_fail():
          patch('core.scrapers.actress.gfriends.lookup_gfriends', return_value=None):
 
         result = get_actress_profile("不存在的女優")
-        assert result is None
+        assert result.data is None
+        assert result.timed_out is False
 
 
 # ============================================================================
@@ -260,13 +263,13 @@ def test_get_actress_profile_cache_hit():
 
         # 第一次呼叫
         result1 = get_actress_profile("桜空もも")
-        assert result1 is not None
+        assert result1.data is not None
         assert graphis_mock.call_count == 1
 
         # 第二次呼叫（應從 cache 取得）
         result2 = get_actress_profile("桜空もも")
-        assert result2 is not None
-        assert result1 == result2
+        assert result2.data is not None
+        assert result1.data == result2.data
         # Mock 不應被再次呼叫
         assert graphis_mock.call_count == 1
 
@@ -296,7 +299,7 @@ def test_get_actress_profile_cache_expired():
 
         # 第一次呼叫
         result1 = get_actress_profile("桜空もも")
-        assert result1 is not None
+        assert result1.data is not None
         assert graphis_mock.call_count == 1
 
         # 模擬時間過期（超過 TTL）
@@ -304,7 +307,7 @@ def test_get_actress_profile_cache_expired():
 
         # 第二次呼叫（應重新抓取）
         result2 = get_actress_profile("桜空もも")
-        assert result2 is not None
+        assert result2.data is not None
         assert graphis_mock.call_count == 2  # 應被再次呼叫
 
 
@@ -326,13 +329,13 @@ def test_get_actress_profile_cache_name_normalization():
 
         # 第一次：正常名稱
         result1 = get_actress_profile("桜空もも")
-        assert result1 is not None
+        assert result1.data is not None
         assert graphis_mock.call_count == 1
 
         # 第二次：帶前後空白（應命中 cache）
         result2 = get_actress_profile("  桜空もも  ")
-        assert result2 is not None
-        assert result1 == result2
+        assert result2.data is not None
+        assert result1.data == result2.data
         assert graphis_mock.call_count == 1  # 不應再次呼叫
 
 
@@ -865,11 +868,12 @@ def test_get_actress_profile_gfriends_wins():
 
         result = get_actress_profile("桜空もも", makers=['S1'])
 
-        assert result is not None
+        assert result.data is not None
         # gfriends wins photo cascade (graphis has no prof_url, javbus is ignored)
-        assert result['img'] == gfriends_url
+        assert result.data['img'] == gfriends_url
         # Backdrop still comes from graphis
-        assert result['backdrop'] == 'https://graphis.ne.jp/model.jpg'
+        assert result.data['backdrop'] == 'https://graphis.ne.jp/model.jpg'
+        assert result.timed_out is False
 
 
 def test_get_actress_profile_graphis_text_wins():
@@ -888,11 +892,12 @@ def test_get_actress_profile_graphis_text_wins():
 
         result = get_actress_profile("桜空もも")
 
-        assert result is not None
+        assert result.data is not None
         # Graphis text wins
-        assert result['age'] == 28
-        assert result['height'] == '160cm'
-        assert result['cup'] == 'G'
+        assert result.data['age'] == 28
+        assert result.data['height'] == '160cm'
+        assert result.data['cup'] == 'G'
+        assert result.timed_out is False
 
 
 def test_get_actress_profile_name_en():
@@ -906,8 +911,9 @@ def test_get_actress_profile_name_en():
 
         result = get_actress_profile("桜空もも")
 
-        assert result is not None
-        assert result.get('name_en') == 'Momo Sakurazora'
+        assert result.data is not None
+        assert result.data.get('name_en') == 'Momo Sakurazora'
+        assert result.timed_out is False
 
 
 def test_get_actress_profile_birth_from_graphis():
@@ -925,11 +931,12 @@ def test_get_actress_profile_birth_from_graphis():
 
         result = get_actress_profile("桜空もも")
 
-        assert result is not None
+        assert result.data is not None
         # birth comes from graphis cascade winner (javbus ignored)
-        assert result.get('birth') == '1997-12-03'
+        assert result.data.get('birth') == '1997-12-03'
         # hometown is None: graphis has no hometown, javbus is ignored
-        assert result.get('hometown') is None
+        assert result.data.get('hometown') is None
+        assert result.timed_out is False
 
 
 def test_get_actress_profile_gfriends_only():
@@ -945,10 +952,11 @@ def test_get_actress_profile_gfriends_only():
 
         result = get_actress_profile("桜空もも", makers=['S1'])
 
-        assert result is not None
+        assert result.data is not None
         # Bug 2 fix: name falls back to queried name arg when all text sources are None
-        assert result['name'] == '桜空もも'
-        assert result['img'] == gfriends_url
+        assert result.data['name'] == '桜空もも'
+        assert result.data['img'] == gfriends_url
+        assert result.timed_out is False
 
 
 # ============================================================================

--- a/tests/integration/test_api_actress.py
+++ b/tests/integration/test_api_actress.py
@@ -1,0 +1,262 @@
+"""
+test_api_actress.py — 女優 API 整合測試
+
+使用 FastAPI TestClient + 真實 SQLite DB（tmp_path）。
+外部依賴（orchestrator + requests）全部 mock。
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+from core.database import init_db
+
+
+# ---------------------------------------------------------------------------
+# Mock data
+# ---------------------------------------------------------------------------
+
+MOCK_PROFILE = {
+    "name": "三上悠亜",
+    "name_en": "Yua Mikami",
+    "text": {
+        "birth": "1993-08-16",
+        "height": "158cm",
+        "cup": "E",
+        "bust": "88",
+        "waist": "58",
+        "hip": "85",
+        "hometown": "東京都",
+        "hobby": "ゲーム",
+        "aliases": ["鬼頭桃菜"],
+        "agency": None,
+        "debut_work": None,
+        "tags": ["美少女", "巨乳"],
+        "nickname": None,
+        "blog_url": "https://example.com",
+        "official_url": None,
+    },
+    "photo_url": "https://example.com/photo.jpg",
+    "photo_source": "gfriends",
+    "img": "https://example.com/photo.jpg",
+    "primary_text_source": "minnano",
+}
+
+ACTRESS_NAME = "三上悠亜"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """建立臨時測試資料庫（空 DB，無預置資料）"""
+    db_path = tmp_path / "test_actress.db"
+    init_db(db_path)
+    return db_path
+
+
+@pytest.fixture
+def client(tmp_db, monkeypatch):
+    """TestClient，monkeypatch get_db_path 指向 tmp DB，mock 外部依賴"""
+    # actress router 從 core.database 匯入 ActressRepository / init_db，
+    # 兩者都透過 core.database.get_db_path() 取得路徑，因此 patch core 層
+    monkeypatch.setattr("core.database.get_db_path", lambda: tmp_db)
+
+    from web.app import app
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# T1: POST /api/actresses/favorite — 成功收藏
+# ---------------------------------------------------------------------------
+
+class TestAddFavorite:
+    """POST /api/actresses/favorite 測試"""
+
+    def test_add_favorite_success(self, client):
+        """mock orchestrator 回 profile → 200，DB 存入，photo_downloaded 有值"""
+        with patch("web.routers.actress.get_cached_profile", return_value=None), \
+             patch("web.routers.actress.get_actress_profile") as mock_get_profile, \
+             patch("web.routers.actress.download_actress_photo", return_value=True), \
+             patch("web.routers.actress.get_local_photo_path", return_value=None):
+
+            from core.scrapers.actress.orchestrator import ProfileResult
+            mock_get_profile.return_value = ProfileResult(data=MOCK_PROFILE, timed_out=False)
+
+            resp = client.post("/api/actresses/favorite", json={"name": ACTRESS_NAME})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["photo_downloaded"] is True
+        actress = data["actress"]
+        assert actress["name"] == ACTRESS_NAME
+        assert actress["name_en"] == "Yua Mikami"
+        assert actress["birth"] == "1993-08-16"
+        assert actress["cup"] == "E"
+
+    def test_add_favorite_uses_cache_hit(self, client):
+        """cache hit → 不呼叫 get_actress_profile，直接存入 DB"""
+        with patch("web.routers.actress.get_cached_profile", return_value=MOCK_PROFILE), \
+             patch("web.routers.actress.get_actress_profile") as mock_get_profile, \
+             patch("web.routers.actress.download_actress_photo", return_value=True), \
+             patch("web.routers.actress.get_local_photo_path", return_value=None):
+
+            resp = client.post("/api/actresses/favorite", json={"name": ACTRESS_NAME})
+
+        assert resp.status_code == 200
+        mock_get_profile.assert_not_called()
+
+    def test_add_favorite_duplicate_returns_409(self, client):
+        """同名再 POST → 409"""
+        # 先收藏一次
+        with patch("web.routers.actress.get_cached_profile", return_value=MOCK_PROFILE), \
+             patch("web.routers.actress.get_actress_profile"), \
+             patch("web.routers.actress.download_actress_photo", return_value=True), \
+             patch("web.routers.actress.get_local_photo_path", return_value=None):
+            client.post("/api/actresses/favorite", json={"name": ACTRESS_NAME})
+
+        # 第二次 POST → 409
+        with patch("web.routers.actress.get_local_photo_path", return_value=None):
+            resp = client.post("/api/actresses/favorite", json={"name": ACTRESS_NAME})
+
+        assert resp.status_code == 409
+        data = resp.json()
+        assert data["error"] == "already_exists"
+        assert "actress" in data
+
+    def test_add_favorite_not_found_returns_404(self, client):
+        """orchestrator 回 data=None, timed_out=False → 404"""
+        with patch("web.routers.actress.get_cached_profile", return_value=None), \
+             patch("web.routers.actress.get_actress_profile") as mock_get_profile:
+
+            from core.scrapers.actress.orchestrator import ProfileResult
+            mock_get_profile.return_value = ProfileResult(data=None, timed_out=False)
+
+            resp = client.post("/api/actresses/favorite", json={"name": "不存在女優XYZ"})
+
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["error"] == "not_found"
+
+    def test_add_favorite_timeout_returns_504(self, client):
+        """orchestrator 超時 → 504"""
+        with patch("web.routers.actress.get_cached_profile", return_value=None), \
+             patch("web.routers.actress.get_actress_profile") as mock_get_profile:
+
+            from core.scrapers.actress.orchestrator import ProfileResult
+            mock_get_profile.return_value = ProfileResult(data=None, timed_out=True)
+
+            resp = client.post("/api/actresses/favorite", json={"name": "タイムアウト女優"})
+
+        assert resp.status_code == 504
+        data = resp.json()
+        assert data["error"] == "timeout"
+
+    def test_add_favorite_empty_name_returns_422(self, client):
+        """空名稱 → 422"""
+        resp = client.post("/api/actresses/favorite", json={"name": ""})
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# T2: GET /api/actresses/{name} — 查詢已收藏女優
+# ---------------------------------------------------------------------------
+
+class TestGetActress:
+    """GET /api/actresses/{name} 測試"""
+
+    def test_get_actress_success(self, client):
+        """已收藏女優 → 200，is_favorite: True"""
+        # 先收藏
+        with patch("web.routers.actress.get_cached_profile", return_value=MOCK_PROFILE), \
+             patch("web.routers.actress.get_actress_profile"), \
+             patch("web.routers.actress.download_actress_photo", return_value=True), \
+             patch("web.routers.actress.get_local_photo_path", return_value=None):
+            client.post("/api/actresses/favorite", json={"name": ACTRESS_NAME})
+
+        # 查詢
+        with patch("web.routers.actress.get_local_photo_path", return_value=None):
+            resp = client.get(f"/api/actresses/{ACTRESS_NAME}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_favorite"] is True
+        actress = data["actress"]
+        assert actress["name"] == ACTRESS_NAME
+
+    def test_get_actress_not_found_returns_404(self, client):
+        """不存在的女優 → 404"""
+        resp = client.get("/api/actresses/不存在女優XYZ")
+
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["error"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# T3: DELETE /api/actresses/{name} — 刪除已收藏女優
+# ---------------------------------------------------------------------------
+
+class TestDeleteActress:
+    """DELETE /api/actresses/{name} 測試"""
+
+    def test_delete_actress_success(self, client):
+        """已收藏女優刪除 → 200，DB 刪除"""
+        # 先收藏
+        with patch("web.routers.actress.get_cached_profile", return_value=MOCK_PROFILE), \
+             patch("web.routers.actress.get_actress_profile"), \
+             patch("web.routers.actress.download_actress_photo", return_value=True), \
+             patch("web.routers.actress.get_local_photo_path", return_value=None):
+            client.post("/api/actresses/favorite", json={"name": ACTRESS_NAME})
+
+        # 刪除
+        with patch("web.routers.actress.delete_local_photo", return_value=True):
+            resp = client.delete(f"/api/actresses/{ACTRESS_NAME}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+
+        # 確認 DB 已刪除
+        resp2 = client.get(f"/api/actresses/{ACTRESS_NAME}")
+        assert resp2.status_code == 404
+
+    def test_delete_actress_not_found_returns_404(self, client):
+        """刪除不存在的女優 → 404"""
+        resp = client.delete("/api/actresses/不存在女優XYZ")
+
+        assert resp.status_code == 404
+        data = resp.json()
+        assert data["error"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# T4: GET /api/actresses/photo/{name} — 本地照片 binary response
+# ---------------------------------------------------------------------------
+
+class TestGetActressPhoto:
+    """GET /api/actresses/photo/{name} 測試"""
+
+    def test_get_photo_success(self, client, tmp_path):
+        """有本地檔案 → 200 + binary content"""
+        # 建立假照片檔案
+        fake_photo = tmp_path / "photo.jpg"
+        fake_photo.write_bytes(b"\xff\xd8\xff\xe0fake_jpeg_content")
+
+        with patch("web.routers.actress.get_local_photo_path", return_value=fake_photo):
+            resp = client.get(f"/api/actresses/photo/{ACTRESS_NAME}")
+
+        assert resp.status_code == 200
+        assert resp.content == b"\xff\xd8\xff\xe0fake_jpeg_content"
+        assert "image/jpeg" in resp.headers["content-type"]
+
+    def test_get_photo_not_found_returns_404(self, client):
+        """無本地照片 → 404"""
+        with patch("web.routers.actress.get_local_photo_path", return_value=None):
+            resp = client.get(f"/api/actresses/photo/{ACTRESS_NAME}")
+
+        assert resp.status_code == 404

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -96,7 +96,7 @@ class TestScannerAPI:
         response = client.get("/api/gallery/player")
         assert response.status_code == 422
         data = response.json()
-        assert data["detail"][0]["type"] == "missing"
+        assert data["error"] == "validation_error"
 
 
 # ============ POST /api/gallery/generate-from-ids ============

--- a/tests/integration/test_api_search.py
+++ b/tests/integration/test_api_search.py
@@ -453,10 +453,15 @@ class TestSearchStreamSSE:
                 status_callback('done', f'found:{len(ids)}')
             return items_list
 
-        mock_profile = {'name': '桜空もも', 'img': 'https://graphis.ne.jp/prof.jpg'}
+        from core.scrapers.actress.orchestrator import ProfileResult
+        mock_profile = ProfileResult(
+            data={'name': '桜空もも', 'img': 'https://graphis.ne.jp/prof.jpg'},
+            timed_out=False
+        )
 
         with patch('web.routers.search.smart_search', side_effect=mock_smart_search), \
-             patch('core.scrapers.actress.orchestrator.get_actress_profile', return_value=mock_profile):
+             patch('core.scrapers.actress.orchestrator.get_actress_profile', return_value=mock_profile), \
+             patch('core.database.ActressRepository.get_by_name', return_value=None):
             response = client.get('/api/search/stream?q=桜空もも')
 
         events = parse_sse_events(response.text)

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -2175,8 +2175,8 @@ class TestHeroImageErrorGuard:
         # 找到 hero-card class 屬性（排除註解）
         match = re.search(r'class="[^"]*hero-card[^"]*"', content)
         assert match, "search.html 缺少 hero-card class 區塊"
-        # 取 hero-card 區塊（往後 800 字元足以覆蓋 img tag）
-        hero_block = content[match.start():match.start() + 800]
+        # 取 hero-card 區塊（往後 1200 字元覆蓋 img tag + overlay）
+        hero_block = content[match.start():match.start() + 1200]
         # 提取 @error 屬性值
         error_match = re.search(r'@error="([^"]*)"', hero_block)
         assert error_match, "hero-card 區塊缺少 @error handler"
@@ -2191,7 +2191,7 @@ class TestHeroImageErrorGuard:
         content = self.SEARCH_HTML.read_text(encoding='utf-8')
         match = re.search(r'class="[^"]*hero-card[^"]*"', content)
         assert match, "search.html 缺少 hero-card class 區塊"
-        hero_block = content[match.start():match.start() + 800]
+        hero_block = content[match.start():match.start() + 1200]
         error_match = re.search(r'@error="([^"]*)"', hero_block)
         assert error_match, "hero-card 區塊缺少 @error handler"
         error_value = error_match.group(1)

--- a/tests/unit/test_actress_aliases_flatten.py
+++ b/tests/unit/test_actress_aliases_flatten.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for _flatten_aliases helper in web/routers/actress.py
+
+Tests the 6 specified cases:
+1. dict list (minnano format) → extract "ja" field
+2. string list (wiki format) → pass-through unchanged
+3. empty list → []
+4. None → []
+5. mixed dict + str → handle both correctly
+6. dict without "ja" key → fallback to empty string
+"""
+
+import pytest
+from web.routers.actress import _flatten_aliases
+
+
+class TestFlattenAliases:
+    def test_dict_list_minnano_format(self):
+        """minnano scraper 回傳 dict list，應取出 ja 欄"""
+        raw = [{"ja": "笹川そら", "hiragana": "ささがわそら", "romaji": "Sasagawa Sora"}]
+        assert _flatten_aliases(raw) == ["笹川そら"]
+
+    def test_string_list_wiki_format(self):
+        """wiki scraper 回傳純字串 list，應保持不變"""
+        raw = ["上川星空", "笹川そら"]
+        assert _flatten_aliases(raw) == ["上川星空", "笹川そら"]
+
+    def test_empty_list(self):
+        """空 list → 回傳空 list"""
+        assert _flatten_aliases([]) == []
+
+    def test_none_input(self):
+        """None → 回傳空 list"""
+        assert _flatten_aliases(None) == []
+
+    def test_mixed_dict_and_str(self):
+        """混合 dict + str → 正確處理兩種型別"""
+        raw = [{"ja": "A"}, "B"]
+        assert _flatten_aliases(raw) == ["A", "B"]
+
+    def test_dict_without_ja_key(self):
+        """dict 無 ja key → fallback 空字串"""
+        raw = [{"en": "foo"}]
+        assert _flatten_aliases(raw) == [""]

--- a/tests/unit/test_actress_photo.py
+++ b/tests/unit/test_actress_photo.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for core/actress_photo.py
+Tests cover: download, rescrape, exception handling, HTTP errors, delete, special chars
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import core.actress_photo as actress_photo
+from core.actress_photo import (
+    download_actress_photo,
+    get_local_photo_path,
+    delete_local_photo,
+)
+
+
+@pytest.fixture
+def gfriends_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr('core.actress_photo.GFRIENDS_DIR', tmp_path / "Gfriends")
+    return tmp_path / "Gfriends"
+
+
+def make_mock_response(status_code=200, content_type="image/jpeg", content=b"fake_image_data"):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.headers = {"Content-Type": content_type}
+    mock_resp.content = content
+    return mock_resp
+
+
+# -------------------------------------------------------------------
+# Test 1: download 成功 + get_local_photo_path 找到
+# -------------------------------------------------------------------
+def test_download_success_and_get_local_path(gfriends_dir):
+    """download_actress_photo() 成功下載後，get_local_photo_path() 能找到檔案"""
+    mock_resp = make_mock_response(status_code=200, content_type="image/jpeg")
+    with patch("core.actress_photo.requests.get", return_value=mock_resp):
+        result = download_actress_photo("田中美久", "https://example.com/photo.jpg", "gfriends")
+
+    assert result is True
+    assert gfriends_dir.exists()
+    found = get_local_photo_path("田中美久")
+    assert found is not None
+    assert found.suffix == ".jpg"
+    assert found.exists()
+
+
+# -------------------------------------------------------------------
+# Test 2: 同名 rescrape（.jpg → .webp），舊檔被刪
+# -------------------------------------------------------------------
+def test_rescrape_old_file_deleted(gfriends_dir):
+    """rescrape 時舊副檔名的檔案被刪，只剩新副檔名的檔案"""
+    # 先建立 Gfriends dir 並放一個舊的 .jpg 檔
+    gfriends_dir.mkdir(parents=True, exist_ok=True)
+    old_file = gfriends_dir / "田中美久.jpg"
+    old_file.write_bytes(b"old_jpeg_data")
+    assert old_file.exists()
+
+    # 再次下載，但這次 Content-Type 是 webp
+    mock_resp = make_mock_response(status_code=200, content_type="image/webp")
+    with patch("core.actress_photo.requests.get", return_value=mock_resp):
+        result = download_actress_photo("田中美久", "https://example.com/photo.webp", "gfriends")
+
+    assert result is True
+    # 舊 .jpg 應該被刪掉
+    assert not old_file.exists()
+    # 新 .webp 應該存在
+    new_file = gfriends_dir / "田中美久.webp"
+    assert new_file.exists()
+    # 目錄裡只有一個檔案
+    files = list(gfriends_dir.glob("田中美久.*"))
+    assert len(files) == 1
+
+
+# -------------------------------------------------------------------
+# Test 3: requests exception → False
+# -------------------------------------------------------------------
+def test_download_requests_exception(gfriends_dir):
+    """requests.get() 拋例外時，download_actress_photo() 回 False，不 re-raise"""
+    import requests as req_module
+    with patch("core.actress_photo.requests.get", side_effect=req_module.exceptions.ConnectionError("no conn")):
+        result = download_actress_photo("佐藤みき", "https://example.com/photo.jpg", "graphis")
+
+    assert result is False
+
+
+# -------------------------------------------------------------------
+# Test 4: HTTP 非 200 → False
+# -------------------------------------------------------------------
+def test_download_http_non_200(gfriends_dir):
+    """HTTP status != 200 時回 False，不寫檔"""
+    mock_resp = make_mock_response(status_code=404, content_type="text/html", content=b"not found")
+    with patch("core.actress_photo.requests.get", return_value=mock_resp):
+        result = download_actress_photo("鈴木りん", "https://example.com/photo.jpg", "wiki")
+
+    assert result is False
+    # 目錄不存在或目錄為空（沒有寫任何檔案）
+    if gfriends_dir.exists():
+        files = list(gfriends_dir.glob("鈴木りん.*"))
+        assert len(files) == 0
+
+
+# -------------------------------------------------------------------
+# Test 5: delete_local_photo 後 get_local_photo_path 回 None
+# -------------------------------------------------------------------
+def test_delete_photo_then_get_returns_none(gfriends_dir):
+    """delete_local_photo() 後 get_local_photo_path() 回 None"""
+    # 先下載一張
+    mock_resp = make_mock_response(status_code=200, content_type="image/png")
+    with patch("core.actress_photo.requests.get", return_value=mock_resp):
+        download_actress_photo("青山あかね", "https://example.com/photo.png", "minnano")
+
+    # 確認下載成功
+    assert get_local_photo_path("青山あかね") is not None
+
+    # 刪除
+    deleted = delete_local_photo("青山あかね")
+    assert deleted is True
+
+    # 現在應回 None
+    assert get_local_photo_path("青山あかね") is None
+
+
+# -------------------------------------------------------------------
+# Test 6: 特殊字元女優名（含 ·）
+# -------------------------------------------------------------------
+def test_special_chars_actress_name(gfriends_dir):
+    """含 · 的女優名可正常下載與讀取；/ \\ : 等非法字元被替換為空格"""
+    mock_resp = make_mock_response(status_code=200, content_type="image/jpeg")
+    with patch("core.actress_photo.requests.get", return_value=mock_resp):
+        result = download_actress_photo("田中·ナナ", "https://example.com/photo.jpg", "gfriends")
+
+    assert result is True
+    found = get_local_photo_path("田中·ナナ")
+    assert found is not None
+    # · 應被保留（不在 illegal_chars 中）
+    assert "田中·ナナ" in found.stem
+    assert found.exists()

--- a/tests/unit/test_actress_repository.py
+++ b/tests/unit/test_actress_repository.py
@@ -1,0 +1,166 @@
+"""Tests for Actress dataclass and ActressRepository in core/database.py"""
+import time
+import pytest
+from pathlib import Path
+
+from core.database import init_db, Actress, ActressRepository
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    path = tmp_path / "test.db"
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def repo(db_path: Path) -> ActressRepository:
+    return ActressRepository(db_path)
+
+
+# ---------------------------------------------------------------------------
+# save() + get_by_name()
+# ---------------------------------------------------------------------------
+
+def test_save_and_get_by_name(repo):
+    actress = Actress(name="深田えいみ", name_en="Eimi Fukada", height="163cm")
+    repo.save(actress)
+
+    result = repo.get_by_name("深田えいみ")
+    assert result is not None
+    assert result.name == "深田えいみ"
+    assert result.name_en == "Eimi Fukada"
+    assert result.height == "163cm"
+
+
+def test_get_by_name_not_found(repo):
+    result = repo.get_by_name("不存在的人")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# save() ON CONFLICT: updated_at 更新, created_at 保留（CD-12）
+# ---------------------------------------------------------------------------
+
+def test_save_upsert_preserves_created_at(repo):
+    actress = Actress(name="三上悠亞", height="157cm")
+    repo.save(actress)
+
+    first = repo.get_by_name("三上悠亞")
+    assert first is not None
+    created_at_first = first.created_at
+    updated_at_first = first.updated_at
+
+    # 稍等確保 CURRENT_TIMESTAMP 有機會不同
+    time.sleep(1.1)
+
+    actress2 = Actress(name="三上悠亞", height="158cm")
+    repo.save(actress2)
+
+    second = repo.get_by_name("三上悠亞")
+    assert second is not None
+    assert second.height == "158cm"
+    # created_at 不變
+    assert second.created_at == created_at_first
+    # updated_at 應更新（或至少不早於第一次）
+    assert second.updated_at >= updated_at_first
+
+
+# ---------------------------------------------------------------------------
+# delete_by_name()
+# ---------------------------------------------------------------------------
+
+def test_delete_by_name_existing(repo):
+    repo.save(Actress(name="橋本ありな"))
+    result = repo.delete_by_name("橋本ありな")
+    assert result is True
+    assert repo.get_by_name("橋本ありな") is None
+
+
+def test_delete_by_name_not_existing(repo):
+    result = repo.delete_by_name("不存在的人")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_all()
+# ---------------------------------------------------------------------------
+
+def test_get_all_correct_count(repo):
+    repo.save(Actress(name="女優A"))
+    repo.save(Actress(name="女優B"))
+    repo.save(Actress(name="女優C"))
+
+    all_actresses = repo.get_all()
+    assert len(all_actresses) == 3
+
+
+def test_get_all_empty(repo):
+    assert repo.get_all() == []
+
+
+# ---------------------------------------------------------------------------
+# exists()
+# ---------------------------------------------------------------------------
+
+def test_exists_true(repo):
+    repo.save(Actress(name="波多野結衣"))
+    assert repo.exists("波多野結衣") is True
+
+
+def test_exists_false(repo):
+    assert repo.exists("不存在的人") is False
+
+
+# ---------------------------------------------------------------------------
+# JSON 欄位（aliases, tags）序列化/反序列化
+# ---------------------------------------------------------------------------
+
+def test_json_fields_roundtrip(repo):
+    actress = Actress(
+        name="夢乃あいか",
+        aliases=["ゆめのあいか", "Aika Yumeno"],
+        tags=["美少女", "スレンダー"],
+    )
+    repo.save(actress)
+
+    result = repo.get_by_name("夢乃あいか")
+    assert result is not None
+    assert result.aliases == ["ゆめのあいか", "Aika Yumeno"]
+    assert result.tags == ["美少女", "スレンダー"]
+
+
+def test_json_fields_empty_list_default(repo):
+    actress = Actress(name="新ありな")
+    repo.save(actress)
+
+    result = repo.get_by_name("新ありな")
+    assert result is not None
+    assert result.aliases == []
+    assert result.tags == []
+
+
+# ---------------------------------------------------------------------------
+# bust/waist/hip None 值正確處理
+# ---------------------------------------------------------------------------
+
+def test_measurements_none(repo):
+    actress = Actress(name="測試女優A")
+    repo.save(actress)
+
+    result = repo.get_by_name("測試女優A")
+    assert result is not None
+    assert result.bust is None
+    assert result.waist is None
+    assert result.hip is None
+
+
+def test_measurements_with_values(repo):
+    actress = Actress(name="測試女優B", bust=88, waist=58, hip=86)
+    repo.save(actress)
+
+    result = repo.get_by_name("測試女優B")
+    assert result is not None
+    assert result.bust == 88
+    assert result.waist == 58
+    assert result.hip == 86

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -47,6 +47,9 @@ EXPECTED_TOOL_NAMES = {
     "get_user_tags",
     "showcase_videos",
     "showcase_video",
+    "favorite_actress",
+    "get_actress",
+    "unfavorite_actress",
 }
 
 REQUIRED_TOOL_FIELDS = [
@@ -93,9 +96,9 @@ class TestCapabilitiesEndpoint:
         data = client.get("/api/capabilities").json()
         assert "retry_hint" in data["error_format"]
 
-    def test_tools_count_is_19(self, client):
+    def test_tools_count_is_22(self, client):
         data = client.get("/api/capabilities").json()
-        assert len(data["tools"]) == 19
+        assert len(data["tools"]) == 22
 
     def test_all_tool_names_present(self, client):
         data = client.get("/api/capabilities").json()

--- a/tests/unit/test_scraper_actress_orchestrator.py
+++ b/tests/unit/test_scraper_actress_orchestrator.py
@@ -18,7 +18,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from core.scrapers.actress.orchestrator import get_actress_profile, _cache, _CACHE_TTL, _compute_age_from_birth
+from core.scrapers.actress.orchestrator import get_actress_profile, get_cached_profile, ProfileResult, _cache, _CACHE_TTL, _compute_age_from_birth
 
 # ---------------------------------------------------------------------------
 # Patch target constants
@@ -152,7 +152,9 @@ class TestHappyPath:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is not None
+        assert isinstance(result, ProfileResult)
+        assert result.data is not None
+        assert result.timed_out is False
 
     def test_primary_text_source_minnano(self):
         minnano = _make_minnano()
@@ -166,8 +168,9 @@ class TestHappyPath:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["primary_text_source"] == "minnano"
-        assert result["text"] == minnano
+        assert result.data["primary_text_source"] == "minnano"
+        assert result.data["text"] == minnano
+        assert result.timed_out is False
 
     def test_photo_cascade_graphis_wins(self):
         minnano = _make_minnano()
@@ -181,9 +184,10 @@ class TestHappyPath:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["photo_source"] == "graphis"
-        assert result["photo_url"] == graphis["prof_url"]
-        assert result["backdrop_url"] == graphis["backdrop_url"]
+        assert result.data["photo_source"] == "graphis"
+        assert result.data["photo_url"] == graphis["prof_url"]
+        assert result.data["backdrop_url"] == graphis["backdrop_url"]
+        assert result.timed_out is False
 
     def test_all_sources_dict(self):
         minnano = _make_minnano()
@@ -197,10 +201,11 @@ class TestHappyPath:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["all_sources"]["minnano"] == minnano
-        assert result["all_sources"]["wiki"] == wiki
-        assert result["all_sources"]["graphis"] == graphis
-        assert result["all_sources"]["gfriends"] == gfurl
+        assert result.data["all_sources"]["minnano"] == minnano
+        assert result.data["all_sources"]["wiki"] == wiki
+        assert result.data["all_sources"]["graphis"] == graphis
+        assert result.data["all_sources"]["gfriends"] == gfurl
+        assert result.timed_out is False
 
     def test_legacy_flat_name_and_img(self):
         minnano = _make_minnano()
@@ -212,8 +217,9 @@ class TestHappyPath:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["name"] == minnano["name_ja"]
-        assert result["img"] == result["photo_url"]
+        assert result.data["name"] == minnano["name_ja"]
+        assert result.data["img"] == result.data["photo_url"]
+        assert result.timed_out is False
 
 
 # ---------------------------------------------------------------------------
@@ -233,11 +239,12 @@ class TestC1Cascade:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["primary_text_source"] == "wiki"
-        assert result["text"] == wiki
-        assert result["name"] == wiki["name_ja"]
+        assert result.data["primary_text_source"] == "wiki"
+        assert result.data["text"] == wiki
+        assert result.data["name"] == wiki["name_ja"]
         # Photo cascade: Graphis still wins because it has prof_url
-        assert result["photo_source"] == "graphis"
+        assert result.data["photo_source"] == "graphis"
+        assert result.timed_out is False
 
     def test_minnano_wiki_none_graphis_wins(self):
         graphis = _make_graphis()
@@ -249,15 +256,16 @@ class TestC1Cascade:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["primary_text_source"] == "graphis"
-        assert result["text"] == graphis
+        assert result.data["primary_text_source"] == "graphis"
+        assert result.data["text"] == graphis
         # Bug 2 fix: name falls back to queried name (text.name is "" in _make_graphis,
         # so the final fallback is the queried `name` arg)
-        assert result["name"] == _ACTRESS_NAME  # queried name fallback via text.name or name arg
+        assert result.data["name"] == _ACTRESS_NAME  # queried name fallback via text.name or name arg
         # Graphis has name_en
-        assert result["name_en"] == graphis["name_en"]
+        assert result.data["name_en"] == graphis["name_en"]
         # Graphis has no birth key
-        assert result["birth"] is None
+        assert result.data["birth"] is None
+        assert result.timed_out is False
 
     def test_all_four_none_returns_none(self):
         with patch(_PATCH_MINNANO, return_value=None), \
@@ -266,7 +274,9 @@ class TestC1Cascade:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is None
+        assert isinstance(result, ProfileResult)
+        assert result.data is None
+        assert result.timed_out is False
 
 
 # ---------------------------------------------------------------------------
@@ -287,9 +297,10 @@ class TestPhotoCascade:
              patch(_PATCH_GFRIENDS, return_value=gfurl):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["photo_source"] == "gfriends"
-        assert result["photo_url"] == gfurl
-        assert result["img"] == gfurl
+        assert result.data["photo_source"] == "gfriends"
+        assert result.data["photo_url"] == gfurl
+        assert result.data["img"] == gfurl
+        assert result.timed_out is False
 
     def test_graphis_none_gfriends_none_wiki_wins(self):
         wiki = _make_wiki()
@@ -300,8 +311,9 @@ class TestPhotoCascade:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["photo_source"] == "wiki"
-        assert result["photo_url"] == wiki["photo_url"]
+        assert result.data["photo_source"] == "wiki"
+        assert result.data["photo_url"] == wiki["photo_url"]
+        assert result.timed_out is False
 
     def test_only_minnano_has_photo(self):
         minnano = _make_minnano()
@@ -312,8 +324,9 @@ class TestPhotoCascade:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["photo_source"] == "minnano"
-        assert result["photo_url"] == minnano["photo_url"]
+        assert result.data["photo_source"] == "minnano"
+        assert result.data["photo_url"] == minnano["photo_url"]
+        assert result.timed_out is False
 
 
 # ---------------------------------------------------------------------------
@@ -336,14 +349,16 @@ class TestTD1Age:
     def test_age_before_birthday_in_year(self):
         # Birth 1998-03-31, frozen 2026-01-01 → hasn't reached birthday → age 27
         result = self._call_with_frozen_now(datetime(2026, 1, 1), "1998-03-31")
-        assert result["current_age"] == 27
-        assert result["age"] == 27
+        assert result.data["current_age"] == 27
+        assert result.data["age"] == 27
+        assert result.timed_out is False
 
     def test_age_after_birthday_in_year(self):
         # Birth 1998-03-31, frozen 2026-04-01 → past birthday → age 28
         result = self._call_with_frozen_now(datetime(2026, 4, 1), "1998-03-31")
-        assert result["current_age"] == 28
-        assert result["age"] == 28
+        assert result.data["current_age"] == 28
+        assert result.data["age"] == 28
+        assert result.timed_out is False
 
     def test_age_none_when_birth_none(self):
         minnano = _make_minnano(birth=None)
@@ -353,8 +368,9 @@ class TestTD1Age:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["current_age"] is None
-        assert result["age"] is None
+        assert result.data["current_age"] is None
+        assert result.data["age"] is None
+        assert result.timed_out is False
 
     def test_age_none_when_birth_invalid(self):
         minnano = _make_minnano(birth="invalid-format")
@@ -364,8 +380,9 @@ class TestTD1Age:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["current_age"] is None
-        assert result["age"] is None
+        assert result.data["current_age"] is None
+        assert result.data["age"] is None
+        assert result.timed_out is False
 
     def test_age_not_read_from_graphis_stale_field(self):
         # Graphis has age=999; orchestrator must compute from birth, not read 999
@@ -380,8 +397,9 @@ class TestTD1Age:
              patch('core.scrapers.actress.orchestrator.datetime', FrozenDT):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["age"] != 999
-        assert result["age"] == 27  # computed, not from graphis
+        assert result.data["age"] != 999
+        assert result.data["age"] == 27  # computed, not from graphis
+        assert result.timed_out is False
 
     def test_age_consistency_age_equals_current_age(self):
         minnano = _make_minnano(birth="1995-06-15")
@@ -394,7 +412,8 @@ class TestTD1Age:
              patch('core.scrapers.actress.orchestrator.datetime', FrozenDT):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result["age"] == result["current_age"]
+        assert result.data["age"] == result.data["current_age"]
+        assert result.timed_out is False
 
 
 # ---------------------------------------------------------------------------
@@ -426,16 +445,16 @@ class TestComputeAgeUnit:
 
 class TestLegacyFlatConsistency:
 
-    def _assert_consistency(self, result):
-        assert result["img"] == result["photo_url"]
-        assert result["backdrop"] == result["backdrop_url"]
-        assert result["age"] == result["current_age"]
-        text = result.get("text")
+    def _assert_consistency(self, data):
+        assert data["img"] == data["photo_url"]
+        assert data["backdrop"] == data["backdrop_url"]
+        assert data["age"] == data["current_age"]
+        text = data.get("text")
         if text is not None:
             # name cascades: text.name_ja → text.name → queried name arg
             expected_name = text.get("name_ja") or text.get("name") or _ACTRESS_NAME
-            assert result["name"] == expected_name
-            assert result["birth"] == text.get("birth")
+            assert data["name"] == expected_name
+            assert data["birth"] == text.get("birth")
 
     def test_consistency_full_happy_path(self):
         minnano = _make_minnano()
@@ -447,7 +466,8 @@ class TestLegacyFlatConsistency:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        self._assert_consistency(result)
+        self._assert_consistency(result.data)
+        assert result.timed_out is False
 
     def test_consistency_wiki_as_text_source(self):
         wiki    = _make_wiki()
@@ -459,7 +479,8 @@ class TestLegacyFlatConsistency:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        self._assert_consistency(result)
+        self._assert_consistency(result.data)
+        assert result.timed_out is False
 
     def test_consistency_only_minnano(self):
         minnano = _make_minnano()
@@ -470,7 +491,8 @@ class TestLegacyFlatConsistency:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        self._assert_consistency(result)
+        self._assert_consistency(result.data)
+        assert result.timed_out is False
 
 
 # ---------------------------------------------------------------------------
@@ -496,7 +518,9 @@ class TestCacheTTL:
         # Scraper should have been called exactly once (cache hit on second call)
         assert mock_minnano.call_count == 1
         # Both results should be identical (from cache)
-        assert result1["name"] == result2["name"] == "初回結果"
+        assert result1.data["name"] == result2.data["name"] == "初回結果"
+        assert result1.timed_out is False
+        assert result2.timed_out is False
 
     def test_cache_expired_fetches_fresh(self):
         """Stale cache entry (older than TTL) causes fresh scraper call."""
@@ -520,7 +544,8 @@ class TestCacheTTL:
 
         # Fresh scraper should have been called
         assert mock_minnano.call_count == 1
-        assert result["name"] == "fresh"
+        assert result.data["name"] == "fresh"
+        assert result.timed_out is False
 
 
 # ---------------------------------------------------------------------------
@@ -556,12 +581,13 @@ class TestMeaningfulTextFilter:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is not None
+        assert result.data is not None
         # Graphis (with real data) must win C1, not the wiki shell
-        assert result["primary_text_source"] == "graphis"
-        assert result["text"] == graphis
+        assert result.data["primary_text_source"] == "graphis"
+        assert result.data["text"] == graphis
         # But wiki dict is still stored in all_sources for reference
-        assert result["all_sources"]["wiki"] == wiki_shell
+        assert result.data["all_sources"]["wiki"] == wiki_shell
+        assert result.timed_out is False
 
     def test_minnano_shell_does_not_suppress_wiki(self):
         """Parallel safety: if minnano returns a shell (no meaningful text), wiki wins."""
@@ -592,8 +618,9 @@ class TestMeaningfulTextFilter:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is not None
-        assert result["primary_text_source"] == "wiki"
+        assert result.data is not None
+        assert result.data["primary_text_source"] == "wiki"
+        assert result.timed_out is False
 
     def test_all_shells_no_text_source(self):
         """All text sources return shells (no meaningful text) → primary_text_source None.
@@ -611,12 +638,13 @@ class TestMeaningfulTextFilter:
 
         # minnano_shell is truthy → not any([...]) guard does not fire
         # but neither shell has meaningful text, so cascade picks no text source
-        assert result is not None
-        assert result["primary_text_source"] is None
-        assert result["text"] is None
-        assert result["current_age"] is None
+        assert result.data is not None
+        assert result.data["primary_text_source"] is None
+        assert result.data["text"] is None
+        assert result.data["current_age"] is None
         # Bug 2 fix: name falls back to queried arg when text is None
-        assert result["name"] == _ACTRESS_NAME
+        assert result.data["name"] == _ACTRESS_NAME
+        assert result.timed_out is False
 
     def test_minnano_aliases_only_wins_c1_over_wiki(self):
         """Codex 2nd review: Minnano's C1 primary value is aliases/agency/debut_work/
@@ -651,14 +679,15 @@ class TestMeaningfulTextFilter:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is not None
+        assert result.data is not None
         # C1 cascade: Minnano wins because aliases is non-empty (C1 primary value proposition)
-        assert result["primary_text_source"] == "minnano"
-        assert result["text"] == minnano_aliases_only
+        assert result.data["primary_text_source"] == "minnano"
+        assert result.data["text"] == minnano_aliases_only
         # Phase 43 auto-populate consumers reach aliases via all_sources.minnano.aliases
-        assert len(result["all_sources"]["minnano"]["aliases"]) == 2
+        assert len(result.data["all_sources"]["minnano"]["aliases"]) == 2
         # Wiki is still stored for reference but not the text source
-        assert result["all_sources"]["wiki"] == wiki
+        assert result.data["all_sources"]["wiki"] == wiki
+        assert result.timed_out is False
 
     def test_minnano_agency_only_wins_c1(self):
         """Same logic as above but with only agency field populated — proves the
@@ -683,9 +712,10 @@ class TestMeaningfulTextFilter:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is not None
-        assert result["primary_text_source"] == "minnano"
-        assert result["text"]["agency"] == "プレステージ"
+        assert result.data is not None
+        assert result.data["primary_text_source"] == "minnano"
+        assert result.data["text"]["agency"] == "プレステージ"
+        assert result.timed_out is False
 
     def test_wiki_other_names_only_wins_c1(self):
         """Codex PR #23 P2: Wiki's `other_names` (別名/芸名 row) must count as
@@ -719,9 +749,10 @@ class TestMeaningfulTextFilter:
              patch(_PATCH_GFRIENDS, return_value=None):
             result = get_actress_profile(_ACTRESS_NAME)
 
-        assert result is not None, \
+        assert result.data is not None, \
             "alias-only wiki must not collapse result to None"
-        assert result["primary_text_source"] == "wiki", \
+        assert result.data["primary_text_source"] == "wiki", \
             "wiki with only other_names must win C1 cascade when other sources miss"
-        assert result["text"] == wiki_other_names_only
-        assert result["all_sources"]["wiki"]["other_names"] == ["松嶋真麻", "別名2"]
+        assert result.data["text"] == wiki_other_names_only
+        assert result.data["all_sources"]["wiki"]["other_names"] == ["松嶋真麻", "別名2"]
+        assert result.timed_out is False

--- a/web/app.py
+++ b/web/app.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import re
 
 from fastapi import FastAPI, Request
-from fastapi.responses import RedirectResponse
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -65,6 +66,14 @@ app.include_router(capabilities_router.router)
 app.include_router(collection_router.router)
 app.include_router(collection_router.user_tags_router)
 app.include_router(actress_router.router)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=422,
+        content={"error": "validation_error", "message": "請求格式錯誤，缺少必要欄位"}
+    )
 
 
 # ============ 輔助函數 ============

--- a/web/app.py
+++ b/web/app.py
@@ -50,6 +50,7 @@ from web.routers import showcase as showcase_router
 from web.routers import motion_lab as motion_lab_router
 from web.routers import capabilities as capabilities_router
 from web.routers import collection as collection_router
+from web.routers import actress as actress_router
 app.include_router(search_router.router)
 app.include_router(config_router.router)
 app.include_router(scraper_router.router)
@@ -63,6 +64,7 @@ app.include_router(motion_lab_router.router)
 app.include_router(capabilities_router.router)
 app.include_router(collection_router.router)
 app.include_router(collection_router.user_tags_router)
+app.include_router(actress_router.router)
 
 
 # ============ 輔助函數 ============

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -209,7 +209,7 @@ def add_favorite(req: FavoriteRequest):
 
     # 5. 下載照片（photo_url 可能為 None，函數內部已有 guard）
     photo_downloaded = download_actress_photo(
-        name, profile.get("photo_url"), profile.get("photo_source")
+        actress.name, profile.get("photo_url"), profile.get("photo_source")
     )
 
     return JSONResponse(

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -17,6 +17,7 @@ from urllib.parse import quote
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
+from core.maker_mapping import load_prefix_mapping
 
 from core.database import ActressRepository, Actress, init_db
 from core.actress_photo import download_actress_photo, get_local_photo_path, delete_local_photo
@@ -126,12 +127,25 @@ def add_favorite(req: FavoriteRequest):
             }
         )
 
-    # 2. cache hit — 不打網路
+    # 2. 番號前綴 → 片商名轉換（前端傳 SSIS，gfriends 需要 S1）
+    resolved_makers = None
+    if req.makers:
+        prefix_map = load_prefix_mapping()
+        seen = set()
+        ordered = []
+        for p in req.makers:
+            maker = prefix_map.get(p.upper())
+            if maker and maker not in seen:
+                seen.add(maker)
+                ordered.append(maker)
+        resolved_makers = ordered or None
+
+    # 3. cache hit — 不打網路
     profile = get_cached_profile(name)
 
-    # 3. cache miss → 重新抓取
+    # 4. cache miss → 重新抓取
     if profile is None:
-        result = get_actress_profile(name, makers=req.makers)
+        result = get_actress_profile(name, makers=resolved_makers)
         if result.data is None:
             if result.timed_out:
                 return JSONResponse(

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -1,0 +1,271 @@
+"""
+女優 API Router — /api/actresses
+
+端點：
+    POST   /api/actresses/favorite          收藏女優
+    GET    /api/actresses/photo/{name}      取得本地照片（binary）
+    GET    /api/actresses/{name}            查詢已收藏女優
+    DELETE /api/actresses/{name}            刪除已收藏女優
+
+注意：photo/{name} 必須定義在 {name} 之前，否則 FastAPI 會將 "photo" 解析為 {name}。
+"""
+
+import re
+from typing import Optional, List
+from urllib.parse import quote
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from core.database import ActressRepository, Actress, init_db
+from core.actress_photo import download_actress_photo, get_local_photo_path, delete_local_photo
+from core.scrapers.actress.orchestrator import (
+    get_cached_profile,
+    get_actress_profile,
+    _compute_age_from_birth as _compute_age,
+)
+from core.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/actresses", tags=["actresses"])
+
+
+# ---------------------------------------------------------------------------
+# Request model
+# ---------------------------------------------------------------------------
+
+class FavoriteRequest(BaseModel):
+    name: str
+    makers: Optional[List[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def _safe_int(v) -> Optional[int]:
+    """帶單位字串（如 '80cm'）或 None → int 或 None"""
+    if v is None:
+        return None
+    try:
+        stripped = re.sub(r"[^\d]", "", str(v))
+        return int(stripped) if stripped else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _actress_to_response(actress: Actress) -> dict:
+    """將 Actress dataclass 轉為 API response dict"""
+    local_path = get_local_photo_path(actress.name)
+    if local_path is not None:
+        photo_url = f"/api/actresses/photo/{quote(actress.name)}"
+    else:
+        photo_url = None
+
+    return {
+        "name": actress.name,
+        "name_en": actress.name_en,
+        "birth": actress.birth,
+        "age": _compute_age(actress.birth),
+        "height": actress.height,
+        "cup": actress.cup,
+        "bust": actress.bust,
+        "waist": actress.waist,
+        "hip": actress.hip,
+        "hometown": actress.hometown,
+        "hobby": actress.hobby,
+        "aliases": actress.aliases or [],
+        "agency": actress.agency,
+        "debut_work": actress.debut_work,
+        "tags": actress.tags or [],
+        "nickname": actress.nickname,
+        "blog_url": actress.blog_url,
+        "official_url": actress.official_url,
+        "photo_url": photo_url,
+        "photo_source": actress.photo_source,
+        "primary_text_source": actress.primary_text_source,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 端點一：POST /api/actresses/favorite — 收藏女優
+# ---------------------------------------------------------------------------
+
+@router.post("/favorite")
+def add_favorite(req: FavoriteRequest):
+    """
+    收藏女優。
+
+    流程：
+    1. 檢查是否已收藏 → 409
+    2. 嘗試從 cache 取得 profile（不打網路）
+    3. cache miss → 呼叫 orchestrator 重新抓取
+    4. 組裝 Actress → DB save → 下載照片
+    5. 回傳 200 with actress data
+    """
+    name = req.name.strip()
+    if not name:
+        return JSONResponse(
+            status_code=422,
+            content={"error": "invalid_name", "message": "name 不可為空"}
+        )
+
+    init_db()
+    repo = ActressRepository()
+
+    # 1. 已收藏檢查 → 409
+    if repo.exists(name):
+        existing = repo.get_by_name(name)
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "already_exists",
+                "actress": _actress_to_response(existing),
+            }
+        )
+
+    # 2. cache hit — 不打網路
+    profile = get_cached_profile(name)
+
+    # 3. cache miss → 重新抓取
+    if profile is None:
+        result = get_actress_profile(name, makers=req.makers)
+        if result.data is None:
+            if result.timed_out:
+                return JSONResponse(
+                    status_code=504,
+                    content={"error": "timeout", "message": "Scraper 超時"}
+                )
+            else:
+                return JSONResponse(
+                    status_code=404,
+                    content={"error": "not_found", "message": "查無此女優"}
+                )
+        profile = result.data
+
+    # 4. 組裝 Actress dataclass
+    text = profile.get("text") or {}
+
+    actress = Actress(
+        name=profile.get("name") or name,
+        name_en=profile.get("name_en"),
+        birth=text.get("birth"),
+        height=text.get("height"),
+        cup=text.get("cup"),
+        bust=_safe_int(text.get("bust")),
+        waist=_safe_int(text.get("waist")),
+        hip=_safe_int(text.get("hip")),
+        hometown=text.get("hometown"),
+        hobby=text.get("hobby"),
+        aliases=text.get("aliases") or [],
+        agency=text.get("agency"),
+        debut_work=text.get("debut_work"),
+        tags=text.get("tags") or [],
+        nickname=text.get("nickname"),
+        blog_url=text.get("blog_url"),
+        official_url=text.get("official_url"),
+        photo_source=profile.get("photo_source"),
+        primary_text_source=profile.get("primary_text_source"),
+    )
+
+    # DB save（ON CONFLICT DO UPDATE）
+    repo.save(actress)
+    logger.info("[actress] 收藏女優：%s", actress.name)
+
+    # 5. 下載照片（photo_url 可能為 None，函數內部已有 guard）
+    photo_downloaded = download_actress_photo(
+        name, profile.get("photo_url"), profile.get("photo_source")
+    )
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "success": True,
+            "actress": _actress_to_response(actress),
+            "photo_downloaded": photo_downloaded,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 端點四：GET /api/actresses/photo/{name} — 本地照片 binary response
+# NOTE：必須定義在 GET /{name} 之前！
+# ---------------------------------------------------------------------------
+
+@router.get("/photo/{name}")
+def get_actress_photo(name: str):
+    """
+    取得女優本地照片（binary image response）。
+    FastAPI 自動 decode URL-encoded path parameter。
+    """
+    path = get_local_photo_path(name)
+    if path is None:
+        return Response(b"", status_code=404)
+
+    _MIME_MAP = {
+        ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+        ".png": "image/png", ".webp": "image/webp", ".gif": "image/gif",
+    }
+    media_type = _MIME_MAP.get(path.suffix.lower(), "image/jpeg")
+
+    return Response(
+        content=path.read_bytes(),
+        media_type=media_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 端點二：GET /api/actresses/{name} — 查詢已收藏女優
+# ---------------------------------------------------------------------------
+
+@router.get("/{name}")
+def get_actress(name: str):
+    """
+    查詢已收藏的女優資料。
+    """
+    init_db()
+    repo = ActressRepository()
+    actress = repo.get_by_name(name)
+    if actress is None:
+        return JSONResponse(
+            status_code=404,
+            content={"error": "not_found"}
+        )
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "actress": _actress_to_response(actress),
+            "is_favorite": True,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 端點三：DELETE /api/actresses/{name} — 刪除已收藏女優
+# ---------------------------------------------------------------------------
+
+@router.delete("/{name}")
+def delete_actress(name: str):
+    """
+    刪除已收藏的女優（DB + 本地照片）。
+    """
+    init_db()
+    repo = ActressRepository()
+
+    if not repo.exists(name):
+        return JSONResponse(
+            status_code=404,
+            content={"error": "not_found"}
+        )
+
+    repo.delete_by_name(name)
+    delete_local_photo(name)  # idempotent，不需檢查回傳值
+    logger.info("[actress] 刪除女優：%s", name)
+
+    return JSONResponse(
+        status_code=200,
+        content={"success": True}
+    )

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -57,6 +57,25 @@ def _safe_int(v) -> Optional[int]:
         return None
 
 
+def _flatten_aliases(raw) -> list:
+    """
+    將 aliases 欄位統一轉為純字串 list。
+
+    minnano scraper 回傳 dict list（每筆含 ja/hiragana/romaji），
+    wiki scraper 回傳純字串 list。
+    前端需要純字串 list，此 helper 統一兩種格式。
+
+    Args:
+        raw: list of dict | list of str | None
+
+    Returns:
+        list of str（空 list 若 raw 為 None 或 []）
+    """
+    if not raw:
+        return []
+    return [a.get("ja", "") if isinstance(a, dict) else str(a) for a in raw]
+
+
 def _actress_to_response(actress: Actress) -> dict:
     """將 Actress dataclass 轉為 API response dict"""
     local_path = get_local_photo_path(actress.name)
@@ -173,7 +192,7 @@ def add_favorite(req: FavoriteRequest):
         hip=_safe_int(text.get("hip")),
         hometown=text.get("hometown"),
         hobby=text.get("hobby"),
-        aliases=text.get("aliases") or [],
+        aliases=_flatten_aliases(text.get("aliases")),
         agency=text.get("agency"),
         debut_work=text.get("debut_work"),
         tags=text.get("tags") or [],

--- a/web/routers/capabilities.py
+++ b/web/routers/capabilities.py
@@ -647,6 +647,70 @@ _TOOLS: list[dict] = [
         "retry_safe": True,
         "_example_template": "curl '{base}/api/gallery/jellyfin-check'",
     },
+    {
+        "name": "favorite_actress",
+        "description": "收藏女優：從本地快取或即時爬取女優資料並存入 DB + 下載照片到本地。寫入 DB + 下載照片到 output/Gfriends/",
+        "method": "POST",
+        "path": "/api/actresses/favorite",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "女優名（日文）"},
+                "makers": {"type": "array", "items": {"type": "string"}, "description": "片商名列表（可選，提升 gfriends 照片查詢精準度）"},
+            },
+            "required": ["name"],
+        },
+        "output_schema": {
+            "success": "boolean",
+            "actress": "Actress — 完整女優資料（含本地 photo_url）",
+            "photo_downloaded": "boolean — 照片是否成功下載",
+        },
+        "side_effect": True,
+        "confirmation_required": True,
+        "idempotent": False,
+        "retry_safe": False,
+        "_example_template": "curl -X POST -H 'Content-Type: application/json' -d '{{\"name\":\"三上悠亜\"}}' {base}/api/actresses/favorite",
+    },
+    {
+        "name": "get_actress",
+        "description": "查詢單一收藏女優資料（含本地照片 URL）",
+        "method": "GET",
+        "path": "/api/actresses/{name}",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "女優名（URL path parameter）"},
+            },
+            "required": ["name"],
+        },
+        "output_schema": {
+            "actress": "Actress",
+            "is_favorite": "boolean — 固定 true（此端點只回傳已收藏女優）",
+        },
+        "retry_safe": True,
+        "_example_template": "curl '{base}/api/actresses/%E4%B8%89%E4%B8%8A%E6%82%A0%E4%BA%9C'",
+    },
+    {
+        "name": "unfavorite_actress",
+        "description": "取消收藏女優（從 DB 刪除 + 刪除本地照片）",
+        "method": "DELETE",
+        "path": "/api/actresses/{name}",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "女優名（URL path parameter）"},
+            },
+            "required": ["name"],
+        },
+        "output_schema": {
+            "success": "boolean",
+        },
+        "side_effect": True,
+        "confirmation_required": True,
+        "idempotent": True,
+        "retry_safe": True,
+        "_example_template": "curl -X DELETE '{base}/api/actresses/%E4%B8%89%E4%B8%8A%E6%82%A0%E4%BA%9C'",
+    },
 ]
 
 

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -178,8 +178,7 @@ def search(
             top_actor = _analyze_top_actor(results, threshold=0.8, min_samples=3)
             if top_actor:
                 logger.info(f"[Actress Profile] Fetching profile for: {top_actor}")
-                from core.scrapers.actress.orchestrator import get_actress_profile
-                actress_profile = get_actress_profile(top_actor, makers=_extract_top_makers(results))
+                actress_profile = _fetch_actress_profile_with_db(top_actor, _extract_top_makers(results))
                 if not actress_profile:
                     logger.info(f"[Actress Profile] Not found for: {top_actor}")
 
@@ -320,6 +319,40 @@ def _analyze_top_actor(results: List[Dict], threshold: float = 0.8, min_samples:
     else:
         logger.info(f"[Consistency] Ratio {ratio:.1%} < {threshold:.0%}, skip actress_profile")
         return None
+
+
+def _fetch_actress_profile_with_db(top_actor: str, makers: list) -> Optional[dict]:
+    """
+    DB 優先查詢：
+    1. 查 ActressRepository
+    2. DB hit → 組裝 response（本地照片 URL），附加 is_favorite=True
+    3. DB miss → 走 orchestrator，附加 is_favorite=False
+
+    Returns:
+        profile dict（前端 actressProfile），或 None（查無資料）
+    """
+    from core.database import ActressRepository, init_db
+    from web.routers.actress import _actress_to_response  # 共用 serializer，避免重複邏輯
+
+    init_db()
+    repo = ActressRepository()
+    actress = repo.get_by_name(top_actor)
+
+    if actress:
+        # DB hit：組裝 actressProfile（前端 legacy flat shape 相容）
+        profile = _actress_to_response(actress)
+        profile["is_favorite"] = True
+        # 補 legacy flat shortcuts（現有 template 依賴）
+        profile["img"] = profile.get("photo_url")
+        return profile
+
+    # DB miss：走 orchestrator（ProfileResult 回傳型別，T3 已改）
+    from core.scrapers.actress.orchestrator import get_actress_profile
+    result = get_actress_profile(top_actor, makers=makers)
+    profile = result.data  # ProfileResult.data
+    if profile:
+        profile["is_favorite"] = False
+    return profile
 
 
 _BATCH_MAX_WORKERS = 2
@@ -500,8 +533,7 @@ async def search_stream(
                     top_actor = _analyze_top_actor(results, threshold=0.8, min_samples=3)
                     if top_actor:
                         logger.info(f"[Actress Profile] Fetching profile for: {top_actor}")
-                        from core.scrapers.actress.orchestrator import get_actress_profile
-                        actress_profile = get_actress_profile(top_actor, makers=_extract_top_makers(results))
+                        actress_profile = _fetch_actress_profile_with_db(top_actor, _extract_top_makers(results))
                         if not actress_profile:
                             logger.info(f"[Actress Profile] Not found for: {top_actor}")
 

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -352,6 +352,11 @@ def _fetch_actress_profile_with_db(top_actor: str, makers: list) -> Optional[dic
     profile = result.data  # ProfileResult.data
     if profile:
         profile["is_favorite"] = False
+        # Flatten aliases: minnano 回傳 dict list，前端需純字串 list
+        from web.routers.actress import _flatten_aliases
+        text = profile.get("text")
+        if text:
+            text["aliases"] = _flatten_aliases(text.get("aliases"))
     return profile
 
 

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -352,11 +352,18 @@ def _fetch_actress_profile_with_db(top_actor: str, makers: list) -> Optional[dic
     profile = result.data  # ProfileResult.data
     if profile:
         profile["is_favorite"] = False
-        # Flatten aliases: minnano 回傳 dict list，前端需純字串 list
+        # 補齊前端需要的頂層欄位（orchestrator legacy flat shape 缺 aliases/tags 等）
         from web.routers.actress import _flatten_aliases
-        text = profile.get("text")
-        if text:
-            text["aliases"] = _flatten_aliases(text.get("aliases"))
+        text = profile.get("text") or {}
+        profile["aliases"] = _flatten_aliases(text.get("aliases"))
+        profile["tags"] = text.get("tags") or []
+        profile["agency"] = text.get("agency")
+        profile["nickname"] = text.get("nickname")
+        profile["debut_work"] = text.get("debut_work")
+        profile["blog_url"] = text.get("blog_url")
+        profile["official_url"] = text.get("official_url")
+        profile["primary_text_source"] = profile.get("primary_text_source")
+        profile["photo_source"] = profile.get("photo_source")
     return profile
 
 

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -777,6 +777,18 @@
     transform-origin: center center;  /* 置中（覆蓋 65% center 的 AV 封面偏移） */
 }
 
+/* T5: Hero Card 愛心 overlay 常駐（已收藏時不需 hover） */
+.hero-card .av-card-preview-overlay.always-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* T5: 已收藏愛心按鈕 — 紅色，不可點擊 */
+.hero-card .btn-glass-circle.is-favorite {
+    color: #ff4d6d;
+    cursor: default;
+}
+
 /* ==================== T6b: 統一 Toast 容器 ==================== */
 .search-toast-container {
     position: fixed;

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -883,3 +883,21 @@
 .sample-gallery .sg-main-img.gsap-animating {
     transition: none !important;
 }
+
+/* ==================== Phase 43 T6: Actress Lightbox ==================== */
+.actress-lightbox-meta .lb-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.actress-lightbox-meta .lb-name-en { font-size: 0.9em; opacity: 0.7; }
+.actress-lightbox-meta .lb-actress-core { font-size: 0.95em; margin: 8px 0; opacity: 0.85; }
+.actress-lightbox-meta .lb-chips-row { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0; }
+.actress-lightbox-meta .lb-chips-more {
+    cursor: pointer; font-size: 0.85em; padding: 2px 8px;
+    border-radius: 12px; border: 1px solid currentColor; opacity: 0.6;
+}
+.actress-lightbox-meta .lb-chips-more:hover { opacity: 1; }
+.actress-lightbox-meta .lb-actress-urls { margin-top: 8px; }
+.actress-lightbox-meta .lb-actress-urls a { display: block; font-size: 0.8em; word-break: break-all; opacity: 0.7; }
+.actress-lightbox-meta .lb-actress-urls a:hover { opacity: 1; text-decoration: underline; }
+
+/* Actress Lightbox Row 1 愛心（inline，使用 .btn-glass-circle） */
+.actress-lb-header .btn-glass-circle { width: 32px; height: 32px; font-size: 1rem; margin-left: auto; }
+.actress-lb-header .btn-glass-circle.is-favorite { color: #ff4d6d; cursor: default; }

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -785,7 +785,7 @@
 
 /* T5: 已收藏愛心按鈕 — 紅色，不可點擊 */
 .hero-card .btn-glass-circle.is-favorite {
-    color: #ff4d6d;
+    color: var(--color-favorite);
     cursor: default;
 }
 
@@ -900,4 +900,4 @@
 
 /* Actress Lightbox Row 1 愛心（inline，使用 .btn-glass-circle） */
 .actress-lb-header .btn-glass-circle { width: 32px; height: 32px; font-size: 1rem; margin-left: auto; }
-.actress-lb-header .btn-glass-circle.is-favorite { color: #ff4d6d; cursor: default; }
+.actress-lb-header .btn-glass-circle.is-favorite { color: var(--color-favorite); cursor: default; }

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -87,6 +87,7 @@
 
     /* Accent 色系（粉紅，女優管理） */
     --accent-pink: #ec4899;           /* Tailwind pink-500 - 女優識別色 */
+    --color-favorite: #ff4d6d;        /* 收藏愛心色 */
 
     /* Error 色系擴展（淡紅，delete hover） */
     --color-error-hover: #ff6b6b;     /* 柔和紅 - 刪除按鈕 hover */

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -148,6 +148,7 @@ window.SearchStateMixin_Base = function () {
 
         // ===== T5: Actress Favorite State =====
         _actressFavoriteLoading: false,
+        _actressFavoriteGen: 0,
         _actressFavoriteTimer: null,
 
         // ===== Phase 43 T6: Actress Chips Expanded State =====
@@ -528,6 +529,7 @@ window.SearchStateMixin_Base = function () {
             const capturedProfile = this.actressProfile;
             const capturedName = this.actressProfile.name;
 
+            const gen = ++this._actressFavoriteGen;
             this._actressFavoriteLoading = true;
 
             // 10s 前端 timeout
@@ -582,7 +584,7 @@ window.SearchStateMixin_Base = function () {
                     console.error('[addFavoriteActress] 例外:', err);
                 }
             } finally {
-                this._actressFavoriteLoading = false;
+                if (this._actressFavoriteGen === gen) this._actressFavoriteLoading = false;
             }
         },
     };

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -150,6 +150,9 @@ window.SearchStateMixin_Base = function () {
         _actressFavoriteLoading: false,
         _actressFavoriteTimer: null,
 
+        // ===== Phase 43 T6: Actress Chips Expanded State =====
+        _actressChipsExpanded: { aliases: false, info: false },
+
         // ===== T6a: Grid Image Error State =====
         // Grid 模式圖片錯誤追蹤
         _gridImageErrors: new Set(),
@@ -453,6 +456,37 @@ window.SearchStateMixin_Base = function () {
             if (h > 0) {
                 cover.style.setProperty('--cover-height', h + 'px');
             }
+        },
+
+        // ===== Phase 43 T6: Actress Chips Helpers =====
+
+        _chipsLimit() {
+            return window.innerWidth < 768 ? 6 : 10;
+        },
+
+        _allInfoChips() {
+            if (!this.actressProfile) return [];
+            const p = this.actressProfile;
+            return [
+                ...(p.tags || []),
+                ...(p.hometown ? [p.hometown] : []),
+                ...(p.nickname ? [p.nickname] : []),
+                ...(p.agency ? [p.agency] : []),
+                ...(p.hobby ? [p.hobby] : []),
+                ...(p.debut_work ? [p.debut_work] : []),
+            ];
+        },
+
+        _visibleAliases() {
+            const aliases = this.actressProfile?.aliases || [];
+            if (this._actressChipsExpanded.aliases) return aliases;
+            return aliases.slice(0, this._chipsLimit());
+        },
+
+        _visibleInfoChips() {
+            const chips = this._allInfoChips();
+            if (this._actressChipsExpanded.info) return chips;
+            return chips.slice(0, this._chipsLimit());
         },
 
         // ===== T5: Actress Favorite =====

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -510,6 +510,17 @@ window.SearchStateMixin_Base = function () {
             return url;
         },
 
+        // ===== T10: Actress Source URL =====
+
+        _actressSourceUrl() {
+            const src = this.actressProfile?.primary_text_source;
+            const name = this.actressProfile?.name;
+            if (!src || !name) return null;
+            if (src === 'wiki') return `https://ja.wikipedia.org/wiki/${encodeURIComponent(name)}`;
+            if (src === 'minnano') return `https://www.minnano-av.com/search_result.php?search_scope=actress&search_word=${encodeURIComponent(name)}`;
+            return null;
+        },
+
         async addFavoriteActress() {
             if (!this.actressProfile || this.actressProfile.is_favorite || this._actressFavoriteLoading) return;
 

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -144,7 +144,11 @@ window.SearchStateMixin_Base = function () {
         lightboxCloseTimer: null,  // F2: delayed clear timer for lightbox close
 
         // ===== T2d: Actress Profile State =====
-        actressProfile: null,      // { name, img, backdrop, birth, age, height, cup, bust, waist, hip, hometown, hobby }
+        actressProfile: null,      // { name, img, backdrop, birth, age, height, cup, bust, waist, hip, hometown, hobby, is_favorite }
+
+        // ===== T5: Actress Favorite State =====
+        _actressFavoriteLoading: false,
+        _actressFavoriteTimer: null,
 
         // ===== T6a: Grid Image Error State =====
         // Grid 模式圖片錯誤追蹤
@@ -448,6 +452,81 @@ window.SearchStateMixin_Base = function () {
             var h = cover.offsetHeight;
             if (h > 0) {
                 cover.style.setProperty('--cover-height', h + 'px');
+            }
+        },
+
+        // ===== T5: Actress Favorite =====
+
+        // 從 searchResults 提取片商前綴（供 /api/actresses/favorite makers 參數）
+        _extractCurrentMakers() {
+            const results = this.searchResults || [];
+            const makers = new Set();
+            results.forEach(r => {
+                if (r.number) {
+                    const m = r.number.match(/^([A-Za-z]+)/);
+                    if (m) makers.add(m[1].toUpperCase());
+                }
+            });
+            return Array.from(makers);
+        },
+
+        async addFavoriteActress() {
+            if (!this.actressProfile || this.actressProfile.is_favorite || this._actressFavoriteLoading) return;
+
+            this._actressFavoriteLoading = true;
+
+            // 10s 前端 timeout
+            const controller = new AbortController();
+            this._actressFavoriteTimer = setTimeout(() => controller.abort(), 10000);
+
+            try {
+                const makers = this._extractCurrentMakers();
+                const resp = await fetch('/api/actresses/favorite', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: this.actressProfile.name, makers }),
+                    signal: controller.signal,
+                });
+
+                clearTimeout(this._actressFavoriteTimer);
+                this._actressFavoriteTimer = null;
+
+                if (resp.status === 200) {
+                    const data = await resp.json();
+                    // 更新 actressProfile：標記已收藏 + 更新 img 為本地路徑
+                    const actress = data.actress || {};
+                    this.actressProfile = {
+                        ...this.actressProfile,
+                        is_favorite: true,
+                        img: actress.photo_url || this.actressProfile.img,
+                    };
+                    this.showToast(window.t('search.actress.favorite_success'), 'success');
+                } else if (resp.status === 409) {
+                    // 已收藏（競態或重複點擊）
+                    const data = await resp.json();
+                    const actress = data.actress || {};
+                    this.actressProfile = {
+                        ...this.actressProfile,
+                        is_favorite: true,
+                        img: actress.photo_url || this.actressProfile.img,
+                    };
+                } else {
+                    const data = await resp.json().catch(() => ({}));
+                    this.showToast(window.t('search.actress.favorite_error'), 'error');
+                    console.error('[addFavoriteActress] 失敗:', resp.status, data);
+                }
+            } catch (err) {
+                clearTimeout(this._actressFavoriteTimer);
+                this._actressFavoriteTimer = null;
+
+                if (err.name === 'AbortError') {
+                    this.showToast(window.t('search.actress.favorite_timeout'), 'error');
+                } else {
+                    this.showToast(window.t('search.actress.favorite_error'), 'error');
+                    console.error('[addFavoriteActress] 例外:', err);
+                }
+            } finally {
+                this._actressFavoriteLoading = false;
             }
         },
     };

--- a/web/static/js/pages/search/state/base.js
+++ b/web/static/js/pages/search/state/base.js
@@ -504,8 +504,18 @@ window.SearchStateMixin_Base = function () {
             return Array.from(makers);
         },
 
+        _safeUrl(url) {
+            if (!url || typeof url !== 'string') return '#';
+            if (!url.startsWith('http://') && !url.startsWith('https://')) return '#';
+            return url;
+        },
+
         async addFavoriteActress() {
             if (!this.actressProfile || this.actressProfile.is_favorite || this._actressFavoriteLoading) return;
+
+            // capture reference before await — 防止 await 期間切女優的 race（同 41d pattern）
+            const capturedProfile = this.actressProfile;
+            const capturedName = this.actressProfile.name;
 
             this._actressFavoriteLoading = true;
 
@@ -518,7 +528,7 @@ window.SearchStateMixin_Base = function () {
                 const resp = await fetch('/api/actresses/favorite', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ name: this.actressProfile.name, makers }),
+                    body: JSON.stringify({ name: capturedName, makers }),
                     signal: controller.signal,
                 });
 
@@ -527,22 +537,23 @@ window.SearchStateMixin_Base = function () {
 
                 if (resp.status === 200) {
                     const data = await resp.json();
-                    // 更新 actressProfile：標記已收藏 + 更新 img 為本地路徑
+                    // stale-check：await 期間可能已切女優，丟棄過時結果
+                    if (this.actressProfile !== capturedProfile) return;
                     const actress = data.actress || {};
                     this.actressProfile = {
-                        ...this.actressProfile,
+                        ...capturedProfile,
                         is_favorite: true,
-                        img: actress.photo_url || this.actressProfile.img,
+                        img: actress.photo_url || capturedProfile.img,
                     };
                     this.showToast(window.t('search.actress.favorite_success'), 'success');
                 } else if (resp.status === 409) {
-                    // 已收藏（競態或重複點擊）
                     const data = await resp.json();
+                    if (this.actressProfile !== capturedProfile) return;
                     const actress = data.actress || {};
                     this.actressProfile = {
-                        ...this.actressProfile,
+                        ...capturedProfile,
                         is_favorite: true,
-                        img: actress.photo_url || this.actressProfile.img,
+                        img: actress.photo_url || capturedProfile.img,
                     };
                 } else {
                     const data = await resp.json().catch(() => ({}));

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -121,6 +121,9 @@ window.SearchStateMixin_GridMode = {
         // T8: 若 gallery 開啟中一併關閉（外部直接關 lightbox 時 gallery 不應殘留）
         if (this.sampleGalleryOpen) this.closeSampleGallery();
 
+        // Phase 43 T6: 重置 actress chips 展開狀態
+        this._actressChipsExpanded = { aliases: false, info: false };
+
         this._lightboxGeneration++;  // B19: invalidate pending $nextTick lightbox callbacks
         // Instant close — kill any in-progress lightbox animations, then sync close
         if (typeof gsap !== 'undefined') {
@@ -152,6 +155,7 @@ window.SearchStateMixin_GridMode = {
         if (this._lightboxAnimating) return;  // D2: guard
         if (!this.actressProfile) return;  // A6-2: 無女優資料時不開啟 lightbox
         this._heroLightboxImageError = false;  // A6-1: 重置圖片錯誤狀態
+        this._actressChipsExpanded = { aliases: false, info: false };  // Phase 43 T6: 重置 chips 展開狀態
         this.lightboxIndex = -1;
         this.lightboxOpen = true;
 

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -142,6 +142,7 @@ window.SearchStateMixin_SearchFlow = {
         this.currentOffset = 0;
         this.hasMoreResults = false;
         this.actressProfile = null;  // T2d: 清空上次的女優資料
+        this._actressFavoriteLoading = false;  // Phase 43: 清空收藏 loading 狀態
         this.displayMode = 'detail';  // T3a: 新搜尋重置顯示模式
         this._gridImageErrors = new Set();  // T6a: 清空 Grid 圖片錯誤記錄
         this._heroCardImageError = false;   // A6-1: 清空 Hero Card 圖片錯誤

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -133,6 +133,12 @@
                           :title="t('search.actress.favorited')">
                         <i class="bi bi-heart-fill"></i>
                     </span>
+                    <button class="lb-action-btn"
+                            x-show="!actressProfile?.is_favorite && _actressSourceUrl()"
+                            @click.stop="openSourceUrl(_actressSourceUrl())"
+                            data-tooltip="{{ t('search.action.open_source_url') }}" aria-label="{{ t('search.action.open_source_url') }}">
+                        <i class="bi bi-box-arrow-up-right"></i>
+                    </button>
                 </div>
 
                 <!-- Row 2: 核心 metadata（· 串接，空欄位跳過） -->
@@ -668,6 +674,12 @@
                         <div class="footer-default" x-show="actressProfile">
                             <span class="av-num" x-text="actressProfile?.name || '-'">-</span>
                             <span class="av-actress" x-text="actressProfile?.age ? actressProfile.age + t('search.unit.age') : ''"></span>
+                            <button class="info-icon-btn"
+                                    x-show="!actressProfile?.is_favorite && _actressSourceUrl()"
+                                    @click.stop="openSourceUrl(_actressSourceUrl())"
+                                    :title="t('search.action.open_source_url')">
+                                <i class="bi bi-box-arrow-up-right"></i>
+                            </button>
                         </div>
                         <!-- T5: footer-hover — height · cup · bust-waist-hip -->
                         <div class="footer-hover" x-show="actressProfile">

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -552,7 +552,9 @@
                      @click="actressProfile && openActressLightbox()">
                     <div class="av-card-preview-img">
                         <!-- A7-Prod: 正常態（actressProfile 有值） -->
-                        <img :src="actressProfile?.img ? `/api/proxy-image?url=${encodeURIComponent(actressProfile.img)}` : ''"
+                        <img :src="actressProfile?.img
+                                 ? (actressProfile.img.startsWith('/api/') ? actressProfile.img : `/api/proxy-image?url=${encodeURIComponent(actressProfile.img)}`)
+                                 : ''"
                              :alt="actressProfile?.name"
                              loading="lazy"
                              x-show="actressProfile && !_heroCardImageError"
@@ -565,15 +567,42 @@
                         </div>
                         <!-- A7-Prod: skeleton 預留態（shimmer） -->
                         <div class="skeleton-cover shimmer" x-show="!actressProfile && _heroSlotReserved"></div>
+                        <!-- T5: 愛心 overlay（CD-13） -->
+                        <div class="av-card-preview-overlay"
+                             :class="actressProfile?.is_favorite ? 'always-visible' : ''"
+                             x-show="actressProfile"
+                             @click.stop>
+                            <!-- 已收藏：常駐實心愛心（CD-10：不可點擊，純指示） -->
+                            <button class="btn-glass-circle is-favorite"
+                                    x-show="actressProfile?.is_favorite"
+                                    disabled
+                                    :title="t('search.actress.favorited')">
+                                <i class="bi bi-heart-fill"></i>
+                            </button>
+                            <!-- Loading：spinner -->
+                            <button class="btn-glass-circle"
+                                    x-show="!actressProfile?.is_favorite && _actressFavoriteLoading"
+                                    disabled>
+                                <span class="loading loading-spinner loading-sm"></span>
+                            </button>
+                            <!-- 未收藏：hover 顯示空心愛心（可點擊） -->
+                            <button class="btn-glass-circle"
+                                    x-show="!actressProfile?.is_favorite && !_actressFavoriteLoading"
+                                    @click="addFavoriteActress()"
+                                    :title="t('search.actress.add_favorite')">
+                                <i class="bi bi-heart"></i>
+                            </button>
+                        </div>
                     </div>
                     <div class="av-card-preview-footer">
-                        <!-- A7-Prod: 正常態 footer -->
+                        <!-- A7-Prod: 正常態 footer — T5: name + age -->
                         <div class="footer-default" x-show="actressProfile">
-                            <span class="av-num" x-text="actressProfile?.birth || '-'">-</span>
-                            <span class="av-actress" x-text="actressProfile?.height || ''"></span>
+                            <span class="av-num" x-text="actressProfile?.name || '-'">-</span>
+                            <span class="av-actress" x-text="actressProfile?.age ? actressProfile.age + t('search.unit.age') : ''"></span>
                         </div>
+                        <!-- T5: footer-hover — height · cup · bust-waist-hip -->
                         <div class="footer-hover" x-show="actressProfile">
-                            <div class="hover-title" x-text="[actressProfile?.name_en || '', actressProfile?.name || '', actressProfile?.age ? actressProfile?.age + '歲' : '', actressProfile?.cup ? actressProfile?.cup + '罩杯' : '', actressProfile?.bust || '', actressProfile?.waist || '', actressProfile?.hip || '', actressProfile?.hometown || '', actressProfile?.hobby || ''].filter(Boolean).join(' · ') || '-'"></div>
+                            <div class="hover-title" x-text="[actressProfile?.height || '', actressProfile?.cup ? actressProfile.cup + t('search.unit.cup') : '', [actressProfile?.bust, actressProfile?.waist, actressProfile?.hip].filter(Boolean).join('-')].filter(Boolean).join(' · ') || '-'"></div>
                         </div>
                         <!-- A7-Prod: skeleton 預留態 footer -->
                         <div class="footer-default" x-show="!actressProfile && _heroSlotReserved">

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -33,7 +33,7 @@
             <!-- Cover Image -->
             <div class="lightbox-cover">
                 <img :src="actressLightboxMode()
-                         ? (actressProfile?.img ? `/api/proxy-image?url=${encodeURIComponent(actressProfile.img)}` : '')
+                         ? (actressProfile?.img ? (actressProfile.img.startsWith('/api/') ? actressProfile.img : `/api/proxy-image?url=${encodeURIComponent(actressProfile.img)}`) : '')
                          : (currentLightboxVideo()?.cover ? `/api/proxy-image?url=${encodeURIComponent(currentLightboxVideo().cover)}` : '')"
                      :alt="actressLightboxMode() ? actressProfile?.name : currentLightboxVideo()?.number"
                      x-show="!_heroLightboxImageError"
@@ -109,6 +109,75 @@
                     <template x-for="tag in (currentLightboxVideo()?.tags || [])" :key="tag">
                         <span class="lb-tag" x-text="tag"></span>
                     </template>
+                </div>
+            </div>
+
+            <!-- Phase 43 T6: Actress Lightbox metadata -->
+            <div class="lightbox-metadata actress-lightbox-meta" x-show="actressLightboxMode()">
+                <!-- Row 1: 名稱 + name_en + 愛心 -->
+                <div class="lb-header actress-lb-header">
+                    <div class="lb-title" x-text="actressProfile?.name || '-'"></div>
+                    <span class="lb-name-en" x-show="actressProfile?.name_en" x-text="actressProfile?.name_en"></span>
+                    <!-- 愛心（Lightbox 版）— CD-10: 只做加入，已收藏純指示 -->
+                    <button class="btn-glass-circle"
+                            x-show="actressProfile && !actressProfile?.is_favorite && !_actressFavoriteLoading"
+                            @click.stop="addFavoriteActress()"
+                            :title="t('search.actress.add_favorite')">
+                        <i class="bi bi-heart"></i>
+                    </button>
+                    <button class="btn-glass-circle" x-show="_actressFavoriteLoading" disabled>
+                        <span class="loading loading-spinner loading-xs"></span>
+                    </button>
+                    <span class="btn-glass-circle is-favorite"
+                          x-show="actressProfile?.is_favorite && !_actressFavoriteLoading"
+                          :title="t('search.actress.favorited')">
+                        <i class="bi bi-heart-fill"></i>
+                    </span>
+                </div>
+
+                <!-- Row 2: 核心 metadata（· 串接，空欄位跳過） -->
+                <div class="lb-actress-core" x-text="[
+                    actressProfile?.age ? actressProfile.age + t('search.unit.age') : '',
+                    actressProfile?.birth || '',
+                    actressProfile?.height || '',
+                    actressProfile?.cup ? actressProfile.cup + t('search.unit.cup') : '',
+                    [actressProfile?.bust, actressProfile?.waist, actressProfile?.hip].filter(Boolean).join('-')
+                ].filter(Boolean).join(' · ')"></div>
+
+                <!-- Row 3: Aliases chips -->
+                <div class="lb-chips-row" x-show="(actressProfile?.aliases || []).length > 0">
+                    <template x-for="alias in _visibleAliases()" :key="alias">
+                        <span class="lb-tag" x-text="alias"></span>
+                    </template>
+                    <span class="lb-chips-more"
+                          x-show="!_actressChipsExpanded.aliases && (actressProfile?.aliases || []).length > _chipsLimit()"
+                          @click="_actressChipsExpanded = {..._actressChipsExpanded, aliases: true}"
+                          x-text="'+' + ((actressProfile?.aliases || []).length - _chipsLimit())">
+                    </span>
+                </div>
+
+                <!-- Row 4: 其餘資訊 chips（tags + hometown + nickname + agency + hobby + debut_work） -->
+                <div class="lb-chips-row" x-show="_allInfoChips().length > 0">
+                    <template x-for="chip in _visibleInfoChips()" :key="chip">
+                        <span class="lb-tag" x-text="chip"></span>
+                    </template>
+                    <span class="lb-chips-more"
+                          x-show="!_actressChipsExpanded.info && _allInfoChips().length > _chipsLimit()"
+                          @click="_actressChipsExpanded = {..._actressChipsExpanded, info: true}"
+                          x-text="'+' + (_allInfoChips().length - _chipsLimit())">
+                    </span>
+                </div>
+
+                <!-- Row 5: 社群連結 -->
+                <div class="lb-actress-urls">
+                    <a x-show="actressProfile?.blog_url"
+                       :href="actressProfile?.blog_url"
+                       target="_blank" rel="noopener"
+                       x-text="actressProfile?.blog_url"></a>
+                    <a x-show="actressProfile?.official_url"
+                       :href="actressProfile?.official_url"
+                       target="_blank" rel="noopener"
+                       x-text="actressProfile?.official_url"></a>
                 </div>
             </div>
         </div>

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -46,10 +46,19 @@
                 </div>
                 <!-- cover-actions: 封面失敗時按鈕仍可用（返回詳情、開啟資料夾等不依賴圖片） -->
                 <div class="cover-actions">
+                    <!-- 返回詳情：影片模式才顯示 -->
                     <button class="lb-action-btn"
-                            @click="actressLightboxMode() ? closeLightbox() : switchToDetail(lightboxIndex)"
+                            x-show="!actressLightboxMode()"
+                            @click="switchToDetail(lightboxIndex)"
                             data-tooltip="{{ t('search.action.back_to_detail') }}" aria-label="{{ t('search.action.back_to_detail') }}">
                         <i class="bi bi-arrow-return-left"></i>
+                    </button>
+                    <!-- Actress source link：取代返回詳情的位置，actress 模式才顯示 -->
+                    <button class="lb-action-btn"
+                            x-show="actressLightboxMode() && !actressProfile?.is_favorite && _actressSourceUrl()"
+                            @click.stop="openSourceUrl(_actressSourceUrl())"
+                            data-tooltip="{{ t('search.action.open_source_url') }}" aria-label="{{ t('search.action.open_source_url') }}">
+                        <i class="bi bi-box-arrow-up-right"></i>
                     </button>
                     <button class="lb-action-btn"
                             @click="openLocal(currentLightboxVideo()?._localStatus?.paths?.[0] || '')"
@@ -133,12 +142,6 @@
                           :title="t('search.actress.favorited')">
                         <i class="bi bi-heart-fill"></i>
                     </span>
-                    <button class="lb-action-btn"
-                            x-show="!actressProfile?.is_favorite && _actressSourceUrl()"
-                            @click.stop="openSourceUrl(_actressSourceUrl())"
-                            data-tooltip="{{ t('search.action.open_source_url') }}" aria-label="{{ t('search.action.open_source_url') }}">
-                        <i class="bi bi-box-arrow-up-right"></i>
-                    </button>
                 </div>
 
                 <!-- Row 2: 核心 metadata（· 串接，空欄位跳過） -->
@@ -674,12 +677,6 @@
                         <div class="footer-default" x-show="actressProfile">
                             <span class="av-num" x-text="actressProfile?.name || '-'">-</span>
                             <span class="av-actress" x-text="actressProfile?.age ? actressProfile.age + t('search.unit.age') : ''"></span>
-                            <button class="info-icon-btn"
-                                    x-show="!actressProfile?.is_favorite && _actressSourceUrl()"
-                                    @click.stop="openSourceUrl(_actressSourceUrl())"
-                                    :title="t('search.action.open_source_url')">
-                                <i class="bi bi-box-arrow-up-right"></i>
-                            </button>
                         </div>
                         <!-- T5: footer-hover — height · cup · bust-waist-hip -->
                         <div class="footer-hover" x-show="actressProfile">

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -171,11 +171,11 @@
                 <!-- Row 5: 社群連結 -->
                 <div class="lb-actress-urls">
                     <a x-show="actressProfile?.blog_url"
-                       :href="actressProfile?.blog_url"
+                       :href="_safeUrl(actressProfile?.blog_url)"
                        target="_blank" rel="noopener"
                        x-text="actressProfile?.blog_url"></a>
                     <a x-show="actressProfile?.official_url"
-                       :href="actressProfile?.official_url"
+                       :href="_safeUrl(actressProfile?.official_url)"
                        target="_blank" rel="noopener"
                        x-text="actressProfile?.official_url"></a>
                 </div>


### PR DESCRIPTION
## Summary
- DB `actresses` 表 + ActressRepository CRUD + 照片下載模組
- API Router 四端點（POST favorite / GET / DELETE / GET photo）
- /search DB 優先查詢（已收藏女優 0 網路請求）+ `is_favorite` 旗標
- Hero Card footer 重設計（name + age + 三圍）+ 愛心收藏 overlay
- Actress Lightbox 重建（上圖下文 5 rows + chips 收合）
- Source link icon（minnano / Wikipedia JP）
- i18n 四語系 + Capabilities 三端點
- Bug fixes: aliases flatten、race guard、URL scheme XSS、422 handler、makers 保序

## Test plan
- [x] 2167 tests passed (unit + integration + frontend lint)
- [x] 敏感資訊掃描 PASS
- [x] 打包完整性 PASS
- [x] 手動 smoke test：收藏女優 → 再搜尋 → hero card 本地照片 + 愛心實心
- [x] 手動 smoke test：Actress lightbox 完整 metadata + aliases chips
- [x] 手動 smoke test：Source link 開啟 minnano / Wikipedia

🤖 Generated with [Claude Code](https://claude.com/claude-code)