### PR TITLE
Phase 50 — Charter Pilot Showcase: 影片視覺語言統一 + UI conventions infra (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-28
+
+本版聚焦在 Showcase 影片模式的視覺語言統一（Phase 50 Charter Pilot）。把 Fluent 2 的設計規範完整套用到 token、白名單、ease 三角色、§6 5 檢查點，並把 visual-charter 從一次性提案升級為正式的 ui-conventions 工作流文件，之後新做頁面有規範可循。對使用者而言介面更一致、動畫節奏更自然，沒有功能變化。
+
+*This release unifies the visual language across Showcase video mode (Phase 50 Charter Pilot) by applying Fluent 2 conventions to tokens, allow-lists, and the three-role ease system. No user-facing feature changes.*
+
+### Added
+
+#### 🎯 50.1 — Phase 1 靜態修齊（charter §1–§4 + §6）
+- 新增 Fluent token 一階對應（blur / shadow / radius / spacing / overlay color），整個 Showcase 視覺基準對齊 (commit 30ce8f2)
+- Blur / Shadow 三階分明，弱 / 中 / 強層級不再亂跳 (commit 6685c49)
+- Radius 改用 token，pill 形狀走白名單統一寫法 (commit 8139716)
+- Spacing 三層分明，6px 個案保留並逐個審判，避免一刀切 (commit 8b1c977)
+- Overlay 顏色 4 階 token 化，hover / active / disabled 不再各自為政 (commit e04812e)
+- DaisyUI 的 .btn / .input 在 Showcase 範圍內加 scoped Fluent 覆寫，第三方元件不污染全域 (commit 4afdc35)
+
+#### 🎯 50.2 — Phase 2 動畫修齊（charter §5 ease 三角色）
+- 新增 Fluent CustomEase 三角色（standard / decel / accel）並在 GSAP 註冊，動畫節奏統一語彙 (commit 9579801)
+- motion-adapter.js 5 處預設 ease 全部換成三角色 (commit 3b58dd8)
+- 進場動畫（playEntry stagger）改用 fluent-decel，視覺更自然 (commit 5c89afc)
+- 排序動畫（playFlipReorder）改用 fluent，標準互動節奏 (commit 7cfc4b6)
+- 篩選翻轉（playFlipFilter）三段拆 fluent / decel / accel (commit 9fb93b9)
+- 模式切換（playModeCrossfade）拆 fluent-accel + fluent-decel，淡出淡入手感對稱 (commit 06f2129)
+- Lightbox 開啟（playLightboxOpen）三段對齊 fluent-decel (commit 5c20842)
+- LightboxSwitch + SampleGallerySwitch 切換動畫換 fluent (commit 8ee3d56)
+- 容器淡入 / 來源 pulse（playContainerFadeIn / playSourcePulse）改 fluent (commit ef02b5b)
+- motion 模組新增 DURATION 三角色常數，業務 caller 全面套用，硬編碼 ms 從業務層消失 (commit e6586c6)
+- showcase.css 7 處 transition 硬編碼換成 fluent token (commit 9b286b1)
+
+### Fixed
+- 檔名截斷後尾端 `.` 在 Windows NTFS 被靜默剝除導致 `shutil.move` 失敗（#31），新增 win32-only 截斷後 rstrip helper，Mac / Linux / WSL ext4 行為不變 (commit f718f8f)
+- Search lightbox 在 Showcase 啟用時定位錯誤，回退 body.fluent-canvas 的 backdrop-filter 改寫 (commit de57171)
+- Lightbox backdrop 30px 模糊太重，UX 仲裁後降到 12px（覆蓋 charter §2 字面值）(commit e586a56)
+- playLightboxOpen 殘留動畫片段清理，加進 charter §5 white-list (commit 6f1d39e)
+- Codex review v3 Phase 1 P1a / P1b / P2 收斂 — Token 命名一致性、tailwind.css 隔離、白名單覆蓋邊界 (commit b37d5df)
+
+### Chore
+- tailwind.css 一次性重編，把 Phase 50 之前累積的 source drift（alias UI / .stack / .invisible / DaisyUI 5.5.17 升級殘留）帶入，避免污染 Phase 50 token diff (commit 197f9a0)
+
 ## [0.7.8] - 2026-04-26
 
 本版聚焦在 Showcase 女優模式的全方位打磨：補齊模式切換動畫、新增女優照片更換功能（含 Physics2D burst picker）、Picker overlay 改為純 CSS viewport-anchored 全裝置適配、以及 Actress Lightbox ghost-fly 補全與 Footer 視覺重設計。

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -5,6 +5,7 @@ Organizer 模組 - 檔案整理功能（重命名、資料夾、封面、NFO）
 
 import os
 import re
+import sys
 import shutil
 import requests
 import html
@@ -35,13 +36,21 @@ def sanitize_filename(name: str) -> str:
     return name
 
 
+def _strip_windows_trailing(name: str) -> str:
+    # Win32 directory creation silently strips trailing dots/spaces, so target
+    # path string and on-disk name diverge → shutil.move WinError 3. See #31.
+    if sys.platform == 'win32':
+        return name.rstrip('. ')
+    return name
+
+
 def truncate_title(title: str, max_len: int = 50) -> str:
     """截斷標題長度"""
     if not title:
         return ''
     if len(title) <= max_len:
         return title
-    return title[:max_len - 3] + '...'
+    return _strip_windows_trailing(title[:max_len - 3] + '...')
 
 
 def truncate_to_chars(text: str, max_chars: int = 60) -> str:
@@ -52,7 +61,7 @@ def truncate_to_chars(text: str, max_chars: int = 60) -> str:
         return text[:max_chars]
     if len(text) <= max_chars:
         return text
-    return text[:max_chars - 3] + '...'
+    return _strip_windows_trailing(text[:max_chars - 3] + '...')
 
 
 def clean_source_suffix(text: str) -> str:

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.7.8"
+__version__ = "0.8.0"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2725,6 +2725,53 @@ class TestFluentCustomEaseRegistered:
                 "fluent CustomEase 註冊不應被 DOMContentLoaded handler 包住"
 
 
+class TestMotionAdapterFluentDefaults:
+    """Phase 50.2.1: motion-adapter.js 5 default ease → fluent 角色"""
+
+    def _js(self):
+        return Path("web/static/js/components/motion-adapter.js").read_text(encoding="utf-8")
+
+    def _scoped(self, fn_name):
+        """擷取從 fn_name 開頭到下一個 /** 區段間的 JS（function body 範圍）"""
+        js = self._js()
+        idx = js.find(fn_name + ":")
+        assert idx > 0, f"找不到 {fn_name}"
+        next_doc = js.find("/**", idx + 1)
+        return js[idx : next_doc if next_doc > 0 else idx + 800]
+
+    def test_play_enter_default_fluent_decel(self):
+        scope = self._scoped("playEnter")
+        assert "opts.ease || 'fluent-decel'" in scope, \
+            "playEnter default ease 應為 'fluent-decel'（charter §5 進場）"
+
+    def test_play_leave_default_fluent_accel(self):
+        scope = self._scoped("playLeave")
+        assert "opts.ease || 'fluent-accel'" in scope, \
+            "playLeave default ease 應為 'fluent-accel'（charter §5 離場）"
+
+    def test_play_stagger_default_fluent_decel(self):
+        scope = self._scoped("playStagger")
+        assert "opts.ease || 'fluent-decel'" in scope, \
+            "playStagger default ease 應為 'fluent-decel'（charter §5 進場 stagger）"
+
+    def test_play_fade_to_default_fluent(self):
+        scope = self._scoped("playFadeTo")
+        assert "opts.ease || 'fluent'" in scope and "opts.ease || 'fluent-decel'" not in scope, \
+            "playFadeTo default ease 應為 'fluent'（charter §5 standard）"
+
+    def test_play_modal_default_fluent_decel(self):
+        scope = self._scoped("playModal")
+        assert "opts.ease || 'fluent-decel'" in scope, \
+            "playModal default ease 應為 'fluent-decel'（charter §5 modal 彈出）"
+
+    def test_no_legacy_power_ease_defaults(self):
+        """confirm 沒有殘留的 power* default ease（在 motion-adapter.js 中）"""
+        js = self._js()
+        # 註解 / 文件字串若引用 power* 不算違規；但 default fallback 不應有
+        assert "opts.ease || 'power" not in js, \
+            "motion-adapter.js 殘留 power* default ease — 未完成 fluent 角色化"
+
+
 class TestGhostFlyGuards:
     """T8: Ghost Fly 架構守衛"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2725,6 +2725,38 @@ class TestFluentCustomEaseRegistered:
                 "fluent CustomEase 註冊不應被 DOMContentLoaded handler 包住"
 
 
+class TestShowcaseCssTransitionTokens:
+    """Phase 50.2.10: showcase.css 影片模式 transition 硬編碼 → fluent token"""
+
+    def _css(self):
+        return Path("web/static/css/pages/showcase.css").read_text(encoding="utf-8")
+
+    def test_no_hardcoded_transition_in_video_mode_range(self):
+        """影片模式範圍（L1500-L1900）transition 不應有硬編碼 0.15s/0.2s"""
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            # 影片模式 transition 區段（plan T2.10 範圍 ~L1500-L1900）
+            if 1500 <= i <= 1900 and "transition:" in line:
+                # 殘留硬編碼 number+s 字面（排除 var(--...) reference）
+                import re
+                if re.search(r"transition:[^;]*\b0?\.\d+s\b", line) and "var(--" not in line:
+                    violations.append(f"L{i}: {line.strip()}")
+        assert not violations, \
+            "影片模式 transition 殘留硬編碼數字：\n" + "\n".join(violations)
+
+    def test_actress_picker_transition_preserved(self):
+        """女優 picker 區（plan T2.10 範圍排除）保留硬編碼 transition"""
+        css = self._css()
+        # picker-check-icon, picker-refresh-btn, picker-open cover-actions
+        assert "transition: opacity 0.15s;" in css, \
+            "picker-check-icon 0.15s 應保留（女優白名單）"
+        assert "transition: all 0.15s;" in css, \
+            "picker-refresh-btn 0.15s 應保留（女優白名單）"
+        assert "transition: opacity 0.2s;" in css, \
+            "picker-open cover-actions 0.2s 應保留（女優白名單）"
+
+
 class TestMotionDurationConstants:
     """Phase 50.2.9: motion.DURATION 三角色常數 + 業務 caller 套用 (CD-1)"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2686,6 +2686,45 @@ class TestActressIconGuard:
         assert "bi-person-badge" not in html, "scanner.html 仍有 bi-person-badge"
 
 
+class TestFluentCustomEaseRegistered:
+    """Phase 50.2.0: motion-adapter.js 同步註冊 fluent CustomEase 三角色"""
+
+    def _js(self):
+        return Path("web/static/js/components/motion-adapter.js").read_text(encoding="utf-8")
+
+    def test_fluent_standard_registered(self):
+        js = self._js()
+        assert "CustomEase.create('fluent'" in js, \
+            "motion-adapter.js 缺 CustomEase.create('fluent', ...) — charter §5 standard"
+
+    def test_fluent_decel_registered(self):
+        js = self._js()
+        assert "CustomEase.create('fluent-decel'" in js, \
+            "motion-adapter.js 缺 CustomEase.create('fluent-decel', ...) — charter §5 decel"
+
+    def test_fluent_accel_registered(self):
+        js = self._js()
+        assert "CustomEase.create('fluent-accel'" in js, \
+            "motion-adapter.js 缺 CustomEase.create('fluent-accel', ...) — charter §5 accel"
+
+    def test_register_is_guarded(self):
+        """guard 寫法避免 CustomEase plugin 載入失敗時 IIFE 炸掉"""
+        js = self._js()
+        assert "typeof CustomEase !== 'undefined'" in js, \
+            "fluent ease 註冊應用 typeof guard 包住"
+
+    def test_register_is_synchronous(self):
+        """同步註冊（不放 DOMContentLoaded handler，CD-2）"""
+        js = self._js()
+        # 註冊區段位於 IIFE 內、var motion 之前；不應出現 DOMContentLoaded wrapper 包裹 CustomEase.create
+        register_idx = js.find("CustomEase.create('fluent'")
+        dom_ready_idx = js.find("DOMContentLoaded")
+        # 若有 DOMContentLoaded（reduced-motion handler 等），其位置必須在 register 之後
+        if dom_ready_idx != -1:
+            assert register_idx < dom_ready_idx, \
+                "fluent CustomEase 註冊不應被 DOMContentLoaded handler 包住"
+
+
 class TestGhostFlyGuards:
     """T8: Ghost Fly 架構守衛"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2796,6 +2796,23 @@ class TestShowcaseAnimationsFluent:
         assert "params.ease || 'fluent'" in scope, \
             "playFlipReorder default ease 應為 'fluent'（charter §5 standard 互動）"
 
+    # === T2.4 — playFlipFilter (main + onEnter ×2 + onLeave) ===
+    def test_play_flip_filter_main_fluent(self):
+        scope = self._scoped("playFlipFilter", 2000)
+        assert "ease: 'fluent'," in scope, \
+            "playFlipFilter Flip.from main ease 應為 'fluent'"
+
+    def test_play_flip_filter_on_enter_fluent_decel(self):
+        scope = self._scoped("playFlipFilter", 2000)
+        # 兩處 onEnter（>10 純 fade / ≤10 scale+fade）皆應為 fluent-decel
+        assert scope.count("ease: 'fluent-decel'") >= 2, \
+            "playFlipFilter onEnter（>10 / ≤10 兩個分支）ease 應為 'fluent-decel'（×2）"
+
+    def test_play_flip_filter_on_leave_fluent_accel(self):
+        scope = self._scoped("playFlipFilter", 2000)
+        assert "ease: 'fluent-accel'" in scope, \
+            "playFlipFilter onLeave ease 應為 'fluent-accel'（charter §5 離場）"
+
     # === showcaseSettle 招牌曲線白名單 — 不動 ===
     def test_showcase_settle_whitelist_preserved(self):
         """showcaseSettle 是 charter §5 white-list 招牌曲線，必須保留"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2807,6 +2807,17 @@ class TestShowcaseAnimationsFluent:
         assert "ease: 'fluent-decel'" in scope, \
             "playModeCrossfade new fade-in 應為 'fluent-decel'（進場）"
 
+    # === T2.6 — playLightboxOpen 3 段 ===
+    def test_play_lightbox_open_three_decel(self):
+        scope = self._scoped("playLightboxOpen", 2500)
+        assert scope.count("ease: 'fluent-decel'") >= 3, \
+            "playLightboxOpen backdrop+content+cover 三段 ease 應為 'fluent-decel'（×3）"
+
+    def test_play_lightbox_open_no_legacy_power(self):
+        scope = self._scoped("playLightboxOpen", 2500)
+        assert "power2.out" not in scope, \
+            "playLightboxOpen 殘留 power2.out — Phase 50.2.6 未完成"
+
     # === T2.4 — playFlipFilter (main + onEnter ×2 + onLeave) ===
     def test_play_flip_filter_main_fluent(self):
         scope = self._scoped("playFlipFilter", 2000)

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2921,16 +2921,33 @@ class TestShowcaseAnimationsFluent:
         assert "ease: 'power2.out'" in scope, \
             "playHeroCardAppear ease 不應被改（女優專屬 white-list）"
 
-    # === T2.6 — playLightboxOpen 3 段 ===
-    def test_play_lightbox_open_three_decel(self):
-        scope = self._scoped("playLightboxOpen", 2500)
-        assert scope.count("ease: 'fluent-decel'") >= 3, \
-            "playLightboxOpen backdrop+content+cover 三段 ease 應為 'fluent-decel'（×3）"
+    # === Phase 50.x revert — playLightboxOpen 3 段保留 power2.out（charter §5 white-list 例外）===
+    # 理由：playLightboxOpen 與 ghost-fly playGridToLightbox (0.38s power2.inOut, CD-3 觀察項)
+    # 並行播放，需保留 power 系曲線族避免節奏錯位。fluent-decel (0,0,0,1) 起步快終端慢
+    # 與 ghost-fly power2.inOut 終端慢視覺重疊，造成「最後一小段卡」。
+    def test_play_lightbox_open_three_power_out(self):
+        """三段（backdrop / content / cover）ease 為 power2.out（white-list 例外）"""
+        scope = self._scoped("playLightboxOpen", 4500)
+        assert scope.count("ease: 'power2.out'") >= 3, \
+            "playLightboxOpen backdrop+content+cover 三段 ease 應為 'power2.out'（×3，charter §5 white-list 例外，與 ghost-fly 並行段）"
 
-    def test_play_lightbox_open_no_legacy_power(self):
-        scope = self._scoped("playLightboxOpen", 2500)
-        assert "power2.out" not in scope, \
-            "playLightboxOpen 殘留 power2.out — Phase 50.2.6 未完成"
+    def test_play_lightbox_open_no_fluent_decel_in_three_phases(self):
+        """三段不應誤用 fluent-decel（與 ghost-fly power2.inOut 終端視覺重疊）"""
+        scope = self._scoped("playLightboxOpen", 4500)
+        assert "ease: 'fluent-decel'" not in scope, \
+            "playLightboxOpen 不應使用 'fluent-decel'（與 ghost-fly playGridToLightbox 並行段視覺重疊；white-list 例外用 power2.out）"
+
+    def test_play_lightbox_open_white_list_comment_present(self):
+        """white-list 例外註解必須留存（避免後續清 hardcoded duration 時誤改）"""
+        scope = self._scoped("playLightboxOpen", 4500)
+        assert "white-list" in scope or "ghost-fly" in scope, \
+            "playLightboxOpen 應有 charter §5 white-list / ghost-fly 並行段註解，標明 power2.out 為刻意保留"
+
+    def test_play_lightbox_open_clearprops_cleanup(self):
+        """onComplete + onInterrupt 補 clearProps 防連點殘留（Phase 50.x cleanup）"""
+        scope = self._scoped("playLightboxOpen", 4500)
+        assert scope.count("clearProps: 'transform,opacity'") >= 4, \
+            "playLightboxOpen onComplete + onInterrupt 應各有 content + coverImg 兩處 clearProps（共 4 處）"
 
     # === T2.4 — playFlipFilter (main + onEnter ×2 + onLeave) ===
     def test_play_flip_filter_main_fluent(self):

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2725,6 +2725,55 @@ class TestFluentCustomEaseRegistered:
                 "fluent CustomEase 註冊不應被 DOMContentLoaded handler 包住"
 
 
+class TestMotionDurationConstants:
+    """Phase 50.2.9: motion.DURATION 三角色常數 + 業務 caller 套用 (CD-1)"""
+
+    def _adapter(self):
+        return Path("web/static/js/components/motion-adapter.js").read_text(encoding="utf-8")
+
+    def _animations(self):
+        return Path("web/static/js/pages/showcase/animations.js").read_text(encoding="utf-8")
+
+    def test_duration_constants_exposed(self):
+        """motion.DURATION 三角色常數透過 IIFE 暴露於 window.OpenAver.motion"""
+        js = self._adapter()
+        assert "DURATION:" in js, "motion-adapter.js 缺 DURATION: 物件定義"
+        # 三角色值對齊 charter §5 (167ms / 333ms / 500ms)
+        assert "fast:" in js and "0.167" in js, "DURATION.fast 應為 0.167 (charter §5 167ms)"
+        assert "medium:" in js and "0.333" in js, "DURATION.medium 應為 0.333 (charter §5 333ms)"
+        assert "emphasis:" in js and "0.5" in js, "DURATION.emphasis 應為 0.5 (charter §5 500ms)"
+
+    def test_adapter_callers_use_duration_constants(self):
+        """motion-adapter.js 內部 caller 使用 motion.DURATION.* 取代 hardcoded fallback"""
+        js = self._adapter()
+        assert js.count("motion.DURATION.") >= 4, \
+            "motion-adapter.js 至少 4 個 caller (playEnter/Leave/FadeTo/Modal/Stagger) 應走 motion.DURATION.*"
+
+    def test_animations_callers_use_duration_constants(self):
+        """showcase/animations.js 業務 caller 使用 OpenAver.motion.DURATION.*"""
+        js = self._animations()
+        assert js.count("OpenAver.motion.DURATION.") >= 8, \
+            "animations.js 至少 8 處 hardcoded duration 應改走 OpenAver.motion.DURATION.*"
+
+    def test_white_list_durations_preserved(self):
+        """白名單 hardcoded duration 不被誤改：
+        - showcaseSettle 招牌曲線 (charter §5 white-list)
+        - HeroCardAppear (女優專屬，plan D10)
+        - SourcePulse 0.1 (低於 DURATION.fast 不適合 bucket)"""
+        js = self._animations()
+        # showcaseSettle: var dur = params.duration || 0.8;
+        assert "params.duration || 0.8" in js, "playSettle (showcaseSettle) duration 0.8 不應被改"
+        # HeroCardAppear: duration: 0.3
+        hero_idx = js.find("playHeroCardAppear")
+        hero_scope = js[hero_idx : hero_idx + 800]
+        assert "duration: 0.3" in hero_scope, "playHeroCardAppear duration 0.3 (女優白名單) 不應被改"
+        # SourcePulse default 0.1 stays
+        pulse_idx = js.find("playSourcePulse")
+        pulse_scope = js[pulse_idx : pulse_idx + 800]
+        assert "options.duration : 0.1" in pulse_scope, \
+            "playSourcePulse default 0.1 (低於 fast bucket) 不應被改"
+
+
 class TestMotionAdapterFluentDefaults:
     """Phase 50.2.1: motion-adapter.js 5 default ease → fluent 角色"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2807,6 +2807,27 @@ class TestShowcaseAnimationsFluent:
         assert "ease: 'fluent-decel'" in scope, \
             "playModeCrossfade new fade-in 應為 'fluent-decel'（進場）"
 
+    # === T2.7 — playLightboxSwitch / playSampleGallerySwitch → fluent ===
+    def test_play_lightbox_switch_fluent(self):
+        scope = self._scoped("playLightboxSwitch", 1500)
+        assert "ease: 'fluent'" in scope, \
+            "playLightboxSwitch ease 應為 'fluent'（charter §5 standard 互動切換）"
+        assert "power2.out" not in scope, "playLightboxSwitch 殘留 power2.out"
+
+    def test_play_sample_gallery_switch_fluent(self):
+        scope = self._scoped("playSampleGallerySwitch", 1300)
+        assert "ease: 'fluent'" in scope, \
+            "playSampleGallerySwitch ease 應為 'fluent'（charter §5 standard 互動切換）"
+        assert "power2.out" not in scope, "playSampleGallerySwitch 殘留 power2.out"
+
+    # === playHeroCardAppear — 女優專屬白名單，不動 ===
+    def test_hero_card_appear_whitelist_not_touched(self):
+        """playHeroCardAppear 為女優專屬（plan D10 white-list），ease 不被本 phase 改"""
+        scope = self._scoped("playHeroCardAppear", 800)
+        # 白名單保留 power2.out（spec scope 排除女優模式）
+        assert "ease: 'power2.out'" in scope, \
+            "playHeroCardAppear ease 不應被改（女優專屬 white-list）"
+
     # === T2.6 — playLightboxOpen 3 段 ===
     def test_play_lightbox_open_three_decel(self):
         scope = self._scoped("playLightboxOpen", 2500)

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2820,6 +2820,18 @@ class TestShowcaseAnimationsFluent:
             "playSampleGallerySwitch ease 應為 'fluent'（charter §5 standard 互動切換）"
         assert "power2.out" not in scope, "playSampleGallerySwitch 殘留 power2.out"
 
+    # === T2.8 — playContainerFadeIn / playSourcePulse ===
+    def test_play_container_fade_in_default_fluent_decel(self):
+        scope = self._scoped("playContainerFadeIn", 800)
+        assert "options.ease || 'fluent-decel'" in scope, \
+            "playContainerFadeIn default ease 應為 'fluent-decel'（charter §5 進場）"
+
+    def test_play_source_pulse_fluent(self):
+        scope = self._scoped("playSourcePulse", 800)
+        assert "ease: 'fluent'" in scope, \
+            "playSourcePulse ease 應為 'fluent'（charter §5 standard yoyo pulse）"
+        assert "power2.inOut" not in scope, "playSourcePulse 殘留 power2.inOut"
+
     # === playHeroCardAppear — 女優專屬白名單，不動 ===
     def test_hero_card_appear_whitelist_not_touched(self):
         """playHeroCardAppear 為女優專屬（plan D10 white-list），ease 不被本 phase 改"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2790,6 +2790,12 @@ class TestShowcaseAnimationsFluent:
         assert "params.easing || 'fluent-decel'" in scope, \
             "playEntry default ease 應為 'fluent-decel'（charter §5 進場）"
 
+    # === T2.3 — playFlipReorder → fluent (standard) ===
+    def test_play_flip_reorder_default_fluent(self):
+        scope = self._scoped("playFlipReorder", 1500)
+        assert "params.ease || 'fluent'" in scope, \
+            "playFlipReorder default ease 應為 'fluent'（charter §5 standard 互動）"
+
     # === showcaseSettle 招牌曲線白名單 — 不動 ===
     def test_showcase_settle_whitelist_preserved(self):
         """showcaseSettle 是 charter §5 white-list 招牌曲線，必須保留"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2772,6 +2772,32 @@ class TestMotionAdapterFluentDefaults:
             "motion-adapter.js 殘留 power* default ease — 未完成 fluent 角色化"
 
 
+class TestShowcaseAnimationsFluent:
+    """Phase 50.2.2-2.8: showcase/animations.js 各動畫 ease → charter §5 fluent 角色"""
+
+    def _js(self):
+        return Path("web/static/js/pages/showcase/animations.js").read_text(encoding="utf-8")
+
+    def _scoped(self, fn_name, length=1500):
+        js = self._js()
+        idx = js.find(fn_name + ":")
+        assert idx > 0, f"找不到 {fn_name}"
+        return js[idx : idx + length]
+
+    # === T2.2 — playEntry → fluent-decel ===
+    def test_play_entry_default_fluent_decel(self):
+        scope = self._scoped("playEntry", 800)
+        assert "params.easing || 'fluent-decel'" in scope, \
+            "playEntry default ease 應為 'fluent-decel'（charter §5 進場）"
+
+    # === showcaseSettle 招牌曲線白名單 — 不動 ===
+    def test_showcase_settle_whitelist_preserved(self):
+        """showcaseSettle 是 charter §5 white-list 招牌曲線，必須保留"""
+        js = self._js()
+        assert 'CustomEase.create("showcaseSettle"' in js, \
+            "showcaseSettle 招牌曲線（white-list）不應被誤刪"
+
+
 class TestGhostFlyGuards:
     """T8: Ghost Fly 架構守衛"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2796,6 +2796,17 @@ class TestShowcaseAnimationsFluent:
         assert "params.ease || 'fluent'" in scope, \
             "playFlipReorder default ease 應為 'fluent'（charter §5 standard 互動）"
 
+    # === T2.5 — playModeCrossfade ===
+    def test_play_mode_crossfade_old_fluent_accel(self):
+        scope = self._scoped("playModeCrossfade", 2000)
+        assert "ease: 'fluent-accel'" in scope, \
+            "playModeCrossfade old fade-out 應為 'fluent-accel'（離場）"
+
+    def test_play_mode_crossfade_new_fluent_decel(self):
+        scope = self._scoped("playModeCrossfade", 2000)
+        assert "ease: 'fluent-decel'" in scope, \
+            "playModeCrossfade new fade-in 應為 'fluent-decel'（進場）"
+
     # === T2.4 — playFlipFilter (main + onEnter ×2 + onLeave) ===
     def test_play_flip_filter_main_fluent(self):
         scope = self._scoped("playFlipFilter", 2000)

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 from PIL import Image
 
-from core.organizer import _detect_suffixes, format_string, organize_file, crop_to_poster, generate_nfo, extract_chinese_title, download_image
+from core.organizer import _detect_suffixes, format_string, organize_file, crop_to_poster, generate_nfo, extract_chinese_title, download_image, truncate_to_chars, truncate_title
 
 
 # ============ _detect_suffixes() 測試 ============
@@ -1824,3 +1824,48 @@ class TestOrganizeSubtitle:
         nfo_content = Path(result["nfo_path"]).read_text(encoding="utf-8")
         assert "中文字幕" in nfo_content, \
             "has_subtitle=False 但有 sidecar 字幕時，NFO 應包含中文字幕 tag"
+
+
+# ============ Issue #31 — Windows trailing-dot truncation ============
+
+class TestTruncateWindowsTrailingDot:
+    """Issue #31: 截斷後尾端 `...` 在 Windows 會被 NTFS 剝除，導致 shutil.move WinError 3"""
+
+    def test_truncate_to_chars_strips_trailing_dots_on_windows(self, monkeypatch):
+        monkeypatch.setattr('core.organizer.sys.platform', 'win32')
+        result = truncate_to_chars("僕が不在の5日間、彼女が他の男と朝から晩までヤリまくっていた胸糞映像 吉高寧々", 40)
+        assert not result.endswith('.'), f"Windows: 截斷結果不應以 . 結尾, got {result!r}"
+        assert not result.endswith(' '), f"Windows: 截斷結果不應以空格結尾, got {result!r}"
+
+    def test_truncate_to_chars_keeps_ellipsis_on_posix(self, monkeypatch):
+        monkeypatch.setattr('core.organizer.sys.platform', 'linux')
+        result = truncate_to_chars("a" * 100, 40)
+        assert result.endswith('...'), f"Non-Windows: 應保留 ... 後綴, got {result!r}"
+        assert len(result) == 40
+
+    def test_truncate_to_chars_no_change_when_under_limit(self, monkeypatch):
+        monkeypatch.setattr('core.organizer.sys.platform', 'win32')
+        result = truncate_to_chars("short", 60)
+        assert result == "short"
+
+    def test_truncate_title_strips_trailing_dots_on_windows(self, monkeypatch):
+        monkeypatch.setattr('core.organizer.sys.platform', 'win32')
+        result = truncate_title("a" * 100, 30)
+        assert not result.endswith('.'), f"Windows truncate_title 結果不應以 . 結尾, got {result!r}"
+
+    def test_truncate_title_keeps_ellipsis_on_posix(self, monkeypatch):
+        monkeypatch.setattr('core.organizer.sys.platform', 'darwin')
+        result = truncate_title("a" * 100, 30)
+        assert result.endswith('...')
+
+    def test_truncate_strips_trailing_space_before_dots_on_windows(self, monkeypatch):
+        # 文字剛好截在空格 + ... → "foo ..."  Windows 會剝成 "foo"
+        monkeypatch.setattr('core.organizer.sys.platform', 'win32')
+        # 構造一個截斷後變 "xxxxx ..." 的字串
+        text = "x" * 36 + " " + "yyy"  # 長度 40, 截到 max=40 不變; 設 max=39 → "xxxx..." 結尾無空格
+        # 直接驗證：任何長度都不應以 . 或空格結尾
+        for limit in (10, 20, 39, 50):
+            r = truncate_to_chars(text, limit)
+            if len(text) > limit and limit > 3:
+                assert not r.endswith('.') and not r.endswith(' '), \
+                    f"limit={limit}: got {r!r}"

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -55,6 +55,9 @@
   --fluent-duration-normal: 250ms;
   --fluent-duration-slow: 300ms;
   --fluent-duration-slower: 400ms;
+  /* Charter v2 §5 三角色補齊（CD-7 命名避讓既有 slow:300ms） */
+  --fluent-duration-medium: 333ms;       /* charter standard 中段過場 */
+  --fluent-duration-emphasis: 500ms;     /* charter 強調級長過場 */
 
   /* 動畫緩動函數 - Fluent 官方規範 */
   --fluent-ease-decel: cubic-bezier(0, 0, 0, 1);        /* 進入動畫 */
@@ -68,8 +71,18 @@
   --fluent-acrylic-bg-light: rgba(255, 255, 255, 0.7);
   --fluent-acrylic-bg-dark: rgba(28, 28, 30, 0.7);
 
+  /* Charter v2 §2 三階玻璃補齊 */
+  --fluent-blur-light: 12px;     /* floating-control 近景（貼合元件薄膜）*/
+  --fluent-blur-heavy: 60px;     /* canvas Mica 主畫布 */
+
   /* Smoke 遮罩 */
   --fluent-smoke: rgba(0, 0, 0, 0.4);
+
+  /* Charter v2 §3 角色色白名單 — Overlay 4 階 */
+  --overlay-gallery:  rgba(0, 0, 0, 0.85);  /* sample gallery 暗幕 */
+  --overlay-modal:    rgba(0, 0, 0, 0.6);   /* lightbox backdrop */
+  --overlay-gradient: rgba(0, 0, 0, 0.55);  /* card hover 漸層 bottom */
+  --overlay-control:  rgba(0, 0, 0, 0.45);  /* 浮在媒體上的控制按鈕 */
 }
 
 /* Dark Theme 陰影 - 更深的陰影 */

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -708,7 +708,7 @@
 .lightbox-metadata .lb-tag {
     padding: 0.15rem 0.5rem;
     background: var(--bg-body);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     font-size: 0.6875rem;
     color: var(--text-secondary);
     border: 1px solid var(--stroke-subtle);
@@ -1528,7 +1528,7 @@ body.sidebar-collapsed .showcase-footer {
     max-height: calc(100vh - 160px);
     object-fit: contain;
     display: block;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     user-select: none;
 }
 
@@ -1551,7 +1551,7 @@ body.sidebar-collapsed .showcase-footer {
 
 .sample-gallery .sg-thumbs::-webkit-scrollbar-thumb {
     background: rgba(255, 255, 255, 0.3);
-    border-radius: 2px;
+    border-radius: var(--fluent-radius-sm);
 }
 
 /* 縮圖按鈕 */
@@ -1562,7 +1562,7 @@ body.sidebar-collapsed .showcase-footer {
     padding: 0;
     background: none;
     border: 2px solid transparent;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     cursor: pointer;
     overflow: hidden;
     transition: border-color 0.15s ease, opacity 0.15s ease;
@@ -1597,7 +1597,7 @@ body.sidebar-collapsed .showcase-footer {
     color: rgba(255, 255, 255, 0.9);
     font-size: 0.8rem;
     padding: 0.25rem 0.6rem;
-    border-radius: 12px;
+    border-radius: var(--radius-pill);
     pointer-events: none;
     user-select: none;
 }
@@ -1670,7 +1670,7 @@ body.sidebar-collapsed .showcase-footer {
     flex-shrink: 0;
     padding: 0.25rem 0.75rem;
     font-size: 0.8rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     border: 1px solid var(--glow-primary);
     background: var(--glow-subtle);
     color: var(--accent);
@@ -1692,7 +1692,7 @@ body.sidebar-collapsed .showcase-footer {
     flex-shrink: 0;
     padding: 0.25rem 0.75rem;
     font-size: 0.8rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     border: 1px solid color-mix(in oklch, var(--accent-secondary) 40%, transparent);
     background: color-mix(in oklch, var(--accent-secondary) 15%, transparent);
     color: var(--accent-secondary);
@@ -1736,7 +1736,7 @@ body.sidebar-collapsed .showcase-footer {
     padding: 0.15rem 0.5rem;
     background: var(--accent);
     color: var(--color-primary-content);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     font-size: 0.6875rem;
 }
 
@@ -1841,7 +1841,7 @@ body.sidebar-collapsed .showcase-footer {
 /* lb-chips-more shared rule for video lightbox tags +N */
 .lightbox-metadata .lb-chips-more {
     cursor: pointer; font-size: 0.85em; padding: 2px 8px;
-    border-radius: 12px; border: 1px solid currentColor; opacity: 0.6;
+    border-radius: var(--radius-md); border: 1px solid currentColor; opacity: 0.6;
 }
 
 /* ==================== Mode Toggle Capsule (44c-T4) ==================== */
@@ -1856,7 +1856,7 @@ body.sidebar-collapsed .showcase-footer {
     align-items: center;
     gap: 2px;
     background: rgba(255, 255, 255, 0.08);
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     padding: 2px;
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -517,8 +517,9 @@
 
     /* Smoke Backdrop — 匹配 gallery_generator.py 舊版風格 */
     background: var(--overlay-modal);
-    backdrop-filter: blur(var(--fluent-blur));
-    -webkit-backdrop-filter: blur(var(--fluent-blur));
+    /* charter §2 仲裁：lightbox backdrop 用 floating-control 12px (非 overlay 30px)，保留 grid spatial reference UX */
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
 
     /* 初始隱藏 */
     opacity: 0;

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -375,7 +375,7 @@
     justify-content: center;
     align-items: flex-end;
     padding-bottom: 12px;
-    background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+    background: linear-gradient(to top, var(--overlay-gradient) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
     opacity: 0;
     transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard);
@@ -516,7 +516,7 @@
     justify-content: center;
 
     /* Smoke Backdrop — 匹配 gallery_generator.py 舊版風格 */
-    background: rgba(0, 0, 0, 0.6);
+    background: var(--overlay-modal);
     backdrop-filter: blur(var(--fluent-blur));
     -webkit-backdrop-filter: blur(var(--fluent-blur));
 
@@ -590,7 +590,7 @@
     height: 44px;
     border: none;
     border-radius: 50%;
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--overlay-control);
     backdrop-filter: blur(var(--fluent-blur-light));
     -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: var(--text-inverse);
@@ -602,6 +602,7 @@
 }
 
 .lightbox-close:hover {
+    /* hover 升階 0.5 (charter §3 個案保留，控制按鈕 hover 強調) */
     background: rgba(0, 0, 0, 0.5);
     transform: scale(1.1);
 }
@@ -724,7 +725,7 @@
     align-items: flex-end;
     padding-bottom: 24px;
     gap: 12px;
-    background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+    background: linear-gradient(to top, var(--overlay-gradient) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
     opacity: 0;
     transition: opacity var(--duration-fast) var(--ease-out);
@@ -821,7 +822,7 @@
     height: 56px;
     border: none;
     border-radius: 50%;
-    background: rgba(0, 0, 0, 0.3);
+    background: var(--overlay-control);
     backdrop-filter: blur(var(--fluent-blur-light));
     -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: var(--text-inverse);
@@ -833,6 +834,7 @@
 }
 
 .lightbox-nav:hover {
+    /* hover 升階 0.5 (charter §3 個案保留，同 .lightbox-close:hover) */
     background: rgba(0, 0, 0, 0.5);
     transform: translateY(-50%) scale(1.1);
 }
@@ -1494,7 +1496,7 @@ body.sidebar-collapsed .showcase-footer {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.85);
+    background: var(--overlay-gallery);
     backdrop-filter: blur(var(--fluent-blur));
     -webkit-backdrop-filter: blur(var(--fluent-blur));
 
@@ -1594,7 +1596,7 @@ body.sidebar-collapsed .showcase-footer {
     position: absolute;
     top: 1rem;
     right: 4rem;
-    background: rgba(0, 0, 0, 0.55);
+    background: var(--overlay-gradient);
     color: rgba(255, 255, 255, 0.9);
     font-size: 0.8rem;
     padding: 0.25rem 0.6rem;
@@ -1608,7 +1610,7 @@ body.sidebar-collapsed .showcase-footer {
     position: absolute;
     top: 0.75rem;
     right: 0.75rem;
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--overlay-control);
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 50%;
     width: 2.25rem;
@@ -1633,7 +1635,7 @@ body.sidebar-collapsed .showcase-footer {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    background: rgba(0, 0, 0, 0.45);
+    background: var(--overlay-control);
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 50%;
     width: 2.5rem;

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -375,7 +375,7 @@
     justify-content: center;
     align-items: flex-end;
     padding-bottom: 12px;
-    background: linear-gradient(to top, var(--overlay-gradient) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+    background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
     opacity: 0;
     transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard);
@@ -2214,10 +2214,23 @@ body.sidebar-collapsed .showcase-footer {
 /* ==================== Phase 50 T5 §6 5 檢查點 — DaisyUI Component Override ==================== */
 /* Fluent 覆寫 .showcase-container 內 DaisyUI .btn / .input（charter §6 5 檢查點：radius/surface/stroke/shadow/hover-focus）*/
 /* CD-4 限制：scoped 在 .showcase-container 內，不影響其他頁面 */
+/* P1b fix: 補齊 Stroke token、Surface token、修正 Focus 為 2px outline + 4px glow（charter §6） */
+
+/* §6 Checkpoint 1 Radius: var(--fluent-radius-md) */
+/* §6 Checkpoint 2 Surface: DaisyUI variant 提供 .btn background；.input 補 var(--surface-1) */
+/* §6 Checkpoint 3 Stroke: border var(--stroke-default) + inset 0 1px 0 dual-layer 內框 */
+/* §6 Checkpoint 4 Shadow: var(--fluent-shadow-2)，hover 升 --fluent-shadow-4 */
+/* §6 Checkpoint 5 Hover/Focus: hover 升 shadow + translateY；focus 2px outline + 4px glow */
 
 .showcase-container .btn {
     border-radius: var(--fluent-radius-md);
-    box-shadow: var(--fluent-shadow-2);
+    /* Stroke: width/style only — 保留 DaisyUI variant border-color (.btn-outline.btn-primary 等) */
+    border-width: 1px;
+    border-style: solid;
+    /* Shadow: 底階 + dual-layer 內框 */
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent),
+        var(--fluent-shadow-2);
     transition:
         background var(--fluent-duration-fast) var(--fluent-ease-standard),
         border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
@@ -2226,22 +2239,41 @@ body.sidebar-collapsed .showcase-footer {
 }
 
 .showcase-container .btn:hover:not(:disabled) {
-    box-shadow: var(--fluent-shadow-4);
+    /* hover 不覆寫 border-color，DaisyUI variant 自管 (.btn-outline.btn-primary primary 強調保留) */
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 12%, transparent),
+        var(--fluent-shadow-4);
     transform: translateY(-1px);
 }
 
 .showcase-container .btn:focus-visible {
-    outline: none;
-    box-shadow: var(--fluent-shadow-2), 0 0 0 3px var(--glow-primary);
+    /* Focus: 2px outline + 4px glow（charter §6 Checkpoint 5 精確規格） */
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent),
+        var(--fluent-shadow-2),
+        0 0 0 4px var(--glow-primary);
 }
 
 .showcase-container .btn:active:not(:disabled) {
     transform: translateY(0);
-    box-shadow: var(--fluent-shadow-2);
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-2);
 }
 
 .showcase-container .input {
     border-radius: var(--fluent-radius-md);
+    /* Surface: 輸入框用 surface-1 基底（charter §6 Checkpoint 2） */
+    background: var(--surface-1);
+    /* Stroke: width/style only — 保留 DaisyUI .input-bordered variant border-color */
+    border-width: 1px;
+    border-style: solid;
+    /* Shadow: 輸入框底階（charter §6 Checkpoint 4） */
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-2);
     transition:
         border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
         box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
@@ -2249,7 +2281,12 @@ body.sidebar-collapsed .showcase-footer {
 
 .showcase-container .input:focus,
 .showcase-container .input:focus-visible {
-    outline: none;
+    /* Focus: 2px outline + 4px glow（charter §6 Checkpoint 5 精確規格） */
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
     border-color: var(--accent);
-    box-shadow: 0 0 0 3px var(--glow-primary);
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent),
+        var(--fluent-shadow-2),
+        0 0 0 4px var(--glow-primary);
 }

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1505,7 +1505,8 @@ body.sidebar-collapsed .showcase-footer {
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
-    transition: opacity 0.2s ease, visibility 0.2s ease;
+    transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard),
+                visibility var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 .sample-gallery.show {
@@ -1569,7 +1570,8 @@ body.sidebar-collapsed .showcase-footer {
     border-radius: var(--fluent-radius-md);
     cursor: pointer;
     overflow: hidden;
-    transition: border-color 0.15s ease, opacity 0.15s ease;
+    transition: border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+                opacity var(--fluent-duration-fast) var(--fluent-ease-standard);
     opacity: 0.6;
 }
 
@@ -1621,7 +1623,8 @@ body.sidebar-collapsed .showcase-footer {
     justify-content: center;
     color: rgba(255, 255, 255, 0.8);
     cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease;
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-standard),
+                color var(--fluent-duration-fast) var(--fluent-ease-standard);
     font-size: 1rem;
     z-index: 10;
 }
@@ -1646,7 +1649,8 @@ body.sidebar-collapsed .showcase-footer {
     justify-content: center;
     color: rgba(255, 255, 255, 0.8);
     cursor: pointer;
-    transition: background 0.15s ease, color 0.15s ease;
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-standard),
+                color var(--fluent-duration-fast) var(--fluent-ease-standard);
     font-size: 1.1rem;
     z-index: 10;
     /* 避免縮圖列遮到箭頭 */
@@ -1679,7 +1683,8 @@ body.sidebar-collapsed .showcase-footer {
     background: var(--glow-subtle);
     color: var(--accent);
     cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease;
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-standard),
+                border-color var(--fluent-duration-fast) var(--fluent-ease-standard);
     white-space: nowrap;
 }
 
@@ -1701,7 +1706,8 @@ body.sidebar-collapsed .showcase-footer {
     background: color-mix(in oklch, var(--accent-secondary) 15%, transparent);
     color: var(--accent-secondary);
     cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease;
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-standard),
+                border-color var(--fluent-duration-fast) var(--fluent-ease-standard);
     white-space: nowrap;
 }
 
@@ -1877,7 +1883,7 @@ body.sidebar-collapsed .showcase-footer {
     align-items: center;
     justify-content: center;
     font-size: 0.9rem;
-    transition: all 0.15s ease;
+    transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 .mode-toggle-btn.active {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -2210,3 +2210,46 @@ body.sidebar-collapsed .showcase-footer {
 .picker-refresh-btn i.spin {
     animation: spin 1s linear infinite;
 }
+
+/* ==================== Phase 50 T5 §6 5 檢查點 — DaisyUI Component Override ==================== */
+/* Fluent 覆寫 .showcase-container 內 DaisyUI .btn / .input（charter §6 5 檢查點：radius/surface/stroke/shadow/hover-focus）*/
+/* CD-4 限制：scoped 在 .showcase-container 內，不影響其他頁面 */
+
+.showcase-container .btn {
+    border-radius: var(--fluent-radius-md);
+    box-shadow: var(--fluent-shadow-2);
+    transition:
+        background var(--fluent-duration-fast) var(--fluent-ease-standard),
+        border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+        box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard),
+        transform var(--fluent-duration-fast) var(--fluent-ease-standard);
+}
+
+.showcase-container .btn:hover:not(:disabled) {
+    box-shadow: var(--fluent-shadow-4);
+    transform: translateY(-1px);
+}
+
+.showcase-container .btn:focus-visible {
+    outline: none;
+    box-shadow: var(--fluent-shadow-2), 0 0 0 3px var(--glow-primary);
+}
+
+.showcase-container .btn:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow: var(--fluent-shadow-2);
+}
+
+.showcase-container .input {
+    border-radius: var(--fluent-radius-md);
+    transition:
+        border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+        box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
+}
+
+.showcase-container .input:focus,
+.showcase-container .input:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--glow-primary);
+}

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -26,8 +26,8 @@
 
     /* Acrylic 毛玻璃效果（Fluent Design 2 - Heavy Glass）*/
     background: var(--bg-header); /* color-mix 85% transparency */
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(var(--fluent-blur));
+    -webkit-backdrop-filter: blur(var(--fluent-blur));
 
     /* Border */
     border-bottom: 1px solid var(--border-light);
@@ -517,8 +517,8 @@
 
     /* Smoke Backdrop — 匹配 gallery_generator.py 舊版風格 */
     background: rgba(0, 0, 0, 0.6);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--fluent-blur));
+    -webkit-backdrop-filter: blur(var(--fluent-blur));
 
     /* 初始隱藏 */
     opacity: 0;
@@ -591,8 +591,8 @@
     border: none;
     border-radius: 50%;
     background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: var(--text-inverse);
     font-size: 1.25rem;
     cursor: pointer;
@@ -742,13 +742,13 @@
     border: 1px solid rgba(255,255,255,0.4);
     border-radius: 50%;
     background: rgba(255,255,255,0.15);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: white;
     font-size: 1.125rem;
     cursor: pointer;
     display: flex; align-items: center; justify-content: center;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    box-shadow: var(--fluent-shadow-8);
     transition: background var(--duration-fast) var(--ease-out),
                 border-color var(--duration-fast) var(--ease-out),
                 transform var(--duration-fast) var(--ease-out),
@@ -759,7 +759,7 @@
     background: rgba(255,255,255,0.3);
     border-color: rgba(255,255,255,0.6);
     transform: scale(1.08);
-    box-shadow: 0 6px 16px rgba(0,0,0,0.4);
+    box-shadow: var(--fluent-shadow-16);
 }
 
 .lb-action-btn:active {
@@ -822,8 +822,8 @@
     border: none;
     border-radius: 50%;
     background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: var(--text-inverse);
     font-size: 1.5rem;
     cursor: pointer;
@@ -1248,8 +1248,8 @@
 
     /* 背景 - 使用 Design System token */
     background: var(--bg-header);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     border-top: 1px solid var(--stroke-subtle);
 
     /* 間距 */
@@ -1331,7 +1331,7 @@ body.sidebar-collapsed .showcase-footer {
     background: var(--surface-1);
     border: 1px solid var(--stroke-default);
     border-radius: var(--radius-sm);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--fluent-shadow-2);
 
     font-family: var(--font-mono);
     font-size: 0.75rem;
@@ -1494,8 +1494,8 @@ body.sidebar-collapsed .showcase-footer {
     align-items: center;
     justify-content: center;
     background: rgba(0, 0, 0, 0.85);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(var(--fluent-blur));
+    -webkit-backdrop-filter: blur(var(--fluent-blur));
 
     /* 初始隱藏 */
     opacity: 0;
@@ -1877,10 +1877,10 @@ body.sidebar-collapsed .showcase-footer {
 
 .mode-toggle-btn.active {
     background: rgba(255, 255, 255, 0.15);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: var(--text-primary);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: var(--fluent-shadow-2);
 }
 
 .mode-toggle-btn:not(.active):hover {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -722,7 +722,7 @@
     display: flex;
     justify-content: center;
     align-items: flex-end;
-    padding-bottom: 20px;
+    padding-bottom: 24px;
     gap: 12px;
     background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
@@ -1280,7 +1280,7 @@ body.sidebar-collapsed .showcase-footer {
 .footer-count {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: 4px; /* micro: icon + 數字緊鄰，charter §4 micro 子網格 */
     white-space: nowrap;
 }
 
@@ -1386,7 +1386,7 @@ body.sidebar-collapsed .showcase-footer {
     font-size: 0.8125rem;
     font-family: var(--font-mono);
     color: var(--text-secondary);
-    padding: 0 6px;
+    padding: 0 8px;
     cursor: pointer;
     user-select: none;
     transition: color var(--duration-fast) var(--ease-out);
@@ -1427,6 +1427,7 @@ body.sidebar-collapsed .showcase-footer {
         display: none;
     }
     .showcase-container {
+        /* layout 對齊 fixed footer 真實渲染高度 (charter §4 例外) */
         padding-bottom: 44px;
     }
 }
@@ -1758,6 +1759,7 @@ body.sidebar-collapsed .showcase-footer {
 
 /* + 新增按鈕 — dashed border */
 .lb-tag-add-btn {
+    /* chip optical 6px (charter §4 micro chip 級例外保留) */
     padding: 1px 6px;
     font-size: 0.7rem;
     line-height: 1.4;

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -5669,6 +5669,8 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 }
 body.fluent-canvas:not(.ds-page) {
   background: radial-gradient(ellipse 100% 60% at 50% -10%, rgba(var(--ds-glow-rgb), 0.10), transparent), radial-gradient(ellipse 70% 50% at 100% 100%, oklch(55% 0.12 85 / 0.06), transparent), var(--bg-body);
+  backdrop-filter: blur(var(--fluent-blur-heavy));
+  -webkit-backdrop-filter: blur(var(--fluent-blur-heavy));
 }
 body.fluent-canvas:not(.ds-page) .main-content {
   background-color: transparent;
@@ -5740,6 +5742,8 @@ body.fluent-canvas:not(.ds-page)::before {
   --fluent-duration-normal: 250ms;
   --fluent-duration-slow: 300ms;
   --fluent-duration-slower: 400ms;
+  --fluent-duration-medium: 333ms;
+  --fluent-duration-emphasis: 500ms;
   --fluent-ease-decel: cubic-bezier(0, 0, 0, 1);
   --fluent-ease-accel: cubic-bezier(1, 0, 1, 1);
   --fluent-ease-standard: cubic-bezier(0.33, 0, 0.67, 1);
@@ -5748,7 +5752,13 @@ body.fluent-canvas:not(.ds-page)::before {
   --fluent-saturate: 140%;
   --fluent-acrylic-bg-light: rgba(255, 255, 255, 0.7);
   --fluent-acrylic-bg-dark: rgba(28, 28, 30, 0.7);
+  --fluent-blur-light: 12px;
+  --fluent-blur-heavy: 60px;
   --fluent-smoke: rgba(0, 0, 0, 0.4);
+  --overlay-gallery: rgba(0, 0, 0, 0.85);
+  --overlay-modal: rgba(0, 0, 0, 0.6);
+  --overlay-gradient: rgba(0, 0, 0, 0.55);
+  --overlay-control: rgba(0, 0, 0, 0.45);
 }
 [data-theme="dim"] {
   --fluent-shadow-2: 0px 0px 2px rgba(0, 0, 0, 0.24), 0px 1px 2px rgba(0, 0, 0, 0.28);

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -5669,8 +5669,6 @@ button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
 }
 body.fluent-canvas:not(.ds-page) {
   background: radial-gradient(ellipse 100% 60% at 50% -10%, rgba(var(--ds-glow-rgb), 0.10), transparent), radial-gradient(ellipse 70% 50% at 100% 100%, oklch(55% 0.12 85 / 0.06), transparent), var(--bg-body);
-  backdrop-filter: blur(var(--fluent-blur-heavy));
-  -webkit-backdrop-filter: blur(var(--fluent-blur-heavy));
 }
 body.fluent-canvas:not(.ds-page) .main-content {
   background-color: transparent;

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -1059,6 +1059,9 @@
   .collapse {
     visibility: collapse;
   }
+  .invisible {
+    visibility: hidden;
+  }
   .visible {
     visibility: visible;
   }
@@ -2533,6 +2536,87 @@
       }
     }
   }
+  .stack {
+    @layer daisyui.l1.l2.l3 {
+      display: inline-grid;
+      grid-template-columns: 3px 4px 1fr 4px 3px;
+      grid-template-rows: 3px 4px 1fr 4px 3px;
+      & > * {
+        height: 100%;
+        width: 100%;
+        &:nth-child(n + 2) {
+          width: 100%;
+          opacity: 70%;
+        }
+        &:nth-child(2) {
+          z-index: 2;
+          opacity: 90%;
+        }
+        &:nth-child(1) {
+          z-index: 3;
+          width: 100%;
+        }
+      }
+    }
+    @layer daisyui.l1.l2 {
+      &, &.stack-bottom {
+        > * {
+          grid-column: 3 / 4;
+          grid-row: 3 / 6;
+          &:nth-child(2) {
+            grid-column: 2 / 5;
+            grid-row: 2 / 5;
+          }
+          &:nth-child(1) {
+            grid-column: 1 / 6;
+            grid-row: 1 / 4;
+          }
+        }
+      }
+      &.stack-top {
+        > * {
+          grid-column: 3 / 4;
+          grid-row: 1 / 4;
+          &:nth-child(2) {
+            grid-column: 2 / 5;
+            grid-row: 2 / 5;
+          }
+          &:nth-child(1) {
+            grid-column: 1 / 6;
+            grid-row: 3 / 6;
+          }
+        }
+      }
+      &.stack-start {
+        > * {
+          grid-column: 1 / 4;
+          grid-row: 3 / 4;
+          &:nth-child(2) {
+            grid-column: 2 / 5;
+            grid-row: 2 / 5;
+          }
+          &:nth-child(1) {
+            grid-column: 3 / 6;
+            grid-row: 1 / 6;
+          }
+        }
+      }
+      &.stack-end {
+        > * {
+          grid-column: 3 / 6;
+          grid-row: 3 / 4;
+          &:nth-child(2) {
+            grid-column: 2 / 5;
+            grid-row: 2 / 5;
+          }
+          &:nth-child(1) {
+            grid-column: 1 / 4;
+            grid-row: 1 / 6;
+          }
+        }
+      }
+    }
+  }
   .modal-backdrop {
     @layer daisyui.l1.l2.l3 {
       grid-column-start: 1;
@@ -3084,6 +3168,9 @@
   .flex-shrink-0 {
     flex-shrink: 0;
   }
+  .shrink {
+    flex-shrink: 1;
+  }
   .flex-grow {
     flex-grow: 1;
   }
@@ -3093,6 +3180,10 @@
   }
   .translate-x-0 {
     --tw-translate-x: calc(var(--spacing) * 0);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-y-2 {
+    --tw-translate-y: calc(var(--spacing) * -2);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .translate-y-0 {
@@ -3142,6 +3233,9 @@
         outline-offset: 2px;
       }
     }
+  }
+  .cursor-not-allowed {
+    cursor: not-allowed;
   }
   .cursor-pointer {
     cursor: pointer;
@@ -4840,97 +4934,239 @@ body {
 :is(#ds-gallery-components, .ds-gallery-composition) .actress-alias-body {
   padding: 1rem;
 }
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-form {
-  margin-bottom: 1rem;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-form-row {
-  display: flex;
-  align-items: flex-end;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-group {
-  flex: 1;
-  min-width: 120px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-group label {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-group input {
-  width: 100%;
-  transition: border-color var(--fluent-duration-fast) var(--fluent-ease-standard), box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-group input:focus {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 4px var(--glow-subtle), inset 0 1px 0 var(--color-base-content);
-  @supports (color: color-mix(in lab, red, red)) {
-    box-shadow: 0 0 0 4px var(--glow-subtle), inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent);
-  }
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-count {
-  font-size: 0.7rem;
-  color: var(--accent);
-  min-height: 1rem;
-  margin-top: 0.25rem;
-  font-weight: 600;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-arrow {
-  color: var(--text-secondary);
-  font-size: 1rem;
-  padding-bottom: 0.5rem;
-  flex-shrink: 0;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .btn-alias-add {
-  padding: 0.5rem 0.75rem;
-  background: var(--accent);
-  color: var(--color-primary-content);
-  border: none;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: background var(--fluent-duration-fast) var(--fluent-ease-standard), transform var(--fluent-duration-fast) var(--fluent-ease-standard), box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.1rem;
-  box-shadow: var(--fluent-shadow-2);
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .btn-alias-add:hover {
-  background: var(--accent-hover);
-  transform: translateY(-1px);
-  box-shadow: 0 0 0 2px var(--accent), 0 0 12px var(--glow-primary), var(--fluent-shadow-4);
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .btn-alias-add:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-preview {
-  font-size: 0.75rem;
-  color: var(--text-secondary);
-  margin-top: 0.5rem;
-  min-height: 1.25rem;
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-toolbar {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  margin-bottom: 0.75rem;
 }
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-preview i {
-  color: var(--accent);
-  font-size: 0.9rem;
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-wrap {
+  flex: 1;
+  min-width: 0;
+  position: relative;
 }
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-list {
-  max-height: 200px;
-  overflow-y: auto;
-  border: 1px solid var(--stroke-default);
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-wrap i {
+  position: absolute;
+  left: 0.625rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  pointer-events: none;
+  transition: color var(--fluent-duration-fast) var(--fluent-ease-standard);
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-input-wrap input {
+  width: 100%;
+  padding-left: 1.75rem;
+  font-size: 0.8rem;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-filter-hint {
+  font-size: 0.675rem;
+  color: var(--text-tertiary);
+  margin-top: 0.25rem;
+  margin-left: 0.25rem;
+  margin-bottom: 0.5rem;
+  display: none;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-filter-hint.visible {
+  display: block;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-filter-hint em {
+  font-style: normal;
+  color: var(--accent-pink);
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-group-row {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--stroke-subtle);
+  flex-wrap: wrap;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-group-row:last-child {
+  border-bottom: none;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
+  position: relative;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-primary {
+  background: var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--accent-pink) 15%, transparent);
+  }
+  color: var(--accent-pink);
+  font-weight: 600;
+  font-size: 0.825rem;
+  border: 1px solid var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in oklch, var(--accent-pink) 25%, transparent);
+  }
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-alias {
+  background: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--color-base-content) 6%, transparent);
+  }
+  color: var(--text-secondary);
+  border: 1px solid var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in oklch, var(--color-base-content) 10%, transparent);
+  }
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-alias:hover {
+  background: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--color-base-content) 10%, transparent);
+  }
+  color: var(--text-primary);
+  border-color: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in oklch, var(--color-base-content) 20%, transparent);
+  }
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-remove {
+  width: 0;
+  overflow: hidden;
+  opacity: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.65rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
+  border: none;
+  background: none;
+  padding: 0;
+  margin-left: -0.125rem;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-alias:hover .alias-pill-remove {
+  width: 14px;
+  opacity: 1;
+  margin-left: 0.125rem;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-remove:hover {
+  color: var(--color-error);
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-pill);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  border: 1px dashed var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px dashed color-mix(in oklch, var(--color-base-content) 12%, transparent);
+  }
+  background: transparent;
+  cursor: pointer;
+  transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
+  white-space: nowrap;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-btn:hover {
+  color: var(--accent-pink);
+  border-color: var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in oklch, var(--accent-pink) 30%, transparent);
+  }
+  background: var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--accent-pink) 5%, transparent);
+  }
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-inline input {
+  width: 120px;
+  height: 1.625rem;
+  font-size: 0.75rem;
+  padding: 0 0.5rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    border: 1px solid color-mix(in oklch, var(--accent-pink) 30%, transparent);
+  }
+  background: var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--accent-pink) 5%, transparent);
+  }
+  color: var(--text-primary);
+  outline: none;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-inline input:focus {
+  border-color: var(--accent-pink);
+  box-shadow: 0 0 0 3px var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-pink) 12%, transparent);
+  }
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-inline button {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: none;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.12s ease;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-inline .btn-cancel {
+  background: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--color-base-content) 8%, transparent);
+  }
+  color: var(--text-secondary);
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-add-inline .btn-cancel:hover {
+  background: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--color-base-content) 15%, transparent);
+  }
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-row-spacer {
+  flex: 1;
+  min-width: 0.5rem;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-trash {
+  width: 1.625rem;
+  height: 1.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-radius: var(--radius-sm);
-  background: var(--bg-body);
+  border: none;
+  background: transparent;
+  color: var(--color-base-content);
+  @supports (color: color-mix(in lab, red, red)) {
+    color: color-mix(in oklch, var(--color-base-content) 20%, transparent);
+  }
+  cursor: pointer;
+  transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
+  flex-shrink: 0;
+  font-size: 0.8rem;
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .alias-trash:hover {
+  color: var(--color-error);
+  background: var(--color-error);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--color-error) 10%, transparent);
+  }
 }
 :is(#ds-gallery-components, .ds-gallery-composition) .alias-list-empty, :is(#ds-gallery-components, .ds-gallery-composition) .alias-list-loading, :is(#ds-gallery-components, .ds-gallery-composition) .alias-list-error {
   padding: 1.5rem;
@@ -4946,86 +5182,6 @@ body {
 }
 :is(#ds-gallery-components, .ds-gallery-composition) .alias-list-error {
   color: var(--color-error);
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-item {
-  display: flex;
-  align-items: center;
-  padding: 0.6rem 0.75rem;
-  gap: 0.5rem;
-  border-bottom: 1px solid var(--stroke-subtle);
-  transition: background var(--fluent-duration-fast) var(--fluent-ease-standard);
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-item:last-child {
-  border-bottom: none;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-item:hover {
-  background: var(--color-base-content);
-  @supports (color: color-mix(in lab, red, red)) {
-    background: color-mix(in oklch, var(--color-base-content) 3%, transparent);
-  }
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-old {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 0.8rem;
-  color: #dcdcaa;
-  min-width: 80px;
-  font-weight: 500;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-item .alias-arrow {
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  padding: 0;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-new {
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 0.8rem;
-  color: #6a9955;
-  flex: 1;
-  font-weight: 500;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-applied {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-  white-space: nowrap;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .btn-alias-delete {
-  opacity: 0;
-  background: transparent;
-  border: none;
-  color: var(--color-error);
-  padding: 0.25rem;
-  cursor: pointer;
-  transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard), color var(--fluent-duration-fast) var(--fluent-ease-standard), transform var(--fluent-duration-fast) var(--fluent-ease-standard);
-  font-size: 0.9rem;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .alias-item:hover .btn-alias-delete {
-  opacity: 1;
-}
-:is(#ds-gallery-components, .ds-gallery-composition) .btn-alias-delete:hover {
-  color: var(--color-error-hover);
-  transform: scale(1.1);
-}
-@media (max-width: 576px) {
-  :is(#ds-gallery-components, .ds-gallery-composition) .alias-form-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  :is(#ds-gallery-components, .ds-gallery-composition) .alias-input-group {
-    min-width: 100%;
-  }
-  :is(#ds-gallery-components, .ds-gallery-composition) .alias-arrow {
-    padding: 0;
-    align-self: center;
-    transform: rotate(90deg);
-  }
-  :is(#ds-gallery-components, .ds-gallery-composition) .btn-alias-add {
-    width: 100%;
-    padding: 0.75rem;
-  }
-  :is(#ds-gallery-components, .ds-gallery-composition) .alias-old, :is(#ds-gallery-components, .ds-gallery-composition) .alias-new {
-    min-width: auto;
-    flex: 1;
-  }
 }
 :is(#settings-components, #ds-settings-components) .settings-form-group {
   display: flex;
@@ -5534,6 +5690,36 @@ body.fluent-canvas:not(.ds-page)::before {
   height: 100%;
   object-fit: cover;
   display: block;
+}
+.no-transform-transition {
+  transition: none !important;
+}
+@keyframes floatingHeartFallback {
+  0% {
+    transform: translate(0, 0) scale(0.6);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(var(--dx, 0px), -100px) scale(1.2);
+    opacity: 0;
+  }
+}
+.floating-heart-fallback {
+  animation: floatingHeartFallback 0.9s ease-out forwards;
+}
+@keyframes heartPulseFallback {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+.btn-heart-pulse {
+  animation: heartPulseFallback 0.3s ease-out forwards;
 }
 :root {
   --fluent-radius-none: 0px;

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -2245,6 +2245,8 @@ body.fluent-canvas:not(.ds-page) {
         radial-gradient(ellipse 100% 60% at 50% -10%, rgba(var(--ds-glow-rgb), 0.10), transparent),
         radial-gradient(ellipse 70% 50% at 100% 100%, oklch(55% 0.12 85 / 0.06), transparent),
         var(--bg-body);
+    backdrop-filter: blur(var(--fluent-blur-heavy));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-heavy));
 }
 
 body.fluent-canvas:not(.ds-page) .main-content {

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -2245,8 +2245,10 @@ body.fluent-canvas:not(.ds-page) {
         radial-gradient(ellipse 100% 60% at 50% -10%, rgba(var(--ds-glow-rgb), 0.10), transparent),
         radial-gradient(ellipse 70% 50% at 100% 100%, oklch(55% 0.12 85 / 0.06), transparent),
         var(--bg-body);
-    backdrop-filter: blur(var(--fluent-blur-heavy));
-    -webkit-backdrop-filter: blur(var(--fluent-blur-heavy));
+    /* Phase 50.1.0 (30ce8f2) 加的 backdrop-filter 已 revert：會把 body 變成
+     * fixed-position 子孫的 containing block，導致 .showcase-lightbox
+     * (position:fixed; inset:0) 在 search 頁以 document 高度為基準置中而非 viewport。
+     * Token --fluent-blur-heavy 保留，待 Phase 51+ 評估在哪個元素 surface 啟用。 */
 }
 
 body.fluent-canvas:not(.ds-page) .main-content {

--- a/web/static/js/components/motion-adapter.js
+++ b/web/static/js/components/motion-adapter.js
@@ -62,7 +62,7 @@
                     opacity: 0,
                     duration: opts.duration || 0.5,
                     stagger: opts.stagger || 0,
-                    ease: opts.ease || 'power3.out',
+                    ease: opts.ease || 'fluent-decel',
                     onComplete: opts.onComplete || null
                 });
             });
@@ -80,7 +80,7 @@
                     y: opts.y !== undefined ? opts.y : -10,
                     opacity: 0,
                     duration: opts.duration || 0.3,
-                    ease: opts.ease || 'power2.in',
+                    ease: opts.ease || 'fluent-accel',
                     onComplete: opts.onComplete || null
                 });
             });
@@ -99,7 +99,7 @@
                     opacity: 0,
                     stagger: opts.stagger || 0.08,
                     duration: opts.duration || 0.6,
-                    ease: opts.ease || 'power3.out',
+                    ease: opts.ease || 'fluent-decel',
                     onComplete: opts.onComplete || null
                 });
             });
@@ -108,7 +108,7 @@
         /**
          * 透明度補間（fade-to）
          *
-         * 用法：OpenAver.motion.playFadeTo(elements, { opacity: 0, duration: 0.2, ease: 'power2.out' })
+         * 用法：OpenAver.motion.playFadeTo(elements, { opacity: 0, duration: 0.2, ease: 'fluent' })
          * 若 reduced-motion 啟用則直接設定最終值不播動畫。
          */
         playFadeTo: function (elements, opts) {
@@ -123,7 +123,7 @@
                 return gsap.to(elements, {
                     opacity: targetOpacity,
                     duration: opts.duration || 0.3,
-                    ease: opts.ease || 'power2.out',
+                    ease: opts.ease || 'fluent',
                     onComplete: opts.onComplete || null
                 });
             });
@@ -141,7 +141,7 @@
                     scale: 0.95,
                     opacity: 0,
                     duration: opts.duration || 0.25,
-                    ease: opts.ease || 'power2.out',
+                    ease: opts.ease || 'fluent-decel',
                     onComplete: opts.onComplete || null
                 });
             });

--- a/web/static/js/components/motion-adapter.js
+++ b/web/static/js/components/motion-adapter.js
@@ -22,6 +22,19 @@
     var motion = {
 
         /**
+         * Phase 50.2.9: GSAP Duration 三角色常數（charter §5，CD-7 命名避讓既有 slow:300ms）
+         *
+         * 對應 input.css :root --fluent-duration-{fast,medium,emphasis}
+         * 業務 GSAP duration 透過 OpenAver.motion.DURATION.fast/medium/emphasis 讀取
+         * （不引入 ES module，沿用既有 IIFE / window.OpenAver pattern — CD-1）
+         */
+        DURATION: {
+            fast:     0.167,   // 微互動、hover、color/opacity 過場
+            medium:   0.333,   // 中等過場（panel 展開、tag 拉開）
+            emphasis: 0.5      // 強調級長過場（lightbox 主動畫、模式切換）
+        },
+
+        /**
          * 建立頁面級動畫 context
          *
          * 用法：Alpine init() 建立，頁面離開自動清理
@@ -60,7 +73,7 @@
                 return gsap.from(elements, {
                     y: opts.y !== undefined ? opts.y : 20,
                     opacity: 0,
-                    duration: opts.duration || 0.5,
+                    duration: opts.duration || motion.DURATION.emphasis,
                     stagger: opts.stagger || 0,
                     ease: opts.ease || 'fluent-decel',
                     onComplete: opts.onComplete || null
@@ -79,7 +92,7 @@
                 return gsap.to(elements, {
                     y: opts.y !== undefined ? opts.y : -10,
                     opacity: 0,
-                    duration: opts.duration || 0.3,
+                    duration: opts.duration || motion.DURATION.medium,
                     ease: opts.ease || 'fluent-accel',
                     onComplete: opts.onComplete || null
                 });
@@ -98,7 +111,7 @@
                     y: opts.y !== undefined ? opts.y : 30,
                     opacity: 0,
                     stagger: opts.stagger || 0.08,
-                    duration: opts.duration || 0.6,
+                    duration: opts.duration || motion.DURATION.emphasis,
                     ease: opts.ease || 'fluent-decel',
                     onComplete: opts.onComplete || null
                 });
@@ -122,7 +135,7 @@
             return this._run(opts.ctx, function () {
                 return gsap.to(elements, {
                     opacity: targetOpacity,
-                    duration: opts.duration || 0.3,
+                    duration: opts.duration || motion.DURATION.medium,
                     ease: opts.ease || 'fluent',
                     onComplete: opts.onComplete || null
                 });
@@ -140,7 +153,7 @@
                 return gsap.from(element, {
                     scale: 0.95,
                     opacity: 0,
-                    duration: opts.duration || 0.25,
+                    duration: opts.duration || motion.DURATION.fast,
                     ease: opts.ease || 'fluent-decel',
                     onComplete: opts.onComplete || null
                 });

--- a/web/static/js/components/motion-adapter.js
+++ b/web/static/js/components/motion-adapter.js
@@ -9,6 +9,16 @@
 (function () {
     window.OpenAver = window.OpenAver || {};
 
+    // Phase 50.2.0: 註冊 Fluent CustomEase（charter §5 三角色）
+    // 同步 guarded register — base.html defer 順序保證 CustomEase plugin 已載入
+    if (typeof CustomEase !== 'undefined') {
+        CustomEase.create('fluent',       '0.33, 0, 0.67, 1');
+        CustomEase.create('fluent-decel', '0, 0, 0, 1');
+        CustomEase.create('fluent-accel', '1, 0, 1, 1');
+    } else {
+        console.warn('[motion-adapter] CustomEase plugin missing, fluent eases not registered');
+    }
+
     var motion = {
 
         /**

--- a/web/static/js/components/motion-adapter.js
+++ b/web/static/js/components/motion-adapter.js
@@ -161,6 +161,18 @@
         },
 
         /**
+         * 清除元素 inline GSAP props（替代直接呼叫 `gsap.set(el, { clearProps })`）。
+         * 用於 timeline.kill() 後同步重置 transform/opacity 等殘留，防連點 stutter。
+         * 不觸發動畫，純 sync prop 重置。
+         * @param {Element} element
+         * @param {string} props - GSAP clearProps 字串（如 'transform,opacity'）
+         */
+        clearProps: function (element, props) {
+            if (!element || typeof gsap === 'undefined') return;
+            gsap.set(element, { clearProps: props });
+        },
+
+        /**
          * @private 在 context 內執行動畫（確保 ctx.revert() 能回收）
          * 如果沒傳 ctx，動畫仍會播放，只是不受 context 管理
          */

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -512,7 +512,7 @@
             // B19: 單相 slide-in（state-first 後 DOM 已是新內容，fade-out 會造成反向閃爍）
             tl.fromTo(contentEl,
                 { opacity: 0, x: xIn },
-                { opacity: 1, x: 0, duration: 0.25, ease: 'power2.out' }
+                { opacity: 1, x: 0, duration: 0.25, ease: 'fluent' }
             );
 
             return tl;
@@ -599,7 +599,7 @@
                     opacity: 1,
                     x: 0,
                     duration: 0.22,
-                    ease: 'power2.out',
+                    ease: 'fluent',
                     clearProps: 'transform,opacity',
                     onComplete: function () {
                         imgEl.classList.remove('gsap-animating');

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -443,14 +443,14 @@
             // 1. Backdrop fade-in
             tl.fromTo(lightboxEl,
                 { opacity: 0 },
-                { opacity: 1, duration: 0.16, ease: 'power2.out' }
+                { opacity: 1, duration: 0.16, ease: 'fluent-decel' }
             );
 
             // 2. Content card scale pop-in
             if (content) {
                 tl.fromTo(content,
                     { scale: 0.95, opacity: 0, transformOrigin: 'center center' },
-                    { scale: 1, opacity: 1, duration: 0.18, ease: 'power2.out', transformOrigin: 'center center' },
+                    { scale: 1, opacity: 1, duration: 0.18, ease: 'fluent-decel', transformOrigin: 'center center' },
                     0.03
                 );
             }
@@ -459,7 +459,7 @@
             if (coverImg && !options.skipCover) {
                 tl.fromTo(coverImg,
                     { y: 12, opacity: 0 },
-                    { y: 0, opacity: 1, duration: 0.16, ease: 'power2.out' },
+                    { y: 0, opacity: 1, duration: 0.16, ease: 'fluent-decel' },
                     '-=0.08'
                 );
             }

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -151,7 +151,7 @@
                 return null;
             }
 
-            var dur = params.duration || 0.5;
+            var dur = params.duration || OpenAver.motion.DURATION.emphasis;
             var staggerVal = params.stagger || 0.04;
             var ease = params.easing || 'fluent-decel';
 
@@ -213,7 +213,7 @@
             // C18: 中斷進行中的動畫
             gsap.killTweensOf(cards);
 
-            var dur = params.duration || 0.5;
+            var dur = params.duration || OpenAver.motion.DURATION.emphasis;
             var ease = params.ease || 'fluent';
 
             // 計算 delta 並收集需要動畫的卡片
@@ -275,7 +275,7 @@
             // C18: 中斷進行中的 Flip 動畫
             Flip.killFlipsOf(cards);
 
-            var dur = params.duration || 0.4;
+            var dur = params.duration || OpenAver.motion.DURATION.medium;
 
             // Flip.from — 含 onEnter/onLeave 進出場回調
             return Flip.from(state, {
@@ -379,7 +379,7 @@
                 if (oldEl) {
                     tl.to(oldEl, {
                         opacity: 0,
-                        duration: 0.15,
+                        duration: OpenAver.motion.DURATION.fast,
                         ease: 'fluent-accel',
                         clearProps: 'opacity',
                         onComplete: function () { callbacks.onOldFadeComplete(); }
@@ -392,7 +392,7 @@
             if (newEl) {
                 tl.fromTo(newEl,
                     { opacity: 0 },
-                    { opacity: 1, duration: 0.2, ease: 'fluent-decel', clearProps: 'opacity' }
+                    { opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel', clearProps: 'opacity' }
                 );
             }
             return tl;
@@ -443,14 +443,14 @@
             // 1. Backdrop fade-in
             tl.fromTo(lightboxEl,
                 { opacity: 0 },
-                { opacity: 1, duration: 0.16, ease: 'fluent-decel' }
+                { opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel' }
             );
 
             // 2. Content card scale pop-in
             if (content) {
                 tl.fromTo(content,
                     { scale: 0.95, opacity: 0, transformOrigin: 'center center' },
-                    { scale: 1, opacity: 1, duration: 0.18, ease: 'fluent-decel', transformOrigin: 'center center' },
+                    { scale: 1, opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel', transformOrigin: 'center center' },
                     0.03
                 );
             }
@@ -459,7 +459,7 @@
             if (coverImg && !options.skipCover) {
                 tl.fromTo(coverImg,
                     { y: 12, opacity: 0 },
-                    { y: 0, opacity: 1, duration: 0.16, ease: 'fluent-decel' },
+                    { y: 0, opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel' },
                     '-=0.08'
                 );
             }
@@ -512,7 +512,7 @@
             // B19: 單相 slide-in（state-first 後 DOM 已是新內容，fade-out 會造成反向閃爍）
             tl.fromTo(contentEl,
                 { opacity: 0, x: xIn },
-                { opacity: 1, x: 0, duration: 0.25, ease: 'fluent' }
+                { opacity: 1, x: 0, duration: OpenAver.motion.DURATION.fast, ease: 'fluent' }
             );
 
             return tl;
@@ -598,7 +598,7 @@
                 {
                     opacity: 1,
                     x: 0,
-                    duration: 0.22,
+                    duration: OpenAver.motion.DURATION.fast,
                     ease: 'fluent',
                     clearProps: 'transform,opacity',
                     onComplete: function () {
@@ -625,7 +625,7 @@
             if (!el) return null;
             if (typeof gsap === 'undefined') return null;
             if (shouldSkip()) return null;
-            var dur = (typeof options.duration === 'number') ? options.duration : 0.2;
+            var dur = (typeof options.duration === 'number') ? options.duration : OpenAver.motion.DURATION.fast;
             var ease = options.ease || 'fluent-decel';
             return gsap.fromTo(el,
                 { opacity: 0 },

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -433,24 +433,36 @@
                 id: 'showcaseLightboxOpen',
                 onComplete: function () {
                     lightboxEl.classList.remove('gsap-animating');
+                    // Phase 50.x cleanup: 清掉動畫過程中累積的 inline transform/opacity，
+                    // 避免被打斷時殘留半路狀態（用戶連點關開造成累積 stutter）
+                    if (content) gsap.set(content, { clearProps: 'transform,opacity' });
+                    if (coverImg && !options.skipCover) gsap.set(coverImg, { clearProps: 'transform,opacity' });
                     if (typeof options.onComplete === 'function') options.onComplete();
                 },
                 onInterrupt: function () {
                     lightboxEl.classList.remove('gsap-animating');
+                    // Phase 50.x cleanup: kill 中斷時 clearProps，避免殘留半路 transform/opacity
+                    if (content) gsap.set(content, { clearProps: 'transform,opacity' });
+                    if (coverImg && !options.skipCover) gsap.set(coverImg, { clearProps: 'transform,opacity' });
                 }
             });
+
+            // Phase 50.x: charter §5 white-list 例外 — 與 ghost-fly playGridToLightbox
+            // (0.38s power2.inOut, CD-3 觀察項) 並行段，保留 power 系曲線族避免節奏錯位。
+            // fluent-decel (0,0,0,1) 起步快終端慢與 ghost-fly power2.inOut 終端慢視覺重疊，
+            // 造成「最後一小段卡」；revert 為 power2.out + 原 duration 解套。
 
             // 1. Backdrop fade-in
             tl.fromTo(lightboxEl,
                 { opacity: 0 },
-                { opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel' }
+                { opacity: 1, duration: 0.16, ease: 'power2.out' }
             );
 
             // 2. Content card scale pop-in
             if (content) {
                 tl.fromTo(content,
                     { scale: 0.95, opacity: 0, transformOrigin: 'center center' },
-                    { scale: 1, opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel', transformOrigin: 'center center' },
+                    { scale: 1, opacity: 1, duration: 0.18, ease: 'power2.out', transformOrigin: 'center center' },
                     0.03
                 );
             }
@@ -459,7 +471,7 @@
             if (coverImg && !options.skipCover) {
                 tl.fromTo(coverImg,
                     { y: 12, opacity: 0 },
-                    { y: 0, opacity: 1, duration: OpenAver.motion.DURATION.fast, ease: 'fluent-decel' },
+                    { y: 0, opacity: 1, duration: 0.16, ease: 'power2.out' },
                     '-=0.08'
                 );
             }

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -280,7 +280,7 @@
             // Flip.from — 含 onEnter/onLeave 進出場回調
             return Flip.from(state, {
                 duration: dur,
-                ease: 'power2.inOut',
+                ease: 'fluent',
                 absolute: true,
                 prune: true,
                 simple: true,
@@ -289,17 +289,17 @@
                     if (els.length > 10) {
                         return gsap.fromTo(els,
                             { opacity: 0 },
-                            { opacity: 1, duration: dur * 0.6, stagger: 0.02, ease: 'power2.out' }
+                            { opacity: 1, duration: dur * 0.6, stagger: 0.02, ease: 'fluent-decel' }
                         );
                     }
                     // 預設：scale + fade（少量卡片進場時效果好）
                     return gsap.fromTo(els,
                         { opacity: 0, scale: 0.85 },
-                        { opacity: 1, scale: 1, duration: dur * 0.8, ease: 'power2.out' }
+                        { opacity: 1, scale: 1, duration: dur * 0.8, ease: 'fluent-decel' }
                     );
                 },
                 onLeave: function (els) {
-                    return gsap.to(els, { opacity: 0, scale: 0.85, duration: dur * 0.6, ease: 'power2.in' });
+                    return gsap.to(els, { opacity: 0, scale: 0.85, duration: dur * 0.6, ease: 'fluent-accel' });
                 },
                 onComplete: function () {
                     gsap.set(cards, { clearProps: 'transform' });

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -626,7 +626,7 @@
             if (typeof gsap === 'undefined') return null;
             if (shouldSkip()) return null;
             var dur = (typeof options.duration === 'number') ? options.duration : 0.2;
-            var ease = options.ease || 'power2.out';
+            var ease = options.ease || 'fluent-decel';
             return gsap.fromTo(el,
                 { opacity: 0 },
                 { opacity: 1, duration: dur, ease: ease, clearProps: 'opacity' }
@@ -650,7 +650,7 @@
                 duration: dur,
                 yoyo: true,
                 repeat: 1,
-                ease: 'power2.inOut'
+                ease: 'fluent'
             });
         }
     };

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -214,7 +214,7 @@
             gsap.killTweensOf(cards);
 
             var dur = params.duration || 0.5;
-            var ease = params.ease || 'power2.inOut';
+            var ease = params.ease || 'fluent';
 
             // 計算 delta 並收集需要動畫的卡片
             var tweens = [];

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -380,7 +380,7 @@
                     tl.to(oldEl, {
                         opacity: 0,
                         duration: 0.15,
-                        ease: 'power2.in',
+                        ease: 'fluent-accel',
                         clearProps: 'opacity',
                         onComplete: function () { callbacks.onOldFadeComplete(); }
                     });
@@ -392,7 +392,7 @@
             if (newEl) {
                 tl.fromTo(newEl,
                     { opacity: 0 },
-                    { opacity: 1, duration: 0.2, ease: 'power2.out', clearProps: 'opacity' }
+                    { opacity: 1, duration: 0.2, ease: 'fluent-decel', clearProps: 'opacity' }
                 );
             }
             return tl;

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -153,7 +153,7 @@
 
             var dur = params.duration || 0.5;
             var staggerVal = params.stagger || 0.04;
-            var ease = params.easing || 'power3.out';
+            var ease = params.easing || 'fluent-decel';
 
             // Viewport 分流：fold 以下卡片瞬間顯示
             var viewportH = window.innerHeight;

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -1671,6 +1671,14 @@ function showcaseState() {
             // Instant close — kill any in-progress lightbox animations, then sync cleanup
             _killLightboxTimelines();
             if (lbEl) lbEl.classList.remove('gsap-animating');
+            // Phase 50.x cleanup: kill timeline 後 clearProps 確保下次 open 從乾淨狀態起
+            // (timeline.kill() 不觸發 onInterrupt，需在此補做；防連點關開累積 stutter)
+            if (lbEl && typeof gsap !== 'undefined') {
+                var _lbContent = lbEl.querySelector('.lightbox-content');
+                var _lbCoverImg = lbEl.querySelector('.lightbox-cover img');
+                if (_lbContent) gsap.set(_lbContent, { clearProps: 'transform,opacity' });
+                if (_lbCoverImg) gsap.set(_lbCoverImg, { clearProps: 'transform,opacity' });
+            }
             this._lightboxAnimating = false;
             this.lightboxOpen = false;
             this.actressLightboxSource = null;   // T5: reset 進入路徑

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -1673,11 +1673,11 @@ function showcaseState() {
             if (lbEl) lbEl.classList.remove('gsap-animating');
             // Phase 50.x cleanup: kill timeline 後 clearProps 確保下次 open 從乾淨狀態起
             // (timeline.kill() 不觸發 onInterrupt，需在此補做；防連點關開累積 stutter)
-            if (lbEl && typeof gsap !== 'undefined') {
+            if (lbEl && window.OpenAver && window.OpenAver.motion) {
                 var _lbContent = lbEl.querySelector('.lightbox-content');
                 var _lbCoverImg = lbEl.querySelector('.lightbox-cover img');
-                if (_lbContent) gsap.set(_lbContent, { clearProps: 'transform,opacity' });
-                if (_lbCoverImg) gsap.set(_lbCoverImg, { clearProps: 'transform,opacity' });
+                window.OpenAver.motion.clearProps(_lbContent, 'transform,opacity');
+                window.OpenAver.motion.clearProps(_lbCoverImg, 'transform,opacity');
             }
             this._lightboxAnimating = false;
             this.lightboxOpen = false;


### PR DESCRIPTION
## Summary

- **Phase 50 Charter Pilot**：Fluent 2 視覺規範完整套用到 Showcase 影片模式（token / 白名單 / ease 三角色 / §6 5 檢查點）
- **UI conventions infra 升級**：visual-charter v2 → 正式 `feature/AI_COLLABORATION/ui-conventions.md` + `ui-cheatsheet.md`，CLAUDE.md / OVERVIEW.md / task-workflow.md trigger 條目補完
- **prd.md 重整**：吸收 soul.md 精華（一句話 / 三軸線 / 拒絕清單 / 秒答 / 元認知）+ phase 進度表精簡為 minor 版本里程碑表
- **0.8.0 minor bump**：規模對齊「全站視覺語言基礎設施 + dev workflow 升級」級別

## 涵蓋範圍

### Phase 1 靜態修齊（charter §1–§4 + §6）
- T0 補 token（blur / shadow / radius / spacing / overlay color 4 階）
- T1–T5：Showcase 影片模式 CSS 對齊（共 6 commit）
- DaisyUI .btn / .input scoped Fluent 覆寫

### Phase 2 動畫修齊（charter §5）
- Fluent CustomEase 三角色（standard / decel / accel）GSAP 註冊
- motion-adapter.js 5 default ease 改三角色 + DURATION 三角色常數
- animations.js 各 play* 函式 ease 角色化（playEntry / FlipReorder / FlipFilter / ModeCrossfade / LightboxOpen / Switch / ContainerFadeIn / SourcePulse）
- showcase.css 7 處 transition 硬編碼 → token

### Phase 3 規範化
- visual-charter.md → feature/AI_COLLABORATION/ui-conventions.md（改名 + 搬遷）
- fluent-cheatsheet.md → feature/AI_COLLABORATION/ui-cheatsheet.md
- soul.md 吸收進 prd.md，feature/soul/ 資料夾 rmdir
- Phase 50 副產物（visual-audit / charter-second-opinion / showcase-charter-preview / ease-verification / codex review.txt）歸檔到 `feature/50-charter-pilot-showcase/archive/`
- task-workflow.md 三處 trigger 條目補 ui-conventions / ui-cheatsheet（Step 1 / 4 / 5）

### Fixed
- #31 Windows NTFS 截斷後尾端 `.` 被剝除導致 `shutil.move` 失敗
- Search lightbox 在 Showcase 啟用時定位錯誤（fluent-canvas backdrop-filter revert）
- Lightbox backdrop UX 仲裁（30px → 12px，覆蓋 charter §2 字面）
- playLightboxOpen ease revert + clearProps cleanup（charter §5 white-list）
- Codex review v3 P1a / P1b / P2 收斂

## Pre-merge 檢查結果

| SA | 結果 |
|---|---|
| 變更收集 + 版號 | v0.8.0 minor bump（charter migration + dev workflow 升級規模）|
| 敏感資訊 + 打包 | ✅ 0 leak / build COPY_ITEMS 完整覆蓋 |
| 全套測試 | ✅ 2749 passed（v0.7.8 baseline 2705 → +44 新測試）|
| 文檔更新 | ✅ version.py / CHANGELOG.md 套用 |
| Capabilities 同步 | ✅ 0 API 改動，無需更新 |
| 測試增量審計 | ✅ 覆蓋充足、無假測試 |
| Code review（lint fix）| ✅ PASS（clearProps 走 motion-adapter 修 lint 違規）|

## Test plan

- [ ] Codex 雲端 review 過 22 commits + 2 pre-merge commits
- [ ] dev server 開 Showcase 影片模式，主觀感受 token / 玻璃 / ease 三角色「整齊」
- [ ] Lightbox 開合 / 連點 / 模式切換 / 排序篩選互動正常
- [ ] 全套測試持續綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)