### PR TITLE
Phase 51 — UI Conventions Application: Showcase 女優模式 + Search + Lightbox 共用化 (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-04-29
+
+本版把 Phase 50 在 Showcase 影片模式驗證過的 ui-conventions（Fluent 2 token / 白名單 / ease 三角色 / §6 5 檢查點）擴展到 Showcase 女優模式 + Search 整頁，並把 lightbox 開門動畫從兩邊各自實作整併到 `shared/ghost-fly.js` 共用。對使用者而言三個主要 surface 視覺與動畫節奏接續，沒有功能變化。
+
+*This release applies the ui-conventions validated in Phase 50 (Showcase video mode) to Showcase actress mode and the Search page, and consolidates the lightbox-open animation into a shared `ghost-fly.js` implementation. No user-facing feature changes.*
+
+### Added
+
+#### 🎯 51.1 — Showcase 女優模式 conventions 套用（Phase 1）
+- 女優模式擴散感受確認 — Phase 50 共用動畫函式 default ease 已對齊三角色，女優 grid 進場 / 排序 / 篩選 / 模式切換感受可接受 (commit 891060a)
+- showcase.css 女優段靜態修齊 — actress card / lightbox / picker overlay / picker card 等 ~14 違規 row 對齊 §1-§4 + §5 CSS transition token 化 (commit d2a2de6)
+- `playHeroCardAppear` ease 試改 fluent-decel（power2.out → fluent-decel，duration 0.3s 保留 hardcoded 白名單）(commit 9dcff7a)
+- `_fadeMetadataPanel` 改三角色 fluent + DURATION.fast（女優 lightbox metadata 淡入淡出）(commit a85f54b)
+- §6 5 檢查點：女優 picker-refresh-btn radius / stroke / focus 對齊（非 DaisyUI .btn 但需 §6 精神）(commit 11ac5e8)
+
+#### 🎯 51.2 — Search 頁靜態修齊（Phase 2）
+- input.css 新增 `--overlay-letterbox` token + `--overlay-badge` token（§3 角色色白名單擴張）(commits 0080118 / 6224b08)
+- search.css §1/§2/§3 靜態修齊 — hardcoded blur / shadow / radius / color 全 token 化（~50 違規 row）(commit 41f2a5b)
+- search.css §4 spacing 三層修齊 — 8pt layout 3 處 / 6px optical 註記 2 處 / stroke 放行 (commit 89d52b6)
+- §6 5 檢查點：search 頁 .btn / .input / .dropdown / .spotlight-search 5 檢查點全通過（沿 Phase 50 T5 完整實作規格） (commit 5dd7a61)
+
+#### 🎯 51.3 — Search GSAP 系統 ease 對齊（Phase 3）
+- §5 白名單預登記：Staging Card `back.out(1.4)` + playOrganizeSuccess checkmark `back.out(1.7)` + playOrganizeFail shake `power1.inOut 0.08s` 三招牌動畫保留不動
+- `playDetailEntry` cover + info 段 → fluent-decel + DURATION.emphasis (commit 0c351c6)
+- `playGridToDetail` / `playDetailToGrid` ghost 飛行 → fluent (standard) (commit 941bf3c)
+- `playDetailToGrid` settle pulse → fluent（0.18s 加 §5 hardcoded duration 白名單）(commit ce80424)
+- `playSlideIn` / `playHeroRemove` / `playGridSettle duration` / `playLightboxSwitch` / `playSampleGallerySwitch` / `playProgressUpdate` / `playAppendCascade` / `playGridFadeIn` 對齊三角色（commits e4b8d2f / 3505e36 / 3190d9a / 9bb2931 / cbf160c / ec7b4c1 / 926faf4 / a304752）
+- `playCoverSwap` → fluent（0.15s 加白名單，意圖即「快速替換無感切換」）(commit 1c0c1b9)
+- `playMiniBurst` → fluent-decel 試改（back.out(1.2) → decel；感受待 dev server 驗證）(commit c3a4eb4)
+- `playOrganizeSuccess` row green flash → fluent-accel（離場淡出，0.8s 加白名單沿 showcaseSettle 模式）(commit 70d7f20)
+
+#### 🎯 51.4 — Lightbox 共用化（Phase 4）
+- 新增 `GhostFly.playLightboxOpen` 共用實作於 `shared/ghost-fly.js`，採 showcase 版完整 cleanup 契約（onComplete + onInterrupt 各對 content/coverImg 做 clearProps，防連點殘留 stutter）(commit 8bf9158)
+- `ShowcaseAnimations.playLightboxOpen` 改 delegate（傳 `timelineId: 'showcaseLightboxOpen'` 維持 killLightboxAnimations 行為） (commit f3cbafe)
+- `SearchAnimations.playLightboxOpen` 改 delegate（不傳 timelineId 沿用預設 `'lightboxOpen'` 維持 grid-mode.js kill 路徑；search 連點 interrupt 行為從 silent 改為 clearProps 正向改善）(commit 35ab2f0)
+- 兩 caller 各刪 ~73 / ~56 行重複碼，淨減 ~70 行 → lightbox 開門動畫 single source of truth
+
+### Fixed
+- T2.4 codex P2：tag 編輯 inline btn fallback 補完（.tag-add-btn dashed restore + .tag-confirm/.tag-cancel）(commit d5940f8)
+- T3.13/T3.15 codex P3：同步 Phase 3 改動後過時 JSDoc default 註解 (commit f341398)
+- T4 codex P3：delegate guard 改 `typeof window.GhostFly?.playLightboxOpen === 'function'` — 防 cache invalidation 場景（舊 cached ghost-fly.js + 新 page animations.js）下舊 GhostFly object 缺新 method 導致 TypeError 炸掉 lightbox open (commit 5e4dc63)
+
 ## [0.8.0] - 2026-04-28
 
 本版聚焦在 Showcase 影片模式的視覺語言統一（Phase 50 Charter Pilot）。把 Fluent 2 的設計規範完整套用到 token、白名單、ease 三角色、§6 5 檢查點，並把 visual-charter 從一次性提案升級為正式的 ui-conventions 工作流文件，之後新做頁面有規範可循。對使用者而言介面更一致、動畫節奏更自然，沒有功能變化。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -4909,3 +4909,31 @@ class TestScannerMissingPillGuard:
         content = self.ZH_TW.read_text(encoding='utf-8')
         assert 'missing_resume_btn' in content, \
             "zh_TW.json 缺少 missing_resume_btn key — T10 i18n 未加入"
+
+
+class TestGhostFlyPlayLightboxOpen:
+    """Phase 51 Phase 4 T4.1：GhostFly.playLightboxOpen 共用實作守衛
+
+    確認 ghost-fly.js 內 playLightboxOpen 函式存在 + cleanup 契約
+    （clearProps）+ opts.timelineId 介面已植入。
+    """
+
+    GHOST_FLY_JS = PROJECT_ROOT / 'web' / 'static' / 'js' / 'shared' / 'ghost-fly.js'
+
+    def test_ghost_fly_has_play_lightbox_open(self):
+        """ghost-fly.js 內 GhostFly.playLightboxOpen 函式存在"""
+        js = self.GHOST_FLY_JS.read_text(encoding='utf-8')
+        assert 'playLightboxOpen' in js, \
+            "ghost-fly.js 缺少 playLightboxOpen — Phase 51 T4.1 共用實作未加入"
+
+    def test_ghost_fly_play_lightbox_open_has_clearprops(self):
+        """playLightboxOpen 採 showcase 版 clearProps cleanup 契約（CD-51-14）"""
+        js = self.GHOST_FLY_JS.read_text(encoding='utf-8')
+        assert 'clearProps' in js, \
+            "ghost-fly.js playLightboxOpen 缺少 clearProps cleanup — CD-51-14 共同契約未植入"
+
+    def test_ghost_fly_play_lightbox_open_has_timeline_id_opt(self):
+        """playLightboxOpen 介面含 opts.timelineId（CD-51-16）"""
+        js = self.GHOST_FLY_JS.read_text(encoding='utf-8')
+        assert 'timelineId' in js, \
+            "ghost-fly.js playLightboxOpen 缺少 timelineId opt — CD-51-16 介面未植入"

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -154,6 +154,89 @@ class TestNoHardcodedColors:
         )
 
 
+class TestSearchCssHardcoded:
+    """Phase 51 T2.4 — search.css §1/§2/§3/§4 hardcoded 守衛
+
+    確保 T2.1（color/blur/radius）/ T2.2（spacing 6px layout）修齊結果不被回退；
+    新加違規會被擋下。allow-list 為 (line_num: reason) dict，新增例外
+    必須提供 reason 字串說明（§3 角色色白名單 / §2 drop-shadow 例外 /
+    var() fallback / §4 micro chip optical 之一）。
+    """
+
+    SEARCH_CSS = PROJECT_ROOT / "web/static/css/pages/search.css"
+
+    HARDCODED_RGBA_ALLOWLIST = {
+        # T2.1 commit 41f2a5b 後狀態：
+        90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
+        780: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+    }
+
+    SIX_PX_ALLOWLIST = {
+        # T2.2 commit 89d52b6 後狀態：
+        235: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
+        516: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
+        571: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
+    }
+
+    def _scan(self, regex: str, allowlist=None):
+        violations = []
+        text = self.SEARCH_CSS.read_text(encoding='utf-8')
+        for i, line in enumerate(text.splitlines(), 1):
+            # 跳過純註解行（CSS comment 不是實際 declaration，提及 6px / rgba 為文檔說明）
+            stripped = line.lstrip()
+            if stripped.startswith('/*') or stripped.startswith('*'):
+                continue
+            if re.search(regex, line):
+                if allowlist and i in allowlist:
+                    continue
+                violations.append((i, line.rstrip()))
+        return violations
+
+    def test_no_hardcoded_rgba_in_search_css(self):
+        """禁 search.css 出現 rgba(0,0,0,...) 硬編碼（須走 var(--overlay-*) 角色色 token）"""
+        violations = self._scan(
+            r'rgba\(\s*0\s*,\s*0\s*,\s*0\s*,',
+            allowlist=self.HARDCODED_RGBA_ALLOWLIST,
+        )
+        assert not violations, (
+            f"search.css 出現新 rgba(0,0,0,...) 硬編碼違規 ({len(violations)} 處)：\n"
+            + "\n".join(f"  L{n}: {l[:100]}" for n, l in violations)
+            + "\n\n請改用 var(--overlay-*) 角色色 token；如為 §2 drop-shadow 例外 / "
+            + "var() fallback，請更新 HARDCODED_RGBA_ALLOWLIST + 說明理由。"
+        )
+
+    def test_no_hardcoded_blur_px_in_search_css(self):
+        """禁 search.css 出現 blur(Npx) 硬編碼（須走 var(--fluent-blur*) 三階）"""
+        violations = self._scan(r'blur\(\s*\d+px')
+        assert not violations, (
+            f"search.css 出現 blur(Npx) 硬編碼違規 ({len(violations)} 處)：\n"
+            + "\n".join(f"  L{n}: {l[:100]}" for n, l in violations)
+            + "\n\n請改用 var(--fluent-blur) (overlay 30px) / var(--fluent-blur-light) (floating-control 12px)。"
+        )
+
+    def test_no_hardcoded_border_radius_px_in_search_css(self):
+        """禁 search.css 出現 border-radius: Npx 硬編碼（須走 var(--fluent-radius-*) 或 var(--radius-*)）"""
+        violations = self._scan(r'border-radius:\s*\d+px')
+        assert not violations, (
+            f"search.css 出現 border-radius: Npx 硬編碼違規 ({len(violations)} 處)：\n"
+            + "\n".join(f"  L{n}: {l[:100]}" for n, l in violations)
+            + "\n\n請改用 var(--fluent-radius-md) (4px 互動級) / var(--radius-md) (12px 容器級)。"
+        )
+
+    def test_no_hardcoded_six_px_layout_in_search_css(self):
+        """禁 search.css 出現 6px layout 違規（padding/margin/gap/etc.）"""
+        # `[:\s]6px(?:\s|;|$)` 限定 6px 出現在 property value 上下文，避免 16px/26px/0.6px 誤抓
+        violations = self._scan(
+            r'[:\s]6px(?:\s|;|$)',
+            allowlist=self.SIX_PX_ALLOWLIST,
+        )
+        assert not violations, (
+            f"search.css 出現新 6px layout 違規 ({len(violations)} 處)：\n"
+            + "\n".join(f"  L{n}: {l[:100]}" for n, l in violations)
+            + "\n\n請改 layout 8pt grid / micro 4px / 加 /* ... optical 6px ... */ 註記 + 更新 SIX_PX_ALLOWLIST。"
+        )
+
+
 class TestNoCreateElement:
     """確認 Alpine state mixins 不用 createElement"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2959,6 +2959,9 @@ class TestShowcaseAnimationsFluent:
             "showcase/animations.js playLightboxOpen 應 delegate window.GhostFly.playLightboxOpen（Phase 51 T4.2）"
         assert "showcaseLightboxOpen" in scope, \
             "showcase/animations.js playLightboxOpen delegate 應傳 timelineId: 'showcaseLightboxOpen'（保留 killLightboxAnimations 行為）"
+        # codex T4-P3：guard 須檢查 method 是 function，防 cache invalidation 下舊 GhostFly object 缺新 method 導致 TypeError
+        assert "typeof window.GhostFly?.playLightboxOpen === 'function'" in scope, \
+            "showcase/animations.js playLightboxOpen delegate 應用 typeof function guard（codex T4-P3）"
 
     def test_search_play_lightbox_open_delegates_to_ghost_fly(self):
         """Phase 51 T4.3: SearchAnimations.playLightboxOpen 改 delegate GhostFly.playLightboxOpen
@@ -2972,6 +2975,9 @@ class TestShowcaseAnimationsFluent:
         # 不應傳 'showcaseLightboxOpen' timelineId（search 沿用預設 'lightboxOpen'）
         assert "showcaseLightboxOpen" not in scope, \
             "search delegate 不應傳 timelineId 'showcaseLightboxOpen'（會破壞 grid-mode.js kill 路徑）"
+        # codex T4-P3：guard 須檢查 method 是 function，防 cache invalidation 下舊 GhostFly object 缺新 method 導致 TypeError
+        assert "typeof window.GhostFly?.playLightboxOpen === 'function'" in scope, \
+            "search/animations.js playLightboxOpen delegate 應用 typeof function guard（codex T4-P3）"
 
     def test_play_lightbox_open_clearprops_cleanup(self):
         """onComplete + onInterrupt 補 clearProps 防連點殘留（CD-51-14 共同契約，實作於 ghost-fly.js）"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2911,12 +2911,12 @@ class TestShowcaseAnimationsFluent:
         assert "power2.inOut" not in scope, "playSourcePulse 殘留 power2.inOut"
 
     # === playHeroCardAppear — 女優專屬白名單，不動 ===
-    def test_hero_card_appear_whitelist_not_touched(self):
-        """playHeroCardAppear 為女優專屬（plan D10 white-list），ease 不被本 phase 改"""
+    def test_hero_card_appear_uses_fluent_decel(self):
+        """Phase 51 T1.3a: playHeroCardAppear 試改 fluent-decel（plan-51 §2.1）"""
         scope = self._scoped("playHeroCardAppear", 800)
-        # 白名單保留 power2.out（spec scope 排除女優模式）
-        assert "ease: 'power2.out'" in scope, \
-            "playHeroCardAppear ease 不應被改（女優專屬 white-list）"
+        # 試改 fluent-decel；若用戶 dev-server 回報感受壞 → revert + re-tighten 到 power2.out + 重新加 white-list 註解
+        assert "ease: 'fluent-decel'" in scope, \
+            "playHeroCardAppear ease 應為 'fluent-decel'（Phase 51 T1.3a 試改）"
 
     # === Phase 50.x revert — playLightboxOpen 3 段保留 power2.out（charter §5 white-list 例外）===
     # 理由：playLightboxOpen 與 ghost-fly playGridToLightbox (0.38s power2.inOut, CD-3 觀察項)

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2726,35 +2726,32 @@ class TestFluentCustomEaseRegistered:
 
 
 class TestShowcaseCssTransitionTokens:
-    """Phase 50.2.10: showcase.css 影片模式 transition 硬編碼 → fluent token"""
+    """Phase 50.2.10 + 51.T1.2: showcase.css transition 硬編碼 → fluent token（影片 + 女優模式全段）"""
 
     def _css(self):
         return Path("web/static/css/pages/showcase.css").read_text(encoding="utf-8")
 
-    def test_no_hardcoded_transition_in_video_mode_range(self):
-        """影片模式範圍（L1500-L1900）transition 不應有硬編碼 0.15s/0.2s"""
+    def test_no_hardcoded_transition_in_showcase_css(self):
+        """整個 showcase.css 的 transition 都不應有硬編碼 0.X s（影片模式 Phase 50 + 女優 Phase 51 T1.2）"""
         lines = self._css().split("\n")
         violations = []
         for i, line in enumerate(lines, 1):
-            # 影片模式 transition 區段（plan T2.10 範圍 ~L1500-L1900）
-            if 1500 <= i <= 1900 and "transition:" in line:
-                # 殘留硬編碼 number+s 字面（排除 var(--...) reference）
+            if "transition:" in line:
                 import re
+                # 殘留硬編碼 number+s 字面（排除 var(--...) reference 與 transition: none）
                 if re.search(r"transition:[^;]*\b0?\.\d+s\b", line) and "var(--" not in line:
                     violations.append(f"L{i}: {line.strip()}")
         assert not violations, \
-            "影片模式 transition 殘留硬編碼數字：\n" + "\n".join(violations)
+            "showcase.css transition 殘留硬編碼數字：\n" + "\n".join(violations)
 
-    def test_actress_picker_transition_preserved(self):
-        """女優 picker 區（plan T2.10 範圍排除）保留硬編碼 transition"""
+    def test_actress_picker_transition_tokenized(self):
+        """Phase 51 T1.2: 女優 picker 三處 transition 已 token 化（fluent-duration-fast + fluent-ease-standard）"""
         css = self._css()
-        # picker-check-icon, picker-refresh-btn, picker-open cover-actions
-        assert "transition: opacity 0.15s;" in css, \
-            "picker-check-icon 0.15s 應保留（女優白名單）"
-        assert "transition: all 0.15s;" in css, \
-            "picker-refresh-btn 0.15s 應保留（女優白名單）"
-        assert "transition: opacity 0.2s;" in css, \
-            "picker-open cover-actions 0.2s 應保留（女優白名單）"
+        # picker-check-icon (opacity), picker-refresh-btn (all), picker-open cover-actions (opacity)
+        assert "transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard)" in css, \
+            "picker-check-icon / cover-actions opacity transition 應使用 fluent token"
+        assert "transition: all var(--fluent-duration-fast) var(--fluent-ease-standard)" in css, \
+            "picker-refresh-btn all transition 應使用 fluent token"
 
 
 class TestMotionDurationConstants:

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2960,6 +2960,19 @@ class TestShowcaseAnimationsFluent:
         assert "showcaseLightboxOpen" in scope, \
             "showcase/animations.js playLightboxOpen delegate 應傳 timelineId: 'showcaseLightboxOpen'（保留 killLightboxAnimations 行為）"
 
+    def test_search_play_lightbox_open_delegates_to_ghost_fly(self):
+        """Phase 51 T4.3: SearchAnimations.playLightboxOpen 改 delegate GhostFly.playLightboxOpen
+        （不傳 timelineId，沿用預設 'lightboxOpen' 維持 grid-mode.js kill 路徑）"""
+        search_js = Path("web/static/js/pages/search/animations.js").read_text(encoding="utf-8")
+        idx = search_js.find("playLightboxOpen: function")
+        assert idx > 0, "找不到 search/animations.js playLightboxOpen"
+        scope = search_js[idx : idx + 800]
+        assert "GhostFly.playLightboxOpen" in scope, \
+            "search/animations.js playLightboxOpen 應 delegate window.GhostFly.playLightboxOpen（Phase 51 T4.3）"
+        # 不應傳 'showcaseLightboxOpen' timelineId（search 沿用預設 'lightboxOpen'）
+        assert "showcaseLightboxOpen" not in scope, \
+            "search delegate 不應傳 timelineId 'showcaseLightboxOpen'（會破壞 grid-mode.js kill 路徑）"
+
     def test_play_lightbox_open_clearprops_cleanup(self):
         """onComplete + onInterrupt 補 clearProps 防連點殘留（CD-51-14 共同契約，實作於 ghost-fly.js）"""
         scope = self._ghost_fly_scoped("playLightboxOpen", 4500)
@@ -3015,9 +3028,14 @@ class TestGhostFlyGuards:
             "showcase/animations.js playLightboxOpen 應 delegate 至 GhostFly（skipCover 透過 options 透傳）"
 
     def test_skip_cover_supported_in_search_animations(self):
-        """search/animations.js playLightboxOpen 支援 skipCover"""
-        js = Path("web/static/js/pages/search/animations.js").read_text(encoding="utf-8")
-        assert "skipCover" in js
+        """playLightboxOpen 支援 skipCover — Phase 51 T4.3 起共用實作於 ghost-fly.js，
+        search delegate 透傳 options（含 skipCover）"""
+        ghost_fly_js = Path("web/static/js/shared/ghost-fly.js").read_text(encoding="utf-8")
+        assert "skipCover" in ghost_fly_js, \
+            "ghost-fly.js playLightboxOpen 共用實作應支援 opts.skipCover"
+        search_js = Path("web/static/js/pages/search/animations.js").read_text(encoding="utf-8")
+        assert "GhostFly.playLightboxOpen" in search_js, \
+            "search/animations.js playLightboxOpen 應 delegate 至 GhostFly（skipCover 透過 options 透傳）"
 
     def test_ghost_fly_fallback_exists_in_search_animations(self):
         """search/animations.js 委派函式有 GhostFly fallback"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2922,29 +2922,49 @@ class TestShowcaseAnimationsFluent:
     # 理由：playLightboxOpen 與 ghost-fly playGridToLightbox (0.38s power2.inOut, CD-3 觀察項)
     # 並行播放，需保留 power 系曲線族避免節奏錯位。fluent-decel (0,0,0,1) 起步快終端慢
     # 與 ghost-fly power2.inOut 終端慢視覺重疊，造成「最後一小段卡」。
+    #
+    # Phase 51 Phase 4 (T4.1/T4.2): playLightboxOpen 實作搬到 shared/ghost-fly.js
+    # 共用化（CD-51-14/15/16）；showcase/animations.js 與 search/animations.js 改 delegate。
+    # 三 guard 改檢查 ghost-fly.js 的共用實作。
+    GHOST_FLY_JS = Path("web/static/js/shared/ghost-fly.js")
+
+    def _ghost_fly_scoped(self, fn_name, length=4500):
+        js = self.GHOST_FLY_JS.read_text(encoding="utf-8")
+        idx = js.find(fn_name + ":")
+        assert idx > 0, f"找不到 {fn_name} in ghost-fly.js"
+        return js[idx : idx + length]
+
     def test_play_lightbox_open_three_power_out(self):
-        """三段（backdrop / content / cover）ease 為 power2.out（white-list 例外）"""
-        scope = self._scoped("playLightboxOpen", 4500)
+        """三段（backdrop / content / cover）ease 為 power2.out（white-list 例外）— 共用實作於 ghost-fly.js"""
+        scope = self._ghost_fly_scoped("playLightboxOpen", 4500)
         assert scope.count("ease: 'power2.out'") >= 3, \
-            "playLightboxOpen backdrop+content+cover 三段 ease 應為 'power2.out'（×3，charter §5 white-list 例外，與 ghost-fly 並行段）"
+            "ghost-fly.js playLightboxOpen backdrop+content+cover 三段 ease 應為 'power2.out'（×3，charter §5 white-list 例外，與 ghost-fly 並行段）"
 
     def test_play_lightbox_open_no_fluent_decel_in_three_phases(self):
-        """三段不應誤用 fluent-decel（與 ghost-fly power2.inOut 終端視覺重疊）"""
-        scope = self._scoped("playLightboxOpen", 4500)
+        """三段不應誤用 fluent-decel（與 ghost-fly power2.inOut 終端視覺重疊）— 共用實作於 ghost-fly.js"""
+        scope = self._ghost_fly_scoped("playLightboxOpen", 4500)
         assert "ease: 'fluent-decel'" not in scope, \
-            "playLightboxOpen 不應使用 'fluent-decel'（與 ghost-fly playGridToLightbox 並行段視覺重疊；white-list 例外用 power2.out）"
+            "ghost-fly.js playLightboxOpen 不應使用 'fluent-decel'（與 playGridToLightbox 並行段視覺重疊；white-list 例外用 power2.out）"
 
     def test_play_lightbox_open_white_list_comment_present(self):
-        """white-list 例外註解必須留存（避免後續清 hardcoded duration 時誤改）"""
-        scope = self._scoped("playLightboxOpen", 4500)
+        """white-list 例外註解必須留存（避免後續清 hardcoded duration 時誤改）— 共用實作於 ghost-fly.js"""
+        scope = self._ghost_fly_scoped("playLightboxOpen", 4500)
         assert "white-list" in scope or "ghost-fly" in scope, \
-            "playLightboxOpen 應有 charter §5 white-list / ghost-fly 並行段註解，標明 power2.out 為刻意保留"
+            "ghost-fly.js playLightboxOpen 應有 §5 white-list / ghost-fly 並行段註解，標明 power2.out 為刻意保留"
+
+    def test_showcase_play_lightbox_open_delegates_to_ghost_fly(self):
+        """Phase 51 T4.2: ShowcaseAnimations.playLightboxOpen 改 delegate GhostFly.playLightboxOpen"""
+        scope = self._scoped("playLightboxOpen", 800)
+        assert "GhostFly.playLightboxOpen" in scope, \
+            "showcase/animations.js playLightboxOpen 應 delegate window.GhostFly.playLightboxOpen（Phase 51 T4.2）"
+        assert "showcaseLightboxOpen" in scope, \
+            "showcase/animations.js playLightboxOpen delegate 應傳 timelineId: 'showcaseLightboxOpen'（保留 killLightboxAnimations 行為）"
 
     def test_play_lightbox_open_clearprops_cleanup(self):
-        """onComplete + onInterrupt 補 clearProps 防連點殘留（Phase 50.x cleanup）"""
-        scope = self._scoped("playLightboxOpen", 4500)
+        """onComplete + onInterrupt 補 clearProps 防連點殘留（CD-51-14 共同契約，實作於 ghost-fly.js）"""
+        scope = self._ghost_fly_scoped("playLightboxOpen", 4500)
         assert scope.count("clearProps: 'transform,opacity'") >= 4, \
-            "playLightboxOpen onComplete + onInterrupt 應各有 content + coverImg 兩處 clearProps（共 4 處）"
+            "ghost-fly.js playLightboxOpen onComplete + onInterrupt 應各有 content + coverImg 兩處 clearProps（共 4 處）"
 
     # === T2.4 — playFlipFilter (main + onEnter ×2 + onLeave) ===
     def test_play_flip_filter_main_fluent(self):
@@ -2984,9 +3004,15 @@ class TestGhostFlyGuards:
         assert "ghost-fly.js" in html
 
     def test_skip_cover_supported_in_showcase_animations(self):
-        """showcase/animations.js playLightboxOpen 支援 skipCover"""
-        js = Path("web/static/js/pages/showcase/animations.js").read_text(encoding="utf-8")
-        assert "skipCover" in js
+        """playLightboxOpen 支援 skipCover — Phase 51 T4.2 起共用實作於 ghost-fly.js，
+        showcase delegate 透過 Object.assign 將 options.skipCover 透傳"""
+        ghost_fly_js = Path("web/static/js/shared/ghost-fly.js").read_text(encoding="utf-8")
+        assert "skipCover" in ghost_fly_js, \
+            "ghost-fly.js playLightboxOpen 共用實作應支援 opts.skipCover"
+        showcase_js = Path("web/static/js/pages/showcase/animations.js").read_text(encoding="utf-8")
+        # Showcase delegate 用 Object.assign 透傳 options（含 skipCover），無需顯式提及
+        assert "GhostFly.playLightboxOpen" in showcase_js, \
+            "showcase/animations.js playLightboxOpen 應 delegate 至 GhostFly（skipCover 透過 options 透傳）"
 
     def test_skip_cover_supported_in_search_animations(self):
         """search/animations.js playLightboxOpen 支援 skipCover"""

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -78,8 +78,9 @@
   /* Smoke 遮罩 */
   --fluent-smoke: rgba(0, 0, 0, 0.4);
 
-  /* Charter v2 §3 角色色白名單 — Overlay 4 階 */
+  /* Charter v2 §3 角色色白名單 — Overlay 5 階 */
   --overlay-gallery:  rgba(0, 0, 0, 0.85);  /* sample gallery 暗幕 */
+  --overlay-badge:    rgba(0, 0, 0, 0.7);   /* picker source badge 背景 */
   --overlay-modal:    rgba(0, 0, 0, 0.6);   /* lightbox backdrop */
   --overlay-gradient: rgba(0, 0, 0, 0.55);  /* card hover 漸層 bottom */
   --overlay-control:  rgba(0, 0, 0, 0.45);  /* 浮在媒體上的控制按鈕 */

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -78,12 +78,13 @@
   /* Smoke 遮罩 */
   --fluent-smoke: rgba(0, 0, 0, 0.4);
 
-  /* Charter v2 §3 角色色白名單 — Overlay 5 階 */
+  /* Charter v2 §3 角色色白名單 — Overlay 6 階 */
   --overlay-gallery:  rgba(0, 0, 0, 0.85);  /* sample gallery 暗幕 */
   --overlay-badge:    rgba(0, 0, 0, 0.7);   /* picker source badge 背景 */
   --overlay-modal:    rgba(0, 0, 0, 0.6);   /* lightbox backdrop */
   --overlay-gradient: rgba(0, 0, 0, 0.55);  /* card hover 漸層 bottom */
   --overlay-control:  rgba(0, 0, 0, 0.45);  /* 浮在媒體上的控制按鈕 */
+  --overlay-letterbox: rgba(0, 0, 0, 0.2);  /* 媒體封面 letterbox 黑邊背景 */
 }
 
 /* Dark Theme 陰影 - 更深的陰影 */

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -146,7 +146,7 @@
     transform: translateX(-50%);
     background: var(--overlay-modal);
     color: var(--text-inverse);
-    padding: 2px 10px;
+    padding: 2px 8px;
     border-radius: var(--fluent-radius-xl);
     font-size: 0.8rem;
 }
@@ -177,7 +177,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 6px;
+    margin-bottom: 8px;
 }
 
 .file-list-header .file-count {
@@ -231,6 +231,7 @@
 
 .file-item .btn-scrape-single {
     flex-shrink: 0;
+    /* row inline btn optical 6px (btn-sm 12px padding 對 row inline 太寬，row 高度有限需獨立微調) */
     padding: 0 6px;
     font-size: 0.7rem;
     line-height: 1.4;
@@ -566,6 +567,7 @@
 }
 
 .tag-add-btn {
+    /* chip optical 6px (charter §4 micro chip 級例外保留，對齊 showcase .lb-tag-add-btn) */
     padding: 1px 6px;
     font-size: 0.7rem;
     line-height: 1;
@@ -894,7 +896,7 @@
 .actress-lightbox-meta .lb-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .actress-lightbox-meta .lb-name-en { font-size: 0.9em; opacity: 0.7; }
 .actress-lightbox-meta .lb-actress-core { font-size: 0.95em; margin: 8px 0; opacity: 0.85; }
-.actress-lightbox-meta .lb-chips-row { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0; }
+.actress-lightbox-meta .lb-chips-row { display: flex; flex-wrap: wrap; gap: 8px; margin: 8px 0; }
 .actress-lightbox-meta .lb-chips-more {
     cursor: pointer; font-size: 0.85em; padding: 2px 8px;
     border-radius: var(--radius-md); border: 1px solid currentColor; opacity: 0.6;

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -14,8 +14,8 @@
     padding: 0.5rem 1rem;
     background: var(--bg-header);
     border-bottom: 1px solid var(--border-light);
-    backdrop-filter: blur(16px) saturate(130%);
-    -webkit-backdrop-filter: blur(16px) saturate(130%);
+    backdrop-filter: blur(var(--fluent-blur)) saturate(var(--fluent-saturate));
+    -webkit-backdrop-filter: blur(var(--fluent-blur)) saturate(var(--fluent-saturate));
     z-index: 100;
 }
 
@@ -54,7 +54,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.2);
+    background: var(--overlay-letterbox);
 }
 
 /* Fix 3: 封面錯誤/無封面 placeholder 置中 */
@@ -86,6 +86,7 @@
     height: 100%;
     max-height: calc(100vh - 200px);
     object-fit: contain !important;  /* Search 不裁切；!important 覆蓋 theme.css (0,1,1) specificity */
+    /* §2 例外：drop-shadow 跟封面去背形狀走（非矩形 box-shadow），無法用 --fluent-shadow-* token（後者是完整 box-shadow 字串）；alpha 0.3 對齊 dim theme fluent-shadow key 0.28 ±0.02 */
     filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.3));
 }
 
@@ -112,7 +113,7 @@
     transform: translateY(-50%);
     width: 44px;
     height: 64px;
-    background: rgba(0, 0, 0, 0.6);
+    background: var(--overlay-modal);
     border: none;
     color: var(--text-inverse);
     font-size: 1.4rem;
@@ -124,7 +125,7 @@
 }
 
 .av-card-full-cover-wrapper .nav-btn:hover {
-    background: rgba(0, 0, 0, 0.8);
+    background: var(--overlay-gallery);
     transform: translateY(-50%) scale(1.05);
 }
 
@@ -143,7 +144,7 @@
     bottom: 50px;
     left: 50%;
     transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.6);
+    background: var(--overlay-modal);
     color: var(--text-inverse);
     padding: 2px 10px;
     border-radius: var(--fluent-radius-xl);
@@ -399,8 +400,8 @@
     right: 0;
     bottom: 0;
     background: color-mix(in oklch, var(--color-base-100) 60%, transparent);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     z-index: 9999;
     display: flex;
     align-items: center;
@@ -767,7 +768,7 @@
     background: var(--color-primary);
     color: var(--color-primary-content);
     padding: 0.1rem 0.4rem;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     white-space: nowrap;
 }
 
@@ -896,7 +897,7 @@
 .actress-lightbox-meta .lb-chips-row { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0; }
 .actress-lightbox-meta .lb-chips-more {
     cursor: pointer; font-size: 0.85em; padding: 2px 8px;
-    border-radius: 12px; border: 1px solid currentColor; opacity: 0.6;
+    border-radius: var(--radius-md); border: 1px solid currentColor; opacity: 0.6;
 }
 .actress-lightbox-meta .lb-chips-more:hover { opacity: 1; }
 .actress-lightbox-meta .lb-actress-urls { margin-top: 8px; }

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -909,3 +909,90 @@
 /* Actress Lightbox Row 1 愛心（inline，使用 .btn-glass-circle） */
 .actress-lb-header .btn-glass-circle { width: 32px; height: 32px; font-size: 1rem; margin-left: auto; }
 .actress-lb-header .btn-glass-circle.is-favorite { color: var(--color-favorite); cursor: default; }
+
+/* ==================== Phase 51 T2.4 §6 5 檢查點 — Search DaisyUI Component Override ==================== */
+/* Fluent 覆寫 .search-container 內 DaisyUI .btn / .textarea（charter §6 5 檢查點：radius/surface/stroke/shadow/hover-focus）*/
+/* CD-4 限制：scoped 在 .search-container 內，不影響其他頁面 / 不動 .spotlight-search（pill 白名單第 1 類 + theme.css CD-4 觀察項，Phase 52 處理）*/
+/* 沿 Phase 50 T5 完整實作規格 verbatim：Stroke (border-width/style only — 不固定 color)；Surface (var(--surface-1) for .textarea)；Shadow + dual-layer inset 0 1px 0；Focus 2px outline + 4px glow */
+
+.search-container .btn {
+    border-radius: var(--fluent-radius-md);
+    border-width: 1px;
+    border-style: solid;
+    /* 不固定 border-color — 保留 DaisyUI variant (.btn-outline.btn-primary 等) */
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent),
+        var(--fluent-shadow-2);
+    transition:
+        background var(--fluent-duration-fast) var(--fluent-ease-standard),
+        border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+        box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard),
+        transform var(--fluent-duration-fast) var(--fluent-ease-standard);
+}
+
+.search-container .btn:hover:not(:disabled) {
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 12%, transparent),
+        var(--fluent-shadow-4);
+    transform: translateY(-1px);
+}
+
+.search-container .btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent),
+        var(--fluent-shadow-2),
+        0 0 0 4px var(--glow-primary);
+}
+
+.search-container .btn:active:not(:disabled) {
+    transform: translateY(0);
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-2);
+}
+
+/* 個案豁免：dashed transparent btn 與 link btn 自有設計語言，不套 dual-layer shadow（視覺衝突）*/
+/* tag-add-btn (.search-container .tag-add-btn 也是 .btn) 自有 dashed border + transparent，dual-layer 內框高光與 dashed pattern 衝突 */
+/* btn-link 自有 link 樣式（無 box），dual-layer shadow 打破 link 語義 */
+.search-container .btn.tag-add-btn,
+.search-container .btn-link {
+    box-shadow: none;
+    background: transparent;
+    /* radius 對齊保留 */
+}
+.search-container .btn.tag-add-btn:hover:not(:disabled),
+.search-container .btn-link:hover:not(:disabled) {
+    box-shadow: none;
+    transform: none;
+}
+.search-container .btn.tag-add-btn:focus-visible,
+.search-container .btn-link:focus-visible {
+    /* 仍保留 focus glow（focus 是 a11y 必需）但移除 dual-layer shadow */
+    box-shadow: 0 0 0 4px var(--glow-primary);
+}
+
+.search-container .textarea {
+    border-radius: var(--fluent-radius-md);
+    background: var(--surface-1);
+    border-width: 1px;
+    border-style: solid;
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-2);
+    transition:
+        border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+        box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
+}
+
+.search-container .textarea:focus,
+.search-container .textarea:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-color: var(--accent);
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 8%, transparent),
+        var(--fluent-shadow-2),
+        0 0 0 4px var(--glow-primary);
+}

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -953,23 +953,45 @@
         var(--fluent-shadow-2);
 }
 
-/* 個案豁免：dashed transparent btn 與 link btn 自有設計語言，不套 dual-layer shadow（視覺衝突）*/
-/* tag-add-btn (.search-container .tag-add-btn 也是 .btn) 自有 dashed border + transparent，dual-layer 內框高光與 dashed pattern 衝突 */
+/* 個案豁免：dashed transparent btn / link btn / tag inline icon-only btn 自有設計語言，不套 dual-layer shadow（視覺衝突）*/
+/* tag-add-btn 自有 dashed border + transparent；tag-confirm / tag-cancel 自有 border:none + transparent + 純文字 ✓/✕ */
 /* btn-link 自有 link 樣式（無 box），dual-layer shadow 打破 link 語義 */
 .search-container .btn.tag-add-btn,
+.search-container .btn.tag-confirm,
+.search-container .btn.tag-cancel,
 .search-container .btn-link {
     box-shadow: none;
     background: transparent;
+    transform: none;
     /* radius 對齊保留 */
 }
+/* tag-add-btn restore base dashed border（被 .search-container .btn 的 border-style: solid override 蓋掉）*/
+.search-container .btn.tag-add-btn {
+    border-style: dashed;
+    border-color: var(--text-muted);
+}
+/* tag-confirm / tag-cancel restore base border:none */
+.search-container .btn.tag-confirm,
+.search-container .btn.tag-cancel {
+    border: none;
+}
 .search-container .btn.tag-add-btn:hover:not(:disabled),
+.search-container .btn.tag-confirm:hover:not(:disabled),
+.search-container .btn.tag-cancel:hover:not(:disabled),
 .search-container .btn-link:hover:not(:disabled) {
     box-shadow: none;
     transform: none;
 }
+/* tag-add-btn hover 保留原 border-color: accent + color: accent */
+.search-container .btn.tag-add-btn:hover:not(:disabled) {
+    border-color: var(--accent);
+    color: var(--accent);
+}
 .search-container .btn.tag-add-btn:focus-visible,
+.search-container .btn.tag-confirm:focus-visible,
+.search-container .btn.tag-cancel:focus-visible,
 .search-container .btn-link:focus-visible {
-    /* 仍保留 focus glow（focus 是 a11y 必需）但移除 dual-layer shadow */
+    /* 保留 focus glow（a11y 必需）但移除 dual-layer shadow */
     box-shadow: 0 0 0 4px var(--glow-primary);
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -375,7 +375,7 @@
     justify-content: center;
     align-items: flex-end;
     padding-bottom: 12px;
-    background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+    background: linear-gradient(to top, var(--overlay-gradient) 0%, rgba(0,0,0,0.2) 60%, transparent 100%); /* mid-stop optical fade */
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
     opacity: 0;
     transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard);
@@ -1833,10 +1833,10 @@ body.sidebar-collapsed .showcase-footer {
 .actress-lightbox-meta .actress-lb-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .actress-lightbox-meta .lb-name-en { font-size: 0.9em; opacity: 0.7; }
 .actress-lightbox-meta .lb-actress-core { font-size: 0.95em; margin: 8px 0; opacity: 0.85; }
-.actress-lightbox-meta .lb-chips-row { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0; }
+.actress-lightbox-meta .lb-chips-row { display: flex; flex-wrap: wrap; gap: 4px; margin: 4px 0; }
 .actress-lightbox-meta .lb-chips-more {
     cursor: pointer; font-size: 0.85em; padding: 2px 8px;
-    border-radius: 12px; border: 1px solid currentColor; opacity: 0.6;
+    border-radius: var(--radius-md); border: 1px solid currentColor; opacity: 0.6;
 }
 .actress-lightbox-meta .lb-chips-more:hover { opacity: 1; }
 .actress-lightbox-meta .lb-actress-urls { margin-top: 8px; }
@@ -1988,7 +1988,7 @@ body.sidebar-collapsed .showcase-footer {
     width: 150px;
     aspect-ratio: 4 / 5;             /* 188px tall on 150 wide */
     height: auto;                    /* 覆寫全域 height: 140px */
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     flex: 0 0 150px;                 /* 覆寫全域 flex: 0 0 100px */
 }
 
@@ -1996,7 +1996,7 @@ body.sidebar-collapsed .showcase-footer {
     object-fit: cover;
     width: 100%;
     height: 100%;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
 }
 
 .picker-current-source {
@@ -2005,7 +2005,7 @@ body.sidebar-collapsed .showcase-footer {
     margin-bottom: 8px;
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 4px;
 }
 
 .picker-candidates-grid {
@@ -2024,12 +2024,12 @@ body.sidebar-collapsed .showcase-footer {
     flex: 0 0 100px;
     width: 100px;
     height: 140px;
-    border-radius: 6px;
+    border-radius: var(--fluent-radius-lg);
     overflow: hidden;
     cursor: pointer;
     opacity: 0;
     transition: none;
-    background: rgba(0, 0, 0, 0.2);
+    background: rgba(0, 0, 0, 0.2); /* sub-tier dim hint, below §3 4-stop overlay range */
 }
 
 .picker-candidate-img {
@@ -2044,8 +2044,8 @@ body.sidebar-collapsed .showcase-footer {
     bottom: 0;
     left: 0;
     right: 0;
-    padding: 4px 6px;
-    background: rgba(0, 0, 0, 0.7);
+    padding: 4px 8px;
+    background: var(--overlay-badge);
     font-size: 0.7em;
     color: var(--text-inverse);
     text-align: center;
@@ -2058,7 +2058,7 @@ body.sidebar-collapsed .showcase-footer {
     opacity: 0;
     margin-right: 3px;
     font-size: 0.6rem;
-    transition: opacity 0.15s;
+    transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 .picker-candidate-card:hover .picker-source-badge {
@@ -2123,10 +2123,10 @@ body.sidebar-collapsed .showcase-footer {
     justify-content: center;
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     cursor: pointer;
     color: var(--text-inverse);
-    transition: all 0.15s;
+    transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 .picker-refresh-btn:hover:not(:disabled) {
@@ -2143,7 +2143,7 @@ body.sidebar-collapsed .showcase-footer {
 .lightbox-cover .cover-actions[data-picker-open="true"] {
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.2s;
+    transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 /* 49c T5fix.B：tablet 兩行 wrap (768–1279px) */

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -2112,6 +2112,13 @@ body.sidebar-collapsed .showcase-footer {
     margin-top: 8px;
 }
 
+/* Phase 51 T1.4 §6 5 檢查點 — picker-refresh-btn（非 DaisyUI，照 §6 精神對齊）
+ * Radius: var(--fluent-radius-md) ✅（T1.2 已 token 化）
+ * Surface: rgba(255,255,255,0.1) 白 tint（floating-control 薄膜語義，§3 觀察項保留）
+ * Stroke: 1px solid rgba(255,255,255,0.2)（width/style + tint border）
+ * Shadow: dual-layer inset + var(--fluent-shadow-2)；hover 升 var(--fluent-shadow-4)
+ * Focus: 2px outline + 4px glow（charter §6 Checkpoint 5 精確規格）
+ */
 .picker-refresh-btn {
     position: absolute;
     top: 12px;
@@ -2124,6 +2131,9 @@ body.sidebar-collapsed .showcase-footer {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: var(--fluent-radius-md);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        var(--fluent-shadow-2);
     cursor: pointer;
     color: var(--text-inverse);
     transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
@@ -2132,6 +2142,23 @@ body.sidebar-collapsed .showcase-footer {
 .picker-refresh-btn:hover:not(:disabled) {
     background: rgba(255, 255, 255, 0.15);
     border-color: rgba(255, 255, 255, 0.3);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        var(--fluent-shadow-4);
+    transform: translateY(-1px);
+}
+
+.picker-refresh-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        var(--fluent-shadow-2),
+        0 0 0 4px var(--glow-primary);
+}
+
+.picker-refresh-btn:active:not(:disabled) {
+    transform: translateY(0);
 }
 
 .picker-refresh-btn:disabled {

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -5757,6 +5757,7 @@ body.fluent-canvas:not(.ds-page)::before {
   --overlay-modal: rgba(0, 0, 0, 0.6);
   --overlay-gradient: rgba(0, 0, 0, 0.55);
   --overlay-control: rgba(0, 0, 0, 0.45);
+  --overlay-letterbox: rgba(0, 0, 0, 0.2);
 }
 [data-theme="dim"] {
   --fluent-shadow-2: 0px 0px 2px rgba(0, 0, 0, 0.24), 0px 1px 2px rgba(0, 0, 0, 0.28);

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -3,10 +3,10 @@
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
-      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-      "Courier New", monospace;
+    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+    'Noto Color Emoji';
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
     --color-black: #000;
     --spacing: 0.25rem;
     --breakpoint-2xl: 96rem;
@@ -56,7 +56,7 @@
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
-    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
     font-feature-settings: var(--default-font-feature-settings, normal);
     font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
@@ -83,7 +83,7 @@
     font-weight: bolder;
   }
   code, kbd, samp, pre {
-    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
     font-feature-settings: var(--default-mono-font-feature-settings, normal);
     font-variation-settings: var(--default-mono-font-variation-settings, normal);
     font-size: 1em;
@@ -183,13 +183,13 @@
   :-moz-ui-invalid {
     box-shadow: none;
   }
-  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
+  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
     appearance: button;
   }
   ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
     height: auto;
   }
-  [hidden]:where(:not([hidden="until-found"])) {
+  [hidden]:where(:not([hidden='until-found'])) {
     display: none !important;
   }
 }
@@ -728,9 +728,6 @@
         width: unset;
       }
     }
-    .prose :where(a&:not(.btn-link)):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-      text-decoration-line: none;
-    }
     @layer daisyui.l1.l2.l3 {
       display: inline-flex;
       flex-shrink: 0;
@@ -1224,7 +1221,6 @@
         grid-row-start: 1;
         aspect-ratio: 1 / 1;
         height: 100%;
-        width: 100%;
         border-radius: var(--radius-selector);
         background-color: currentcolor;
         translate: 0;
@@ -3544,6 +3540,9 @@
     text-transform: uppercase;
   }
   .btn-link {
+    .prose :where(&):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+      text-decoration-line: none;
+    }
     @layer daisyui.l1 {
       text-decoration-line: underline;
       outline-color: currentcolor;
@@ -5754,6 +5753,7 @@ body.fluent-canvas:not(.ds-page)::before {
   --fluent-blur-heavy: 60px;
   --fluent-smoke: rgba(0, 0, 0, 0.4);
   --overlay-gallery: rgba(0, 0, 0, 0.85);
+  --overlay-badge: rgba(0, 0, 0, 0.7);
   --overlay-modal: rgba(0, 0, 0, 0.6);
   --overlay-gradient: rgba(0, 0, 0, 0.55);
   --overlay-control: rgba(0, 0, 0, 0.45);

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -967,7 +967,7 @@
             if (rowEl) {
                 gsap.fromTo(rowEl,
                     { backgroundColor: 'rgba(0, 200, 100, 0.15)' },
-                    { backgroundColor: 'transparent', duration: 0.8, ease: 'power2.out', clearProps: 'backgroundColor' }
+                    { backgroundColor: 'transparent', duration: 0.8, ease: 'fluent-accel', clearProps: 'backgroundColor' }
                 );
             }
         },

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -886,7 +886,7 @@
             // B19: 單相 slide-in（state-first 後 DOM 已是新內容，fade-out 會造成反向閃爍）
             tl.fromTo(contentEl,
                 { opacity: 0, x: xIn },
-                { opacity: 1, x: 0, duration: 0.25, ease: 'power2.out' }
+                { opacity: 1, x: 0, duration: OpenAver.motion.DURATION.fast, ease: 'fluent' }
             );
 
             return tl;

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -190,7 +190,7 @@
             }
 
             var dur = options.duration || 0.6;
-            var ease = options.ease || 'back.out(1.2)';
+            var ease = options.ease || 'fluent-decel';
             var staggerVal = options.stagger || 0.05;
             var batchZ = ((options.batchZ || 0) * 10) + 100;
 

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -790,7 +790,12 @@
             // CD-51-14：共用實作採 showcase 版完整 cleanup 契約（onComplete/onInterrupt
             // 各對 content/coverImg 做 clearProps），對 search 為正向行為改善
             // （防連點殘留 stutter）。
-            return window.GhostFly ? window.GhostFly.playLightboxOpen(lightboxEl, options) : null;
+            // typeof guard（codex T4-P3）：window.GhostFly 存在但 playLightboxOpen
+            // method 缺（cache invalidation 場景：舊 ghost-fly.js + 新 animations.js）
+            // 時 fallback null，避免 TypeError 直接炸掉 lightbox open。
+            return typeof window.GhostFly?.playLightboxOpen === 'function'
+                ? window.GhostFly.playLightboxOpen(lightboxEl, options)
+                : null;
         },
 
         /**

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -357,7 +357,7 @@
         /**
          * Skeleton grid 整體轉場淡入（seed 收到後、Progress → Grid 轉場）
          *
-         * 輕量整體淡入，讓 skeleton grid 出現時不突兀。（保留不改）
+         * 輕量整體淡入，讓 skeleton grid 出現時不突兀。
          *
          * @param {Element} gridEl - .search-grid 元素
          * @returns {gsap.core.Tween|null}
@@ -1030,9 +1030,9 @@
          *
          * @param {Element[]} newCards - 新批次卡片 DOM 元素陣列
          * @param {object} [options] - 可選動畫參數
-         * @param {number} [options.duration=0.35] - 單張動畫時長（秒）
+         * @param {number} [options.duration=DURATION.medium] - 單張動畫時長（秒）
          * @param {number} [options.stagger=0.03] - 卡片間隔（秒）
-         * @param {string} [options.ease='power2.out'] - GSAP ease
+         * @param {string} [options.ease='fluent-decel'] - GSAP ease
          * @returns {null|gsap.core.Tween}
          */
         playAppendCascade: function (newCards, options) {

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -634,7 +634,7 @@
 
             return gsap.fromTo(containerEl,
                 { x: xFrom, opacity: 0 },
-                { x: 0, opacity: 1, duration: 0.3, ease: 'power3.out' }
+                { x: 0, opacity: 1, duration: OpenAver.motion.DURATION.medium, ease: 'fluent-decel' }
             );
         },
 

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -652,8 +652,8 @@
             if (!flipState) return;
             if (typeof Flip === 'undefined') return;
             if (shouldSkip()) return;
-            var dur = options.duration || 0.4;
-            var ease = options.ease || 'power2.out';
+            var dur = options.duration || OpenAver.motion.DURATION.medium;
+            var ease = options.ease || 'fluent-decel';
             Flip.from(flipState, {
                 duration: dur,
                 ease: ease

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -410,8 +410,8 @@
                 return null;
             }
 
-            var dur = 0.6;
-            var ease = 'power3.out';
+            var dur = OpenAver.motion.DURATION.emphasis;
+            var ease = 'fluent-decel';
             var skipCover = options.skipCover === true;
 
             var tl = gsap.timeline({ id: 'searchDetailEntry' });

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -923,8 +923,8 @@
                 {
                     opacity: 1,
                     x: 0,
-                    duration: 0.22,
-                    ease: 'power2.out',
+                    duration: OpenAver.motion.DURATION.fast,
+                    ease: 'fluent',
                     clearProps: 'transform,opacity',
                     onComplete: function () {
                         imgEl.classList.remove('gsap-animating');

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -372,8 +372,8 @@
 
             return gsap.from(gridEl, {
                 opacity: 0,
-                duration: 0.25,
-                ease: 'power1.out'
+                duration: OpenAver.motion.DURATION.fast,
+                ease: 'fluent-decel'
             });
         },
 

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -581,7 +581,7 @@
                         // target settle: micro scale pulse
                         gsap.fromTo(targetCardEl,
                             { scale: 1.02 },
-                            { scale: 1, duration: 0.18, ease: 'power2.out' }
+                            { scale: 1, duration: 0.18, ease: 'fluent' }
                         );
                     }
                 }

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -1014,8 +1014,8 @@
             }
             return gsap.to(barEl, {
                 width: percent + '%',
-                duration: 0.3,
-                ease: 'power2.out',
+                duration: OpenAver.motion.DURATION.medium,
+                ease: 'fluent',
                 overwrite: 'auto'
             });
         },

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -478,7 +478,7 @@
 
             var self = this;
             var dur = 0.38;
-            var ease = 'power2.inOut';
+            var ease = 'fluent';
 
             // C4: 清除 ghost 舊動畫（re-entrant safety）
             gsap.killTweensOf(ghost);
@@ -555,7 +555,7 @@
             gsap.set(targetImg, { opacity: 0 });
 
             var dur = 0.38;
-            var ease = 'power2.inOut';
+            var ease = 'fluent';
 
             // C4: 清除 ghost 舊動畫
             gsap.killTweensOf(ghost);

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -284,7 +284,7 @@
             // 快速 crossfade（opacity 0→1，0.15s）
             return gsap.fromTo(imgEl,
                 { opacity: 0 },
-                { opacity: 1, duration: 0.15, ease: 'power2.out' }
+                { opacity: 1, duration: 0.15, ease: 'fluent' }
             );
         },
 

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -1069,9 +1069,9 @@
                 {
                     opacity: 1,
                     y: 0,
-                    duration: options.duration || 0.35,
+                    duration: options.duration || OpenAver.motion.DURATION.medium,
                     stagger: options.stagger || 0.03,
-                    ease: options.ease || 'power2.out',
+                    ease: options.ease || 'fluent-decel',
                     clearProps: 'transform,opacity'
                 }
             );

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -710,7 +710,7 @@
                 return null;
             }
 
-            var dur = options.duration || 0.8;
+            var dur = options.duration || OpenAver.motion.DURATION.emphasis;
             var scaleVal = options.scale || 1.06;
             var ease = options.ease || 'settle';
             var rowCount = options.rows || 3;

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -784,61 +784,13 @@
          * @returns {gsap.core.Timeline|null}
          */
         playLightboxOpen: function (lightboxEl, options) {
-            options = options || {};
-
-            if (!lightboxEl) return null;
-            if (typeof gsap === 'undefined') return null;
-            if (shouldSkip()) return null;
-
-            var content = lightboxEl.querySelector('.lightbox-content');
-            var coverImg = lightboxEl.querySelector('.lightbox-cover img');
-
-            // C4: 清除舊動畫
-            gsap.killTweensOf(lightboxEl);
-            if (content) gsap.killTweensOf(content);
-            if (coverImg) gsap.killTweensOf(coverImg);
-
-            // C21: 暫時關掉 CSS transition
-            if (!lightboxEl.classList.contains('gsap-animating')) {
-                lightboxEl.classList.add('gsap-animating');
-            }
-
-            var tl = gsap.timeline({
-                id: 'lightboxOpen',
-                onComplete: function () {
-                    lightboxEl.classList.remove('gsap-animating');
-                    if (typeof options.onComplete === 'function') options.onComplete();
-                },
-                onInterrupt: function () {
-                    lightboxEl.classList.remove('gsap-animating');
-                }
-            });
-
-            // 1. Backdrop fade-in
-            tl.fromTo(lightboxEl,
-                { opacity: 0 },
-                { opacity: 1, duration: 0.16, ease: 'power2.out' }
-            );
-
-            // 2. Content card scale pop-in
-            if (content) {
-                tl.fromTo(content,
-                    { scale: 0.95, opacity: 0, transformOrigin: 'center center' },
-                    { scale: 1, opacity: 1, duration: 0.18, ease: 'power2.out', transformOrigin: 'center center' },
-                    0.03
-                );
-            }
-
-            // 3. Cover image slide-up fade-in（ghost fly 時跳過）
-            if (coverImg && !options.skipCover) {
-                tl.fromTo(coverImg,
-                    { y: 12, opacity: 0 },
-                    { y: 0, opacity: 1, duration: 0.16, ease: 'power2.out' },
-                    '-=0.08'
-                );
-            }
-
-            return tl;
+            // Phase 51 Phase 4 (T4.3): delegate to GhostFly.playLightboxOpen 共用實作。
+            // 不傳 timelineId，沿用預設 'lightboxOpen'，維持 grid-mode.js 既有
+            // gsap.getById('lightboxOpen')?.kill() 的 kill 路徑不變。
+            // CD-51-14：共用實作採 showcase 版完整 cleanup 契約（onComplete/onInterrupt
+            // 各對 content/coverImg 做 clearProps），對 search 為正向行為改善
+            // （防連點殘留 stutter）。
+            return window.GhostFly ? window.GhostFly.playLightboxOpen(lightboxEl, options) : null;
         },
 
         /**

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -572,7 +572,7 @@
                     opacity: 1,
                     y: 0,
                     duration: 0.3,
-                    ease: 'power2.out',
+                    ease: 'fluent-decel',
                     clearProps: 'transform,opacity'
                 }
             );

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -413,10 +413,15 @@
             // Phase 51 Phase 4 (T4.2): delegate to GhostFly.playLightboxOpen 共用實作。
             // timelineId 維持 'showcaseLightboxOpen' 以保留既有 killLightboxAnimations
             // (animations.js: this.killLightboxAnimations) 對 gsap.getById('showcaseLightboxOpen') 的查找。
-            return window.GhostFly ? window.GhostFly.playLightboxOpen(
-                lightboxEl,
-                Object.assign({ timelineId: 'showcaseLightboxOpen' }, options || {})
-            ) : null;
+            // typeof guard（codex T4-P3）：window.GhostFly 存在但 playLightboxOpen
+            // method 缺（cache invalidation 場景：舊 ghost-fly.js + 新 animations.js）
+            // 時 fallback null，避免 TypeError 直接炸掉 lightbox open。
+            return typeof window.GhostFly?.playLightboxOpen === 'function'
+                ? window.GhostFly.playLightboxOpen(
+                    lightboxEl,
+                    Object.assign({ timelineId: 'showcaseLightboxOpen' }, options || {})
+                )
+                : null;
         },
 
         /**

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -410,73 +410,13 @@
          * @returns {gsap.core.Timeline|null}
          */
         playLightboxOpen: function (lightboxEl, options) {
-            options = options || {};
-
-            if (!lightboxEl) return null;
-            if (typeof gsap === 'undefined') return null;
-            if (shouldSkip()) return null;
-
-            var content = lightboxEl.querySelector('.lightbox-content');
-            var coverImg = lightboxEl.querySelector('.lightbox-cover img');
-
-            // C4: 清除舊動畫
-            gsap.killTweensOf(lightboxEl);
-            if (content) gsap.killTweensOf(content);
-            if (coverImg) gsap.killTweensOf(coverImg);
-
-            // C21: 暫時關掉 CSS transition
-            if (!lightboxEl.classList.contains('gsap-animating')) {
-                lightboxEl.classList.add('gsap-animating');
-            }
-
-            var tl = gsap.timeline({
-                id: 'showcaseLightboxOpen',
-                onComplete: function () {
-                    lightboxEl.classList.remove('gsap-animating');
-                    // Phase 50.x cleanup: 清掉動畫過程中累積的 inline transform/opacity，
-                    // 避免被打斷時殘留半路狀態（用戶連點關開造成累積 stutter）
-                    if (content) gsap.set(content, { clearProps: 'transform,opacity' });
-                    if (coverImg && !options.skipCover) gsap.set(coverImg, { clearProps: 'transform,opacity' });
-                    if (typeof options.onComplete === 'function') options.onComplete();
-                },
-                onInterrupt: function () {
-                    lightboxEl.classList.remove('gsap-animating');
-                    // Phase 50.x cleanup: kill 中斷時 clearProps，避免殘留半路 transform/opacity
-                    if (content) gsap.set(content, { clearProps: 'transform,opacity' });
-                    if (coverImg && !options.skipCover) gsap.set(coverImg, { clearProps: 'transform,opacity' });
-                }
-            });
-
-            // Phase 50.x: charter §5 white-list 例外 — 與 ghost-fly playGridToLightbox
-            // (0.38s power2.inOut, CD-3 觀察項) 並行段，保留 power 系曲線族避免節奏錯位。
-            // fluent-decel (0,0,0,1) 起步快終端慢與 ghost-fly power2.inOut 終端慢視覺重疊，
-            // 造成「最後一小段卡」；revert 為 power2.out + 原 duration 解套。
-
-            // 1. Backdrop fade-in
-            tl.fromTo(lightboxEl,
-                { opacity: 0 },
-                { opacity: 1, duration: 0.16, ease: 'power2.out' }
-            );
-
-            // 2. Content card scale pop-in
-            if (content) {
-                tl.fromTo(content,
-                    { scale: 0.95, opacity: 0, transformOrigin: 'center center' },
-                    { scale: 1, opacity: 1, duration: 0.18, ease: 'power2.out', transformOrigin: 'center center' },
-                    0.03
-                );
-            }
-
-            // 3. Cover image slide-up fade-in（ghost fly 時跳過）
-            if (coverImg && !options.skipCover) {
-                tl.fromTo(coverImg,
-                    { y: 12, opacity: 0 },
-                    { y: 0, opacity: 1, duration: 0.16, ease: 'power2.out' },
-                    '-=0.08'
-                );
-            }
-
-            return tl;
+            // Phase 51 Phase 4 (T4.2): delegate to GhostFly.playLightboxOpen 共用實作。
+            // timelineId 維持 'showcaseLightboxOpen' 以保留既有 killLightboxAnimations
+            // (animations.js: this.killLightboxAnimations) 對 gsap.getById('showcaseLightboxOpen') 的查找。
+            return window.GhostFly ? window.GhostFly.playLightboxOpen(
+                lightboxEl,
+                Object.assign({ timelineId: 'showcaseLightboxOpen' }, options || {})
+            ) : null;
         },
 
         /**

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -2562,8 +2562,8 @@ function showcaseState() {
             if (rows.length === 0) return;
             OpenAver.motion.playFadeTo(rows, {
                 opacity: out ? 0 : 1,
-                duration: 0.2,
-                ease: 'power2.out'
+                duration: OpenAver.motion.DURATION.fast,
+                ease: out ? 'fluent-accel' : 'fluent-decel'
             });
         },
 

--- a/web/static/js/shared/ghost-fly.js
+++ b/web/static/js/shared/ghost-fly.js
@@ -432,6 +432,96 @@
                     }, delay);
                 }(i * (Math.random() * 80))); // 0–80ms stagger
             }
+        },
+
+        /**
+         * Lightbox open 三段共用動畫（Phase 51 Phase 4 共用化）
+         *
+         * showcase / search 兩邊 caller 透過 delegate 呼叫本函式。
+         * 三段 ease/duration 內部 hardcode（與 ui-conventions §5 white-list
+         * playLightboxOpen 三段一致；CD-51-9 確認與 ghost-fly playGridToLightbox
+         * 0.38s power2.inOut 並行段不可改 fluent-decel，否則「最後一小段卡」）。
+         *
+         * Cleanup 契約採 showcase 版完整 clearProps（CD-51-14）：onComplete /
+         * onInterrupt 均對 content / coverImg 做 clearProps: transform,opacity，
+         * 防連點觸發 interrupt 後殘留 inline style 造成 stutter。
+         *
+         * @param {Element} lightboxEl - .showcase-lightbox / .search-lightbox 根元素
+         * @param {object} [opts] - { skipCover, onComplete, timelineId }
+         * @param {boolean} [opts.skipCover] - true 時跳過第三段 cover slide-up（ghost-fly 接 lightbox 場景用）
+         * @param {Function} [opts.onComplete] - timeline onComplete 回調
+         * @param {string} [opts.timelineId='lightboxOpen'] - timeline ID（showcase delegate 傳 'showcaseLightboxOpen'）
+         * @returns {gsap.core.Timeline|null}
+         */
+        playLightboxOpen: function (lightboxEl, opts) {
+            opts = opts || {};
+
+            if (!lightboxEl) return null;
+            if (typeof gsap === 'undefined') return null;
+            if (window.OpenAver && window.OpenAver.prefersReducedMotion) return null;
+
+            var content = lightboxEl.querySelector('.lightbox-content');
+            var coverImg = lightboxEl.querySelector('.lightbox-cover img');
+
+            // C4: 清除舊動畫
+            gsap.killTweensOf(lightboxEl);
+            if (content) gsap.killTweensOf(content);
+            if (coverImg) gsap.killTweensOf(coverImg);
+
+            // C21: 暫時關掉 CSS transition
+            if (!lightboxEl.classList.contains('gsap-animating')) {
+                lightboxEl.classList.add('gsap-animating');
+            }
+
+            var timelineId = opts.timelineId || 'lightboxOpen';
+
+            var tl = gsap.timeline({
+                id: timelineId,
+                onComplete: function () {
+                    lightboxEl.classList.remove('gsap-animating');
+                    // CD-51-14 cleanup：清掉動畫過程中累積的 inline transform/opacity，
+                    // 避免被打斷時殘留半路狀態（用戶連點關開造成累積 stutter）
+                    if (content) gsap.set(content, { clearProps: 'transform,opacity' });
+                    if (coverImg && !opts.skipCover) gsap.set(coverImg, { clearProps: 'transform,opacity' });
+                    if (typeof opts.onComplete === 'function') opts.onComplete();
+                },
+                onInterrupt: function () {
+                    lightboxEl.classList.remove('gsap-animating');
+                    // CD-51-14 cleanup：kill 中斷時 clearProps，避免殘留半路 transform/opacity
+                    if (content) gsap.set(content, { clearProps: 'transform,opacity' });
+                    if (coverImg && !opts.skipCover) gsap.set(coverImg, { clearProps: 'transform,opacity' });
+                }
+            });
+
+            // ui-conventions §5 white-list（playLightboxOpen 三段）：
+            // 與 ghost-fly playGridToLightbox (0.38s power2.inOut) 並行段，
+            // 保留 power 系曲線族避免「最後一小段卡」（fix 50.2 經驗）。
+
+            // 1. Backdrop fade-in
+            tl.fromTo(lightboxEl,
+                { opacity: 0 },
+                { opacity: 1, duration: 0.16, ease: 'power2.out' }
+            );
+
+            // 2. Content card scale pop-in
+            if (content) {
+                tl.fromTo(content,
+                    { scale: 0.95, opacity: 0, transformOrigin: 'center center' },
+                    { scale: 1, opacity: 1, duration: 0.18, ease: 'power2.out', transformOrigin: 'center center' },
+                    0.03
+                );
+            }
+
+            // 3. Cover image slide-up fade-in（ghost fly 時跳過）
+            if (coverImg && !opts.skipCover) {
+                tl.fromTo(coverImg,
+                    { y: 12, opacity: 0 },
+                    { y: 0, opacity: 1, duration: 0.16, ease: 'power2.out' },
+                    '-=0.08'
+                );
+            }
+
+            return tl;
         }
     };
 


### PR DESCRIPTION
## Summary

把 Phase 50 在 Showcase 影片模式驗證過的 ui-conventions（Fluent 2 token / 白名單 / ease 三角色 / §6 5 檢查點）擴展到 Showcase 女優模式 + Search 整頁，並把 lightbox 開門動畫從兩邊各自實作整併到 `shared/ghost-fly.js` 共用。**4 個 phase / 31 commits / 0 功能變化 / 0 後端變更**。

- **Phase 1（女優模式）**：showcase.css 女優段靜態修齊 + `playHeroCardAppear` / `_fadeMetadataPanel` 三角色對齊 + picker-refresh-btn §6 5 檢查點
- **Phase 2（search 靜態）**：input.css 新 token（`--overlay-letterbox` / `--overlay-badge`）+ search.css §1-§4 修齊 + §6 5 檢查點對 `.btn` / `.input` / `.dropdown` / `.spotlight-search`
- **Phase 3（search GSAP）**：14 commits 對齊 §5 三角色 ease + 6 條 §5 白名單擴張（Staging Card / OrganizeSuccess / OrganizeFail shake / settle pulse 0.18s / playCoverSwap 0.15s / row flash 0.8s / playLightboxOpen 三段擴張至 search 版）
- **Phase 4（lightbox 共用化）**：`shared/ghost-fly.js` 新增 `GhostFly.playLightboxOpen` 共用實作；showcase / search caller 各自 delegate（淨減 ~70 行重複碼）；search 連點 interrupt cleanup 從 silent 改為 clearProps（正向改善，防殘留 stutter）

## Code review trail

- Codex T2.4-P2：tag 編輯 inline btn fallback 補完
- Codex T3.13/T3.15-P3：同步 Phase 3 改動後過時 JSDoc default 註解
- Codex T4-P3：delegate guard 改 `typeof window.GhostFly?.playLightboxOpen === 'function'`，防 cache invalidation 場景下 TypeError 炸掉 lightbox open

## Test plan

- [x] 全套測試 **2758 passed** (4:37)（`pytest tests/ -v --ignore=tests/smoke --ignore=tests/e2e -m "not smoke and not e2e"`）
- [x] frontend lint：`tests/test_frontend_lint.py` + `tests/unit/test_frontend_lint.py` 共 813 passed（含 Phase 51 新增 7 條 guard：3 條 `TestGhostFlyPlayLightboxOpen` + 既有 4 條 white-list guard 改指 ghost-fly.js + 2 條 delegate guard）
- [x] 敏感資訊掃描 CLEAN
- [x] 打包完整性 OK（`web/` 已在 build COPY_ITEMS 涵蓋，無新 top-level）
- [x] dev server 三 surface 視覺驗收（影片 / 女優 / search lightbox 開合）— 留給 reviewer
- [ ] 高風險動畫感受確認（plan §4.4）：T3.3 ghost 飛行 / T3.7 playGridSettle -37% / T3.16 playMiniBurst 彈跳感 / T3.9-T3.10-T3.15 duration -33%
- [ ] Phase 4 連點 interrupt 驗證：search lightbox 連點開→關→開，content/coverImg 無殘留 inline transform/opacity（T4.3 DoD）

## 範圍 / Scope

| Surface | 狀態 |
|---|---|
| Showcase 影片模式 | Phase 50 已通過，本 PR 不得 regression |
| Showcase 女優模式 | Phase 51 Phase 1 應用 ui-conventions |
| Search 整頁 | Phase 51 Phase 2/3 應用 ui-conventions |
| Lightbox 開門動畫 | Phase 51 Phase 4 共用化 single source of truth |
| Backend / API / DB / i18n | 不動 |

## 文檔

- `core/version.py`：0.8.0 → 0.8.1（patch bump）
- `CHANGELOG.md`：新增 [0.8.1] 區塊（51.1-51.4 四 phase 摘要 + Fixed 區塊三條 codex review 修正）

## Plan reference

- Plan：`feature/51-ui-conventions-actress-search/plan-51.md`（gitignored）
- Conventions：`feature/AI_COLLABORATION/ui-conventions.md`（gitignored，§5 白名單已擴張至 11 條 Special Motion + 5 條 Hardcoded Duration）
- 沿 Phase 50 Charter Pilot 確立的 ui-conventions 規則本體不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)