### PR TITLE
Phase 52 — UI Conventions Finish + Soul-Alignment Cleanup (v0.8.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
   - `console.*`
   - technical terms such as NFO, API Key, Jellyfin, Proxy
   - browser/platform built-in text
+  - **`design-system` and `motion-lab` page demo content** — these are internal dev-reference pages (not in main nav, not user-facing), and demo labels often contain Fluent design tokens (`fluent-decel`, `Acrylic 30px`, `--surface-1` etc.) that should not be translated. Page chrome (nav / page title) still goes through i18n; only demo body text is exempt.
 - At milestone/release, all 4 locales must have identical key sets.
 
 ### General code quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-04-29
+
+本版把 ui-conventions 套用到剩餘 5 頁（scanner / settings / help / design-system / motion-lab），並把幾條與「軟體靈魂」對不上的舊互動清掉：原生 `confirm()` / `alert()` 替換成風格一致的 fluent-modal 與 toast，showcase toolbar per-page 下拉移除（Settings 為唯一真理來源）。對使用者而言視覺更整齊、確認對話更貼近主視覺、複製失敗時用得到完整訊息（不再只看到截斷 500 字）。
+
+*This release applies ui-conventions to the remaining 5 utility/demo pages and cleans up legacy interactions (native confirm/alert → fluent-modal/toast). No user-facing feature changes — only consistency, polish, and accessibility improvements.*
+
+### Added
+
+#### 🎯 52.1 — 5 頁靜態 UI 修齊（Phase 1）
+- scanner / settings / help / design-system / motion-lab 五頁 §1-§4 + §6 5 檢查點修齊（commits 3ce4c7f / ba804bf / 26131be / c0185a7 / 20713ac / 95b5e0a / a50014f / 21be2b6 / 19e9725 / 9eb64db / 8a94ba7 / ca8952a / a2ae5f8 / 6e4e617 / 93c0a1e / 6e4e584 / 40de310）
+- design-system 新增 §1 pill 5 類白名單 / §2 三階 token / §3 overlay 5 swatch / §4 spacing 三層 / §6 5 檢查點 pass-fail demo（commits 6e4e617 / 93c0a1e / 6e4e584）
+- settings.css §6 .input / .select / settings-header 沿用 plan-50 P1b 完整規格（commits 26131be / c0185a7 / 95b5e0a）
+- motion_lab.html §1 blur / §2 shadow / §3 color & radius / §5 transition token 化（commits 5ba0285 / 35d141e / 7f44a76 / 7adbfec / 29cf36e / 060c5a5）
+- TestSettingsCssHardcoded / TestHelpCssHardcoded / TestDesignSystemCssHardcoded / TestMotionLabHtmlHardcoded 4 條 lint guard
+
+#### 🎯 52.2 — Motion Lab 動畫 demo 補齊（Phase 2）
+- 新增 §5 三角色 ease 並排 demo（fluent / fluent-decel / fluent-accel）+ T2.1 範圍 ease 殘留清（commit 1fd4fd4）
+- 新增 §5 Duration 三 bucket demo（fast 167ms / medium 333ms / emphasis 500ms 並排對照）+ T2.2 範圍 ease 殘留清（commit 41b7751）
+- 新增 §5 Special Motion 白名單 demo（Burst / Floating Hearts / showcaseSettle / SourcePulse）+ T2.3 範圍 ease 殘留清（commit 5dbcc82）
+
+#### 🎯 52.3 — Soul-Alignment Cleanup（Phase 3）
+- Showcase toolbar per-page 下拉移除，Settings 接管為唯一真理來源（既有 localStorage 殘留 fallback 到 settings default，無 migration）(commit 6201b91)
+- `removeActress()` / `resetConfig()` / `deleteAliasGroup()` 三處原生 `confirm()` 改 fluent-modal + i18n 4 keys 各一組（commits 4b784fe / ee37b37 / 492d650）
+- 15 處 `alert()` 改 showToast + i18n 14 keys（scanner ×8 含 1 處 fluent-modal `<pre>` 可選取 dump 取代 truncate 500 字 / settings ×1 / search file-list ×5 / search result-card ×1）(commit f2d2b67)
+
+### Fixed
+- T3.2 codex P2：`items_per_page` 預設值用 `??` 而非 `||`，保留合法 numeric 0（避免被 falsy 0 吞掉）(commit 0d195bc)
+- T3.6 codex P2：scanner.js copyLogs / copyOutputPath 兩處 `navigator.clipboard.writeText` 補 availability guard，clipboard undefined 時 fallback 才會觸發（之前 sync TypeError 跳過 .catch chain，用戶以為「複製成功」）(commit 37db4bd)
+- T3.7：result-card.js / showcase/core.js `openLocal()` 同類 pre-existing bug sweep — 三元 guard 把 sync TypeError 收斂為 `Promise.resolve(false)` 重用既有 fail UX；新增通用 lint guard 防未來新檔再犯（commit 397a412）
+- Phase 1 codex 5 條 finding（commit 783c6c4）
+- Phase 2 codex motion_lab.html `--accent-primary` / `--accent-secondary` 統一 + skip-note 文案（commit 968ce51）
+
 ## [0.8.1] - 2026-04-29
 
 本版把 Phase 50 在 Showcase 影片模式驗證過的 ui-conventions（Fluent 2 token / 白名單 / ease 三角色 / §6 5 檢查點）擴展到 Showcase 女優模式 + Search 整頁，並把 lightbox 開門動畫從兩邊各自實作整併到 `shared/ghost-fly.js` 共用。對使用者而言三個主要 surface 視覺與動畫節奏接續，沒有功能變化。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -300,6 +300,11 @@
       "discard": "不儲存",
       "save": "儲存更改"
     },
+    "reset_modal": {
+      "title": "重置所有設定",
+      "body": "確定要重置所有設定嗎？此操作將刪除所有自訂設定，無法復原。",
+      "confirm": "確認重置"
+    },
     "status": {
       "loading_models": "載入模型中...",
       "connecting": "連線中...",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -434,7 +434,13 @@
       "confirm": "確認加入",
       "delete_group_title": "刪除此女優別名組",
       "delete_alias_title": "移除此別名",
-      "error_conflict": "別名衝突"
+      "error_conflict": "別名衝突",
+      "delete_group_modal": {
+        "title": "刪除別名組",
+        "body": "確定要刪除「{name}」的整筆別名組嗎？此操作無法復原。",
+        "cancel": "取消",
+        "confirm": "確認刪除"
+      }
     },
     "dirty_modal": {
       "title": "尚未儲存的變更",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -578,7 +578,12 @@
       "addNotFound": "找不到此女優",
       "addTimeout": "抓取超時，請稍後再試",
       "remove": "移除最愛",
-      "removeConfirm": "確認移除 {name}？",
+      "remove_modal": {
+        "title": "移除收藏",
+        "body": "確定要從收藏移除「{name}」嗎？此操作無法復原。",
+        "cancel": "取消",
+        "confirm": "確認移除"
+      },
       "removeSuccess": "已從收藏移除",
       "empty": "尚未收藏任何女優",
       "emptyHint": "點擊右上角 + 新增收藏",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -462,8 +462,7 @@
     },
     "toolbar": {
       "sort_prefix": "排序",
-      "mode_prefix": "模式",
-      "per_page_prefix": "每頁"
+      "mode_prefix": "模式"
     },
     "sort": {
       "date": "日期",
@@ -501,9 +500,6 @@
       "videos_count": " 部",
       "films": "部作品",
       "actresses": "位女優"
-    },
-    "per_page": {
-      "all": "全部"
     },
     "status": {
       "total_prefix": "共",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -162,7 +162,11 @@
       "scrape_complete": "批次整理完成：成功 {success}，失敗 {failed}",
       "scrape_complete_dup": "批次整理完成：成功 {success}，失敗 {failed}，重複 {duplicate}",
       "no_search_results": "此檔案沒有搜尋結果",
-      "scrape_failed": "{filename} 整理失敗"
+      "scrape_failed": "{filename} 整理失敗",
+      "no_valid_files": "無有效影片檔案（無法識別番號）",
+      "desktop_only": "此功能需要在桌面應用程式中使用",
+      "load_failed": "載入失敗，請重試",
+      "translate_failed": "翻譯失敗，請重試"
     },
     "duplicate": {
       "title": "檔案重複",
@@ -175,6 +179,9 @@
   },
   "settings": {
     "page_title": "設定",
+    "toast": {
+      "desktop_only": "此功能需要在桌面應用程式中使用"
+    },
     "header": {
       "title": "設定",
       "font_size_prefix": "字體大小",
@@ -340,6 +347,19 @@
   },
   "scanner": {
     "page_title": "列表生成",
+    "toast": {
+      "desktop_only": "此功能需要在桌面應用程式中使用",
+      "folder_already_added": "此資料夾已在列表中",
+      "copy_path_failed": "複製失敗，路徑：{path}",
+      "generate_error": "產生失敗，請查看日誌",
+      "nfo_update_error": "NFO 補齊失敗，請查看日誌",
+      "jellyfin_update_error": "Jellyfin 圖片補齊失敗，請查看日誌"
+    },
+    "copy_fail_modal": {
+      "title": "複製日誌失敗",
+      "body": "clipboard 寫入失敗，請手動選取以下文字按 Ctrl+C 複製：",
+      "close": "關閉"
+    },
     "drag_overlay": {
       "hint": "放開以加入資料夾"
     },

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -4350,6 +4350,52 @@ class TestSettingsResetConfigNoNativeConfirm:
         )
 
 
+class TestScannerDeleteAliasGroupNoNativeConfirm:
+    """T3.5 (CD-52-11): deleteAliasGroup 改 fluent-modal 後 scanner.js 不再含原 confirm 完整文字
+
+    用「資料指紋」式精準字串匹配，避免誤命中 L239 page-lifecycle confirm
+    （'確定要離開嗎？' — backlog OQ 不在 Phase 52 範圍）+ L734 clearLogs
+    confirm（'確定要清除所有日誌嗎？...' — Phase 52 不入）。
+
+    額外 assert 三個新 method 名個別存在（避免假陰性 — 若 deleteAliasGroup
+    被混進 confirmRemoveActress 等不相關名稱，弱守衛仍會 pass）。
+    """
+
+    SCANNER_JS = PROJECT_ROOT / 'web' / 'static' / 'js' / 'pages' / 'scanner.js'
+
+    def test_scanner_no_delete_alias_group_native_confirm(self):
+        """T3.5: deleteAliasGroup native confirm 已替換為 fluent-modal"""
+        scanner_js = self.SCANNER_JS.read_text(encoding="utf-8")
+        # 守衛舊 native confirm 完整文字（含「確定要刪除「」+ 「整筆別名組嗎？」）
+        assert "確定要刪除「" not in scanner_js, (
+            "T3.5 違規：deleteAliasGroup() native confirm 已於 T3.5 替換為 fluent-modal"
+        )
+        assert "整筆別名組嗎？" not in scanner_js, (
+            "T3.5 違規：deleteAliasGroup() native confirm 已於 T3.5 替換為 fluent-modal"
+        )
+
+    def test_scanner_has_delete_alias_group_modal_methods(self):
+        """T3.5: 三個新 method 個別存在（強守衛,避免名字混過去）"""
+        scanner_js = self.SCANNER_JS.read_text(encoding="utf-8")
+        # 個別 assert，避免「deleteAliasGroup in scanner.js」這種會被舊名混過去的弱 guard
+        assert "openDeleteAliasGroupModal" in scanner_js, (
+            "T3.5 違規：openDeleteAliasGroupModal method 應存在（modal trigger 入口）"
+        )
+        assert "confirmDeleteAliasGroup" in scanner_js, (
+            "T3.5 違規：confirmDeleteAliasGroup method 應存在（API 執行入口）"
+        )
+        assert "cancelDeleteAliasGroupModal" in scanner_js, (
+            "T3.5 違規：cancelDeleteAliasGroupModal method 應存在（dismiss 入口）"
+        )
+
+    def test_scanner_html_escape_ladder_includes_delete_alias_group(self):
+        """T3.5: scanner.html root escape.window ladder 含 deleteAliasGroupModalOpen"""
+        scanner_html = (PROJECT_ROOT / 'web' / 'templates' / 'scanner.html').read_text(encoding="utf-8")
+        assert "deleteAliasGroupModalOpen && cancelDeleteAliasGroupModal" in scanner_html, (
+            "T3.5 違規：scanner.html root @keydown.escape.window 應串接 deleteAliasGroupModal 的 cancel"
+        )
+
+
 class TestSampleGalleryTemplateGuard:
     """T8：Search Sample Gallery 模板守衛
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -4275,6 +4275,23 @@ class TestShowcasePerPageRemoval:
         )
 
 
+class TestShowcaseRemoveActressNoNativeConfirm:
+    """T3.3 (CD-52-11): removeActress 改 fluent-modal 後 showcase/core.js 不再用 native confirm
+
+    確保 window.confirm 不回歸（fluent-modal pattern 取代）。
+    """
+
+    SHOWCASE_CORE_JS = PROJECT_ROOT / 'web' / 'static' / 'js' / 'pages' / 'showcase' / 'core.js'
+
+    def test_showcase_no_native_confirm(self):
+        """T3.3: removeActress 改 fluent-modal 後 showcase/core.js 不再用 window.confirm"""
+        core_js = self.SHOWCASE_CORE_JS.read_text(encoding="utf-8")
+        assert "window.confirm(" not in core_js, (
+            "T3.3 違規：removeActress() native confirm 已於 T3.3 替換為 fluent-modal — "
+            "showcase/core.js 不應再含 window.confirm("
+        )
+
+
 class TestSampleGalleryTemplateGuard:
     """T8：Search Sample Gallery 模板守衛
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -4217,6 +4217,42 @@ class TestGridPerPageGuard:
             "切到 grid 時若 perPage=0 必須降級為 120"
         )
 
+    def test_guard5_items_per_page_uses_nullish_coalescing(self):
+        """Guard 5 (T3.2 P2 fix): items_per_page 預設值必須用 `??` 而非 `||`
+
+        Settings UI 允許 items_per_page=0（"全部"選項，settings.html L663），
+        後端 `core/config.py:GalleryConfig.items_per_page` 沒有 gt=0 validator → 0 會透傳到前端。
+        若用 `||` 會把 0 視為 falsy 走 fallback 90，導致：
+          1. showcase init 永遠拿不到 0，grid+perPage=0→120 降級邏輯（Guard 1/3/4）永遠不觸發
+          2. settings 載入時把存檔的 0 顯示成 90，"全部" 選項失效
+
+        必須用 `??`（nullish coalescing）只對 null/undefined 走 fallback，保留 numeric 0。
+        """
+        showcase_core = self.CORE_JS.read_text(encoding='utf-8')
+        settings_js = (PROJECT_ROOT / 'web' / 'static' / 'js' / 'pages' / 'settings.js').read_text(encoding='utf-8')
+
+        # 禁止 `items_per_page || ...` pattern（吞 0 的寫法）
+        bad_pattern = re.compile(r'items_per_page\s*\|\|')
+        showcase_bad = bad_pattern.findall(showcase_core)
+        settings_bad = bad_pattern.findall(settings_js)
+        assert not showcase_bad, (
+            "T3.2 P2 違規：showcase/core.js 含 `items_per_page ||` — "
+            "Settings 的 items_per_page=0 ('全部') 會被吞成 fallback，必須改用 `??`"
+        )
+        assert not settings_bad, (
+            "T3.2 P2 違規：settings.js 含 `items_per_page ||` — "
+            "載入存檔的 items_per_page=0 ('全部') 會被吞成 fallback，必須改用 `??`"
+        )
+
+        # 正向斷言：showcase / settings 都必須有 `items_per_page ?? <number>` 寫法
+        good_pattern = re.compile(r'items_per_page\s*\?\?\s*\d+')
+        assert good_pattern.search(showcase_core), (
+            "T3.2 P2 違規：showcase/core.js 缺少 `items_per_page ?? <number>` 預設值寫法"
+        )
+        assert good_pattern.search(settings_js), (
+            "T3.2 P2 違規：settings.js 缺少 `items_per_page ?? <number>` 預設值寫法"
+        )
+
 
 class TestShowcasePerPageRemoval:
     """T3.2 (CD-52-3): showcase toolbar perPage selector 已移除守衛

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -4292,6 +4292,28 @@ class TestShowcaseRemoveActressNoNativeConfirm:
         )
 
 
+class TestSettingsResetConfigNoNativeConfirm:
+    """T3.4 (CD-52-11): resetConfig 改 fluent-modal 後 settings.js 不再含原 confirm 文字
+
+    用「資料指紋」式精準字串匹配，避免誤命中 cycleLocale (L262) 既有 confirm —
+    該 confirm 屬 backlog，不在 Phase 52 範圍。
+    """
+
+    SETTINGS_JS = PROJECT_ROOT / 'web' / 'static' / 'js' / 'pages' / 'settings.js'
+
+    def test_settings_resetconfig_no_native_confirm(self):
+        """T3.4: resetConfig 改 fluent-modal 後 settings.js 不再含原 confirm 完整文字
+
+        守衛字串對齊舊 native confirm 完整文（含尾句號），與新 i18n key 內容
+        ('...無法復原。') 不重疊，避免 fallback 內聯時誤觸發。
+        """
+        settings_js = self.SETTINGS_JS.read_text(encoding="utf-8")
+        assert "確定要重置所有設定嗎？此操作將刪除所有自訂設定。" not in settings_js, (
+            "T3.4 違規：resetConfig() native confirm 已於 T3.4 替換為 fluent-modal — "
+            "settings.js 不應再含舊 native confirm 完整字串"
+        )
+
+
 class TestSampleGalleryTemplateGuard:
     """T8：Search Sample Gallery 模板守衛
 

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -5086,3 +5086,73 @@ class TestGhostFlyPlayLightboxOpen:
         js = self.GHOST_FLY_JS.read_text(encoding='utf-8')
         assert 'timelineId' in js, \
             "ghost-fly.js playLightboxOpen 缺少 timelineId opt — CD-51-16 介面未植入"
+
+
+class TestT36ToastI18nKeys:
+    """T3.6 (CD-52-11): alert→toast 改寫後新 i18n keys 必須存在於 zh_TW.json"""
+
+    LOCALE_FILE = PROJECT_ROOT / "locales" / "zh_TW.json"
+
+    REQUIRED_KEYS = [
+        # scanner.toast (6)
+        "scanner.toast.desktop_only",
+        "scanner.toast.folder_already_added",
+        "scanner.toast.copy_path_failed",
+        "scanner.toast.generate_error",
+        "scanner.toast.nfo_update_error",
+        "scanner.toast.jellyfin_update_error",
+        # scanner.copy_fail_modal (3)
+        "scanner.copy_fail_modal.title",
+        "scanner.copy_fail_modal.body",
+        "scanner.copy_fail_modal.close",
+        # settings.toast (1)
+        "settings.toast.desktop_only",
+        # search.toast (4)
+        "search.toast.no_valid_files",
+        "search.toast.desktop_only",
+        "search.toast.load_failed",
+        "search.toast.translate_failed",
+    ]
+
+    def test_all_t36_keys_exist_in_zh_tw(self):
+        import json
+        data = json.loads(self.LOCALE_FILE.read_text(encoding="utf-8"))
+
+        def get_nested(d, dotted):
+            cur = d
+            for part in dotted.split("."):
+                if not isinstance(cur, dict) or part not in cur:
+                    return None
+                cur = cur[part]
+            return cur if isinstance(cur, str) else None
+
+        missing = [k for k in self.REQUIRED_KEYS if get_nested(data, k) is None]
+        assert not missing, f"T3.6 違規：zh_TW.json 缺 i18n keys：{missing}"
+
+
+class TestScannerCopyFailModal:
+    """T3.6: scanner.html copyFailModal markup + scanner.js 三 method + escape ladder"""
+
+    SCANNER_JS = PROJECT_ROOT / "web" / "static" / "js" / "pages" / "scanner.js"
+    SCANNER_HTML = PROJECT_ROOT / "web" / "templates" / "scanner.html"
+
+    def test_scanner_js_has_copy_fail_modal_methods(self):
+        content = self.SCANNER_JS.read_text(encoding="utf-8")
+        assert "openCopyFailModal" in content, \
+            "T3.6: openCopyFailModal method 應存在（取代 L728 truncated alert）"
+        assert "closeCopyFailModal" in content, \
+            "T3.6: closeCopyFailModal method 應存在"
+        assert "copyFailModalOpen" in content, \
+            "T3.6: copyFailModalOpen state 應存在"
+
+    def test_scanner_html_has_copy_fail_modal_markup(self):
+        content = self.SCANNER_HTML.read_text(encoding="utf-8")
+        assert "copy_fail_modal.title" in content, \
+            "T3.6: scanner.html 應有 copy_fail_modal markup（i18n key）"
+        assert "copy-fail-pre" in content, \
+            "T3.6: scanner.html copyFailModal 應含 .copy-fail-pre class"
+
+    def test_scanner_html_escape_ladder_includes_copy_fail_modal(self):
+        content = self.SCANNER_HTML.read_text(encoding="utf-8")
+        assert "copyFailModalOpen && closeCopyFailModal" in content, \
+            "T3.6: scanner.html root @keydown.escape.window 應串接 copyFailModal 的 close"

--- a/tests/test_frontend_lint.py
+++ b/tests/test_frontend_lint.py
@@ -4191,35 +4191,6 @@ class TestGridPerPageGuard:
             "grid mode 下 perPage=0 必須降級為 120（this.perPage = 120）"
         )
 
-    def test_guard2_dropdown_all_has_mode_condition(self):
-        """Guard 2: 「全部」dropdown item 必須有 mode 條件"""
-        content = self.SHOWCASE_HTML.read_text(encoding='utf-8')
-        lines = content.split('\n')
-
-        # 找到包含 perPage = 0 或 perPage == 0 的行（全部選項）
-        perpage0_lines = []
-        for i, line in enumerate(lines):
-            if re.search(r'perPage\s*==?\s*0', line):
-                perpage0_lines.append((i, line))
-
-        assert perpage0_lines, "找不到 perPage=0 的 dropdown item"
-
-        # 至少有一行（全部選項的元素）包含 mode 相關條件
-        # 檢查該行及前後 2 行的上下文
-        found_mode_guard = False
-        for line_idx, _ in perpage0_lines:
-            context_start = max(0, line_idx - 2)
-            context_end = min(len(lines), line_idx + 3)
-            context = '\n'.join(lines[context_start:context_end])
-            if re.search(r"mode\s*[!=]==?\s*['\"]grid['\"]", context):
-                found_mode_guard = True
-                break
-
-        assert found_mode_guard, (
-            "F2 違規：showcase.html 的「全部」dropdown item (perPage=0) 缺少 mode 條件 — "
-            "grid mode 下「全部」選項必須 disabled 或隱藏"
-        )
-
     def test_guard3_restoreState_has_grid_perPage0_guard(self):
         """Guard 3: restoreState 必須含 grid+perPage=0 降級邏輯"""
         content = self.CORE_JS.read_text(encoding='utf-8')
@@ -4244,6 +4215,63 @@ class TestGridPerPageGuard:
         assert has_grid_check and has_downgrade, (
             "F2 違規：switchMode() 缺少 grid+perPage=0 降級 — "
             "切到 grid 時若 perPage=0 必須降級為 120"
+        )
+
+
+class TestShowcasePerPageRemoval:
+    """T3.2 (CD-52-3): showcase toolbar perPage selector 已移除守衛
+
+    禁止 perPageOpen / onPerPageChange 等已移除符號回歸。
+    settings 的 items_per_page UI 不在此守衛範圍。
+    """
+
+    SHOWCASE_HTML = PROJECT_ROOT / 'web' / 'templates' / 'showcase.html'
+    SHOWCASE_CORE_JS = PROJECT_ROOT / 'web' / 'static' / 'js' / 'pages' / 'showcase' / 'core.js'
+    LOCALE_ZH_TW = PROJECT_ROOT / 'locales' / 'zh_TW.json'
+
+    def test_showcase_html_no_perPageOpen(self):
+        """showcase.html 不再含 perPageOpen state binding（toolbar dropdown 已刪）"""
+        content = self.SHOWCASE_HTML.read_text(encoding='utf-8')
+        assert 'perPageOpen' not in content, (
+            "T3.2 違規：showcase.html 不應再含 perPageOpen — "
+            "toolbar perPage dropdown 已於 T3.2 (CD-52-3) 移除"
+        )
+
+    def test_showcase_html_no_onPerPageChange(self):
+        """showcase.html 不再含 onPerPageChange handler 呼叫"""
+        content = self.SHOWCASE_HTML.read_text(encoding='utf-8')
+        assert 'onPerPageChange' not in content, (
+            "T3.2 違規：showcase.html 不應再含 onPerPageChange — "
+            "toolbar perPage dropdown 已於 T3.2 (CD-52-3) 移除"
+        )
+
+    def test_showcase_core_js_no_perPageOpen_state(self):
+        """core.js 不再含 perPageOpen: state property"""
+        content = self.SHOWCASE_CORE_JS.read_text(encoding='utf-8')
+        assert 'perPageOpen:' not in content, (
+            "T3.2 違規：showcase/core.js 不應再含 perPageOpen state property — "
+            "toolbar perPage dropdown 已於 T3.2 (CD-52-3) 移除"
+        )
+
+    def test_showcase_core_js_no_onPerPageChange_method(self):
+        """core.js 不再含 onPerPageChange() method"""
+        content = self.SHOWCASE_CORE_JS.read_text(encoding='utf-8')
+        assert 'onPerPageChange()' not in content, (
+            "T3.2 違規：showcase/core.js 不應再含 onPerPageChange() method — "
+            "toolbar perPage dropdown 已於 T3.2 (CD-52-3) 移除"
+        )
+
+    def test_locale_zh_tw_no_per_page_keys(self):
+        """zh_TW.json 不再含 showcase.toolbar.per_page_prefix 與 showcase.per_page 段"""
+        content = self.LOCALE_ZH_TW.read_text(encoding='utf-8')
+        assert 'per_page_prefix' not in content, (
+            "T3.2 違規：zh_TW.json 不應再含 per_page_prefix — "
+            "showcase toolbar perPage 已於 T3.2 (CD-52-3) 移除"
+        )
+        # 檢查 showcase.per_page 段（注意避開 settings.gallery.items_per_page_label / help.other_per_page）
+        assert '"per_page":' not in content, (
+            "T3.2 違規：zh_TW.json 不應再含 showcase.per_page 段（含 \"all\": \"全部\"） — "
+            "showcase toolbar perPage 已於 T3.2 (CD-52-3) 移除"
         )
 
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2351,6 +2351,39 @@ class TestShowcaseActressI18n:
             "T3.3 違規：showcase.actress.removeConfirm 應已隨 native confirm → fluent-modal 改寫從 zh_TW 移除"
 
 
+class TestSettingsResetModalI18n:
+    """T3.4 (CD-52-11): resetConfig fluent-modal i18n key 守衛
+
+    沿 TestShowcaseActressI18n.test_remove_modal_keys_in_zh_tw pattern，
+    開發期只守 zh_TW.json；其他 locale 走 milestone 同步（依 i18n.md 規則）。
+    """
+
+    LOCALES_ROOT = Path(__file__).parent.parent.parent / "locales"
+
+    def _locale(self, name):
+        return json.loads((self.LOCALES_ROOT / name).read_text(encoding="utf-8"))
+
+    def _get_nested(self, d, dotted_key):
+        keys = dotted_key.split(".")
+        cur = d
+        for k in keys:
+            if not isinstance(cur, dict) or k not in cur:
+                return None
+            cur = cur[k]
+        return cur
+
+    @pytest.mark.parametrize("key", [
+        "settings.reset_modal.title",
+        "settings.reset_modal.body",
+        "settings.reset_modal.confirm",
+    ])
+    def test_reset_modal_keys_in_zh_tw(self, key):
+        """T3.4: reset_modal.* 3 keys 在 zh_TW.json 存在（cancel 複用 common.action.cancel 不需新增）"""
+        data = self._locale("zh_TW.json")
+        val = self._get_nested(data, key)
+        assert val is not None, f"zh_TW.json 缺少 {key}（T3.4 fluent-modal i18n key）"
+
+
 class TestShowcaseLightboxSentinel:
     """Phase 44b-T4: Lightbox -1 sentinel nav guards"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4687,3 +4687,54 @@ class TestPickerIntegrationGuard:
             "newCard 必須使用 cards[myIndex]，不可用 cards[this._candidates.length - 1]"
         assert "cards[this._candidates.length - 1]" not in body, \
             "candidate handler 不可使用 cards[this._candidates.length - 1]（race bug：所有 handler 拿到同一張卡）"
+
+
+class TestSettingsCssHardcoded:
+    """Phase 52 T1.2.4: settings.css hardcoded 硬編碼守衛（防未來回潮）"""
+
+    def _css(self):
+        return Path("web/static/css/pages/settings.css").read_text(encoding="utf-8")
+
+    def test_no_hardcoded_transition_duration_in_settings_css(self):
+        """settings.css 所有 transition 不應有硬編碼數字秒數（須用 var(--fluent-duration-*)）
+
+        Pattern: transition 值含 0.Xs 或 .Xs 數字字面，且不含 var(--
+        允許：comments（// 或 /* 開頭行）中的說明文字
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if "transition:" in line:
+                # 尋找硬編碼數字秒數（0.Xs 或 .Xs），且不含 var(--
+                if re.search(r"transition:[^;]*\b0?\.\d+s\b", line) and "var(--" not in line:
+                    violations.append(f"L{i}: {line.strip()}")
+        assert not violations, (
+            "settings.css transition 殘留硬編碼數字秒數（應改用 var(--fluent-duration-*)）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_blur_px_in_settings_css(self):
+        """settings.css 不應出現 hardcoded blur(Npx)（須用 token 或 CSS 變數）
+
+        守住未來修改不引入硬編碼 blur。（當前 settings.css 無 blur，此 guard 守住零基線）
+        """
+        css = self._css()
+        lines = css.split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # .settings-header backdrop-filter 使用 blur()，但那是 backdrop-filter 非 filter
+            # 只守 filter: blur(Npx) 形式（非 backdrop-filter）
+            if re.search(r"(?<!backdrop-)filter\s*:[^;]*blur\(\d+px\)", line):
+                violations.append(f"L{i}: {line.strip()}")
+        assert not violations, (
+            "settings.css 出現 hardcoded filter: blur(Npx)（請改用 CSS 變數）：\n"
+            + "\n".join(violations)
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5153,3 +5153,43 @@ class TestMotionLabT2DurationBuckets:
         """motion_lab.html 含 DURATION.fast 標籤（duration-buckets panel box label）"""
         assert "DURATION.fast" in self._html(), \
             "motion_lab.html 缺少 DURATION.fast 標籤（§5 Duration Buckets panel box label 未加入）"
+
+
+# ─── 52-T2.3: §5 Special Motion White-list Demo 守衛 ──────────────────────────
+MOTION_LAB_HTML_T2_3 = Path(__file__).parent.parent.parent / "web" / "templates" / "motion_lab.html"
+MOTION_LAB_JS_T2_3 = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "motion-lab.js"
+
+
+class TestMotionLabT2SpecialMotion:
+    """52-T2.3: 守衛 §5 Special Motion 白名單 demo 必要元素"""
+
+    def _html(self) -> str:
+        return MOTION_LAB_HTML_T2_3.read_text(encoding="utf-8")
+
+    def _js(self) -> str:
+        return MOTION_LAB_JS_T2_3.read_text(encoding="utf-8")
+
+    def test_html_has_special_motion_tab(self):
+        """motion_lab.html tab bar 含 special-motion tab button"""
+        assert "special-motion" in self._html(), \
+            "motion_lab.html tab bar 缺少 special-motion tab（§5 Special Motion 白名單 tab 未加入）"
+
+    def test_js_has_play_special_motion_checkmark_demo(self):
+        """motion-lab.js 含 playSpecialMotionCheckmarkDemo 函式"""
+        assert "playSpecialMotionCheckmarkDemo" in self._js(), \
+            "motion-lab.js 缺少 playSpecialMotionCheckmarkDemo（§5 Special Motion checkmark demo 函式未加入）"
+
+    def test_js_has_play_special_motion_shake_demo(self):
+        """motion-lab.js 含 playSpecialMotionShakeDemo 函式"""
+        assert "playSpecialMotionShakeDemo" in self._js(), \
+            "motion-lab.js 缺少 playSpecialMotionShakeDemo（§5 Special Motion shake demo 函式未加入）"
+
+    def test_js_has_play_special_motion_pulse_demo(self):
+        """motion-lab.js 含 playSpecialMotionPulseDemo 函式"""
+        assert "playSpecialMotionPulseDemo" in self._js(), \
+            "motion-lab.js 缺少 playSpecialMotionPulseDemo（§5 Special Motion pulse demo 函式未加入）"
+
+    def test_html_has_whitelist_skip_note(self):
+        """motion_lab.html special-motion panel 含 whitelist-skip-note 跳過說明"""
+        assert "whitelist-skip-note" in self._html(), \
+            "motion_lab.html 缺少 whitelist-skip-note（§5 Special Motion 跳過條目說明未加入）"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -1734,6 +1734,24 @@ class TestNoAlertInSearchJs:
         assert "alert(" not in content, \
             "settings.js 含原生 alert()，應改用 this.showToast()"
 
+    def test_scanner_clipboard_has_availability_guard(self):
+        """T3.6 P2 fix: scanner.js 兩處 clipboard call 必須有 availability guard
+
+        navigator.clipboard 在 HTTP / 舊 WebView 為 undefined，
+        若直接呼叫 navigator.clipboard.writeText(...) 會在 property access 階段
+        sync throw TypeError，.then().catch() chain 的 .catch 完全不會跑，
+        導致 copyLogs 的 fail modal / copyOutputPath 的 error toast 被跳過。
+        守衛 if (!navigator.clipboard?.writeText) 必須在兩處 clipboard call 之前。
+        """
+        content = SCANNER_JS.read_text(encoding="utf-8")
+        # 兩處 copy 點都應該有 ?. optional chaining guard
+        guard_count = content.count("navigator.clipboard?.writeText")
+        assert guard_count >= 2, (
+            f"scanner.js 應該有至少 2 處 navigator.clipboard?.writeText 守衛 "
+            f"（copyLogs + copyOutputPath），目前只有 {guard_count} 處。"
+            "若沒守衛，clipboard API 不存在時 .catch() 完全不會觸發。"
+        )
+
 
 class TestNavigateLoadMore:
     """T3b 守衛：navigate() 在最後一片時 await loadMore + state-first slide"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5124,3 +5124,32 @@ class TestMotionLabT2EaseRoles:
             "playCardStreamIn 仍含 power3.out（應改為 fluent-decel）"
         assert "power2.out" not in block, \
             "playCardStreamIn 仍含 power2.out（應改為 fluent-decel）"
+
+
+MOTION_LAB_HTML_T2_2 = Path(__file__).parent.parent.parent / "web" / "templates" / "motion_lab.html"
+MOTION_LAB_JS_T2_2 = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "motion-lab.js"
+
+
+class TestMotionLabT2DurationBuckets:
+    """52-T2.2: 守衛 §5 Duration Buckets 並排 demo 必要元素"""
+
+    def _html(self) -> str:
+        return MOTION_LAB_HTML_T2_2.read_text(encoding="utf-8")
+
+    def _js(self) -> str:
+        return MOTION_LAB_JS_T2_2.read_text(encoding="utf-8")
+
+    def test_html_has_duration_buckets_tab(self):
+        """motion_lab.html tab bar 含 duration-buckets tab button"""
+        assert "duration-buckets" in self._html(), \
+            "motion_lab.html tab bar 缺少 duration-buckets tab（§5 Duration Buckets tab 未加入）"
+
+    def test_js_has_play_duration_buckets_demo(self):
+        """motion-lab.js 含 playDurationBucketsDemo 函式"""
+        assert "playDurationBucketsDemo" in self._js(), \
+            "motion-lab.js 缺少 playDurationBucketsDemo（§5 Duration Buckets demo 函式未加入）"
+
+    def test_html_shows_duration_fast_label(self):
+        """motion_lab.html 含 DURATION.fast 標籤（duration-buckets panel box label）"""
+        assert "DURATION.fast" in self._html(), \
+            "motion_lab.html 缺少 DURATION.fast 標籤（§5 Duration Buckets panel box label 未加入）"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2146,10 +2146,14 @@ class TestShowcaseActressCRUD:
             "showcase/core.js 仍含 rescrapeActress() 方法（49b-T5 應已刪除）"
 
     def test_remove_actress_method(self):
-        """core.js 含 removeActress() 方法"""
+        """core.js 含 T3.3 拆出的 3 個 modal-flow methods（open / confirm / cancel）"""
         js = self._js()
-        assert "removeActress" in js, \
-            "showcase/core.js 缺少 removeActress() 方法（[🗑 移除最愛] 女優 CRUD）"
+        assert "openRemoveActressModal" in js, \
+            "showcase/core.js 缺少 openRemoveActressModal()（T3.3: trigger button 入口）"
+        assert "confirmRemoveActress" in js, \
+            "showcase/core.js 缺少 confirmRemoveActress()（T3.3: DELETE API + closeLightbox flow）"
+        assert "cancelRemoveActressModal" in js, \
+            "showcase/core.js 缺少 cancelRemoveActressModal()（T3.3: dismiss flow，三 dismiss 路徑收口）"
 
     # --- showcase.html popover guards ---
 
@@ -2172,10 +2176,10 @@ class TestShowcaseActressCRUD:
             "showcase.html 仍含 rescrapeActress() handler（44c-T7 應已移除 lightbox 按鈕）"
 
     def test_remove_handler_in_template(self):
-        """showcase.html 含 removeActress() handler"""
+        """showcase.html 含 openRemoveActressModal() handler（T3.3：fluent-modal 取代 native confirm）"""
         html = self._html()
-        assert "removeActress()" in html, \
-            "showcase.html 缺少 removeActress()（Row 6 移除最愛按鈕 @click handler）"
+        assert "openRemoveActressModal()" in html, \
+            "showcase.html 缺少 openRemoveActressModal()（Row 6 移除最愛按鈕 @click handler — T3.3 fluent-modal）"
 
     def test_search_actress_films_method(self):
         """core.js 含 searchActressFilms() 方法"""
@@ -2307,7 +2311,6 @@ class TestShowcaseActressI18n:
         "showcase.actress.addNotFound",
         "showcase.actress.addTimeout",
         "showcase.actress.remove",
-        "showcase.actress.removeConfirm",
         "showcase.actress.removeSuccess",
         "showcase.actress.empty",
         "showcase.actress.emptyHint",
@@ -2327,6 +2330,25 @@ class TestShowcaseActressI18n:
             data = self._locale(locale_file)
             val = self._get_nested(data, key)
             assert val is not None, f"{locale_file} 缺少 {key}"
+
+    @pytest.mark.parametrize("key", [
+        "showcase.actress.remove_modal.title",
+        "showcase.actress.remove_modal.body",
+        "showcase.actress.remove_modal.cancel",
+        "showcase.actress.remove_modal.confirm",
+    ])
+    def test_remove_modal_keys_in_zh_tw(self, key):
+        """T3.3: remove_modal.* 4 keys 在 zh_TW.json 存在（其他 locale 走 milestone 同步，依 i18n.md 規則）"""
+        data = self._locale("zh_TW.json")
+        val = self._get_nested(data, key)
+        assert val is not None, f"zh_TW.json 缺少 {key}（T3.3 fluent-modal i18n key）"
+
+    def test_removeConfirm_orphan_removed_zh_tw(self):
+        """T3.3: 舊 native confirm key showcase.actress.removeConfirm 已從 zh_TW 移除（孤兒 key 清理）"""
+        data = self._locale("zh_TW.json")
+        val = self._get_nested(data, "showcase.actress.removeConfirm")
+        assert val is None, \
+            "T3.3 違規：showcase.actress.removeConfirm 應已隨 native confirm → fluent-modal 改寫從 zh_TW 移除"
 
 
 class TestShowcaseLightboxSentinel:
@@ -2395,10 +2417,10 @@ class TestShowcaseLightboxSentinel:
             "handleKeydown lightbox 分支缺少 showFavoriteActresses 判斷（影片模式 hero card 鍵盤導航會走錯分支）"
 
     def test_removeActress_button_has_xshow_guard(self):
-        """removeActress button gated by x-show="showFavoriteActresses\""""
+        """removeActress button gated by x-show="showFavoriteActresses"（T3.3：trigger 改為 openRemoveActressModal()）"""
         html = self._html()
-        idx = html.find("removeActress()")
-        assert idx != -1, "removeActress() handler not found in showcase.html"
+        idx = html.find("openRemoveActressModal()")
+        assert idx != -1, "openRemoveActressModal() handler not found in showcase.html"
         # 找 removeActress button 的區塊（往前 300 字）
         surrounding = html[max(0, idx - 300):idx + 100]
         assert "showFavoriteActresses" in surrounding, \

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4829,6 +4829,28 @@ class TestHelpCssHardcoded:
             + "\n".join(violations)
         )
 
+    def test_no_hardcoded_transition_duration_in_help_css(self):
+        """help.css 所有 transition 不應有硬編碼數字秒數（須用 var(--fluent-duration-*)）
+
+        Pattern: transition 值含 0.Xs 或 .Xs 數字字面，且不含 var(--
+        允許：comments（// 或 /* 開頭行）中的說明文字
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if "transition:" in line:
+                # 尋找硬編碼數字秒數（0.Xs 或 .Xs），且不含 var(--
+                if re.search(r"transition:[^;]*\b0?\.\d+s\b", line) and "var(--" not in line:
+                    violations.append(f"L{i}: {line.strip()}")
+        assert not violations, (
+            "help.css transition 殘留硬編碼數字秒數（應改用 var(--fluent-duration-*)）：\n"
+            + "\n".join(violations)
+        )
+
 
 class TestDesignSystemCssHardcoded:
     """Phase 52 T1.4.7: design-system.css hardcoded 硬編碼守衛（防未來回潮）
@@ -5011,12 +5033,17 @@ class TestMotionLabHtmlHardcoded:
         )
 
     def test_no_hardcoded_transition_duration_in_motion_lab_html(self):
-        """motion_lab.html <style> 區塊 transition 不應含裸數字秒數硬編碼
+        """motion_lab.html <style> 區塊 transition 不應含裸數字秒數或非 fluent 前綴 alias 硬編碼
 
         允許例外（留 Phase 2 處理，已標記白名單）：
         - .picker-source-badge transition: background 0.15s
         - .picker-check-icon transition: opacity 0.15s
         這兩處屬 Picker demo 的細節 transition，Phase 1 不改動，Phase 2 統一處理。
+
+        非 fluent 前綴 alias 規則：
+        - 禁止 var(--duration-*) — 應改用 var(--fluent-duration-*)
+        - 禁止 var(--ease-*) — 應改用 var(--fluent-ease-*)
+        這些 alias 已在 theme.css 定義，但 motion_lab 的 <style> 應直接用 canonical token。
         """
         css = self._style_blocks()
         lines = css.split("\n")
@@ -5034,10 +5061,17 @@ class TestMotionLabHtmlHardcoded:
             if stripped in phase2_whitelist:
                 continue
             if "transition:" in line:
+                # 1. 裸數字秒數（不含任何 var(-- 前綴）
                 if re.search(r"transition:[^;]*\b0?\.\d+s\b", line) and "var(--" not in line:
                     violations.append(f"L{i}: {stripped}")
+                    continue
+                # 2. 非 fluent 前綴 alias：var(--duration-*) 或 var(--ease-*)
+                #    （直接命中即是 alias，fluent 前綴版本為 var(--fluent-duration-*) 不命中此 pattern）
+                if re.search(r"var\(--(?:duration|ease)-", line):
+                    violations.append(f"L{i}: {stripped}")
         assert not violations, (
-            "motion_lab.html <style> transition 殘留裸數字秒數（應改用 var(--fluent-duration-*)；"
+            "motion_lab.html <style> transition 殘留裸數字秒數或非 fluent 前綴 alias\n"
+            "（應改用 var(--fluent-duration-*) / var(--fluent-ease-*)；"
             "picker 兩處 0.15s 已列 Phase 2 whitelist）：\n"
             + "\n".join(violations)
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4933,3 +4933,111 @@ class TestDesignSystemCssHardcoded:
             "rgba(var(--ds-glow-rgb), ...) 不在此範疇因 pattern 不命中）：\n"
             + "\n".join(violations)
         )
+
+
+class TestMotionLabHtmlHardcoded:
+    """T1.5.6: 確認 motion_lab.html <style> 區塊內無 hardcoded 視覺值（blur / hex / radius / transition）
+
+    掃描策略：僅掃 <style>...</style> block 內容，不掃 HTML style="..." 屬性
+    （demo 區大量合法 inline style 用於展示，不納入守衛範疇）
+    """
+
+    def _style_blocks(self) -> str:
+        """提取 motion_lab.html 所有 <style> block 內容合併"""
+        html = MOTION_LAB_HTML.read_text(encoding="utf-8")
+        blocks = re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL)
+        return "\n".join(blocks)
+
+    def test_no_hardcoded_blur_px_in_motion_lab_html(self):
+        """motion_lab.html <style> 區塊不含 hardcoded blur(Npx)（須用 var(--fluent-blur-*)）"""
+        css = self._style_blocks()
+        matches = re.findall(r"blur\(\d+px\)", css)
+        assert not matches, (
+            f"motion_lab.html <style> 仍有 hardcoded blur(Npx)，請改用 var(--fluent-blur-light/overlay/heavy)：{matches}"
+        )
+
+    def test_no_hardcoded_hex_color_in_motion_lab_html(self):
+        """motion_lab.html <style> 區塊不含裸 hardcoded hex color（#xxx / #xxxxxx）
+
+        允許例外：
+        - var(..., #fff) 形式的 CSS fallback 值（在 var() 內部，pattern 不命中）
+        """
+        css = self._style_blocks()
+        lines = css.split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # 找裸 hex（不在 var() 內部）：pattern 尋找 # 後接 3/4/6/8 hex digits，
+            # 但排除 var(..., #xxx) 形式（前方有逗號 + 空格）
+            # 實作：先移除 var( ... ) 內容再搜尋
+            line_no_var_fallback = re.sub(r"var\([^)]*\)", "", line)
+            if re.search(r"#[0-9a-fA-F]{3,8}\b", line_no_var_fallback):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "motion_lab.html <style> 殘留裸 hex 硬編碼（應改用 token；var() 內 fallback 除外）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_border_radius_px_in_motion_lab_html(self):
+        """motion_lab.html <style> 區塊 border-radius 不應含裸 px 數字硬編碼
+
+        允許例外：
+        - border-radius: 50%（圓形語義，比例值不是像素）
+        - var(--fluent-radius-*, Npx) 的 fallback px 值（在 var() 內部）
+        """
+        css = self._style_blocks()
+        lines = css.split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if "border-radius" not in line:
+                continue
+            # 允許 50%
+            if re.search(r"border-radius\s*:\s*50%", line):
+                continue
+            # 移除 var() 內容再搜尋
+            line_no_var = re.sub(r"var\([^)]*\)", "", line)
+            if re.search(r"border-radius\s*:[^;]*\d+px", line_no_var):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "motion_lab.html <style> border-radius 殘留裸 px 硬編碼（應改用 var(--fluent-radius-*)；"
+            "50% 及 var() 內 fallback 除外）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_transition_duration_in_motion_lab_html(self):
+        """motion_lab.html <style> 區塊 transition 不應含裸數字秒數硬編碼
+
+        允許例外（留 Phase 2 處理，已標記白名單）：
+        - .picker-source-badge transition: background 0.15s
+        - .picker-check-icon transition: opacity 0.15s
+        這兩處屬 Picker demo 的細節 transition，Phase 1 不改動，Phase 2 統一處理。
+        """
+        css = self._style_blocks()
+        lines = css.split("\n")
+        violations = []
+        # Phase 2 whitelist：picker demo 兩處細節 transition（已知，留 Phase 2 處理）
+        phase2_whitelist = {
+            "transition: background 0.15s;",
+            "transition: opacity 0.15s;",
+        }
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # Phase 2 whitelist
+            if stripped in phase2_whitelist:
+                continue
+            if "transition:" in line:
+                if re.search(r"transition:[^;]*\b0?\.\d+s\b", line) and "var(--" not in line:
+                    violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "motion_lab.html <style> transition 殘留裸數字秒數（應改用 var(--fluent-duration-*)；"
+            "picker 兩處 0.15s 已列 Phase 2 whitelist）：\n"
+            + "\n".join(violations)
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4828,3 +4828,108 @@ class TestHelpCssHardcoded:
             "50% 圓形 badge 語義值免除；var fallback 內的 px 允許）：\n"
             + "\n".join(violations)
         )
+
+
+class TestDesignSystemCssHardcoded:
+    """Phase 52 T1.4.7: design-system.css hardcoded 硬編碼守衛（防未來回潮）
+
+    design-system 是 demo 頁，§6 fail 樣本 HTML 內含 hardcoded 值是有意展示（inline style）。
+    守衛只掃 CSS 層（design-system.css），不掃 HTML。
+    """
+
+    def _css(self):
+        return Path("web/static/css/pages/design-system.css").read_text(encoding="utf-8")
+
+    def test_no_hardcoded_blur_px_in_design_system_css(self):
+        """design-system.css 不應出現 hardcoded blur(Npx)（須用 var(--fluent-blur*) 三階）
+
+        涵蓋 filter: 與 backdrop-filter:（含 -webkit- 前綴）— 都是 §2 玻璃三階規則。
+        允許例外：
+        - 純註釋行（/* / // / * 開頭）
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if re.search(r"blur\(\s*\d+px", line):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "design-system.css 出現 hardcoded blur(Npx) 違規（涵蓋 filter / backdrop-filter，"
+            "請改用 var(--fluent-blur) (overlay 30px) / var(--fluent-blur-light) (floating 12px) / "
+            "var(--fluent-blur-heavy) (canvas 60px)）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_border_radius_px_in_design_system_css(self):
+        """design-system.css border-radius 不應出現數字 px 硬編碼（應改用 var(--fluent-radius-*)）
+
+        允許例外：
+        - border-radius: 50%（圓形 badge 語義，比例值不是像素）
+        - border-radius: 999px（radius-pill 白名單，語義 pill 值）
+        - border-radius: 0px（歸零語義值）
+        - var(--fluent-radius-*, Npx) 的 fallback px 值（在 var() 內部，不算裸硬編碼）
+        - 純註釋行（/* / // / * 開頭）
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # 抓 border-radius: Npx（排除 50%/999px/0px 語義值）
+            if not re.search(r"border-radius\s*:[^;]*\d+px", line):
+                continue
+            # 允許 50% 圓形、999px pill、0px 歸零
+            if re.search(r"border-radius\s*:\s*(50%|999px|0px)", line):
+                continue
+            # 允許：Npx 只出現在 var(--..., Npx) fallback 內
+            line_without_var = re.sub(r"var\([^)]*\)", "", line)
+            if re.search(r"border-radius\s*:[^;]*\d+px", line_without_var):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "design-system.css border-radius 殘留 px 硬編碼（應改用 var(--fluent-radius-*)；"
+            "50% / 999px / 0px 語義值免除；var fallback 內的 px 允許）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_box_shadow_raw_rgba_in_design_system_css(self):
+        """design-system.css box-shadow 不應出現裸 rgba(數字) 硬編碼（須用 Fluent token）
+
+        允許例外：
+        - rgba(var(--...), ...) — var() 包裝，token 化間接引用（如 ds-glow-rgb）
+        - 純註釋行（/* / // / * 開頭）
+        - inset dual-layer：inset 0 Npx Npx rgba(...) — §2 dual-layer 修法後仍允許 dual-layer
+          內的 rgba（.btn.state-active 的 inset dual-layer 是有意展示，含 var() 不在此排除）
+
+        注意：此 test 只排除「box-shadow: 0 Npx Npx rgba(純數字)」模式，
+        rgba(var(...)) 因為 pattern 要求第一個字元非數字所以不命中。
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # 只看 box-shadow 行
+            if "box-shadow" not in line:
+                continue
+            # 匹配裸 rgba(數字, ...) — 第一個參數是純數字（非 var()）
+            if not re.search(r"\brgba\(\s*\d", line):
+                continue
+            # 允許：inset-only dual-layer（§2 dual-layer 示範，全為 inset 值不影響外部陰影）
+            # 方法：先移除 rgba(...) 內容再以逗號分割，判斷每個 term 是否都有 inset 前綴
+            shadow_value = re.sub(r"box-shadow\s*:", "", line).strip().rstrip(";")
+            shadow_no_rgba = re.sub(r"rgba\([^)]*\)", "RGBA", shadow_value)
+            if all(t.strip().startswith("inset") for t in shadow_no_rgba.split(",") if t.strip()):
+                continue
+            violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "design-system.css box-shadow 殘留裸 rgba() 硬編碼（應改用 var(--fluent-shadow-*)；"
+            "rgba(var(--ds-glow-rgb), ...) 不在此範疇因 pattern 不命中）：\n"
+            + "\n".join(violations)
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4736,3 +4736,95 @@ class TestSettingsCssHardcoded:
             "請改用 var(--fluent-blur) (overlay 30px) / var(--fluent-blur-light) (floating 12px)）：\n"
             + "\n".join(violations)
         )
+
+
+class TestHelpCssHardcoded:
+    """Phase 52 T1.3.3: help.css hardcoded 硬編碼守衛（防未來回潮）"""
+
+    def _css(self):
+        return Path("web/static/css/pages/help.css").read_text(encoding="utf-8")
+
+    def _is_design_intent_line(self, line: str) -> bool:
+        """判斷該行是否為 dim override block 內的 design-intent 固定色（允許例外）"""
+        return "design-intent:" in line
+
+    def test_no_hardcoded_oklch_in_help_css(self):
+        """help.css 不應出現裸 oklch(數字) 硬編碼值
+
+        允許例外：
+        - 純白 oklch(100% 0 0)（charter §3 接受的純色）
+        - 純黑 oklch(0% 0 0)（charter §3 接受的純色）
+        - dim override block 內含 design-intent 標記的固定色（terminal box 設計意圖）
+        - 純註釋行（/* / // / * 開頭）
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # 跳過 dim override block 內的 design-intent 固定色
+            if self._is_design_intent_line(line):
+                continue
+            # 允許純白 / 純黑
+            if re.search(r"oklch\(100%\s+0\s+0\)", line):
+                continue
+            if re.search(r"oklch\(0%\s+0\s+0\)", line):
+                continue
+            # 抓裸 oklch(數字...) 違規（允許 color-mix 內引用，但裸 oklch 數字值違規）
+            if re.search(r"\boklch\(\s*\d", line):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "help.css 殘留裸 oklch 數字硬編碼（應改用 token，純白/純黑/dim design-intent 除外）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_rgba_in_help_css(self):
+        """help.css 不應出現 hardcoded rgba(數字) 值（須改用 token 或 color-mix）
+
+        允許例外：
+        - 純註釋行（/* / // / * 開頭）
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            if re.search(r"\brgba\(\s*\d", line):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "help.css 出現 hardcoded rgba() 違規（應改用 token 或 color-mix(in oklch, ...)）：\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_hardcoded_border_radius_px_in_help_css(self):
+        """help.css border-radius 不應出現數字 px 硬編碼（應改用 var(--fluent-radius-*)）
+
+        允許例外：
+        - border-radius: 50%（圓形 badge 語義，比例值不是像素）
+        - var(--fluent-radius-*, Npx) 的 fallback px 值（在 var() 內部，不算裸硬編碼）
+        - 純註釋行（/* / // / * 開頭）
+        """
+        lines = self._css().split("\n")
+        violations = []
+        for i, line in enumerate(lines, 1):
+            stripped = line.strip()
+            # 跳過純註釋行
+            if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # 抓 border-radius: Npx（排除 50% 等比例值）
+            if not re.search(r"border-radius\s*:[^;]*\d+px", line):
+                continue
+            # 允許：Npx 只出現在 var(--..., Npx) fallback 內（屬於合法 token 用法）
+            # 去除 var(--...) 區塊後再判斷是否殘留裸 Npx
+            line_without_var = re.sub(r"var\([^)]*\)", "", line)
+            if re.search(r"border-radius\s*:[^;]*\d+px", line_without_var):
+                violations.append(f"L{i}: {stripped}")
+        assert not violations, (
+            "help.css border-radius 殘留 px 硬編碼（應改用 var(--fluent-radius-md/lg)；"
+            "50% 圓形 badge 語義值免除；var fallback 內的 px 允許）：\n"
+            + "\n".join(violations)
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -1702,12 +1702,37 @@ SEARCH_STATE_DIR = Path(__file__).parent.parent.parent / "web" / "static" / "js"
 
 
 class TestNoAlertInSearchJs:
-    """39c-T2c: search state JS 不應使用原生 alert()，改用 showToast"""
+    """39c-T2c + T3.6: search/scanner/settings JS 不應使用原生 alert()，改用 showToast / fluent-modal"""
 
     def test_no_alert_in_batch_js(self):
         content = (SEARCH_STATE_DIR / "batch.js").read_text(encoding="utf-8")
         assert "alert(" not in content, \
             "batch.js 含原生 alert()，應改用 this.showToast()"
+
+    def test_no_alert_in_file_list_js(self):
+        """T3.6: file-list.js 5 處 alert 已改 showToast"""
+        content = (SEARCH_STATE_DIR / "file-list.js").read_text(encoding="utf-8")
+        assert "alert(" not in content, \
+            "file-list.js 含原生 alert()，應改用 this.showToast()"
+
+    def test_no_alert_in_result_card_js(self):
+        """T3.6: result-card.js 1 處 alert 已改 showToast"""
+        content = (SEARCH_STATE_DIR / "result-card.js").read_text(encoding="utf-8")
+        assert "alert(" not in content, \
+            "result-card.js 含原生 alert()，應改用 this.showToast()"
+
+    def test_no_alert_in_scanner_js(self):
+        """T3.6: scanner.js 8 處 alert 已改 showToast / fluent-modal"""
+        content = SCANNER_JS.read_text(encoding="utf-8")
+        assert "alert(" not in content, \
+            "scanner.js 含原生 alert()，應改用 this.showToast() 或 fluent-modal"
+
+    def test_no_alert_in_settings_js(self):
+        """T3.6: settings.js 1 處 alert 已改 showToast"""
+        settings_js = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "settings.js"
+        content = settings_js.read_text(encoding="utf-8")
+        assert "alert(" not in content, \
+            "settings.js 含原生 alert()，應改用 this.showToast()"
 
 
 class TestNavigateLoadMore:

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5075,3 +5075,52 @@ class TestMotionLabHtmlHardcoded:
             "picker 兩處 0.15s 已列 Phase 2 whitelist）：\n"
             + "\n".join(violations)
         )
+
+
+# ─── 52-T2.1: §5 Ease Roles Demo 守衛 ────────────────────────────────────────
+MOTION_LAB_HTML_T2 = Path(__file__).parent.parent.parent / "web" / "templates" / "motion_lab.html"
+MOTION_LAB_JS_T2 = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "motion-lab.js"
+
+
+class TestMotionLabT2EaseRoles:
+    """52-T2.1: 守衛 §5 Ease Roles 並排 demo 必要元素"""
+
+    def _html(self) -> str:
+        return MOTION_LAB_HTML_T2.read_text(encoding="utf-8")
+
+    def _js(self) -> str:
+        return MOTION_LAB_JS_T2.read_text(encoding="utf-8")
+
+    def test_html_contains_fluent_decel(self):
+        """motion_lab.html 含 fluent-decel 字樣（Ease Roles select 選項或 demo panel）"""
+        assert "fluent-decel" in self._html(), \
+            "motion_lab.html 缺少 fluent-decel（§5 Ease Roles select / demo panel 未加入）"
+
+    def test_html_contains_fluent_accel(self):
+        """motion_lab.html 含 fluent-accel 字樣（Ease Roles select 選項或 demo panel）"""
+        assert "fluent-accel" in self._html(), \
+            "motion_lab.html 缺少 fluent-accel（§5 Ease Roles select / demo panel 未加入）"
+
+    def test_html_has_ease_roles_tab(self):
+        """motion_lab.html tab bar 含 ease-roles tab button"""
+        assert "ease-roles" in self._html(), \
+            "motion_lab.html tab bar 缺少 ease-roles tab（§5 Ease Roles tab 未加入）"
+
+    def test_js_has_play_ease_roles_demo(self):
+        """motion-lab.js 含 playEaseRolesDemo 函式"""
+        assert "playEaseRolesDemo" in self._js(), \
+            "motion-lab.js 缺少 playEaseRolesDemo（§5 Ease Roles demo 函式未加入）"
+
+    def test_js_no_bare_back_out_in_stream(self):
+        """motion-lab.js playCardStreamIn 不含裸 power2.out / power3.out（已改 fluent-decel）"""
+        js = self._js()
+        # 找到 playCardStreamIn 區塊（到下一個函式前）
+        start = js.find("playCardStreamIn:")
+        assert start != -1, \
+            "playCardStreamIn 函式不見了；如果是重命名請更新此守衛"
+        end = js.find("\n        /**", start + 1)
+        block = js[start:end] if end != -1 else js[start:]
+        assert "power3.out" not in block, \
+            "playCardStreamIn 仍含 power3.out（應改為 fluent-decel）"
+        assert "power2.out" not in block, \
+            "playCardStreamIn 仍含 power2.out（應改為 fluent-decel）"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4718,23 +4718,21 @@ class TestSettingsCssHardcoded:
         )
 
     def test_no_hardcoded_blur_px_in_settings_css(self):
-        """settings.css 不應出現 hardcoded blur(Npx)（須用 token 或 CSS 變數）
+        """settings.css 不應出現 hardcoded blur(Npx)（須用 var(--fluent-blur*) 三階）
 
-        守住未來修改不引入硬編碼 blur。（當前 settings.css 無 blur，此 guard 守住零基線）
+        涵蓋 filter: 與 backdrop-filter:（含 -webkit- 前綴）— 都是 §1 玻璃三階規則。
         """
         css = self._css()
         lines = css.split("\n")
         violations = []
         for i, line in enumerate(lines, 1):
             stripped = line.strip()
-            # 跳過純註釋行
             if stripped.startswith("/*") or stripped.startswith("//") or stripped.startswith("*"):
                 continue
-            # .settings-header backdrop-filter 使用 blur()，但那是 backdrop-filter 非 filter
-            # 只守 filter: blur(Npx) 形式（非 backdrop-filter）
-            if re.search(r"(?<!backdrop-)filter\s*:[^;]*blur\(\d+px\)", line):
+            if re.search(r"blur\(\s*\d+px", line):
                 violations.append(f"L{i}: {line.strip()}")
         assert not violations, (
-            "settings.css 出現 hardcoded filter: blur(Npx)（請改用 CSS 變數）：\n"
+            "settings.css 出現 hardcoded blur(Npx) 違規（涵蓋 filter / backdrop-filter，"
+            "請改用 var(--fluent-blur) (overlay 30px) / var(--fluent-blur-light) (floating 12px)）：\n"
             + "\n".join(violations)
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -1752,6 +1752,31 @@ class TestNoAlertInSearchJs:
             "若沒守衛，clipboard API 不存在時 .catch() 完全不會觸發。"
         )
 
+    def test_all_clipboard_writetext_files_have_availability_guard(self):
+        """T3.7: 全 web/static/js 任何使用 navigator.clipboard.writeText 的檔案
+        必須同時含 ?. optional chaining 守衛形式（navigator.clipboard?.writeText）。
+
+        此守衛防止未來新檔案再犯同類 pre-existing bug（HTTP / 舊 WebView
+        clipboard undefined 時 sync TypeError 跳過 .catch chain）。
+        既知合法檔（截至 T3.7）：scanner.js（×2 + ×2 guards）、help.js、
+        result-card.js、showcase/core.js — 全部含 ?. 守衛形式。
+        """
+        js_root = Path(__file__).parent.parent.parent / "web" / "static" / "js"
+        offenders = []
+        for js_file in js_root.rglob("*.js"):
+            text = js_file.read_text(encoding="utf-8")
+            if "navigator.clipboard.writeText" not in text:
+                continue
+            if "navigator.clipboard?.writeText" not in text:
+                offenders.append(str(js_file.relative_to(js_root)))
+        assert not offenders, (
+            f"以下檔案使用 navigator.clipboard.writeText 但缺 ?. 守衛形式："
+            f"{offenders}。"
+            "請改寫成 if (!navigator.clipboard?.writeText) { ...fallback...; return; } "
+            "或 navigator.clipboard?.writeText ? ... : fallback 三元，"
+            "避免 clipboard undefined 時 sync TypeError 跳過 .catch。"
+        )
+
 
 class TestNavigateLoadMore:
     """T3b 守衛：navigate() 在最後一片時 await loadMore + state-first slide"""

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -1073,7 +1073,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 6px;
+    margin-bottom: var(--space-2, 8px); /* §4 layout 8pt grid */
 }
 
 /* Collapse toggle */
@@ -1472,7 +1472,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 6px;
+    margin-bottom: var(--space-2, 8px); /* §4 layout 8pt grid */
 }
 
 .ds-search-composition .ds-comp-file-count {
@@ -2079,7 +2079,7 @@
 .ds-toast-comparison code {
     font-size: 0.75rem;
     padding: 1px 4px;
-    border-radius: 3px;
+    border-radius: var(--fluent-radius-sm); /* §3 code badge 用 sm(2px) */
     background: color-mix(in oklch, var(--color-base-content) 8%, transparent);
     color: var(--accent);
 }

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -2190,8 +2190,8 @@
     background:
         radial-gradient(ellipse 80% 80% at 20% 50%, rgba(var(--ds-glow-rgb), 0.3), transparent),
         linear-gradient(135deg, oklch(65% 0.15 250 / 0.3) 0%, oklch(55% 0.12 85 / 0.2) 100%);
-    backdrop-filter: blur(16px) saturate(130%);
-    -webkit-backdrop-filter: blur(16px) saturate(130%);
+    backdrop-filter: blur(var(--fluent-blur)) saturate(130%);
+    -webkit-backdrop-filter: blur(var(--fluent-blur)) saturate(130%);
 }
 
 .ds-material-toolbar-label {
@@ -2367,8 +2367,8 @@
 .ds-page .showcase-toolbar {
     position: static;
     background: var(--bg-header);
-    backdrop-filter: blur(16px) saturate(130%);
-    -webkit-backdrop-filter: blur(16px) saturate(130%);
+    backdrop-filter: blur(var(--fluent-blur)) saturate(130%);
+    -webkit-backdrop-filter: blur(var(--fluent-blur)) saturate(130%);
     border-bottom: 1px solid var(--border-light);
     padding: 0.75rem 1.5rem;
     display: flex;

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -1073,7 +1073,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: var(--space-2, 8px); /* §4 layout 8pt grid */
+    margin-bottom: 8px; /* §4 layout 8pt grid */
 }
 
 /* Collapse toggle */
@@ -1472,7 +1472,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: var(--space-2, 8px); /* §4 layout 8pt grid */
+    margin-bottom: 8px; /* §4 layout 8pt grid */
 }
 
 .ds-search-composition .ds-comp-file-count {
@@ -2407,7 +2407,7 @@
 .ds-pill-whitelist-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: var(--space-4, 1rem);
+    gap: 16px; /* §4 layout 8pt grid */
     margin-top: 1rem;
 }
 
@@ -2490,7 +2490,7 @@
 .ds-overlay-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: var(--space-3, 0.75rem);
+    gap: 12px; /* §4 spacingM (12px Fluent layout) */
     margin-top: 1rem;
 }
 
@@ -2536,7 +2536,7 @@
 .ds-spacing-layer-table {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: var(--space-3, 0.75rem);
+    gap: 12px; /* §4 spacingM (12px Fluent layout) */
     margin-top: 1rem;
 }
 
@@ -2601,7 +2601,7 @@
 .ds-checkpoint-pair {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: var(--space-4, 1rem);
+    gap: 16px; /* §4 layout 8pt grid */
     margin-bottom: 0.75rem;
 }
 

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -2401,3 +2401,74 @@
     align-items: center;
     gap: 0.5rem;
 }
+
+/* ==================== §1 Pill Whitelist Demo ==================== */
+
+.ds-pill-whitelist-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-4, 1rem);
+    margin-top: 1rem;
+}
+
+.ds-pill-card {
+    border: 1px solid var(--border-light);
+    border-radius: var(--fluent-radius-lg);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: var(--bg-card);
+}
+
+.ds-pill-card-demo {
+    min-height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem;
+    background: var(--bg-body);
+    border-radius: var(--fluent-radius-md);
+}
+
+/* Simulated spotlight-search pill */
+.ds-pill-demo-spotlight {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    border-radius: var(--radius-pill);
+    background: color-mix(in oklch, var(--color-base-content) 5%, transparent);
+    border: 1px solid var(--stroke-subtle);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    width: 100%;
+    max-width: 160px;
+}
+
+.ds-pill-card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.ds-pill-card-class {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.ds-pill-card-desc {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.ds-pill-card-token {
+    font-size: 0.7rem;
+    padding: 1px 4px;
+    border-radius: var(--fluent-radius-sm);
+    background: color-mix(in oklch, var(--accent) 10%, transparent);
+    color: var(--accent);
+    display: inline-block;
+}

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -2510,7 +2510,7 @@
     gap: 2px;
     padding: 0.5rem;
     width: 100%;
-    background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
+    background: linear-gradient(to top, var(--overlay-gradient), transparent);
 }
 
 .ds-overlay-token {

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -2472,3 +2472,61 @@
     color: var(--accent);
     display: inline-block;
 }
+
+/* ==================== §2 三階 token 標籤 ==================== */
+
+.ds-token-label {
+    font-size: 0.7rem;
+    padding: 1px 5px;
+    border-radius: var(--fluent-radius-sm);
+    background: color-mix(in oklch, var(--color-primary) 12%, transparent);
+    color: var(--color-primary);
+    font-weight: 600;
+    display: inline-block;
+}
+
+/* ==================== §3 Overlay Role Swatches ==================== */
+
+.ds-overlay-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: var(--space-3, 0.75rem);
+    margin-top: 1rem;
+}
+
+.ds-overlay-swatch {
+    height: 100px;
+    border-radius: var(--fluent-radius-lg);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--border-light);
+    display: flex;
+    align-items: flex-end;
+}
+
+.ds-overlay-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 0.5rem;
+    width: 100%;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
+}
+
+.ds-overlay-token {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: oklch(100% 0 0);
+    font-family: monospace;
+}
+
+.ds-overlay-alpha {
+    font-size: 0.65rem;
+    color: oklch(100% 0 0 / 0.75);
+    font-family: monospace;
+}
+
+.ds-overlay-usage {
+    font-size: 0.65rem;
+    color: oklch(100% 0 0 / 0.65);
+}

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -2530,3 +2530,124 @@
     font-size: 0.65rem;
     color: oklch(100% 0 0 / 0.65);
 }
+
+/* ==================== §4 Spacing 三層標籤 ==================== */
+
+.ds-spacing-layer-table {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--space-3, 0.75rem);
+    margin-top: 1rem;
+}
+
+.ds-spacing-layer {
+    border: 1px solid var(--border-light);
+    border-radius: var(--fluent-radius-lg);
+    overflow: hidden;
+}
+
+.ds-spacing-layer-header {
+    padding: 0.5rem 1rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: oklch(100% 0 0);
+}
+
+.ds-layer-layout { background: var(--color-primary); }
+.ds-layer-micro { background: var(--color-secondary); }
+.ds-layer-stroke { background: var(--accent); }
+
+.ds-spacing-layer-body {
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: var(--bg-card);
+}
+
+.ds-spacing-layer-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    font-size: 0.8rem;
+}
+
+.ds-layer-tag {
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 1px 5px;
+    border-radius: var(--fluent-radius-sm);
+    flex-shrink: 0;
+    align-self: center;
+}
+
+.ds-layer-tag-ok { background: color-mix(in oklch, var(--color-success) 15%, transparent); color: var(--color-success); }
+.ds-layer-tag-ban { background: color-mix(in oklch, var(--color-error) 15%, transparent); color: var(--color-error); }
+.ds-layer-tag-note { background: color-mix(in oklch, var(--color-warning) 15%, transparent); color: var(--color-warning); }
+.ds-layer-tag-example { background: color-mix(in oklch, var(--color-base-content) 10%, transparent); color: var(--text-secondary); }
+
+/* ==================== §6 5 檢查點 pass/fail 對照 ==================== */
+
+.ds-checkpoint-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 1.25rem 0 0.5rem;
+    padding-left: 0.5rem;
+    border-left: 3px solid var(--accent);
+}
+
+.ds-checkpoint-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4, 1rem);
+    margin-bottom: 0.75rem;
+}
+
+.ds-checkpoint-fail {
+    border: 2px dashed var(--color-error);
+    border-radius: var(--fluent-radius-lg);
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: color-mix(in oklch, var(--color-error) 4%, transparent);
+}
+
+.ds-checkpoint-pass {
+    border: 2px solid var(--color-success);
+    border-radius: var(--fluent-radius-lg);
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: color-mix(in oklch, var(--color-success) 4%, transparent);
+}
+
+.ds-cpf-title {
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+
+.ds-checkpoint-fail .ds-cpf-title { color: var(--color-error); }
+.ds-checkpoint-pass .ds-cpf-title { color: var(--color-success); }
+
+.ds-cpf-demo {
+    flex: 1;
+    min-height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+.ds-cpf-code {
+    font-size: 0.7rem;
+    padding: 2px 6px;
+    border-radius: var(--fluent-radius-sm);
+    background: color-mix(in oklch, var(--color-base-content) 8%, transparent);
+    color: var(--text-muted);
+    word-break: break-all;
+}

--- a/web/static/css/pages/design-system.css
+++ b/web/static/css/pages/design-system.css
@@ -498,7 +498,7 @@
 
 .ds-radius-item:hover {
     transform: scale(1.08);
-    box-shadow: 0 8px 24px rgba(var(--ds-glow-rgb), 0.3);
+    box-shadow: var(--fluent-shadow-16), 0 0 16px var(--glow-primary);
 }
 
 [data-theme="dim"] .ds-radius-item {
@@ -1029,7 +1029,8 @@
 /* 強制 Active 狀態（按鈕）*/
 .btn.state-active {
     transform: translateY(0) scale(0.98);
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+    /* §2 dual-layer: inset 改符合 Fluent dual-layer 規格 */
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.08), inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* 強制 Focus 狀態（輸入框）*/
@@ -1420,7 +1421,7 @@
     font-size: 1.4rem;
     cursor: pointer;
     border-radius: var(--fluent-radius-lg);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--fluent-shadow-8);
     transition: background var(--duration-fast) var(--fluent-ease-standard), transform var(--duration-fast) var(--fluent-ease-standard);
 }
 

--- a/web/static/css/pages/help.css
+++ b/web/static/css/pages/help.css
@@ -15,9 +15,9 @@
 /* ========== AI 整合入口 — Terminal box（固定深色，不隨 theme 切換）========== */
 
 .hero-terminal {
-    background: oklch(20% 0.01 250);
-    color: oklch(85% 0.02 180);
-    border: 1px solid oklch(30% 0.01 250);
+    background: var(--surface-2);
+    color: var(--text-primary);
+    border: 1px solid var(--stroke-default);
     border-radius: var(--fluent-radius-lg, 8px);
     box-shadow:
         inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
@@ -29,7 +29,7 @@
 }
 
 .terminal-prompt {
-    color: oklch(55% 0.15 160);  /* 低飽和青綠，暗示終端指令 */
+    color: var(--color-success);
     margin-right: 0.4em;
     user-select: none;
 }
@@ -41,7 +41,7 @@
     background: transparent;
     border: none;
     cursor: pointer;
-    color: oklch(65% 0.02 180);
+    color: var(--text-muted);
     font-size: 0.85rem;
     padding: 0.15rem 0.3rem;
     border-radius: var(--fluent-radius-md);
@@ -49,14 +49,14 @@
 }
 
 .terminal-copy-btn:hover {
-    color: oklch(90% 0.04 180);
-    background: oklch(30% 0.01 250);
+    color: var(--text-primary);
+    background: var(--surface-1);
 }
 
 /* ========== 工作流程 ========== */
 
 .workflow-arrow {
-    color: oklch(0.65 0.13 160);
+    color: var(--color-success);
     flex-shrink: 0;
     display: flex;
     align-items: center;
@@ -74,11 +74,18 @@
     justify-content: center;
     font-size: 0.65rem;
     font-weight: 700;
-    background: oklch(0.55 0.13 160);
-    color: oklch(0.95 0 0);
+    background: var(--color-success);
+    color: oklch(100% 0 0);
     margin-right: 0.3rem;
 }
 
 .workflow-step-icon {
     font-size: 1.5rem;
+}
+
+/* dim mode: terminal box 固定深色（保留終端機視覺語意） */
+[data-theme="dim"] .hero-terminal {
+    background: oklch(15% 0.005 250);  /* design-intent: 深底，比 surface-2 dim 值更深 */
+    color: oklch(90% 0.02 180);        /* design-intent: 偏青綠終端字 */
+    border-color: oklch(28% 0.005 250); /* design-intent: 深邊框固定色 */
 }

--- a/web/static/css/pages/help.css
+++ b/web/static/css/pages/help.css
@@ -45,7 +45,7 @@
     font-size: 0.85rem;
     padding: 0.15rem 0.3rem;
     border-radius: var(--fluent-radius-md);
-    transition: color 0.15s, background 0.15s;
+    transition: color var(--fluent-duration-fast) var(--fluent-ease-standard), background var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 .terminal-copy-btn:hover {

--- a/web/static/css/pages/help.css
+++ b/web/static/css/pages/help.css
@@ -19,7 +19,9 @@
     color: oklch(85% 0.02 180);
     border: 1px solid oklch(30% 0.01 250);
     border-radius: var(--fluent-radius-lg, 8px);
-    box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-4);
     font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', ui-monospace, monospace;
     font-size: 0.9rem;
     padding: 0.75rem 1rem;
@@ -42,7 +44,7 @@
     color: oklch(65% 0.02 180);
     font-size: 0.85rem;
     padding: 0.15rem 0.3rem;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     transition: color 0.15s, background 0.15s;
 }
 
@@ -66,7 +68,7 @@
 .workflow-step-num {
     width: 1.25rem;
     height: 1.25rem;
-    border-radius: 50%;
+    border-radius: 50%; /* shape: circle (icon badge, §1 白名單：比例值語義明確) */
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/web/static/css/pages/scanner.css
+++ b/web/static/css/pages/scanner.css
@@ -16,8 +16,8 @@
     align-items: center;
     /* T8.2: Acrylic 材質 */
     background: var(--bg-header);
-    backdrop-filter: blur(12px) saturate(120%);
-    -webkit-backdrop-filter: blur(12px) saturate(120%);
+    backdrop-filter: blur(var(--fluent-blur-light)) saturate(120%);
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light)) saturate(120%);
     border-bottom: 1px solid var(--stroke-subtle);
     padding-bottom: 1rem;
     margin-bottom: 0.5rem;
@@ -173,8 +173,8 @@
     right: 0;
     bottom: 0;
     background: color-mix(in oklch, var(--color-base-100) 60%, transparent);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     z-index: 9999;
     display: flex;
     align-items: center;

--- a/web/static/css/pages/scanner.css
+++ b/web/static/css/pages/scanner.css
@@ -215,3 +215,20 @@
 .mini-terminal-body.filter-warn .log-error {
     display: none !important;
 }
+
+/* TASK-52.3.6: copy fail modal pre block (clipboard fail fallback dump) */
+.copy-fail-pre {
+    max-height: 50vh;
+    overflow-y: auto;
+    user-select: text;
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+    font-size: 0.85em;
+    padding: 0.75rem;
+    margin: 0.75rem 0;
+    background: var(--surface-1);
+    border: 1px solid var(--stroke-default);
+    border-radius: var(--fluent-radius-md);
+    color: var(--text-default, currentColor);
+}

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -455,6 +455,26 @@
     /* §6 Checkpoint 5 Focus：theme.css L2161 input:focus-visible 2px outline + 4px glow ✅，不重複 */
 }
 
+#settings-components .select {
+    /* §6 Checkpoint 1 Radius */
+    border-radius: var(--fluent-radius-md);         /* 4px */
+    /* §6 Checkpoint 2 Surface */
+    background: var(--surface-1);
+    /* §6 Checkpoint 3 Stroke — width/style only，不固定 color（保留 DaisyUI variant 顏色機制）*/
+    border-width: 1px;
+    border-style: solid;
+    /* §6 Checkpoint 4 Shadow — dual-layer: 頂部內高光 + 外縱深 */
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-2);
+    /* §5 transition fluent 化 */
+    transition:
+        border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+        box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
+    /* §6 Checkpoint 5 Focus：theme.css L2162 select:focus-visible 2px outline + 4px glow ✅，不重複 */
+    /* 版面屬性 flex:1; max-width:300px 由 theme.css L1670 提供，本 block 不覆寫 */
+}
+
 /* ==================== Form Loading State ==================== */
 
 /* 載入期間視覺提示：半透明 + wait cursor */

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -89,7 +89,7 @@
     /* 2. Folder Layers Row - 垂直堆疊 */
     #settings-components .folder-layers-row {
         flex-direction: column;
-        gap: var(--space-2); /* 8px，對齊同區塊 .settings-form-row gap: 8px（L72）*/
+        gap: 8px; /* §4 layout 8pt — 對齊 .settings-form-row gap (L72) */
     }
 
     #settings-components .folder-separator {
@@ -152,7 +152,7 @@
 
     /* API Key Alert - 縮小 padding */
     #settings-components .api-key-alert {
-        padding: var(--space-2) var(--space-4); /* 8px 16px（§4 8pt grid）*/
+        padding: 8px 16px; /* §4 layout 8pt grid */
         font-size: 0.75rem;
     }
 

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -434,6 +434,27 @@
     align-items: center;
 }
 
+/* ==================== §6 Override: .input / .select P1b 規格（Radius/Surface/Stroke/Shadow）==================== */
+
+#settings-components .input {
+    /* §6 Checkpoint 1 Radius */
+    border-radius: var(--fluent-radius-md);         /* 4px */
+    /* §6 Checkpoint 2 Surface */
+    background: var(--surface-1);
+    /* §6 Checkpoint 3 Stroke — width/style only，不固定 color（保留 DaisyUI variant 顏色機制）*/
+    border-width: 1px;
+    border-style: solid;
+    /* §6 Checkpoint 4 Shadow — dual-layer: 頂部內高光 + 外縱深 */
+    box-shadow:
+        inset 0 1px 0 color-mix(in oklch, var(--color-base-content) 6%, transparent),
+        var(--fluent-shadow-2);
+    /* §5 transition fluent 化 */
+    transition:
+        border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+        box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
+    /* §6 Checkpoint 5 Focus：theme.css L2161 input:focus-visible 2px outline + 4px glow ✅，不重複 */
+}
+
 /* ==================== Form Loading State ==================== */
 
 /* 載入期間視覺提示：半透明 + wait cursor */

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -188,8 +188,8 @@
     gap: 1rem;
     /* T8.2: Acrylic 材質 */
     background: var(--bg-header);
-    backdrop-filter: blur(12px) saturate(120%);
-    -webkit-backdrop-filter: blur(12px) saturate(120%);
+    backdrop-filter: blur(var(--fluent-blur-light)) saturate(120%);
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light)) saturate(120%);
     border-bottom: 1px solid var(--stroke-subtle);
     padding-bottom: 1rem;
     margin-bottom: 0.5rem;

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -89,7 +89,7 @@
     /* 2. Folder Layers Row - 垂直堆疊 */
     #settings-components .folder-layers-row {
         flex-direction: column;
-        gap: 12px;
+        gap: var(--space-2); /* 8px，對齊同區塊 .settings-form-row gap: 8px（L72）*/
     }
 
     #settings-components .folder-separator {
@@ -152,7 +152,7 @@
 
     /* API Key Alert - 縮小 padding */
     #settings-components .api-key-alert {
-        padding: 10px 12px;
+        padding: var(--space-2) var(--space-4); /* 8px 16px（§4 8pt grid）*/
         font-size: 0.75rem;
     }
 
@@ -305,7 +305,7 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 6px;
+    gap: 6px; /* optical 6px (CD-5: source badge optical spacing) */
 }
 
 /* 覆蓋 theme.css 的 .settings-form-group .settings-hint { margin-left: 48px } */
@@ -316,7 +316,7 @@
 /* 預設：淡出（未啟用狀態）*/
 #settings-components .source-badge {
     opacity: 0.35;
-    transition: opacity 0.2s ease, text-decoration 0.2s ease;
+    transition: opacity var(--fluent-duration-fast) var(--fluent-ease-standard), text-decoration var(--fluent-duration-fast) var(--fluent-ease-standard);
     font-weight: 500;
     letter-spacing: 0.01em;
     border: 1px solid color-mix(in oklch, var(--color-base-content) 20%, transparent);

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -458,8 +458,9 @@
 #settings-components .select {
     /* §6 Checkpoint 1 Radius */
     border-radius: var(--fluent-radius-md);         /* 4px */
-    /* §6 Checkpoint 2 Surface */
-    background: var(--surface-1);
+    /* §6 Checkpoint 2 Surface — 用 background-color 不用 background shorthand，
+       否則會把 DaisyUI v5 .select 的 background-image gradient chevron 殺掉 */
+    background-color: var(--surface-1);
     /* §6 Checkpoint 3 Stroke — width/style only，不固定 color（保留 DaisyUI variant 顏色機制）*/
     border-width: 1px;
     border-style: solid;

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -335,6 +335,12 @@
     box-shadow: var(--fluent-shadow-8);
 }
 
+/* C21: GSAP cascade 進場期間關掉 CSS transition + 阻擋 hover 搶 transform */
+.actress-card.gsap-animating {
+    pointer-events: none;
+    transition: none !important;
+}
+
 .actress-card-photo {
     aspect-ratio: 3 / 4;   /* portrait，比 video card 的 3/2 更窄 */
     overflow: hidden;

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -320,7 +320,7 @@ body {
     position: absolute;
     inset: 0;
     background: oklch(0% 0 0 / 0.4);
-    backdrop-filter: blur(2px);
+    /* CD-52-8 T1.4.1: 移除 blur(2px)，overlay card-actions 不需 floating-control 三階 */
     opacity: 0;
     display: flex;
     align-items: center;

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -971,6 +971,12 @@ body {
     box-shadow: none !important;
 }
 
+/* C21: GSAP cascade 進場期間關掉 CSS transition + 阻擋 hover 搶 transform */
+.av-card-preview.gsap-animating {
+    pointer-events: none;
+    transition: none !important;
+}
+
 /* Preview Card - 發光邊 Hover */
 :is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview:hover {
     transform: translateY(-4px) scale(1.01);

--- a/web/static/js/components/motion-adapter.js
+++ b/web/static/js/components/motion-adapter.js
@@ -11,7 +11,13 @@
 
     // Phase 50.2.0: 註冊 Fluent CustomEase（charter §5 三角色）
     // 同步 guarded register — base.html defer 順序保證 CustomEase plugin 已載入
+    // 必須先 gsap.registerPlugin(CustomEase) 後再 create，否則 ease 不會進入 gsap.parseEase 的查表，
+    // 導致 'fluent' / 'fluent-decel' / 'fluent-accel' 在純依賴 motion-adapter 的頁面（如 motion-lab）
+    // 全 fallback 為線性 ease，視覺差異消失。
     if (typeof CustomEase !== 'undefined') {
+        if (typeof gsap !== 'undefined' && typeof gsap.registerPlugin === 'function') {
+            gsap.registerPlugin(CustomEase);
+        }
         CustomEase.create('fluent',       '0.33, 0, 0.67, 1');
         CustomEase.create('fluent-decel', '0, 0, 0, 1');
         CustomEase.create('fluent-accel', '1, 0, 1, 1');

--- a/web/static/js/pages/motion-lab-state.js
+++ b/web/static/js/pages/motion-lab-state.js
@@ -74,7 +74,7 @@ function motionLabPage() {
             duration: 0.5,
             stagger: 0.04,
             flipDuration: 0.5,
-            flipEase: 'power2.inOut',
+            flipEase: 'fluent',
             flipPrune: true,
             filterQuery: '',
             filterEnterStyle: 'opacityScale',
@@ -170,6 +170,12 @@ function motionLabPage() {
             if (typeof window.MotionLab === 'undefined') return;
             const boxEls = [refs.easeBox0, refs.easeBox1, refs.easeBox2];
             window.MotionLab.playEaseRolesDemo(boxEls, this.params);
+        },
+
+        onPlayDurationBuckets(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            const boxEls = [refs.durBox0, refs.durBox1, refs.durBox2, refs.durBox3];
+            window.MotionLab.playDurationBucketsDemo(boxEls, this.params);
         },
 
         async onDetailEntry() {
@@ -766,7 +772,7 @@ function motionLabPage() {
                 await this.$nextTick();
                 const heroGridEl = this.$refs.heroGrid;
                 if (heroGridEl && typeof gsap !== 'undefined') {
-                    gsap.from(heroGridEl, { opacity: 0, duration: 0.25, ease: 'power1.out' });
+                    gsap.from(heroGridEl, { opacity: 0, duration: 0.25, ease: 'fluent-decel' });
                 }
 
                 // 延遲後處理 hero
@@ -823,7 +829,7 @@ function motionLabPage() {
                 await this.$nextTick();
                 const heroGridEl = this.$refs.heroGrid;
                 if (heroGridEl && typeof gsap !== 'undefined') {
-                    gsap.from(heroGridEl, { opacity: 0, duration: 0.25, ease: 'power1.out' });
+                    gsap.from(heroGridEl, { opacity: 0, duration: 0.25, ease: 'fluent-decel' });
                 }
 
                 // 延遲後處理 hero

--- a/web/static/js/pages/motion-lab-state.js
+++ b/web/static/js/pages/motion-lab-state.js
@@ -27,7 +27,7 @@ function motionLabPage() {
         stagingParams: {
             batchInterval: 800,
             minBatchCount: 3,
-            burstEase: 'back.out(1.2)',
+            burstEase: 'back.out(1.2)', // §5 white-list: Burst Picker
             burstDuration: 0.6,
             coverInterval: 300,
         },
@@ -176,6 +176,31 @@ function motionLabPage() {
             if (typeof window.MotionLab === 'undefined') return;
             const boxEls = [refs.durBox0, refs.durBox1, refs.durBox2, refs.durBox3];
             window.MotionLab.playDurationBucketsDemo(boxEls, this.params);
+        },
+
+        onPlayWhitelistBurstPicker(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            window.MotionLab.playSpecialMotionBurstPickerDemo(refs.whitelistBurstPickerEl, this.params);
+        },
+
+        onPlayWhitelistStagingEntry(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            window.MotionLab.playSpecialMotionStagingEntryDemo(refs.whitelistStagingEntryEl, this.params);
+        },
+
+        onPlayWhitelistCheckmark(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            window.MotionLab.playSpecialMotionCheckmarkDemo(refs.whitelistCheckmarkEl, this.params);
+        },
+
+        onPlayWhitelistShake(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            window.MotionLab.playSpecialMotionShakeDemo(refs.whitelistShakeEl, this.params);
+        },
+
+        onPlayWhitelistPulse(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            window.MotionLab.playSpecialMotionPulseDemo(refs.whitelistPulseEl, this.params);
         },
 
         async onDetailEntry() {

--- a/web/static/js/pages/motion-lab-state.js
+++ b/web/static/js/pages/motion-lab-state.js
@@ -7,7 +7,7 @@ function motionLabPage() {
             duration: 0.6,
             stagger: 0.05,
             clipRevealDur: 0.5,
-            easing: 'back.out(1.2)',
+            easing: 'fluent',
             flipMode: 'Flip',
             reducedMotionSim: false,
             speed: 0.5,
@@ -164,6 +164,12 @@ function motionLabPage() {
                     window.MotionLab.playClipPathReveal(gridEl, this.params);
                 }
             }
+        },
+
+        onPlayEaseRoles(refs) {
+            if (typeof window.MotionLab === 'undefined') return;
+            const boxEls = [refs.easeBox0, refs.easeBox1, refs.easeBox2];
+            window.MotionLab.playEaseRolesDemo(boxEls, this.params);
         },
 
         async onDetailEntry() {

--- a/web/static/js/pages/motion-lab.js
+++ b/web/static/js/pages/motion-lab.js
@@ -784,7 +784,7 @@
 
             return gsap.fromTo(imgEl,
                 { opacity: 0 },
-                { opacity: 1, duration: 0.15, ease: 'power2.out' }
+                { opacity: 1, duration: 0.15, ease: 'fluent-decel' }
             );
         },
 
@@ -804,7 +804,7 @@
             }
             gsap.fromTo(stagingCardEl,
                 { scale: 0.6, opacity: 0 },
-                { scale: 1, opacity: 1, duration: 0.35, ease: 'back.out(1.4)' }
+                { scale: 1, opacity: 1, duration: 0.35, ease: 'back.out(1.4)' } // §5 white-list: Staging Card 進場 morph
             );
         },
 
@@ -820,7 +820,7 @@
             if (shouldSkip(options)) return;
             // 不 killTweensOf：允許和入場動畫並存
             gsap.to(stagingCardEl, {
-                scale: 1.08, duration: 0.12, ease: 'power2.out',
+                scale: 1.08, duration: 0.12, ease: 'fluent-decel',
                 yoyo: true, repeat: 1,
                 onComplete: function () {
                     gsap.set(stagingCardEl, { scale: 1 });
@@ -841,7 +841,7 @@
             if (shouldSkip(options)) return;
             // 不 killTweensOf：exit tween 若在進行中不能打斷
             gsap.to(stagingCardEl, {
-                scale: 1.04, duration: 0.08, ease: 'power2.out',
+                scale: 1.04, duration: 0.08, ease: 'fluent-decel',
                 yoyo: true, repeat: 1
             });
         },
@@ -867,7 +867,7 @@
                 return;
             }
             gsap.to(stagingCardEl, {
-                scale: 0.7, opacity: 0, duration: 0.3, ease: 'power2.in',
+                scale: 0.7, opacity: 0, duration: 0.3, ease: 'fluent-accel',
                 onComplete: function () {
                     if (typeof onComplete === 'function') onComplete();
                 }
@@ -1190,7 +1190,7 @@
                 opacity: 0,
                 x: xShift,
                 duration: dur * 0.6,
-                ease: 'power2.in',
+                ease: 'fluent-accel',
                 stagger: { each: staggerVal, from: staggerFrom }
             });
 
@@ -1200,7 +1200,7 @@
                 opacity: 1,
                 x: 0,
                 duration: dur,
-                ease: 'power3.out',
+                ease: 'fluent-decel',
                 stagger: { each: staggerVal, from: staggerFrom },
                 onComplete: function () {
                     gsap.set(cards, { clearProps: 'transform,opacity' });
@@ -1238,7 +1238,7 @@
 
             var dur = params.duration || 0.5;
             var staggerVal = params.stagger || 0.04;
-            var ease = params.easing || 'power3.out';
+            var ease = params.easing || 'fluent-decel';
             var style = params.style || 'stagger';
 
             // Viewport 分流：fold 以下卡片瞬間顯示
@@ -1372,6 +1372,112 @@
             gsap.to(boxEls[1], { x: targetX, duration: medium,   ease: 'fluent' });
             gsap.to(boxEls[2], { x: targetX, duration: emphasis, ease: 'fluent' });
             gsap.to(boxEls[3], { x: targetX, duration: slow,     ease: 'fluent' });
+        },
+
+        /**
+         * §5 Special Motion 白名單 demo — Burst Picker 候選卡彈出
+         * §5 white-list: back.out(1.2~1.7)（Burst Picker 招牌彈跳）
+         * C4: killTweensOf
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element} el - preview box DOM 元素
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playSpecialMotionBurstPickerDemo: function (el, params) {
+            params = params || {};
+            if (!el) return;
+            gsap.killTweensOf(el);
+            gsap.set(el, { clearProps: 'all' });
+            if (shouldSkip(params)) {
+                gsap.set(el, { scale: 1, opacity: 1 });
+                return;
+            }
+            gsap.fromTo(el,
+                { scale: 0, opacity: 0 },
+                { scale: 1, opacity: 1, duration: 0.35, ease: 'back.out(1.2)' } // §5 white-list: Burst Picker
+            );
+        },
+
+        /**
+         * §5 Special Motion 白名單 demo — Staging Card 進場 morph
+         * §5 white-list: back.out(1.4) + 0.35s（Staging Card 招牌進場）
+         * C4: killTweensOf
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element} el - preview box DOM 元素
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playSpecialMotionStagingEntryDemo: function (el, params) {
+            if (!el) return;
+            window.MotionLab.playStagingEntry(el, params || {});
+        },
+
+        /**
+         * §5 Special Motion 白名單 demo — playOrganizeSuccess checkmark 彈出
+         * §5 white-list: back.out(1.7) + 0.35s（整理成功 checkmark 招牌彈跳）
+         * C4: killTweensOf
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element} el - checkmark DOM 元素
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playSpecialMotionCheckmarkDemo: function (el, params) {
+            params = params || {};
+            if (!el) return;
+            gsap.killTweensOf(el);
+            gsap.set(el, { clearProps: 'all' });
+            if (shouldSkip(params)) {
+                gsap.set(el, { scale: 1, opacity: 1 });
+                return;
+            }
+            gsap.fromTo(el,
+                { scale: 0, opacity: 0 },
+                { scale: 1, opacity: 1, duration: 0.35, ease: 'back.out(1.7)' } // §5 white-list: playOrganizeSuccess checkmark
+            );
+        },
+
+        /**
+         * §5 Special Motion 白名單 demo — playOrganizeFail shake
+         * §5 white-list: power1.inOut + 0.08s yoyo×3（整理失敗水平 shake 律動）
+         * C4: killTweensOf
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element} el - shake 目標 DOM 元素
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playSpecialMotionShakeDemo: function (el, params) {
+            params = params || {};
+            if (!el) return;
+            gsap.killTweensOf(el);
+            gsap.set(el, { clearProps: 'all' });
+            if (shouldSkip(params)) {
+                gsap.set(el, { x: 0 });
+                return;
+            }
+            gsap.fromTo(el,
+                { x: -8 },
+                { x: 8, duration: 0.08, ease: 'power1.inOut', yoyo: true, repeat: 3, // §5 white-list: playOrganizeFail shake
+                    onComplete: function () { gsap.set(el, { x: 0 }); }
+                }
+            );
+        },
+
+        /**
+         * §5 Special Motion 白名單 demo — SourcePulse micro feedback
+         * §5 white-list: fluent (yoyo) 0.1s（低於 fast bucket，純 micro feedback）
+         * C4: killTweensOf
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element} el - pulse 目標 DOM 元素
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playSpecialMotionPulseDemo: function (el, params) {
+            params = params || {};
+            if (!el) return;
+            gsap.killTweensOf(el);
+            gsap.set(el, { clearProps: 'all' });
+            if (shouldSkip(params)) {
+                gsap.set(el, { scale: 1 });
+                return;
+            }
+            gsap.to(el, {
+                scale: 1.3, duration: 0.1, ease: 'fluent', yoyo: true, repeat: 1 // §5 white-list: SourcePulse micro
+            });
         },
     };
 

--- a/web/static/js/pages/motion-lab.js
+++ b/web/static/js/pages/motion-lab.js
@@ -211,7 +211,7 @@
                 gsap.to(infoEl, {
                     opacity: 0,
                     duration: 0.12,
-                    ease: 'power2.in',
+                    ease: 'fluent-accel',
                     onComplete: resolve  // C1: onComplete 只 resolve Promise
                 });
             });
@@ -240,7 +240,7 @@
             // C6: 不使用旋轉，只用 scale
             gsap.fromTo(cardEl,
                 { scale: 1.02 },
-                { scale: 1, duration: 0.18, ease: 'power2.out' }
+                { scale: 1, duration: 0.18, ease: 'fluent-decel' }
             );
         },
 
@@ -383,7 +383,7 @@
         playSharedCoverTransition: function (ghost, fromRect, toRect, params) {
             params = params || {};
             var dur = params.duration || 0.38;
-            var ease = params.easing || 'power2.inOut';
+            var ease = params.easing || 'fluent';
 
             // C4: 清除舊動畫
             gsap.killTweensOf(ghost);
@@ -466,13 +466,13 @@
                 // C6: 不使用 rotationX/Y/Z
                 tl.fromTo(targetEl,
                     { opacity: 0, scale: 0.94 },
-                    { opacity: 1, scale: 1, duration: targetDur, ease: 'power2.out' }
+                    { opacity: 1, scale: 1, duration: targetDur, ease: 'fluent-decel' }
                 );
 
                 // source cover：輕微淡出（若 sourceEl 存在）
                 if (sourceEl) {
                     tl.to(sourceEl,
-                        { opacity: 0, duration: sourceDur, ease: 'power2.out' },
+                        { opacity: 0, duration: sourceDur, ease: 'fluent-decel' },
                         0  // 與 target 動畫同時開始
                     );
                 }
@@ -530,7 +530,7 @@
                     x: xTo,
                     opacity: 0,
                     duration: dur,
-                    ease: 'power2.in',
+                    ease: 'fluent-accel',
                     onComplete: resolve  // C1: onComplete 只 resolve Promise
                 }).timeScale(detailSpeed);
             });
@@ -911,7 +911,7 @@
                 return null;
             }
             var dur = options.duration || 0.5;
-            var ease = options.ease || 'power2.out';
+            var ease = options.ease || 'fluent-decel';
             return gsap.fromTo(img,
                 { opacity: 0, scale: 1.05 },
                 { opacity: 1, scale: 1, duration: dur, ease: ease }
@@ -934,7 +934,7 @@
                 if (shouldSkip(options)) { resolve(); return; }
 
                 var dur = options.duration || 0.4;
-                var ease = options.ease || 'power2.out';
+                var ease = options.ease || 'fluent';
                 Flip.from(flipState, {
                     duration: dur,
                     ease: ease,
@@ -1061,7 +1061,7 @@
 
             // 3. Flip.from — 動畫從舊位置到新位置
             var dur = params.duration || 0.5;
-            var ease = params.ease || 'power2.inOut';
+            var ease = params.ease || 'fluent';
 
             return Flip.from(state, {
                 duration: dur,
@@ -1117,7 +1117,7 @@
 
             return Flip.from(state, {
                 duration: dur,
-                ease: 'power2.inOut',
+                ease: 'fluent',
                 absolute: true,
                 prune: true,
                 simple: true,
@@ -1126,22 +1126,22 @@
                     if (enterStyle === 'fadeUp') {
                         return gsap.fromTo(els,
                             { opacity: 0, y: 20 },
-                            { opacity: 1, y: 0, duration: dur * 0.8, ease: 'power2.out' });
+                            { opacity: 1, y: 0, duration: dur * 0.8, ease: 'fluent-decel' });
                     }
                     // default: opacityScale
                     return gsap.fromTo(els,
                         { opacity: 0, scale: 0.85 },
-                        { opacity: 1, scale: 1, duration: dur * 0.8, ease: 'power2.out' });
+                        { opacity: 1, scale: 1, duration: dur * 0.8, ease: 'fluent-decel' });
                 },
                 onLeave: function (els) {
                     // leaveStyle branching
                     if (leaveStyle === 'opacityOnly') {
                         return gsap.to(els,
-                            { opacity: 0, duration: dur * 0.6, ease: 'power2.in' });
+                            { opacity: 0, duration: dur * 0.6, ease: 'fluent-accel' });
                     }
                     // default: opacityScale
                     return gsap.to(els,
-                        { opacity: 0, scale: 0.85, duration: dur * 0.6, ease: 'power2.in' });
+                        { opacity: 0, scale: 0.85, duration: dur * 0.6, ease: 'fluent-accel' });
                 },
                 onComplete: function () {
                     var visible = gridEl.querySelectorAll(
@@ -1333,6 +1333,45 @@
             gsap.to(boxEls[0], { x: targetX, duration: dur, ease: 'fluent' });
             gsap.to(boxEls[1], { x: targetX, duration: dur, ease: 'fluent-decel' });
             gsap.to(boxEls[2], { x: targetX, duration: dur, ease: 'fluent-accel' });
+        },
+
+        /**
+         * §5 Duration Buckets 並排對比 demo
+         * 四個 box 同時播放相同 ease（fluent standard），只改 duration
+         * C4: killTweensOf(boxEls)
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element[]} boxEls - 四個 .duration-bucket-box DOM 元素陣列
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playDurationBucketsDemo: function (boxEls, params) {
+            params = params || {};
+
+            if (!boxEls || boxEls.length < 4 || boxEls.some(function (el) { return !el; })) return;
+
+            // C4: 清除舊動畫
+            gsap.killTweensOf(boxEls);
+
+            var lane = boxEls[0].parentElement;
+            var targetX = lane ? Math.max(0, lane.offsetWidth - 60 - 24) : 200;
+
+            if (shouldSkip(params)) {
+                gsap.set(boxEls, { x: targetX, yPercent: -50 });
+                return;
+            }
+
+            gsap.set(boxEls, { clearProps: 'all' });
+            gsap.set(boxEls, { x: 0, yPercent: -50 });
+
+            var D = window.OpenAver && window.OpenAver.motion && window.OpenAver.motion.DURATION;
+            var fast     = D ? D.fast     : 0.167;
+            var medium   = D ? D.medium   : 0.333;
+            var emphasis = D ? D.emphasis : 0.5;
+            var slow     = 0.3;
+
+            gsap.to(boxEls[0], { x: targetX, duration: fast,     ease: 'fluent' });
+            gsap.to(boxEls[1], { x: targetX, duration: medium,   ease: 'fluent' });
+            gsap.to(boxEls[2], { x: targetX, duration: emphasis, ease: 'fluent' });
+            gsap.to(boxEls[3], { x: targetX, duration: slow,     ease: 'fluent' });
         },
     };
 

--- a/web/static/js/pages/motion-lab.js
+++ b/web/static/js/pages/motion-lab.js
@@ -79,7 +79,7 @@
             }
 
             var dur = params.duration || 0.6;
-            var ease = params.easing || 'back.out(1.2)';
+            var ease = params.easing || 'fluent';
             var staggerVal = params.stagger || 0.05;
 
             // viewport 分流：可視卡片 → burst 動畫，fold 以下 → 瞬間顯示
@@ -166,7 +166,7 @@
 
             var dur = params.clipRevealDur || 0.5;
             var speed = params.speed || 1;
-            var ease = params.easing || 'power3.out';
+            var ease = params.easing || 'fluent-decel';
 
             // C6: 禁止旋轉，使用 clip-path 展開
             // 速度同步：與 burst timeline 的 timeScale 保持一致
@@ -271,7 +271,7 @@
             }
 
             var dur = params.duration || 0.6;
-            var ease = params.easing || 'power3.out';
+            var ease = params.easing || 'fluent-decel';
             var detailSpeed = params.detailSpeed || 1;
 
             // skipCover: ghost transition 已處理封面動畫，只播 info 進場
@@ -559,7 +559,7 @@
 
             var dur = (params.duration || 0.6) * 0.5;
             var xFrom = direction === 'next' ? 40 : -40;
-            var ease = params.easing || 'power3.out';
+            var ease = params.easing || 'fluent-decel';
             var detailSpeed = params.detailSpeed || 1;
 
             return gsap.fromTo(containerEl,
@@ -631,14 +631,14 @@
             if (style === 'fadeScale') {
                 return gsap.fromTo(imgEl,
                     { opacity: 0, scale: 0.92 },
-                    { opacity: 1, scale: 1, duration: 0.3, ease: 'power2.out' }
+                    { opacity: 1, scale: 1, duration: 0.3, ease: 'fluent-decel' }
                 );
             }
 
             if (style === 'fadeUp') {
                 return gsap.fromTo(imgEl,
                     { opacity: 0, y: 20 },
-                    { opacity: 1, y: 0, duration: 0.35, ease: 'power3.out' }
+                    { opacity: 1, y: 0, duration: 0.35, ease: 'fluent-decel' }
                 );
             }
 
@@ -646,14 +646,14 @@
                 // C6: clip-path 展開，無旋轉、無位移
                 return gsap.fromTo(imgEl,
                     { clipPath: 'inset(100% 0 0 0)' },
-                    { clipPath: 'inset(0% 0% 0% 0%)', duration: 0.4, ease: 'power2.out' }
+                    { clipPath: 'inset(0% 0% 0% 0%)', duration: 0.4, ease: 'fluent-decel' }
                 );
             }
 
             // 未知 style 降級為 fadeScale
             return gsap.fromTo(imgEl,
                 { opacity: 0, scale: 0.92 },
-                { opacity: 1, scale: 1, duration: 0.3, ease: 'power2.out' }
+                { opacity: 1, scale: 1, duration: 0.3, ease: 'fluent-decel' }
             );
         },
 
@@ -699,7 +699,7 @@
             }
 
             var dur = options.duration || options.burstDuration || 0.6;
-            var ease = options.ease || options.burstEase || 'back.out(1.2)';
+            var ease = options.ease || options.burstEase || 'back.out(1.2)'; // §5 white-list: Burst Picker
             var staggerVal = options.stagger || 0.05;
             var batchZ = ((options.batchZ || 0) * 10) + 100;
 
@@ -1287,6 +1287,52 @@
             });
 
             return tl;
+        },
+
+        /**
+         * §5 Ease Roles 並排對比 Demo
+         * 三個 box 同時以 fluent / fluent-decel / fluent-accel 播放，讓開發者直觀比較三角色差異。
+         * C4: killTweensOf(boxEls)
+         * C6: 不使用旋轉
+         * C23: shouldSkip reduced-motion guard
+         * @param {Element[]} boxEls - 三個 .ease-role-box DOM 元素陣列
+         * @param {object} params - Alpine 傳入的 params 物件（含 reducedMotionSim）
+         */
+        playEaseRolesDemo: function (boxEls, params) {
+            params = params || {};
+
+            if (!boxEls || boxEls.length < 3 || boxEls.some(function (el) { return !el; })) return;
+
+            // C4: 清除舊動畫
+            gsap.killTweensOf(boxEls);
+
+            // P3 #1: 動態計算 targetX，避免 box 在窄 viewport 跑出 lane 邊界
+            // lane.offsetWidth − box width(80px) − start left(12px) − gutter(12px)
+            var lane = boxEls[0].parentElement;
+            var targetX = lane ? Math.max(0, lane.offsetWidth - 80 - 24) : 200;
+
+            // CSS .ease-role-box 用 transform: translateY(-50%) 做垂直居中。
+            // GSAP 寫 inline transform for x 會覆蓋 CSS transform，必須補 yPercent: -50
+            // 一起寫進 GSAP 的 transform cache，否則動畫期間 box 會掉到 lane 底邊被裁切。
+            // C23: reduced-motion 降級 — 直接跳最終狀態（P2 #2: 改為跳 targetX，非 clearProps）
+            if (shouldSkip(params)) {
+                gsap.set(boxEls, { x: targetX, yPercent: -50 });
+                return;
+            }
+
+            // 重播前清乾淨 leftover transform / will-change / opacity，再回起點
+            gsap.set(boxEls, { clearProps: 'all' });
+            gsap.set(boxEls, { x: 0, yPercent: -50 });
+
+            var dur = window.OpenAver && window.OpenAver.motion && window.OpenAver.motion.DURATION
+                ? window.OpenAver.motion.DURATION.emphasis
+                : 0.5;
+
+            // 三條同時觸發（Standard / Enter / Exit）
+            // yPercent 已在 gsap.set 寫進 transform cache，tween 只動 x 會自動保留 yPercent
+            gsap.to(boxEls[0], { x: targetX, duration: dur, ease: 'fluent' });
+            gsap.to(boxEls[1], { x: targetX, duration: dur, ease: 'fluent-decel' });
+            gsap.to(boxEls[2], { x: targetX, duration: dur, ease: 'fluent-accel' });
         },
     };
 

--- a/web/static/js/pages/scanner.js
+++ b/web/static/js/pages/scanner.js
@@ -726,6 +726,14 @@ function scannerPage() {
 
         const text = this.logEntries.map(entry => entry.message).join('\n');
 
+        // T3.6 P2 fix: guard against undefined navigator.clipboard (HTTP / older WebView)
+        // 若無 Clipboard API，直接走 fail modal fallback；
+        // 否則 .then/.catch chain 會在 sync property access 階段就 TypeError，.catch 不會跑。
+        if (!navigator.clipboard?.writeText) {
+            this.openCopyFailModal(text);
+            return;
+        }
+
         navigator.clipboard.writeText(text).then(() => {
             this.showToast(`已複製 ${this.logEntries.length} 筆日誌`, 'success');
         }).catch(() => {
@@ -1227,14 +1235,25 @@ function scannerPage() {
     copyOutputPath() {
         if (!this.outputPath) return;
 
-        navigator.clipboard.writeText(this.outputPath).then(() => {
-            this.showToast('已複製: ' + this.outputPath, 'success');
-        }).catch(() => {
+        // T3.6 P2 fix: guard against undefined navigator.clipboard
+        // sync property access on undefined 會 throw TypeError，.catch 不會跑。
+        const showFailToast = () => {
             this.showToast(
                 window.t('scanner.toast.copy_path_failed').replace('{path}', this.outputPath),
                 'error',
                 4000
             );
+        };
+
+        if (!navigator.clipboard?.writeText) {
+            showFailToast();
+            return;
+        }
+
+        navigator.clipboard.writeText(this.outputPath).then(() => {
+            this.showToast('已複製: ' + this.outputPath, 'success');
+        }).catch(() => {
+            showFailToast();
         });
     },
 

--- a/web/static/js/pages/scanner.js
+++ b/web/static/js/pages/scanner.js
@@ -55,6 +55,11 @@ function scannerPage() {
     onlineSearchTarget: '',      // 要加到哪個 primary_name
     onlineSearchDone: false,     // 搜尋完成旗標（用於顯示「無搜尋建議」）
 
+    // ===== Alias v2: Delete Group Modal (T3.5) =====
+    deleteAliasGroupModalOpen: false,
+    _deleteAliasGroupLoading: false,
+    _pendingDeleteAliasGroupName: null,
+
     // ===== T7b: State Machine =====
     state: 'idle',  // 'idle' | 'generating' | 'nfoUpdating' | 'done' | 'error'
 
@@ -1281,9 +1286,32 @@ function scannerPage() {
     },
 
     // ===== Alias v2: Delete Group =====
-    async deleteAliasGroup(name) {
-        if (!confirm(`確定要刪除「${name}」的整筆別名組嗎？`)) return;
+    // T3.5: thin wrapper, 保留外部呼叫名（template @click="deleteAliasGroup(...)" 不需動）
+    deleteAliasGroup(name) {
+        this.openDeleteAliasGroupModal(name);
+    },
 
+    // ===== Alias v2: Delete Group Modal — Open (T3.5) =====
+    openDeleteAliasGroupModal(name) {
+        this._pendingDeleteAliasGroupName = name;
+        this.deleteAliasGroupModalOpen = true;
+    },
+
+    // ===== Alias v2: Delete Group Modal — Cancel (T3.5) =====
+    cancelDeleteAliasGroupModal() {
+        this.deleteAliasGroupModalOpen = false;
+        this._pendingDeleteAliasGroupName = null;
+    },
+
+    // ===== Alias v2: Delete Group Modal — Confirm (T3.5) =====
+    async confirmDeleteAliasGroup() {
+        const name = this._pendingDeleteAliasGroupName;
+        if (!name) {
+            this.deleteAliasGroupModalOpen = false;
+            this._pendingDeleteAliasGroupName = null;
+            return;
+        }
+        this._deleteAliasGroupLoading = true;
         try {
             const resp = await fetch(`/api/actress-aliases/${encodeURIComponent(name)}`, {
                 method: 'DELETE'
@@ -1298,6 +1326,10 @@ function scannerPage() {
             }
         } catch (e) {
             this.showToast('刪除失敗: ' + e.message, 'error');
+        } finally {
+            this._deleteAliasGroupLoading = false;
+            this.deleteAliasGroupModalOpen = false;
+            this._pendingDeleteAliasGroupName = null;
         }
     },
 

--- a/web/static/js/pages/scanner.js
+++ b/web/static/js/pages/scanner.js
@@ -60,6 +60,10 @@ function scannerPage() {
     _deleteAliasGroupLoading: false,
     _pendingDeleteAliasGroupName: null,
 
+    // ===== T3.6: Copy Logs Fail Modal =====
+    copyFailModalOpen: false,
+    copyFailDump: '',
+
     // ===== T7b: State Machine =====
     state: 'idle',  // 'idle' | 'generating' | 'nfoUpdating' | 'done' | 'error'
 
@@ -467,7 +471,7 @@ function scannerPage() {
     async selectFolder() {
         if (typeof window.pywebview === 'undefined' || !window.pywebview.api) {
             this.toggleManualInput();
-            alert('此功能需要在桌面應用程式中使用');
+            this.showToast(window.t('scanner.toast.desktop_only'), 'info');
             return;
         }
 
@@ -494,7 +498,7 @@ function scannerPage() {
             this.directories.push(folderPath);
             this.configDirty = true;
         } else {
-            alert('此資料夾已在列表中');
+            this.showToast(window.t('scanner.toast.folder_already_added'), 'warning');
         }
     },
 
@@ -512,7 +516,7 @@ function scannerPage() {
         if (!path) return;
 
         if (this.directories.includes(path)) {
-            alert('此資料夾已在列表中');
+            this.showToast(window.t('scanner.toast.folder_already_added'), 'warning');
             return;
         }
 
@@ -725,8 +729,19 @@ function scannerPage() {
         navigator.clipboard.writeText(text).then(() => {
             this.showToast(`已複製 ${this.logEntries.length} 筆日誌`, 'success');
         }).catch(() => {
-            alert('複製失敗，日誌內容：\n\n' + text.substring(0, 500) + '...');
+            this.openCopyFailModal(text);
         });
+    },
+
+    // T3.6: Copy Logs Fail Modal — fluent-modal <pre> dump fallback
+    openCopyFailModal(text) {
+        this.copyFailDump = text || '';
+        this.copyFailModalOpen = true;
+    },
+
+    closeCopyFailModal() {
+        this.copyFailModalOpen = false;
+        this.copyFailDump = '';
     },
 
     confirmClearAll() {
@@ -848,7 +863,8 @@ function scannerPage() {
         } catch (e) {
             this.state = 'error';
             localStorage.setItem('avlist_generating', 'false');
-            alert('發生錯誤: ' + e.message);
+            console.error('[Scanner] generate error:', e);
+            this.showToast(window.t('scanner.toast.generate_error'), 'error', 4000);
         }
     },
 
@@ -925,7 +941,8 @@ function scannerPage() {
         } catch (e) {
             this.state = 'error';
             localStorage.setItem('avlist_generating', 'false');
-            alert('發生錯誤: ' + e.message);
+            console.error('[Scanner] runNfoUpdate error:', e);
+            this.showToast(window.t('scanner.toast.nfo_update_error'), 'error', 4000);
         }
     },
 
@@ -1001,7 +1018,8 @@ function scannerPage() {
         } catch (e) {
             this.state = 'error';
             localStorage.setItem('avlist_generating', 'false');
-            alert('發生錯誤: ' + e.message);
+            console.error('[Scanner] runJellyfinImageUpdate error:', e);
+            this.showToast(window.t('scanner.toast.jellyfin_update_error'), 'error', 4000);
         }
     },
 
@@ -1212,7 +1230,11 @@ function scannerPage() {
         navigator.clipboard.writeText(this.outputPath).then(() => {
             this.showToast('已複製: ' + this.outputPath, 'success');
         }).catch(() => {
-            alert('複製失敗，路徑：' + this.outputPath);
+            this.showToast(
+                window.t('scanner.toast.copy_path_failed').replace('{path}', this.outputPath),
+                'error',
+                4000
+            );
         });
     },
 

--- a/web/static/js/pages/search/animations.js
+++ b/web/static/js/pages/search/animations.js
@@ -1021,6 +1021,9 @@
 
             if (!visible.length) return null;
 
+            // C21: cascade 進場期間 hover 不可搶 transform 控制權
+            visible.forEach(function (c) { c.classList.add('gsap-animating'); });
+
             return gsap.fromTo(visible,
                 { opacity: 0, y: 16 },
                 {
@@ -1029,7 +1032,13 @@
                     duration: options.duration || OpenAver.motion.DURATION.medium,
                     stagger: options.stagger || 0.03,
                     ease: options.ease || 'fluent-decel',
-                    clearProps: 'transform,opacity'
+                    clearProps: 'transform,opacity',
+                    onComplete: function () {
+                        visible.forEach(function (c) { c.classList.remove('gsap-animating'); });
+                    },
+                    onInterrupt: function () {
+                        visible.forEach(function (c) { c.classList.remove('gsap-animating'); });
+                    }
                 }
             );
         }

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -332,7 +332,7 @@ window.SearchStateMixin_FileList = {
 
         // 檢查空列表
         if (validIndices.length === 0) {
-            alert('無有效影片檔案（無法識別番號）');
+            this.showToast(window.t('search.toast.no_valid_files'), 'warning');
             return;
         }
 
@@ -399,7 +399,7 @@ window.SearchStateMixin_FileList = {
 
     async addFiles() {
         if (typeof window.pywebview === 'undefined' || !window.pywebview.api) {
-            alert('此功能需要在桌面應用程式中使用');
+            this.showToast(window.t('search.toast.desktop_only'), 'info');
             return;
         }
         try {
@@ -414,7 +414,7 @@ window.SearchStateMixin_FileList = {
 
     async addFolder() {
         if (typeof window.pywebview === 'undefined' || !window.pywebview.api) {
-            alert('此功能需要在桌面應用程式中使用');
+            this.showToast(window.t('search.toast.desktop_only'), 'info');
             return;
         }
         try {
@@ -439,7 +439,7 @@ window.SearchStateMixin_FileList = {
 
             if (!result.success) {
                 console.error('[LoadFavorite]', result.error);
-                alert('載入失敗，請重試');
+                this.showToast(window.t('search.toast.load_failed'), 'error');
                 return;
             }
 
@@ -456,7 +456,7 @@ window.SearchStateMixin_FileList = {
         } catch (err) {
             if (err.name === 'AbortError') return;  // T4.3: 靜默忽略取消
             console.error('[LoadFavorite]', err);
-            alert('載入失敗，請重試');
+            this.showToast(window.t('search.toast.load_failed'), 'error');
         } finally {
             this.isLoadingFavorite = false;
             this._clearAbort('loadFavorite', loadFavoriteSignal);  // T4.3: 操作完成清除 registry（比對 signal 避免刪掉新請求）

--- a/web/static/js/pages/search/state/result-card.js
+++ b/web/static/js/pages/search/state/result-card.js
@@ -374,9 +374,11 @@ window.SearchStateMixin_ResultCard = {
         const displayPath = pathToDisplay(folder);
 
         // 2. 複製到剪貼簿
-        const clipboardOk = navigator.clipboard.writeText(displayPath)
-            .then(() => true)
-            .catch(() => false);
+        // T3.7 fix: guard against undefined navigator.clipboard (HTTP / older WebView)
+        // sync property access 在 clipboard undefined 時會 TypeError，.catch 不會跑。
+        const clipboardOk = navigator.clipboard?.writeText
+            ? navigator.clipboard.writeText(displayPath).then(() => true).catch(() => false)
+            : Promise.resolve(false);
 
         // 3. PyWebView 桌面模式：額外開啟資料夾
         if (window.pywebview?.api?.open_folder) {

--- a/web/static/js/pages/search/state/result-card.js
+++ b/web/static/js/pages/search/state/result-card.js
@@ -137,7 +137,7 @@ window.SearchStateMixin_ResultCard = {
             await this._translateWithAILogic();
         } catch (error) {
             console.error('[Translate] 翻譯失敗:', error);
-            alert('翻譯失敗，請重試');
+            this.showToast(window.t('search.toast.translate_failed'), 'error');
         } finally {
             this.isTranslating = false;
         }

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -358,7 +358,9 @@ function settingsPage() {
                     this.form.avlistMode = config.gallery?.default_mode || 'image';
                     this.form.avlistSort = config.gallery?.default_sort || 'date';
                     this.form.avlistOrder = config.gallery?.default_order || 'descending';
-                    this.form.avlistItemsPerPage = config.gallery?.items_per_page || 90;
+                    // T3.2 P2 fix: `??` 而非 `||` — items_per_page=0 是 "全部" 合法選項，
+                    // 用 `||` 會把 0 吞掉變 90，導致存檔後重開 settings 顯示錯誤。
+                    this.form.avlistItemsPerPage = config.gallery?.items_per_page ?? 90;
                     this.form.avlistMinSize = config.gallery?.min_size_mb || 0;
                     this.form.avlistOutputDir = config.gallery?.output_dir || 'output';
                     this.form.avlistOutputFilename = config.gallery?.output_filename || 'gallery_output.html';

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -84,6 +84,10 @@ function settingsPage() {
         // Dirty Check Modal State
         dirtyCheckModalOpen: false,
 
+        // Reset Config Modal State (T3.4)
+        resetConfigModalOpen: false,
+        _resetConfigLoading: false,
+
         // ===== Dirty Check State =====
         savedState: null,
         savedOpenaiUseCustomModel: false,
@@ -834,21 +838,37 @@ function settingsPage() {
             }
         },
 
-        async resetConfig() {
-            if (confirm('確定要重置所有設定嗎？此操作將刪除所有自訂設定。')) {
-                try {
-                    const resp = await fetch('/api/config', { method: 'DELETE' });
-                    const result = await resp.json();
-                    if (result.success) {
-                        await this.loadConfig();
-                        this.showToast('已恢復預設設定', 'success');
-                    } else {
-                        this.showToast('重置失敗: ' + result.error, 'error');
-                    }
-                } catch (e) {
-                    this.showToast('重置失敗: ' + e.message, 'error');
+        // ===== Reset Config Modal (T3.4: confirm → fluent-modal + i18n) =====
+        openResetConfigModal() {
+            this.resetConfigModalOpen = true;
+        },
+
+        cancelResetConfigModal() {
+            this.resetConfigModalOpen = false;
+        },
+
+        async confirmResetConfig() {
+            this._resetConfigLoading = true;
+            try {
+                const resp = await fetch('/api/config', { method: 'DELETE' });
+                const result = await resp.json();
+                if (result.success) {
+                    await this.loadConfig();
+                    this.showToast('已恢復預設設定', 'success');
+                } else {
+                    this.showToast('重置失敗: ' + result.error, 'error');
                 }
+            } catch (e) {
+                this.showToast('重置失敗: ' + e.message, 'error');
+            } finally {
+                this._resetConfigLoading = false;
+                this.resetConfigModalOpen = false;
             }
+        },
+
+        async resetConfig() {
+            // Thin wrapper：保留向後相容，template @click="resetConfig()" 不需改
+            this.openResetConfigModal();
         },
 
         insertVariable(targetField, varName) {

--- a/web/static/js/pages/settings.js
+++ b/web/static/js/pages/settings.js
@@ -826,7 +826,7 @@ function settingsPage() {
 
         async selectOutputFolder() {
             if (typeof window.pywebview === 'undefined' || !window.pywebview.api) {
-                alert('此功能需要在桌面應用程式中使用');
+                this.showToast(window.t('settings.toast.desktop_only'), 'info');
                 return;
             }
 

--- a/web/static/js/pages/showcase/animations.js
+++ b/web/static/js/pages/showcase/animations.js
@@ -177,13 +177,20 @@
             var fromVars = { opacity: 0, y: 20 };
             gsap.set(visible, fromVars);
 
-            var tl = gsap.timeline({ id: 'showcaseEntry' });
-            tl.to(visible, { opacity: 1, y: 0, duration: dur, ease: ease, stagger: staggerVal });
+            // C21: cascade 進場期間 hover 不可搶 transform 控制權
+            visible.forEach(function (c) { c.classList.add('gsap-animating'); });
 
-            // 動畫結束後清除 inline styles
-            tl.eventCallback('onComplete', function () {
-                gsap.set(visible, { clearProps: 'transform,opacity' });
+            var tl = gsap.timeline({
+                id: 'showcaseEntry',
+                onComplete: function () {
+                    visible.forEach(function (c) { c.classList.remove('gsap-animating'); });
+                    gsap.set(visible, { clearProps: 'transform,opacity' });
+                },
+                onInterrupt: function () {
+                    visible.forEach(function (c) { c.classList.remove('gsap-animating'); });
+                }
             });
+            tl.to(visible, { opacity: 1, y: 0, duration: dur, ease: ease, stagger: staggerVal });
 
             return tl;
         },

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -176,6 +176,11 @@ function showcaseState() {
         _pickerSSE: null,
         _pickerTimeoutTimer: null,
 
+        // T3.3: Remove Actress fluent-modal 狀態
+        removeActressModalOpen: false,
+        _removeActressLoading: false,
+        _pendingRemoveActressName: null,
+
         // User Tags 狀態 (T4)
         addingLbTag: false,
         newLbTagValue: '',
@@ -959,11 +964,27 @@ function showcaseState() {
             }
         },
 
-        async removeActress() {
+        // T3.3: Remove Actress fluent-modal 三段路徑（open / confirm / cancel）
+        // 取代既有 removeActress() + window.confirm 流程；trigger button 改呼 openRemoveActressModal()
+        openRemoveActressModal() {
             if (!this.currentLightboxActress) return;
-            const name = this.currentLightboxActress.name;
-            const confirmed = window.confirm(window.t('showcase.actress.removeConfirm').replace('{name}', name));
-            if (!confirmed) return;
+            // 快照當下女優名 — modal 期間 lightbox 翻頁也不影響待刪對象
+            this._pendingRemoveActressName = this.currentLightboxActress.name;
+            this.removeActressModalOpen = true;
+        },
+
+        cancelRemoveActressModal() {
+            this.removeActressModalOpen = false;
+            this._pendingRemoveActressName = null;
+        },
+
+        async confirmRemoveActress() {
+            const name = this._pendingRemoveActressName;
+            if (!name) {
+                this.removeActressModalOpen = false;
+                return;
+            }
+            this._removeActressLoading = true;
             try {
                 const resp = await fetch(`/api/actresses/${encodeURIComponent(name)}`, {
                     method: 'DELETE',
@@ -973,23 +994,26 @@ function showcaseState() {
                     const idx = _actresses.findIndex(a => a.name === name);
                     if (idx >= 0) _actresses.splice(idx, 1);
                     this.applyActressFilterAndSort();
+                    // stale guard: lightbox switched to a different actress during request
                     if (this.currentLightboxActress?.name !== name) {
-                        // stale guard: lightbox switched to a different actress during request
-                        // array cleanup already done above, but don't close lightbox
                         this.showToast(window.t('showcase.actress.removeSuccess'), 'success');
-                        return;
-                    }
-                    this.closeActressLightbox();
-                    this.showToast(window.t('showcase.actress.removeSuccess'), 'success');
-                    var searchTerm = this.search.trim();
-                    if (searchTerm) {
-                        this._checkPreciseActressMatch(searchTerm, 'manual');
+                    } else {
+                        this.closeActressLightbox();
+                        this.showToast(window.t('showcase.actress.removeSuccess'), 'success');
+                        var searchTerm = this.search.trim();
+                        if (searchTerm) {
+                            this._checkPreciseActressMatch(searchTerm, 'manual');
+                        }
                     }
                 } else {
                     this.showToast(data.error || 'Error', 'error');
                 }
             } catch (e) {
                 this.showToast('Error', 'error');
+            } finally {
+                this._removeActressLoading = false;
+                this.removeActressModalOpen = false;
+                this._pendingRemoveActressName = null;
             }
         },
 
@@ -2555,6 +2579,16 @@ function showcaseState() {
         handleKeydown(e) {
             // 1. 輸入框中不處理快捷鍵
             if (e.target.tagName === 'INPUT') return;
+
+            // T3.3: Remove Actress modal 開啟時，Esc 優先關閉 modal（不冒泡到 lightbox close）
+            if (e.key === 'Escape' && this.removeActressModalOpen) {
+                this.cancelRemoveActressModal();
+                e.preventDefault();
+                e.stopPropagation();
+                return;
+            }
+            // T3.3: Remove Actress modal 開啟期間鎖其他鍵（← / → / S / A / 數字鍵全失效）
+            if (this.removeActressModalOpen) return;
 
             // 49b T4cd: Picker 開啟時，Esc 優先關閉 picker（不冒泡到 lightbox close）
             if (e.key === 'Escape' && this._pickerOpen) {

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -300,7 +300,9 @@ function showcaseState() {
             const cfg = window.__SHOWCASE_CONFIG__ || {};
             const defaultSort = cfg.default_sort || 'date';
             const defaultOrder = cfg.default_order === 'ascending' ? 'asc' : 'desc';
-            const defaultPerPage = cfg.items_per_page || 90;
+            // T3.2 P2 fix: `??` 而非 `||` — Settings 允許 items_per_page=0（"全部"語意），
+            // 必須保留 numeric 0 讓下方 grid+perPage=0→120 降級邏輯有機會觸發。
+            const defaultPerPage = cfg.items_per_page ?? 90;
 
             // 2. 從 localStorage 恢復（優先於 config）
             const saved = localStorage.getItem('showcase_state');

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -124,7 +124,6 @@ function showcaseState() {
         // Toolbar Dropdown 狀態
         sortOpen: false,
         modeOpen: false,
-        perPageOpen: false,
 
         search: '',
         sort: 'date',         // M2a 先用硬編碼，M4 才從 config/localStorage 恢復
@@ -317,16 +316,16 @@ function showcaseState() {
             const urlNum = (key) => { const v = urlParams.get(key); return v !== null && v !== '' ? v : undefined; };
             this.sort = urlParams.get('sort') || state.sort || defaultSort;
             this.order = urlParams.get('order') || state.order || defaultOrder;
-            const rawPerPage = parseInt(urlNum('perPage') ?? state.perPage ?? defaultPerPage);
-            this.perPage = Number.isNaN(rawPerPage) ? defaultPerPage : rawPerPage;
+            // T3.2 (CD-52-3): perPage 只從 cfg.items_per_page，URL params + localStorage 不再參與
+            // 既有 user 的 localStorage state.perPage / URL ?perPage=N 被 silently 忽略（CD-52-4）
+            this.perPage = defaultPerPage;
             this.page = parseInt(urlNum('page') ?? state.page ?? 1) || 1;
             this.search = urlParams.get('search') || state.search || '';
             this.mode = urlParams.get('mode') || state.mode || 'grid';
             if (!['grid', 'table', 'list'].includes(this.mode)) this.mode = 'grid';
-            // F2: grid + perPage=0 組合降級 + 持久化修正值
+            // F2: grid + perPage=0 組合降級（settings 若存 items_per_page=0 之防呆）
             if (this.mode === 'grid' && this.perPage === 0) {
                 this.perPage = 120;
-                this.saveState();
             }
             // ★ 44a: 女優模式 — 只從 localStorage，不加 URL params（避免汙染 shareable link）
             this.showFavoriteActresses = state.showFavoriteActresses === true;  // 嚴格 === true
@@ -339,7 +338,7 @@ function showcaseState() {
             const state = {
                 sort: this.sort,
                 order: this.order,
-                perPage: this.perPage,
+                // T3.2 (CD-52-3): perPage 不再寫入 localStorage（每次 init 重讀 cfg.items_per_page）
                 page: this.page,
                 search: this.search,
                 mode: this.mode,
@@ -354,7 +353,7 @@ function showcaseState() {
             if (this.search) params.set('search', this.search);
             if (this.sort !== 'date') params.set('sort', this.sort);
             if (this.order !== 'desc') params.set('order', this.order);
-            if (this.perPage !== 90) params.set('perPage', this.perPage);
+            // T3.2 (CD-52-3): perPage 不再寫入 URL params（每次 init 重讀 cfg.items_per_page）
             if (this.page !== 1) params.set('page', this.page);
             if (this.mode !== 'grid') params.set('mode', this.mode);
 
@@ -1269,21 +1268,6 @@ function showcaseState() {
                 var gen = ++this._animGeneration;
                 this.$nextTick(() => { requestAnimationFrame(() => {
                     if (this._animGeneration !== gen) return;  // stale
-                    var grid = document.querySelector('.showcase-grid');
-                    window.ShowcaseAnimations?.playEntry?.(grid);
-                }); });
-            }
-        },
-
-        onPerPageChange() {
-            this.page = 1;
-            this.updatePagination();
-            this.saveState();  // M2c: 持久化狀態
-            // B17: 切換每頁數量後播放進場動畫
-            if (this.mode === 'grid') {
-                var gen = ++this._animGeneration;
-                this.$nextTick(() => { requestAnimationFrame(() => {
-                    if (this._animGeneration !== gen) return;
                     var grid = document.querySelector('.showcase-grid');
                     window.ShowcaseAnimations?.playEntry?.(grid);
                 }); });

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -2040,9 +2040,11 @@ function showcaseState() {
             const displayPath = pathToDisplay(folder);
 
             // 2. 複製到剪貼簿
-            const clipboardOk = navigator.clipboard.writeText(displayPath)
-                .then(() => true)
-                .catch(() => false);
+            // T3.7 fix: guard against undefined navigator.clipboard (HTTP / older WebView)
+            // sync property access 在 clipboard undefined 時會 TypeError，.catch 不會跑。
+            const clipboardOk = navigator.clipboard?.writeText
+                ? navigator.clipboard.writeText(displayPath).then(() => true).catch(() => false)
+                : Promise.resolve(false);
 
             // 3. PyWebView 桌面模式：額外開啟資料夾
             if (window.pywebview?.api?.open_folder) {

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -679,6 +679,89 @@
                     </button>
                 </div>
             </div>
+
+            <!-- §1 Pill 999px 白名單 -->
+            <div class="ds-subsection">
+                <h3>§1 Pill 999px 白名單（5 類）</h3>
+                <p class="ds-desc">ui-conventions §1：<code>border-radius: 999px</code>（<code>--radius-pill</code>）限這 5 類使用，其他元件用 <code>var(--fluent-radius-*)</code> token。</p>
+                <div class="ds-pill-whitelist-grid">
+
+                    <!-- 1. spotlight-search -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo">
+                            <div class="ds-pill-demo-spotlight">
+                                <i class="bi bi-search"></i>
+                                <span>搜尋演員...</span>
+                            </div>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 1 · <code>.spotlight-search</code></span>
+                            <p class="ds-pill-card-desc">頁面頂部 Spotlight 搜尋框</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                    <!-- 2. btn-hero -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo">
+                            <button class="btn-hero btn-hero-primary" style="pointer-events: none;">
+                                <i class="bi bi-play-fill"></i> 開始掃描
+                            </button>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 2 · <code>.btn-hero</code></span>
+                            <p class="ds-pill-card-desc">Hero CTA 行動呼籲大按鈕</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                    <!-- 3. lb-tag / lb-user-tag -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo" style="display: flex; gap: 0.4rem; flex-wrap: wrap; justify-content: center;">
+                            <span class="lb-tag">動作</span>
+                            <span class="lb-tag">喜劇</span>
+                            <span class="lb-user-tag">自訂標籤</span>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 3 · <code>.lb-tag</code> / <code>.lb-user-tag</code></span>
+                            <p class="ds-pill-card-desc">Lightbox 元資料 tag chips</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                    <!-- 4. badge -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo" style="display: flex; gap: 0.4rem; flex-wrap: wrap; justify-content: center;">
+                            <span class="badge badge-primary">NEW</span>
+                            <span class="badge badge-secondary">HD</span>
+                            <span class="badge badge-accent">4K</span>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 4 · <code>.badge</code> 類</span>
+                            <p class="ds-pill-card-desc">數量徽章、狀態 badge</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                    <!-- 5. control action pill -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo" style="display: flex; gap: 0.4rem; flex-wrap: wrap; justify-content: center;">
+                            <button class="sg-open-btn" style="pointer-events: none;">
+                                <i class="bi bi-images"></i> 樣本圖
+                            </button>
+                            <button class="fetch-samples-btn" style="pointer-events: none;">
+                                <i class="bi bi-download"></i> 取得
+                            </button>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 5 · <code>.sg-open-btn</code> / <code>.fetch-samples-btn</code> / <code>.mode-toggle</code></span>
+                            <p class="ds-pill-card-desc">Lightbox / control action pill</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
         </section>
 
         <!-- 區塊 4: Form Controls (accent-bar 樣式) -->

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -2113,8 +2113,7 @@
                 <h3>Hero Terminal</h3>
                 <p class="ds-desc">
                     來源：<code>help.html</code> Hero Card 右欄的 AI 整合入口指令框。
-                    <strong>固定深色背景（<code>oklch(20% 0.01 250)</code>），不隨 Light / Dark theme 切換</strong>，
-                    確保終端外觀在任何主題下一致。
+                    <strong>背景使用 <code>var(--surface-2)</code> 跟隨主題；<code>[data-theme="dim"]</code> override 固定深色（<code>oklch(20% 0.01 250)</code>）確保 dim 模式終端外觀一致</strong>。
                     右上角有複製按鈕，點擊後圖示切換為 ✓，1.5 秒後自動復原。
                 </p>
 
@@ -2130,7 +2129,7 @@
                         </button>
                     </div>
                     <small style="color: var(--text-muted); display: block; margin-top: 0.5rem;">
-                        ↑ Light 與 Dark 模式下皆呈現相同的深色終端外觀
+                        ↑ Light 模式下跟隨 <code>var(--surface-2)</code>；Dim 模式 override 固定深色終端外觀
                     </small>
                 </div>
 
@@ -2147,8 +2146,8 @@
                 <div class="ds-note" style="margin-top: 1rem;">
                     <strong>技術細節：</strong>
                     <ul style="margin-top: 0.5rem; padding-left: 1.5rem;">
-                        <li><code>.hero-terminal</code>：背景硬編碼 <code>oklch(20% 0.01 250)</code>，不受 <code>[data-theme]</code> 影響</li>
-                        <li><code>.terminal-prompt</code>：低飽和青綠 <code>oklch(55% 0.15 160)</code>，<code>user-select: none</code></li>
+                        <li><code>.hero-terminal</code>：背景 <code>var(--surface-2)</code>，<code>[data-theme="dim"] .hero-terminal</code> override 為固定深色 <code>oklch(20% 0.01 250)</code>（design-intent）</li>
+                        <li><code>.terminal-prompt</code>：青綠 <code>var(--color-success)</code>（iOS Green，與 <code>.workflow-arrow</code>/<code>.workflow-step-num</code> 統一動作指引色），<code>user-select: none</code></li>
                         <li><code>.terminal-copy-btn</code>：絕對定位右上角，<code>:hover</code> 有背景高亮</li>
                         <li>此頁 CSS 由局部 <code>&lt;style&gt;</code> 提供；production 版定義見 <code>help.css</code> 行 17–52</li>
                     </ul>

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -442,6 +442,65 @@
                 <p class="ds-note">💡 Dark theme 陰影深度加倍（opacity: 0.24/0.28），自動跟隨主題切換</p>
             </div>
 
+            <!-- §4 Spacing 三層分明 -->
+            <div class="ds-subsection">
+                <h3>§4 Spacing 三層分明</h3>
+                <p class="ds-desc">ui-conventions §4：三層分類，嚴格對號入座。</p>
+                <div class="ds-spacing-layer-table">
+                    <div class="ds-spacing-layer">
+                        <div class="ds-spacing-layer-header ds-layer-layout">Layout 8pt grid</div>
+                        <div class="ds-spacing-layer-body">
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-ok">允許值</span>
+                                <code>8px · 16px · 24px · 32px · 48px · 64px</code>
+                            </div>
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-ban">禁止</span>
+                                <code>6px（改 8px 或加 optical 註釋）</code>
+                            </div>
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-example">用途</span>
+                                <span>元件間距、section padding、card gap</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ds-spacing-layer">
+                        <div class="ds-spacing-layer-header ds-layer-micro">Micro 2–4px</div>
+                        <div class="ds-spacing-layer-body">
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-ok">允許值</span>
+                                <code>2px · 4px</code>
+                            </div>
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-note">例外</span>
+                                <code>6px chip optical 例外須加 /* optical §4 micro chip */ 註釋</code>
+                            </div>
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-example">用途</span>
+                                <span>icon gap、badge padding、chip 內距</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ds-spacing-layer">
+                        <div class="ds-spacing-layer-header ds-layer-stroke">Stroke 1–3px</div>
+                        <div class="ds-spacing-layer-body">
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-ok">允許值</span>
+                                <code>1px · 2px · 3px</code>
+                            </div>
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-ban">禁止</span>
+                                <code>border: 2px solid red（不走 token）</code>
+                            </div>
+                            <div class="ds-spacing-layer-row">
+                                <span class="ds-layer-tag ds-layer-tag-example">用途</span>
+                                <span>border / outline / separator 線條粗細</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Spacing Scale 展示 -->
             <div class="ds-subsection">
                 <h3>Spacing Scale</h3>
@@ -976,6 +1035,91 @@
                                 </div>
                             </div>
                         </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- §6 5 檢查點 pass/fail 對照 -->
+            <div class="ds-subsection">
+                <h3>§6 5 檢查點 pass/fail 對照</h3>
+                <p class="ds-desc">ui-conventions §6：每次 PR 前確認這 5 點。左欄為違規示範（紅虛線），右欄為正確寫法（綠實線）。</p>
+
+                <!-- 1. Radius -->
+                <div class="ds-checkpoint-label">1. Radius — 用 token，不硬編碼 px</div>
+                <div class="ds-checkpoint-pair">
+                    <div class="ds-checkpoint-fail">
+                        <span class="ds-cpf-title">✗ 違規</span>
+                        <div class="ds-cpf-demo" style="border-radius: 3px; background: var(--surface-1); padding: 0.75rem; text-align: center;">border-radius: 3px</div>
+                        <code class="ds-cpf-code">border-radius: 3px</code>
+                    </div>
+                    <div class="ds-checkpoint-pass">
+                        <span class="ds-cpf-title">✓ 正確</span>
+                        <div class="ds-cpf-demo" style="border-radius: var(--fluent-radius-md); background: var(--surface-1); padding: 0.75rem; text-align: center;">fluent-radius-md</div>
+                        <code class="ds-cpf-code">border-radius: var(--fluent-radius-md)</code>
+                    </div>
+                </div>
+
+                <!-- 2. Surface -->
+                <div class="ds-checkpoint-label">2. Surface — 用 surface token，不寫 hardcoded rgba</div>
+                <div class="ds-checkpoint-pair">
+                    <div class="ds-checkpoint-fail">
+                        <span class="ds-cpf-title">✗ 違規</span>
+                        <div class="ds-cpf-demo" style="background: rgba(255,255,255,0.5); padding: 0.75rem; text-align: center; border-radius: var(--fluent-radius-md);">rgba(255,255,255,0.5)</div>
+                        <code class="ds-cpf-code">background: rgba(255,255,255,0.5)</code>
+                    </div>
+                    <div class="ds-checkpoint-pass">
+                        <span class="ds-cpf-title">✓ 正確</span>
+                        <div class="ds-cpf-demo" style="background: var(--surface-1); padding: 0.75rem; text-align: center; border-radius: var(--fluent-radius-md);">var(--surface-1)</div>
+                        <code class="ds-cpf-code">background: var(--surface-1)</code>
+                    </div>
+                </div>
+
+                <!-- 3. Stroke -->
+                <div class="ds-checkpoint-label">3. Stroke — 1px + stroke token，不任意加粗或用色彩硬編碼</div>
+                <div class="ds-checkpoint-pair">
+                    <div class="ds-checkpoint-fail">
+                        <span class="ds-cpf-title">✗ 違規</span>
+                        <div class="ds-cpf-demo" style="border: 2px solid red; padding: 0.75rem; text-align: center; border-radius: var(--fluent-radius-md);">2px solid red</div>
+                        <code class="ds-cpf-code">border: 2px solid red</code>
+                    </div>
+                    <div class="ds-checkpoint-pass">
+                        <span class="ds-cpf-title">✓ 正確</span>
+                        <div class="ds-cpf-demo" style="border: 1px solid var(--stroke-default); padding: 0.75rem; text-align: center; border-radius: var(--fluent-radius-md);">1px stroke-default</div>
+                        <code class="ds-cpf-code">border: 1px solid var(--stroke-default)</code>
+                    </div>
+                </div>
+
+                <!-- 4. Shadow -->
+                <div class="ds-checkpoint-label">4. Shadow — 用 Fluent token，不寫裸 rgba</div>
+                <div class="ds-checkpoint-pair">
+                    <div class="ds-checkpoint-fail">
+                        <span class="ds-cpf-title">✗ 違規</span>
+                        <div class="ds-cpf-demo" style="box-shadow: 0 4px 8px rgba(0,0,0,0.5); padding: 0.75rem; text-align: center; border-radius: var(--fluent-radius-md); background: var(--surface-1);">0 4px 8px rgba(0,0,0,0.5)</div>
+                        <code class="ds-cpf-code">box-shadow: 0 4px 8px rgba(0,0,0,0.5)</code>
+                    </div>
+                    <div class="ds-checkpoint-pass">
+                        <span class="ds-cpf-title">✓ 正確</span>
+                        <div class="ds-cpf-demo" style="box-shadow: var(--fluent-shadow-8); padding: 0.75rem; text-align: center; border-radius: var(--fluent-radius-md); background: var(--surface-1);">fluent-shadow-8</div>
+                        <code class="ds-cpf-code">box-shadow: var(--fluent-shadow-8)</code>
+                    </div>
+                </div>
+
+                <!-- 5. Hover / Focus -->
+                <div class="ds-checkpoint-label">5. Hover / Focus — 必須有 focus-ring，不可缺少可訪問性樣式</div>
+                <div class="ds-checkpoint-pair">
+                    <div class="ds-checkpoint-fail">
+                        <span class="ds-cpf-title">✗ 違規</span>
+                        <div class="ds-cpf-demo" style="padding: 0.75rem; text-align: center;">
+                            <button style="padding: 0.4rem 1rem; border-radius: var(--fluent-radius-md); border: 1px solid var(--stroke-default); background: var(--surface-1); outline: none; cursor: default;">無 focus-ring</button>
+                        </div>
+                        <code class="ds-cpf-code">outline: none（無任何補充）</code>
+                    </div>
+                    <div class="ds-checkpoint-pass">
+                        <span class="ds-cpf-title">✓ 正確</span>
+                        <div class="ds-cpf-demo" style="padding: 0.75rem; text-align: center;">
+                            <button class="ds-focus-demo-btn" style="padding: 0.4rem 1rem; border-radius: var(--fluent-radius-md); border: 1px solid var(--stroke-default); background: var(--surface-1); cursor: default; outline: 2px solid var(--accent); outline-offset: 4px; box-shadow: 0 0 0 4px var(--glow-primary);">有 focus-ring</button>
+                        </div>
+                        <code class="ds-cpf-code">outline: 2px solid var(--accent); outline-offset: 4px; box-shadow: 0 0 0 4px var(--glow-primary)</code>
                     </div>
                 </div>
             </div>

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -322,6 +322,49 @@
                     <small>Small Text - 0.875rem</small>
                 </div>
             </div>
+
+            <!-- §3 Overlay 角色色 -->
+            <div class="ds-subsection">
+                <h3>§3 Overlay 角色色（4 階 + Phase 51 letterbox）</h3>
+                <p class="ds-desc">ui-conventions §3：遮罩用角色色 token，不寫 hardcoded rgba。</p>
+                <div class="ds-overlay-grid">
+                    <div class="ds-overlay-swatch" style="background: var(--overlay-gallery);">
+                        <div class="ds-overlay-info">
+                            <span class="ds-overlay-token">--overlay-gallery</span>
+                            <span class="ds-overlay-alpha">rgba(0,0,0,0.85)</span>
+                            <span class="ds-overlay-usage">sample gallery 暗幕</span>
+                        </div>
+                    </div>
+                    <div class="ds-overlay-swatch" style="background: var(--overlay-modal);">
+                        <div class="ds-overlay-info">
+                            <span class="ds-overlay-token">--overlay-modal</span>
+                            <span class="ds-overlay-alpha">rgba(0,0,0,0.6)</span>
+                            <span class="ds-overlay-usage">lightbox backdrop</span>
+                        </div>
+                    </div>
+                    <div class="ds-overlay-swatch" style="background: var(--overlay-gradient);">
+                        <div class="ds-overlay-info">
+                            <span class="ds-overlay-token">--overlay-gradient</span>
+                            <span class="ds-overlay-alpha">rgba(0,0,0,0.55)</span>
+                            <span class="ds-overlay-usage">card hover 漸層 bottom</span>
+                        </div>
+                    </div>
+                    <div class="ds-overlay-swatch" style="background: var(--overlay-control);">
+                        <div class="ds-overlay-info">
+                            <span class="ds-overlay-token">--overlay-control</span>
+                            <span class="ds-overlay-alpha">rgba(0,0,0,0.45)</span>
+                            <span class="ds-overlay-usage">浮在媒體上的控制按鈕</span>
+                        </div>
+                    </div>
+                    <div class="ds-overlay-swatch" style="background: var(--overlay-letterbox);">
+                        <div class="ds-overlay-info">
+                            <span class="ds-overlay-token">--overlay-letterbox</span>
+                            <span class="ds-overlay-alpha">rgba(0,0,0,0.2)</span>
+                            <span class="ds-overlay-usage">媒體封面 letterbox 黑邊</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </section>
 
         <!-- 區塊 2: Fluent Design Tokens (accent-bar 樣式) -->
@@ -513,7 +556,7 @@
                             <span class="ds-material-class">body.fluent-canvas</span>
                             <span class="ds-material-desc">Mica 氛圍背景 — 全頁底層漸層 + noise overlay</span>
                             <div class="ds-material-tokens">
-                                <code>--ds-glow-rgb: 90, 200, 250</code>
+                                <code class="ds-token-label">--fluent-blur-heavy (60px)</code>
                                 <code>radial-gradient + noise 0.025 opacity</code>
                             </div>
                         </div>
@@ -529,10 +572,10 @@
                         <div class="ds-material-info">
                             <span class="ds-material-name">Toolbar (Shell)</span>
                             <span class="ds-material-class">.fluent-toolbar</span>
-                            <span class="ds-material-desc">工具列標準 Acrylic — 輕量毛玻璃，背景透出氛圍層</span>
+                            <span class="ds-material-desc">工具列標準 Acrylic — Overlay 階毛玻璃，背景透出氛圍層</span>
                             <div class="ds-material-tokens">
-                                <code>blur: 16px, saturate: 130%</code>
-                                <code>bg: var(--bg-header)</code>
+                                <code class="ds-token-label">--fluent-blur (30px)</code>
+                                <code>saturate: 130% · bg: var(--bg-header)</code>
                             </div>
                         </div>
                     </div>
@@ -547,7 +590,7 @@
                         <div class="ds-material-info">
                             <span class="ds-material-name">Surface Elevation</span>
                             <span class="ds-material-class">inset highlight + shadow</span>
-                            <span class="ds-material-desc">卡片材質邊界感 — 頂部 1px 高光線 + Fluent 陰影，無 blur</span>
+                            <span class="ds-material-desc">卡片材質邊界感 — 頂部 1px 高光線 + Fluent 陰影，無 blur（floating-control 用 <code class="ds-token-label">--fluent-blur-light (12px)</code>）</span>
                             <div class="ds-material-tokens">
                                 <code>inset 0 1px 0 oklch(base-content 8%)</code>
                                 <code>+ var(--fluent-shadow-4)</code>

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -761,6 +761,11 @@
                     @click="tab = 'ease-roles'; onResetStaging(); onResetHero(); onResetPicker()">
                 §5 Ease 角色
             </button>
+            <button class="motion-lab-tab"
+                    :class="{ active: tab === 'duration-buckets' }"
+                    @click="tab = 'duration-buckets'; onResetStaging(); onResetHero(); onResetPicker()">
+                §5 Duration Buckets
+            </button>
         </div>
     </div>
 
@@ -1402,6 +1407,14 @@
                 x-cloak
                 @click="onPlayEaseRoles($refs)">
             <i class="bi bi-play-fill"></i> Play Ease Roles
+        </button>
+
+        <!-- ===== §5 Duration Buckets 控制項 ===== -->
+        <button class="control-btn primary"
+                x-show="tab === 'duration-buckets'"
+                x-cloak
+                @click="onPlayDurationBuckets($refs)">
+            <i class="bi bi-play-fill"></i> Play Duration Buckets
         </button>
     </div>
 
@@ -2198,6 +2211,50 @@
             </div>
         </div>
 
+        <!-- ===== §5 Duration Buckets 並排對比 ===== -->
+        <div x-show="tab === 'duration-buckets'" x-cloak class="duration-buckets-panel">
+            <h5 class="duration-buckets-title">§5 Duration Buckets 對比</h5>
+            <p class="duration-buckets-desc">四個 box 同時播放相同 ease（fluent standard），只改 duration，直觀看時長差異</p>
+            <div class="duration-buckets-track">
+                <div class="duration-bucket-item">
+                    <div class="duration-bucket-label">
+                        <span class="duration-bucket-name">fast 167ms</span>
+                        <code class="duration-bucket-code">DURATION.fast</code>
+                    </div>
+                    <div class="duration-bucket-lane">
+                        <div class="duration-bucket-box" x-ref="durBox0"></div>
+                    </div>
+                </div>
+                <div class="duration-bucket-item">
+                    <div class="duration-bucket-label">
+                        <span class="duration-bucket-name">medium 333ms</span>
+                        <code class="duration-bucket-code">DURATION.medium</code>
+                    </div>
+                    <div class="duration-bucket-lane">
+                        <div class="duration-bucket-box" x-ref="durBox1"></div>
+                    </div>
+                </div>
+                <div class="duration-bucket-item">
+                    <div class="duration-bucket-label">
+                        <span class="duration-bucket-name">emphasis 500ms</span>
+                        <code class="duration-bucket-code">DURATION.emphasis</code>
+                    </div>
+                    <div class="duration-bucket-lane">
+                        <div class="duration-bucket-box" x-ref="durBox2"></div>
+                    </div>
+                </div>
+                <div class="duration-bucket-item">
+                    <div class="duration-bucket-label">
+                        <span class="duration-bucket-name">slow 300ms (legacy)</span>
+                        <code class="duration-bucket-code">0.3</code>
+                    </div>
+                    <div class="duration-bucket-lane">
+                        <div class="duration-bucket-box" x-ref="durBox3"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div>
 
 </div>
@@ -2562,6 +2619,87 @@
     top: 50%;
     transform: translateY(-50%);
     width: 80px;
+    height: 48px;
+    background: var(--accent-secondary);
+    border-radius: var(--fluent-radius-md);
+    opacity: 0.85;
+}
+
+/* ===== §5 Duration Buckets 並排對比面板 ===== */
+.duration-buckets-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 2rem 1.5rem;
+    width: 100%;
+}
+
+.duration-buckets-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.duration-buckets-desc {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.duration-buckets-track {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: min(640px, 90vw);
+}
+
+.duration-bucket-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.duration-bucket-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 200px;
+}
+
+.duration-bucket-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.duration-bucket-code {
+    font-size: 0.75rem;
+    color: var(--accent-primary);
+    background: var(--surface-1);
+    border-radius: var(--fluent-radius-sm);
+    padding: 0.1rem 0.35rem;
+    width: fit-content;
+}
+
+.duration-bucket-lane {
+    flex: 1;
+    height: 80px;
+    background: var(--surface-1);
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--stroke-subtle);
+}
+
+.duration-bucket-box {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 60px;
     height: 48px;
     background: var(--accent-secondary);
     border-radius: var(--fluent-radius-md);

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -603,8 +603,8 @@
     border: 1px solid rgba(255,255,255,0.4);
     border-radius: 50%;
     background: rgba(255,255,255,0.15);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: white;
     font-size: 1.125rem;
     cursor: pointer;
@@ -2223,8 +2223,8 @@
     border: none;
     border-radius: 50%;
     background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: var(--text-inverse, #fff);
     font-size: 1rem;
     cursor: default;
@@ -2262,8 +2262,8 @@
     font-size: 0.7rem;
     padding: 3px 8px;
     border-radius: 4px;
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
 }
 
 /* Metadata 區（模擬 .lightbox-metadata） */
@@ -2388,8 +2388,8 @@
     top: 1.5rem;       /* lightbox padding 對應，視覺上貼齊封面左上角 */
     left: 1.5rem;
     background: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: #fff;
     padding: 4px 12px;
     border-radius: 4px;

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -55,7 +55,7 @@
     font-weight: 500;
     border: 1px solid transparent;
     cursor: pointer;
-    transition: all 0.15s;
+    transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
 }
 
 .motion-lab-tab.active {
@@ -148,7 +148,7 @@
     background: var(--bg-primary);
     color: var(--text-primary);
     cursor: pointer;
-    transition: all 0.15s;
+    transition: all var(--fluent-duration-fast) var(--fluent-ease-standard);
     white-space: nowrap;
 }
 
@@ -248,7 +248,7 @@
     background: var(--bg-secondary);
     border: 1px solid var(--border-light);
     cursor: pointer;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: transform var(--fluent-duration-fast) var(--fluent-ease-standard), box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
     position: relative;
 }
 
@@ -587,7 +587,7 @@
     justify-content: center;
     align-items: flex-end;
     padding-bottom: 20px;
-    gap: 12px;
+    gap: 12px; /* spacingM (12px Fluent layout) */
     background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
     opacity: 0;

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -766,6 +766,11 @@
                     @click="tab = 'duration-buckets'; onResetStaging(); onResetHero(); onResetPicker()">
                 §5 Duration Buckets
             </button>
+            <button class="motion-lab-tab"
+                    :class="{ active: tab === 'special-motion' }"
+                    @click="tab = 'special-motion'; onResetStaging(); onResetHero(); onResetPicker()">
+                §5 Special Motion 白名單
+            </button>
         </div>
     </div>
 
@@ -1415,6 +1420,38 @@
                 x-cloak
                 @click="onPlayDurationBuckets($refs)">
             <i class="bi bi-play-fill"></i> Play Duration Buckets
+        </button>
+
+        <!-- ===== §5 Special Motion 白名單控制項 ===== -->
+        <button class="control-btn primary"
+                x-show="tab === 'special-motion'"
+                x-cloak
+                @click="onPlayWhitelistBurstPicker($refs)">
+            <i class="bi bi-play-fill"></i> Play Burst Picker
+        </button>
+        <button class="control-btn primary"
+                x-show="tab === 'special-motion'"
+                x-cloak
+                @click="onPlayWhitelistStagingEntry($refs)">
+            <i class="bi bi-play-fill"></i> Play Staging Entry
+        </button>
+        <button class="control-btn primary"
+                x-show="tab === 'special-motion'"
+                x-cloak
+                @click="onPlayWhitelistCheckmark($refs)">
+            <i class="bi bi-play-fill"></i> Play Checkmark
+        </button>
+        <button class="control-btn primary"
+                x-show="tab === 'special-motion'"
+                x-cloak
+                @click="onPlayWhitelistShake($refs)">
+            <i class="bi bi-play-fill"></i> Play Shake
+        </button>
+        <button class="control-btn primary"
+                x-show="tab === 'special-motion'"
+                x-cloak
+                @click="onPlayWhitelistPulse($refs)">
+            <i class="bi bi-play-fill"></i> Play Pulse
         </button>
     </div>
 
@@ -2211,6 +2248,82 @@
             </div>
         </div>
 
+        <!-- ===== §5 Special Motion 白名單 demo ===== -->
+        <div x-show="tab === 'special-motion'" x-cloak class="special-motion-panel">
+            <h5 class="special-motion-title">§5 Special Motion 白名單</h5>
+            <p class="special-motion-desc">各條目獨立招牌動畫，ease 不走三角色，保留視覺個性</p>
+            <div class="special-motion-track">
+
+                <!-- 1. Burst Picker 候選卡彈出 -->
+                <div class="special-motion-item">
+                    <div class="special-motion-label">
+                        <span class="special-motion-name">Burst Picker 候選卡彈出</span>
+                        <code class="special-motion-ease">back.out(1.2~1.7)</code>
+                    </div>
+                    <div class="special-motion-stage">
+                        <div class="special-motion-box" x-ref="whitelistBurstPickerEl"></div>
+                    </div>
+                </div>
+
+                <!-- 2. Staging Card 進場 morph -->
+                <div class="special-motion-item">
+                    <div class="special-motion-label">
+                        <span class="special-motion-name">Staging Card 進場 morph</span>
+                        <code class="special-motion-ease">back.out(1.4) + 0.35s</code>
+                    </div>
+                    <div class="special-motion-stage">
+                        <div class="special-motion-box" x-ref="whitelistStagingEntryEl"></div>
+                    </div>
+                </div>
+
+                <!-- 3. playOrganizeSuccess checkmark -->
+                <div class="special-motion-item">
+                    <div class="special-motion-label">
+                        <span class="special-motion-name">playOrganizeSuccess checkmark</span>
+                        <code class="special-motion-ease">back.out(1.7) + 0.35s</code>
+                    </div>
+                    <div class="special-motion-stage">
+                        <div class="special-motion-checkmark" x-ref="whitelistCheckmarkEl">✓</div>
+                    </div>
+                </div>
+
+                <!-- 4. playOrganizeFail shake -->
+                <div class="special-motion-item">
+                    <div class="special-motion-label">
+                        <span class="special-motion-name">playOrganizeFail shake</span>
+                        <code class="special-motion-ease">power1.inOut + 0.08s yoyo×3</code>
+                    </div>
+                    <div class="special-motion-stage">
+                        <div class="special-motion-box" x-ref="whitelistShakeEl"></div>
+                    </div>
+                </div>
+
+                <!-- 5. SourcePulse micro feedback -->
+                <div class="special-motion-item">
+                    <div class="special-motion-label">
+                        <span class="special-motion-name">SourcePulse micro feedback</span>
+                        <code class="special-motion-ease">fluent yoyo 0.1s</code>
+                    </div>
+                    <div class="special-motion-stage">
+                        <div class="special-motion-dot" x-ref="whitelistPulseEl"></div>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- 跳過條目說明 -->
+            <div class="special-motion-skip-section">
+                <p class="whitelist-skip-note">以下條目因環境依賴無法在 motion-lab 建立獨立 demo：</p>
+                <ul class="whitelist-skip-list">
+                    <li><strong>Floating Hearts 粒子</strong>：依賴 Physics2D Plugin，見 picker tab</li>
+                    <li><strong>FLIP 排序洗牌</strong>：已有 showcase tab FLIP demo</li>
+                    <li><strong>Ghost Fly 飛行</strong>：已有 ghost-fly tab demo</li>
+                    <li><strong>playLightboxOpen 三段</strong>：依賴 ghost-fly 並行段，見 showcase lightbox</li>
+                    <li><strong>showcaseSettle 招牌 settle</strong>：已有 settle tab demo</li>
+                </ul>
+            </div>
+        </div>
+
         <!-- ===== §5 Duration Buckets 並排對比 ===== -->
         <div x-show="tab === 'duration-buckets'" x-cloak class="duration-buckets-panel">
             <h5 class="duration-buckets-title">§5 Duration Buckets 對比</h5>
@@ -2535,6 +2648,125 @@
 /* C21 配套：ghost-fly 飛行期間停用 cover-img CSS transition */
 .picker-cover-img.gsap-animating {
     transition: none !important;
+}
+
+/* ===== §5 Special Motion 白名單 demo 面板 ===== */
+.special-motion-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 2rem 1.5rem;
+    width: 100%;
+}
+
+.special-motion-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.special-motion-desc {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.special-motion-track {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: min(640px, 90vw);
+}
+
+.special-motion-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.special-motion-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 200px;
+}
+
+.special-motion-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.special-motion-ease {
+    font-size: 0.75rem;
+    color: var(--accent-primary);
+    background: var(--surface-1);
+    border-radius: var(--fluent-radius-sm);
+    padding: 0.1rem 0.35rem;
+    width: fit-content;
+}
+
+.special-motion-stage {
+    flex: 1;
+    height: 80px;
+    background: var(--surface-1);
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--stroke-subtle);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.special-motion-box {
+    width: 64px;
+    height: 48px;
+    background: var(--accent-secondary);
+    border-radius: var(--fluent-radius-md);
+    opacity: 0.85;
+}
+
+.special-motion-checkmark {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--color-success);
+    line-height: 1;
+}
+
+.special-motion-dot {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--accent-primary);
+    opacity: 0.9;
+}
+
+.special-motion-skip-section {
+    width: min(640px, 90vw);
+    padding: 1rem;
+    background: var(--surface-1);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--stroke-subtle);
+}
+
+.whitelist-skip-note {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+
+.whitelist-skip-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
 }
 
 /* ===== §5 Ease Roles 並排對比面板 ===== */

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -304,7 +304,7 @@
 
 .motion-lab-grid .av-card-preview:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--fluent-shadow-8);
 }
 
 .motion-lab-grid .av-card-preview-img {
@@ -609,7 +609,7 @@
     font-size: 1.125rem;
     cursor: pointer;
     display: flex; align-items: center; justify-content: center;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    box-shadow: var(--fluent-shadow-8);
     transition: background var(--duration-fast) var(--ease-out),
                 border-color var(--duration-fast) var(--ease-out),
                 transform var(--duration-fast) var(--ease-out),
@@ -619,7 +619,7 @@
     background: rgba(255,255,255,0.3);
     border-color: rgba(255,255,255,0.6);
     transform: scale(1.08);
-    box-shadow: 0 6px 16px rgba(0,0,0,0.4);
+    box-shadow: var(--fluent-shadow-16);
 }
 .css-anim-demos .lb-action-btn:active {
     transform: scale(0.95);

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -35,8 +35,8 @@
 .motion-lab-badge {
     font-size: 0.65rem;
     font-weight: 700;
-    background: #f59e0b;
-    color: #1c1c1e;
+    background: var(--color-warning);
+    color: var(--color-base-content);
     padding: 0.1rem 0.4rem;
     border-radius: var(--fluent-radius-md);
     letter-spacing: 0.05em;
@@ -60,7 +60,7 @@
 
 .motion-lab-tab.active {
     background: var(--accent-primary);
-    color: #fff;
+    color: oklch(100% 0 0);
     border-color: var(--accent-primary);
 }
 
@@ -154,7 +154,7 @@
 
 .control-btn:hover:not(:disabled) {
     background: var(--accent-primary);
-    color: #fff;
+    color: oklch(100% 0 0);
     border-color: var(--accent-primary);
 }
 
@@ -165,7 +165,7 @@
 
 .control-btn.primary {
     background: var(--accent-primary);
-    color: #fff;
+    color: oklch(100% 0 0);
     border-color: var(--accent-primary);
 }
 
@@ -174,13 +174,13 @@
 }
 
 .control-btn.danger {
-    border-color: #ef4444;
-    color: #ef4444;
+    border-color: var(--color-error);
+    color: var(--color-error);
 }
 
 .control-btn.danger:hover:not(:disabled) {
-    background: #ef4444;
-    color: #fff;
+    background: var(--color-error);
+    color: oklch(100% 0 0);
 }
 
 /* 預覽區 */
@@ -297,7 +297,7 @@
     font-size: 0.65rem;
     font-weight: 700;
     background: var(--accent-primary);
-    color: #fff;
+    color: oklch(100% 0 0);
     padding: 0.1rem 0.4rem;
     border-radius: var(--fluent-radius-md);
 }
@@ -2269,7 +2269,7 @@
     top: 8px;
     right: 8px;
     background: rgba(0, 0, 0, 0.65);
-    color: #fff;
+    color: oklch(100% 0 0);
     font-size: 0.7rem;
     padding: 3px 8px;
     border-radius: var(--fluent-radius-md);
@@ -2343,7 +2343,7 @@
     left: 0;
     right: 0;
     background: rgba(0, 0, 0, 0.65);
-    color: #fff;
+    color: oklch(100% 0 0);
     font-size: 0.65rem;
     text-align: center;
     padding: 2px 4px;
@@ -2358,8 +2358,8 @@
     transition: opacity 0.15s;
 }
 .picker-candidate-card:hover .picker-source-badge {
-    background: var(--accent-success, #22c55e);
-    color: #fff;
+    background: var(--color-success);
+    color: oklch(100% 0 0);
 }
 .picker-candidate-card:hover .picker-check-icon {
     opacity: 1;
@@ -2401,7 +2401,7 @@
     background: rgba(0, 0, 0, 0.5);
     backdrop-filter: blur(var(--fluent-blur-light));
     -webkit-backdrop-filter: blur(var(--fluent-blur-light));
-    color: #fff;
+    color: oklch(100% 0 0);
     padding: 4px 12px;
     border-radius: var(--fluent-radius-md);
     z-index: 10;

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -591,7 +591,7 @@
     background: linear-gradient(to top, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
     border-radius: 0 0 var(--radius-sm) var(--radius-sm);
     opacity: 0;
-    transition: opacity var(--duration-fast) var(--ease-out);
+    transition: opacity var(--fluent-duration-fast) var(--fluent-ease-decel);
 }
 .css-anim-demos .lightbox-cover:hover .cover-actions,
 .css-anim-demos .lightbox-cover:focus-within .cover-actions {
@@ -610,10 +610,10 @@
     cursor: pointer;
     display: flex; align-items: center; justify-content: center;
     box-shadow: var(--fluent-shadow-8);
-    transition: background var(--duration-fast) var(--ease-out),
-                border-color var(--duration-fast) var(--ease-out),
-                transform var(--duration-fast) var(--ease-out),
-                box-shadow var(--duration-fast) var(--ease-out);
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-decel),
+                border-color var(--fluent-duration-fast) var(--fluent-ease-decel),
+                transform var(--fluent-duration-fast) var(--fluent-ease-decel),
+                box-shadow var(--fluent-duration-fast) var(--fluent-ease-decel);
 }
 .css-anim-demos .lb-action-btn:hover {
     background: rgba(255,255,255,0.3);
@@ -638,7 +638,7 @@
     border-radius: var(--radius-sm);
     pointer-events: none;
     opacity: 0;
-    transition: opacity var(--duration-fast) var(--ease-out);
+    transition: opacity var(--fluent-duration-fast) var(--fluent-ease-decel);
 }
 .css-anim-demos .lb-action-btn[data-tooltip]:hover::after,
 .css-anim-demos .lb-action-btn[data-tooltip]:focus-visible::after {
@@ -674,8 +674,8 @@
     color: var(--text-secondary);
     text-decoration: none;
     border-radius: var(--radius-sm);
-    transition: background var(--duration-fast) var(--ease-out),
-                color var(--duration-fast) var(--ease-out);
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-decel),
+                color var(--fluent-duration-fast) var(--fluent-ease-decel);
     white-space: nowrap;
 }
 .css-anim-demos .dropdown-item:hover {

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -756,6 +756,11 @@
                     @click="tab = 'picker'; onResetStaging(); onResetHero()">
                 Photo Picker
             </button>
+            <button class="motion-lab-tab"
+                    :class="{ active: tab === 'ease-roles' }"
+                    @click="tab = 'ease-roles'; onResetStaging(); onResetHero(); onResetPicker()">
+                §5 Ease 角色
+            </button>
         </div>
     </div>
 
@@ -811,10 +816,13 @@
         <div class="control-group">
             <span class="control-label">Ease</span>
             <select class="control-select" x-model="params.easing">
-                <option value="back.out(1.2)">back.out(1.2)</option>
-                <option value="power3.out">power3.out</option>
-                <option value="elastic.out(1,0.3)">elastic.out(1,0.3)</option>
-                <option value="power2.inOut">power2.inOut</option>
+                <option value="fluent">fluent（standard，互動）</option>
+                <option value="fluent-decel">fluent-decel（enter，進場）</option>
+                <option value="fluent-accel">fluent-accel（exit，離場）</option>
+                <option value="back.out(1.2)">back.out(1.2)（pre-charter，已禁用）</option>
+                <option value="power3.out">power3.out（pre-charter，已禁用）</option>
+                <option value="elastic.out(1,0.3)">elastic.out(1,0.3)（pre-charter，已禁用）</option>
+                <option value="power2.inOut">power2.inOut（pre-charter；白名單：Burst Picker FLIP）</option>
                 <option value="none">none</option>
             </select>
         </div>
@@ -1385,6 +1393,16 @@
                    x-model.number="pickerParams.streamInterval">
             <span class="control-value" x-text="pickerParams.streamInterval + 'ms'"></span>
         </div>
+
+        <!-- ===== §5 Ease Roles 控制項 ===== -->
+        <div class="control-divider"></div>
+
+        <button class="control-btn primary"
+                x-show="tab === 'ease-roles'"
+                x-cloak
+                @click="onPlayEaseRoles($refs)">
+            <i class="bi bi-play-fill"></i> Play Ease Roles
+        </button>
     </div>
 
     <!-- 預覽區 -->
@@ -2142,6 +2160,44 @@
             </div>
         </div>
 
+        <!-- ===== §5 Ease Roles 並排對比 ===== -->
+        <div x-show="tab === 'ease-roles'" x-cloak class="ease-roles-panel">
+            <h5 class="ease-roles-title">§5 Ease 角色對比</h5>
+            <p class="ease-roles-desc">三條曲線同步播放，Standard S 曲線 ／ Enter 慢起快停 ／ Exit 快起慢停</p>
+            <div class="ease-roles-track">
+                <div class="ease-role-item">
+                    <div class="ease-role-label">
+                        <span class="ease-role-name">Standard</span>
+                        <code class="ease-role-code">fluent</code>
+                        <code class="ease-role-bezier">cubic-bezier(0.33, 0, 0.67, 1)</code>
+                    </div>
+                    <div class="ease-role-lane">
+                        <div class="ease-role-box" x-ref="easeBox0"></div>
+                    </div>
+                </div>
+                <div class="ease-role-item">
+                    <div class="ease-role-label">
+                        <span class="ease-role-name">Enter（進場）</span>
+                        <code class="ease-role-code">fluent-decel</code>
+                        <code class="ease-role-bezier">cubic-bezier(0, 0, 0, 1)</code>
+                    </div>
+                    <div class="ease-role-lane">
+                        <div class="ease-role-box" x-ref="easeBox1"></div>
+                    </div>
+                </div>
+                <div class="ease-role-item">
+                    <div class="ease-role-label">
+                        <span class="ease-role-name">Exit（離場）</span>
+                        <code class="ease-role-code">fluent-accel</code>
+                        <code class="ease-role-bezier">cubic-bezier(1, 0, 1, 1)</code>
+                    </div>
+                    <div class="ease-role-lane">
+                        <div class="ease-role-box" x-ref="easeBox2"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div>
 
 </div>
@@ -2422,6 +2478,94 @@
 /* C21 配套：ghost-fly 飛行期間停用 cover-img CSS transition */
 .picker-cover-img.gsap-animating {
     transition: none !important;
+}
+
+/* ===== §5 Ease Roles 並排對比面板 ===== */
+.ease-roles-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 2rem 1.5rem;
+    width: 100%;
+}
+
+.ease-roles-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.ease-roles-desc {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-align: center;
+}
+
+.ease-roles-track {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: min(640px, 90vw);
+}
+
+.ease-role-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.ease-role-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 200px;
+}
+
+.ease-role-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.ease-role-code {
+    font-size: 0.75rem;
+    color: var(--accent-primary);
+    background: var(--surface-1);
+    border-radius: var(--fluent-radius-sm);
+    padding: 0.1rem 0.35rem;
+    width: fit-content;
+}
+
+.ease-role-bezier {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    background: transparent;
+    padding: 0;
+}
+
+.ease-role-lane {
+    flex: 1;
+    height: 80px;
+    background: var(--surface-1);
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--stroke-subtle);
+}
+
+.ease-role-box {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 80px;
+    height: 48px;
+    background: var(--accent-secondary);
+    border-radius: var(--fluent-radius-md);
+    opacity: 0.85;
 }
 
 </style>

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -38,7 +38,7 @@
     background: #f59e0b;
     color: #1c1c1e;
     padding: 0.1rem 0.4rem;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     letter-spacing: 0.05em;
     text-transform: uppercase;
 }
@@ -50,7 +50,7 @@
 
 .motion-lab-tab {
     padding: 0.35rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--fluent-radius-lg);
     font-size: 0.8rem;
     font-weight: 500;
     border: 1px solid transparent;
@@ -120,7 +120,7 @@
 .control-select {
     font-size: 0.75rem;
     padding: 0.2rem 0.4rem;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     border: 1px solid var(--border-light);
     background: var(--bg-primary);
     color: var(--text-primary);
@@ -143,7 +143,7 @@
     padding: 0.3rem 0.65rem;
     font-size: 0.75rem;
     font-weight: 500;
-    border-radius: 5px;
+    border-radius: var(--fluent-radius-md);
     border: 1px solid var(--border-light);
     background: var(--bg-primary);
     color: var(--text-primary);
@@ -201,7 +201,7 @@
     height: 44px;
     background: var(--bg-secondary);
     border: 1px solid var(--border-light);
-    border-radius: 10px;
+    border-radius: var(--radius-md);
     display: flex;
     align-items: center;
     padding: 0 1rem;
@@ -243,7 +243,7 @@
 
 /* av-card-preview 與 search 頁保持一致結構 */
 .motion-lab-grid .av-card-preview {
-    border-radius: 8px;
+    border-radius: var(--fluent-radius-xl);
     overflow: hidden;
     background: var(--bg-secondary);
     border: 1px solid var(--border-light);
@@ -265,7 +265,7 @@
 .staging-anchor .av-card-preview {
     min-width: 280px;
     position: relative;
-    border-radius: 8px;
+    border-radius: var(--fluent-radius-xl);
     background: var(--bg-secondary);
     border: 1px solid var(--border-light);
     pointer-events: auto;   /* staging card 本身可正常互動與動畫渲染 */
@@ -299,7 +299,7 @@
     background: var(--accent-primary);
     color: #fff;
     padding: 0.1rem 0.4rem;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
 }
 
 .motion-lab-grid .av-card-preview:hover {
@@ -1476,8 +1476,7 @@
              x-show="tab === 'staging' && stagingOverlayVisible">
             <div class="av-card-preview rotating-border-spotlight"
                  :class="{ active: stagingRunning && !params.reducedMotionSim }"
-                 x-ref="stagingCard"
-                 style="border-radius: 8px;">
+                 x-ref="stagingCard">
                 <div class="av-card-preview-img">
                     <img x-ref="stagingImg"
                          :src="stagingCurrentCover || ''"
@@ -1930,7 +1929,7 @@
             <!-- Demo 2: Cover-Actions Reveal -->
             <div>
                 <h5 style="color: var(--text-primary); font-weight: 600; margin: 0 0 1rem;">Cover-Actions Reveal — Gradient Overlay + Glass Buttons</h5>
-                <div class="lightbox-cover" style="position: relative; width: 280px; aspect-ratio: 3/2; overflow: hidden; border-radius: 8px; background: #444; cursor: pointer; display: block;">
+                <div class="lightbox-cover css-anim-cover-mock">
                     <div style="width: 100%; height: 100%; background: linear-gradient(135deg, #3a3a4a 0%, #555566 50%, #3a3a4a 100%);"></div>
                     <div class="cover-actions">
                         <button class="lb-action-btn" data-tooltip="返回詳情" type="button">
@@ -2153,6 +2152,18 @@
     to { transform: rotate(360deg); }
 }
 
+/* Cover-Actions Reveal demo mock cover（T1.5.3：inline style → class） */
+.css-anim-cover-mock {
+    position: relative;
+    width: 280px;
+    aspect-ratio: 3/2;
+    overflow: hidden;
+    border-radius: var(--fluent-radius-xl);
+    background: var(--color-base-300);
+    cursor: pointer;
+    display: block;
+}
+
 /* Stream-in Skeleton */
 .skeleton-cover {
     width: 100%;
@@ -2180,7 +2191,7 @@
 /* Hero Slot: hero-card 邊框提示 */
 .hero-card {
     border: 2px solid var(--accent-primary);
-    border-radius: 8px;
+    border-radius: var(--fluent-radius-xl);
 }
 
 .hero-card .av-card-preview-footer {
@@ -2261,7 +2272,7 @@
     color: #fff;
     font-size: 0.7rem;
     padding: 3px 8px;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     backdrop-filter: blur(var(--fluent-blur-light));
     -webkit-backdrop-filter: blur(var(--fluent-blur-light));
 }
@@ -2306,7 +2317,7 @@
     width: 100px;
     flex: 0 0 100px;  /* fix3: 防止 flex container 把 6 卡 shrink 到 lightbox 寬度（Codex P1）*/
     cursor: pointer;
-    border-radius: 6px;
+    border-radius: var(--fluent-radius-lg);
     overflow: hidden;
     border: 1px solid var(--border-primary, var(--stroke-default));
     will-change: transform;
@@ -2392,7 +2403,7 @@
     -webkit-backdrop-filter: blur(var(--fluent-blur-light));
     color: #fff;
     padding: 4px 12px;
-    border-radius: 4px;
+    border-radius: var(--fluent-radius-md);
     z-index: 10;
     pointer-events: none;
 }

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -59,9 +59,9 @@
 }
 
 .motion-lab-tab.active {
-    background: var(--accent-primary);
+    background: var(--accent-secondary);
     color: oklch(100% 0 0);
-    border-color: var(--accent-primary);
+    border-color: var(--accent-secondary);
 }
 
 .motion-lab-tab:not(.active):not(:disabled) {
@@ -106,14 +106,14 @@
 .control-value {
     font-size: 0.75rem;
     font-weight: 600;
-    color: var(--accent-primary);
+    color: var(--accent-secondary);
     min-width: 2.5rem;
     text-align: right;
 }
 
 .control-slider {
     width: 100px;
-    accent-color: var(--accent-primary);
+    accent-color: var(--accent-secondary);
     cursor: pointer;
 }
 
@@ -128,7 +128,7 @@
 }
 
 .control-checkbox {
-    accent-color: var(--accent-primary);
+    accent-color: var(--accent-secondary);
     cursor: pointer;
 }
 
@@ -153,9 +153,9 @@
 }
 
 .control-btn:hover:not(:disabled) {
-    background: var(--accent-primary);
+    background: var(--accent-secondary);
     color: oklch(100% 0 0);
-    border-color: var(--accent-primary);
+    border-color: var(--accent-secondary);
 }
 
 .control-btn:disabled {
@@ -164,9 +164,9 @@
 }
 
 .control-btn.primary {
-    background: var(--accent-primary);
+    background: var(--accent-secondary);
     color: oklch(100% 0 0);
-    border-color: var(--accent-primary);
+    border-color: var(--accent-secondary);
 }
 
 .control-btn.primary:hover:not(:disabled) {
@@ -296,7 +296,7 @@
 .staging-counter-badge {
     font-size: 0.65rem;
     font-weight: 700;
-    background: var(--accent-primary);
+    background: var(--accent-secondary);
     color: oklch(100% 0 0);
     padding: 0.1rem 0.4rem;
     border-radius: var(--fluent-radius-md);
@@ -2317,7 +2317,7 @@
                 <ul class="whitelist-skip-list">
                     <li><strong>Floating Hearts 粒子</strong>：依賴 Physics2D Plugin，見 picker tab</li>
                     <li><strong>FLIP 排序洗牌</strong>：已有 showcase tab FLIP demo</li>
-                    <li><strong>Ghost Fly 飛行</strong>：已有 ghost-fly tab demo</li>
+                    <li><strong>Ghost Fly 飛行</strong>：見 Showcase tab lightbox 互動 demo</li>
                     <li><strong>playLightboxOpen 三段</strong>：依賴 ghost-fly 並行段，見 showcase lightbox</li>
                     <li><strong>showcaseSettle 招牌 settle</strong>：已有 settle tab demo</li>
                 </ul>
@@ -2416,12 +2416,12 @@
 
 /* Hero Slot: hero-card 邊框提示 */
 .hero-card {
-    border: 2px solid var(--accent-primary);
+    border: 2px solid var(--accent-secondary);
     border-radius: var(--fluent-radius-xl);
 }
 
 .hero-card .av-card-preview-footer {
-    background: color-mix(in srgb, var(--accent-primary) 15%, transparent);
+    background: color-mix(in srgb, var(--accent-secondary) 15%, transparent);
 }
 
 /* ===== Photo Picker Burst 樣式 — 模擬 actress lightbox 形式 ===== */
@@ -2702,7 +2702,7 @@
 
 .special-motion-ease {
     font-size: 0.75rem;
-    color: var(--accent-primary);
+    color: var(--accent-secondary);
     background: var(--surface-1);
     border-radius: var(--fluent-radius-sm);
     padding: 0.1rem 0.35rem;
@@ -2741,7 +2741,7 @@
     width: 24px;
     height: 24px;
     border-radius: 50%;
-    background: var(--accent-primary);
+    background: var(--accent-secondary);
     opacity: 0.9;
 }
 
@@ -2821,7 +2821,7 @@
 
 .ease-role-code {
     font-size: 0.75rem;
-    color: var(--accent-primary);
+    color: var(--accent-secondary);
     background: var(--surface-1);
     border-radius: var(--fluent-radius-sm);
     padding: 0.1rem 0.35rem;
@@ -2909,7 +2909,7 @@
 
 .duration-bucket-code {
     font-size: 0.75rem;
-    color: var(--accent-primary);
+    color: var(--accent-secondary);
     background: var(--surface-1);
     border-radius: var(--fluent-radius-sm);
     padding: 0.1rem 0.35rem;

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -12,7 +12,7 @@
      @dragleave.document="handleDragLeave($event)"
      @dragover.document.prevent
      @drop.document.prevent="handleDrop($event)"
-     @keydown.escape.window="dirtyCheckModalOpen && dirtyCheckCancel(); missingConfirmModalOpen && cancelLargeMissingEnrich();">
+     @keydown.escape.window="dirtyCheckModalOpen && dirtyCheckCancel(); missingConfirmModalOpen && cancelLargeMissingEnrich(); deleteAliasGroupModalOpen && cancelDeleteAliasGroupModal();">
     <!-- Drag Overlay (must be inside x-data scope) -->
     <div class="drag-overlay" id="dragOverlay" x-show="showDragOverlay" x-transition.opacity>
         <div class="drag-overlay-content">
@@ -423,6 +423,33 @@
                     <span x-show="clearCacheLoading" class="loading loading-spinner loading-xs"></span>
                     <span x-show="!clearCacheLoading"><i class="bi bi-trash3"></i></span>
                     {{ t('scanner.clear_cache_modal.confirm') }}
+                </button>
+            </div>
+        </div>
+    </dialog>
+
+    <!-- TASK-52.3.5: Delete Alias Group Confirm Modal -->
+    <dialog class="modal fluent-modal"
+            :class="{ 'modal-open': deleteAliasGroupModalOpen }"
+            @click.self="cancelDeleteAliasGroupModal()">
+        <div class="modal-box fluent-modal-box">
+            <h3 class="fluent-modal-title">
+                <i class="bi bi-exclamation-triangle text-warning"></i>
+                {{ t('scanner.alias.delete_group_modal.title') }}
+            </h3>
+            <p class="fluent-modal-body"
+               x-text="window.t('scanner.alias.delete_group_modal.body').replace('{name}', _pendingDeleteAliasGroupName || '')">
+            </p>
+            <div class="modal-action fluent-modal-actions">
+                <button type="button" class="btn btn-ghost" @click="cancelDeleteAliasGroupModal()">
+                    {{ t('scanner.alias.delete_group_modal.cancel') }}
+                </button>
+                <button type="button" class="btn btn-error"
+                        @click="confirmDeleteAliasGroup()"
+                        :disabled="_deleteAliasGroupLoading">
+                    <span x-show="_deleteAliasGroupLoading" class="loading loading-spinner loading-xs"></span>
+                    <span x-show="!_deleteAliasGroupLoading"><i class="bi bi-trash3"></i></span>
+                    {{ t('scanner.alias.delete_group_modal.confirm') }}
                 </button>
             </div>
         </div>

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -12,7 +12,7 @@
      @dragleave.document="handleDragLeave($event)"
      @dragover.document.prevent
      @drop.document.prevent="handleDrop($event)"
-     @keydown.escape.window="dirtyCheckModalOpen && dirtyCheckCancel(); missingConfirmModalOpen && cancelLargeMissingEnrich(); deleteAliasGroupModalOpen && cancelDeleteAliasGroupModal();">
+     @keydown.escape.window="dirtyCheckModalOpen && dirtyCheckCancel(); missingConfirmModalOpen && cancelLargeMissingEnrich(); deleteAliasGroupModalOpen && cancelDeleteAliasGroupModal(); copyFailModalOpen && closeCopyFailModal();">
     <!-- Drag Overlay (must be inside x-data scope) -->
     <div class="drag-overlay" id="dragOverlay" x-show="showDragOverlay" x-transition.opacity>
         <div class="drag-overlay-content">
@@ -450,6 +450,25 @@
                     <span x-show="_deleteAliasGroupLoading" class="loading loading-spinner loading-xs"></span>
                     <span x-show="!_deleteAliasGroupLoading"><i class="bi bi-trash3"></i></span>
                     {{ t('scanner.alias.delete_group_modal.confirm') }}
+                </button>
+            </div>
+        </div>
+    </dialog>
+
+    <!-- TASK-52.3.6: Copy Logs Fail Modal (clipboard fail fallback) -->
+    <dialog class="modal fluent-modal"
+            :class="{ 'modal-open': copyFailModalOpen }"
+            @click.self="closeCopyFailModal()">
+        <div class="modal-box fluent-modal-box">
+            <h3 class="fluent-modal-title">
+                <i class="bi bi-exclamation-triangle text-warning"></i>
+                {{ t('scanner.copy_fail_modal.title') }}
+            </h3>
+            <p class="fluent-modal-body">{{ t('scanner.copy_fail_modal.body') }}</p>
+            <pre class="copy-fail-pre" x-text="copyFailDump"></pre>
+            <div class="modal-action fluent-modal-actions">
+                <button type="button" class="btn btn-ghost" @click="closeCopyFailModal()">
+                    {{ t('scanner.copy_fail_modal.close') }}
                 </button>
             </div>
         </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -753,6 +753,34 @@
         </div>
     </dialog>
 
+    <!-- TASK-52.3.4: Reset Config Confirm Modal -->
+    <dialog class="modal fluent-modal"
+            :class="{ 'modal-open': resetConfigModalOpen }"
+            @click.self="cancelResetConfigModal()"
+            @keydown.escape.window="resetConfigModalOpen && cancelResetConfigModal()">
+        <div class="modal-box fluent-modal-box">
+            <h3 class="fluent-modal-title">
+                <i class="bi bi-exclamation-triangle text-warning"></i>
+                {{ t('settings.reset_modal.title') }}
+            </h3>
+            <p class="fluent-modal-body">
+                {{ t('settings.reset_modal.body') }}
+            </p>
+            <div class="modal-action fluent-modal-actions">
+                <button type="button" class="btn btn-ghost" @click="cancelResetConfigModal()">
+                    {{ t('common.action.cancel') }}
+                </button>
+                <button type="button" class="btn btn-error"
+                        @click="confirmResetConfig()"
+                        :disabled="_resetConfigLoading">
+                    <span x-show="_resetConfigLoading" class="loading loading-spinner loading-xs"></span>
+                    <span x-show="!_resetConfigLoading"><i class="bi bi-arrow-counterclockwise"></i></span>
+                    {{ t('settings.reset_modal.confirm') }}
+                </button>
+            </div>
+        </div>
+    </dialog>
+
 <!-- Toast 容器（Alpine controlled）-->
 <div class="toast toast-end toast-top z-[9999]" x-show="_toast.visible" x-cloak x-transition>
     <div class="alert" :class="`alert-${_toast.type}`">

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -548,7 +548,7 @@
                                 </button>
                                 <button class="lb-action-btn lb-action-btn--danger"
                                         x-show="showFavoriteActresses"
-                                        @click.stop="removeActress()"
+                                        @click.stop="openRemoveActressModal()"
                                         :data-tooltip="t('showcase.actress.remove')"
                                         :aria-label="t('showcase.actress.remove')">
                                     <i class="bi bi-trash"></i>
@@ -882,6 +882,36 @@
     </div>
 
     </div>
+
+    <!-- TASK-52.3.3: Remove Actress Confirm Modal（取代原 window.confirm）
+         Esc 雙重防線：handleKeydown 入口攔截 + dialog 自身 @keydown.escape.window 冗餘
+         backdrop click 走 cancelRemoveActressModal() 統一三 dismiss 路徑 -->
+    <dialog class="modal fluent-modal"
+            :class="{ 'modal-open': removeActressModalOpen }"
+            @click.self="cancelRemoveActressModal()"
+            @keydown.escape.window="removeActressModalOpen && cancelRemoveActressModal()">
+        <div class="modal-box fluent-modal-box">
+            <h3 class="fluent-modal-title">
+                <i class="bi bi-exclamation-triangle text-warning"></i>
+                {{ t('showcase.actress.remove_modal.title') }}
+            </h3>
+            <p class="fluent-modal-body"
+               x-text="t('showcase.actress.remove_modal.body').replace('{name}', _pendingRemoveActressName || '')">
+            </p>
+            <div class="modal-action fluent-modal-actions">
+                <button type="button" class="btn btn-ghost" @click="cancelRemoveActressModal()">
+                    {{ t('showcase.actress.remove_modal.cancel') }}
+                </button>
+                <button type="button" class="btn btn-error"
+                        @click="confirmRemoveActress()"
+                        :disabled="_removeActressLoading">
+                    <span x-show="_removeActressLoading" class="loading loading-spinner loading-xs"></span>
+                    <span x-show="!_removeActressLoading"><i class="bi bi-trash3"></i></span>
+                    {{ t('showcase.actress.remove_modal.confirm') }}
+                </button>
+            </div>
+        </div>
+    </dialog>
 
     <!-- Toast (M3h) -->
     <div class="toast toast-bottom toast-center fluent-toast-container"

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -107,7 +107,7 @@
                     <!-- 排序 -->
                     <div class="toolbar-dropdown-wrap" @click.outside="sortOpen = false">
                         <button class="btn-icon"
-                                @click="sortOpen = !sortOpen; modeOpen = false; perPageOpen = false"
+                                @click="sortOpen = !sortOpen; modeOpen = false"
                                 :title="t('showcase.toolbar.sort_prefix') + ': ' + sort"
                                 :class="{ 'active': sortOpen }">
                             <i class="bi bi-funnel"></i>
@@ -145,7 +145,7 @@
                     <!-- 顯示模式 -->
                     <div class="toolbar-dropdown-wrap" @click.outside="modeOpen = false">
                         <button class="btn-icon"
-                                @click="modeOpen = !modeOpen; sortOpen = false; perPageOpen = false"
+                                @click="modeOpen = !modeOpen; sortOpen = false"
                                 :title="t('showcase.toolbar.mode_prefix') + ': ' + (mode === 'grid' ? t('showcase.mode.grid') : mode === 'table' ? t('showcase.mode.table') : t('showcase.mode.list'))"
                                 :class="{ 'active': modeOpen }">
                             <i class="bi" :class="mode === 'grid' ? 'bi-grid-3x3' : mode === 'table' ? 'bi-table' : 'bi-list-ul'"></i>
@@ -170,30 +170,6 @@
                             title="{{ t('showcase.action.toggle_info') }}">
                         <i class="bi bi-eye"></i>
                     </button>
-                    <!-- 每頁數量 -->
-                    <div class="toolbar-dropdown-wrap" @click.outside="perPageOpen = false">
-                        <button class="btn-icon"
-                                @click="perPageOpen = !perPageOpen; sortOpen = false; modeOpen = false"
-                                :title="t('showcase.toolbar.per_page_prefix') + ': ' + (perPage == 0 ? t('showcase.per_page.all') : perPage + ' ' + t('showcase.unit.videos'))"
-                                :class="{ 'active': perPageOpen }">
-                            <i class="bi bi-list-nested"></i>
-                        </button>
-                        <div class="toolbar-dropdown" x-show="perPageOpen" x-transition.opacity.duration.150ms @click.stop>
-                            <a href="#" class="dropdown-item" :class="{ 'active': perPage == 30 }"
-                               @click.prevent="perPage = 30; onPerPageChange(); perPageOpen = false">30 {{ t('showcase.unit.videos') }}</a>
-                            <a href="#" class="dropdown-item" :class="{ 'active': perPage == 45 }"
-                               @click.prevent="perPage = 45; onPerPageChange(); perPageOpen = false">45 {{ t('showcase.unit.videos') }}</a>
-                            <a href="#" class="dropdown-item" :class="{ 'active': perPage == 60 }"
-                               @click.prevent="perPage = 60; onPerPageChange(); perPageOpen = false">60 {{ t('showcase.unit.videos') }}</a>
-                            <a href="#" class="dropdown-item" :class="{ 'active': perPage == 90 }"
-                               @click.prevent="perPage = 90; onPerPageChange(); perPageOpen = false">90 {{ t('showcase.unit.videos') }}</a>
-                            <a href="#" class="dropdown-item" :class="{ 'active': perPage == 120 }"
-                               @click.prevent="perPage = 120; onPerPageChange(); perPageOpen = false">120 {{ t('showcase.unit.videos') }}</a>
-                            <a href="#" class="dropdown-item"
-                               :class="{ 'active': perPage == 0, 'disabled pointer-events-none opacity-40': mode === 'grid' }"
-                               @click.prevent="if (mode !== 'grid') { perPage = 0; onPerPageChange(); perPageOpen = false }">{{ t('showcase.per_page.all') }}</a>
-                        </div>
-                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Phase 52 完成 ui-conventions 全頁覆蓋 + soul-alignment cleanup：

- **Phase 1**：5 utility/demo 頁（scanner / settings / help / design-system / motion-lab）§1-§4 + §6 5 檢查點靜態修齊；design-system 補 §1-§6 規則 demo
- **Phase 2**：motion-lab 補 §5 三角色 ease + Duration 三 bucket + Special 白名單 demo
- **Phase 3**：Soul cleanup — Showcase toolbar per-page 移除（Settings 唯一真理來源）/ 4 處原生 `confirm()` → fluent-modal + i18n / 15 處 `alert()` → showToast + i18n / scanner copyLogs 失敗 dump → fluent-modal `<pre>` 可選取（取代 truncate 500 字）

## Pre-merge 檢查

- ✅ 全套測試 **2811 passed** / 4:51（zh_CN/ja/en 各缺 25 keys 為 i18n.md 開發期規則預期，milestone 階段同步）
- ✅ 敏感掃描 clean
- ✅ 打包 COPY_ITEMS 覆蓋足夠（無新頂層目錄）
- ✅ Capabilities 不需同步（Phase 52 純 UI/CSS/i18n，無 routers 改動）
- ✅ 測試增量無重複 / 無漏 / 守衛強度足

## 主要 commits（17 commits）

**Phase 1（5 頁靜態修齊 + lint guard）**：13 commits（3ce4c7f 起）
**Phase 2（motion-lab demo）**：3 commits（1fd4fd4 / 41b7751 / 5dbcc82）
**Phase 3（soul cleanup）**：5 必入 + 3 codex fix
- 6201b91 T3.2 toolbar perPage 移除
- 4b784fe T3.3 removeActress modal
- ee37b37 T3.4 resetConfig modal
- 0d195bc T3.2 P2: items_per_page \`??\` (保留 numeric 0)
- 492d650 T3.5 deleteAliasGroup modal
- f2d2b67 T3.6 15 處 alert → toast（含 copyLogs fail modal）
- 37db4bd T3.6 P2: clipboard availability guard（scanner ×2）
- 397a412 T3.7: clipboard guard sweep（result-card / showcase + 通用 lint）
- b0f6a2a chore(0.8.2) version + CHANGELOG

## 行為變化（用戶可感知）

- Showcase toolbar 不再有 per-page 下拉，數值由 Settings 控制
- 移除女優 / 重置設定 / 刪除別名組三個確認對話框視覺與主介面一致
- 13 條彈窗式錯誤 / 提示變成 toast，不打斷操作流
- 複製日誌失敗時可看到完整內容並手動複製（不再只看到 500 字截斷）

## Test plan

- [ ] CI lint + unit + integration 全綠
- [ ] Codex review 無 Critical / High finding（已自審 fix 三輪 P2）
- [ ] dev server 五頁視覺巡檢（scanner / settings / help / design-system / motion-lab）
- [ ] dev server 4 個 fluent-modal 開合 / Esc / backdrop / cancel / confirm 五路徑
- [ ] dev server 15 處 toast 嚴重度顏色（info / warning / error）
- [ ] dev server copyFailModal `<pre>` 可選取 + Ctrl-A / Ctrl-C 手動複製
- [ ] dev server clipboard API 不存在環境（HTTP）下兩處 openLocal 仍正確顯示「複製失敗」toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)