### PR TITLE
v0.8.3 - Alpine Uplift & Notification Center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-05-02
+
+本版帶來兩個獨立升級包：53a 補齊四個 Alpine 官方插件（焦點鎖、切頁狀態保留、平滑展開、指向交叉偵測），同時修正 showcase 切頁殘留動畫鬼影；53b 新增全站通知中心（sidebar 鈴鐺 + 抽屜），讓 Scanner 掃描與批次補完的開始/完成/失敗事件即時可見，從任何頁面甚至跨裝置都能查閱，不再需要停在 Scanner 頁面等待。
+
+*This release includes two upgrade packs: 53a adds four official Alpine plugins (focus trap, persistent state, smooth collapse, intersection observer) and fixes animation ghost on page leave; 53b adds a global Notification Center (sidebar bell + drawer) for real-time visibility of Scanner and batch-enrich events across all pages and devices.*
+
+### Added
+
+#### 🔔 53b — 通知中心（Notification Center）
+- **sidebar 鈴鐺 + 通知抽屜**：help 上方常駐鈴鐺 icon，有未讀事件時亮彩色點（資訊藍 / 成功綠 / 警告黃 / 錯誤紅），點開抽屜從右側滑出顯示最近 10 筆事件記錄
+- **後端 buffer**：deque maxlen=10，RLock thread-safe，`emit_notification()` helper 供任意 router 呼叫
+- **Scanner / Batch-enrich 接入**：掃描開始（info）/ 完成（success）/ 部分失敗（warn）/ 中斷（error）四種狀態通知；批次補完同樣三段接入
+- **跨裝置一致**：通知 buffer 存在後端程序記憶體，電腦跑掃描、手機打開也能看到同一份記錄
+- **3 個 REST 端點**：GET /api/notifications（查詢）/ POST /api/notifications/read（標已讀）/ DELETE /api/notifications（清空）
+- **i18n 14 個 notif.* key**（zh_TW.json）；其他語系 milestone 補齊
+- **Capabilities 3 個新 tool**：get_notifications / mark_notifications_read / clear_notifications（含 side_effect / confirmation_required 安全標記）
+- **Unit test 5 + Integration test 6**：buffer 邏輯與 API 端點完整覆蓋
+
+#### 🔌 53a — Alpine 輕量升級包
+- **Alpine 釘版 3.15.12**：persist / collapse / focus / intersect / anchor 5 個插件統一版本，不再使用 3.x.x 浮動版
+- **showcase Lightbox 焦點鎖**（x-trap.inert）：Lightbox 開啟時 Tab 鍵只在燈箱內循環，背景對螢幕閱讀器標記 aria-hidden
+- **showcase_state 改 $persist**：篩選條件、排序、模式切頁後自動保留（升級後舊的 localStorage 值仍可讀取）
+- **settings 摺疊展開動畫**（x-collapse）：進階刮削設定 / 進階顯示選項展開收合從硬切換改為平滑高度動畫
+- **scanner 女優別名管理**：header 整列可點擊展開（不只圖示）
+
+### Fixed
+
+- **showcase 切頁不殘留鬼影**：頁面離開時補呼叫 `_resetPicker()` + `GhostFly.cleanupStaleGhosts()`，快速切頁後不出現浮動圖片殘像
+- **Ghost-fly lightbox 關閉疊圖**：關閉反向動畫期間隱藏 lightbox 大圖，避免新舊動畫疊圖
+- **Photo picker burst 修正**：hover 凍結 + desktop layout reflow + 改 method B defer-burst（partial 置中 + loading 完整覆蓋）
+- **scanner 通知 early return 修正**：directories 未設定時 early return 不再殘留孤兒 "掃描開始" 通知
+- **鈴鐺 icon 對齊**：nav-link--bell 改用 -webkit-fill-available 消除 button UA fit-content 造成的 2.5px 右偏
+
 ## [0.8.2] - 2026-04-29
 
 本版把 ui-conventions 套用到剩餘 5 頁（scanner / settings / help / design-system / motion-lab），並把幾條與「軟體靈魂」對不上的舊互動清掉：原生 `confirm()` / `alert()` 替換成風格一致的 fluent-modal 與 toast，showcase toolbar per-page 下拉移除（Settings 為唯一真理來源）。對使用者而言視覺更整齊、確認對話更貼近主視覺、複製失敗時用得到完整訊息（不再只看到截斷 500 字）。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -479,12 +479,19 @@
   },
   "notif": {
     "title": "通知",
-    "empty": "目前沒有通知",
     "clear_all": "全部清空",
-    "scanner_failed": "掃描失敗",
+    "empty": "目前沒有通知",
+    "open": "開啟通知",
+    "close": "關閉通知",
+    "dialog_label": "通知中心",
+    "scanner_started": "掃描開始",
     "scanner_done": "掃描完成",
-    "batch_enrich_started": "開始批次補完",
-    "batch_enrich_done_with_errors": "批次補完完成（部分失敗）"
+    "scanner_done_with_errors": "掃描完成（部分失敗）",
+    "scanner_failed": "掃描中斷",
+    "batch_enrich_started": "批次補完開始",
+    "batch_enrich_done": "批次補完完成",
+    "batch_enrich_done_with_errors": "批次補完（部分失敗）",
+    "batch_enrich_failed": "批次補完中斷"
   },
   "showcase": {
     "page_title": "影片瀏覽",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -477,6 +477,15 @@
       "confirm": "確認刪除"
     }
   },
+  "notif": {
+    "title": "通知",
+    "empty": "目前沒有通知",
+    "clear_all": "全部清空",
+    "scanner_failed": "掃描失敗",
+    "scanner_done": "掃描完成",
+    "batch_enrich_started": "開始批次補完",
+    "batch_enrich_done_with_errors": "批次補完完成（部分失敗）"
+  },
   "showcase": {
     "page_title": "影片瀏覽",
     "placeholder": {

--- a/scripts/build-css.sh
+++ b/scripts/build-css.sh
@@ -28,13 +28,15 @@ case "$MODE" in
         "$TAILWIND_CLI" -i "$INPUT_CSS" -o "$OUTPUT_CSS" --watch
         ;;
     prod)
-        echo "Building CSS in production mode (minify)..."
-        "$TAILWIND_CLI" -i "$INPUT_CSS" -o "$OUTPUT_CSS" --minify
+        # 不 minify 進 git — readable 多行版方便 review diff / grep / blame。
+        # 真要 minify 在部署 pipeline 做（GitHub Actions 等），不進版控。
+        echo "Building CSS (readable multi-line, no minify)..."
+        "$TAILWIND_CLI" -i "$INPUT_CSS" -o "$OUTPUT_CSS"
         ;;
     *)
         echo "Usage: $0 [dev|prod]"
         echo "  dev  - Development mode with watch (default)"
-        echo "  prod - Production mode with minify"
+        echo "  prod - One-shot build, readable multi-line output"
         exit 1
         ;;
 esac

--- a/tests/integration/test_notifications_api.py
+++ b/tests/integration/test_notifications_api.py
@@ -84,3 +84,27 @@ def test_highest_unread_level_priority(client):
     client.post("/api/notifications/read")
     emit_notification("warn", "notif.scanner_done_with_errors")
     assert client.get("/api/notifications").json()["highest_unread_level"] == "warn"
+
+
+def test_scanner_no_directory_emits_no_started(client):
+    """scanner_started 在無 directories 時不應 emit（P2-2 regression guard）。
+
+    沒有 scannerRouter 可以直接呼叫 scanner_generate，用 mock config 驗證 emit 邏輯：
+    當 directories 為空時，emit_notification 不應被呼叫（不殘留 scanner_started）。
+    """
+    import unittest.mock as mock
+    from web.routers.notifications import _notifications
+
+    # 模擬 directories 為空的 config
+    empty_config = {"gallery": {"directories": [], "output_dir": "output", "output_filename": "gallery_output.html", "path_mappings": {}, "min_size_mb": 0, "default_mode": "image", "default_sort": "date", "default_order": "descending", "items_per_page": 90}, "general": {"theme": "light"}}
+
+    with mock.patch("web.routers.scanner.load_config", return_value=empty_config):
+        from web.routers.scanner import generate_avlist
+        # 消費完 generator（否則 yield 不執行）
+        events = list(generate_avlist())
+
+    # 驗證：沒有 scanner_started 通知（early return path 不應 emit started）
+    notif_keys = [n["title_key"] for n in _notifications]
+    assert "notif.scanner_started" not in notif_keys, f"scanner_started 不應在 no-directory 路徑出現，但找到：{notif_keys}"
+    # 驗證：SSE stream 包含 error 事件
+    assert any("error" in e for e in events), "no-directory 路徑應產生 SSE error 事件"

--- a/tests/integration/test_notifications_api.py
+++ b/tests/integration/test_notifications_api.py
@@ -1,0 +1,86 @@
+"""
+tests/integration/test_notifications_api.py — 通知中心 API 端點測試（53b）
+
+用 FastAPI TestClient 打 GET / POST / DELETE。依 CLAUDE.md 測試分層：API 端點 → integration/。
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def reset_buffer():
+    import web.routers.notifications as notif_mod
+    notif_mod._notifications.clear()
+    notif_mod._read_ids.clear()
+    yield
+    notif_mod._notifications.clear()
+    notif_mod._read_ids.clear()
+
+
+@pytest.fixture
+def client():
+    from web.app import app
+    return TestClient(app)
+
+
+def test_get_empty(client):
+    """無 emit 時 GET 回空 buffer + 0 unread + null highest。"""
+    res = client.get("/api/notifications")
+    body = res.json()
+    assert body["items"] == []
+    assert body["unread_count"] == 0
+    assert body["highest_unread_level"] is None
+
+
+def test_get_with_items(client):
+    """emit 2 筆後 GET 回最新在前 + 全部未讀。"""
+    from web.routers.notifications import emit_notification
+    emit_notification("info", "notif.scanner_started")
+    emit_notification("warn", "notif.scanner_done_with_errors")
+    body = client.get("/api/notifications").json()
+    assert len(body["items"]) == 2
+    assert body["items"][0]["title_key"] == "notif.scanner_done_with_errors"
+    assert body["unread_count"] == 2
+    assert body["highest_unread_level"] == "warn"
+
+
+def test_post_read_marks_all(client):
+    """POST /read 後 GET 顯示全部已讀。"""
+    from web.routers.notifications import emit_notification
+    emit_notification("info", "notif.scanner_started")
+    emit_notification("warn", "notif.batch_enrich_done_with_errors")
+
+    res = client.post("/api/notifications/read")
+    assert res.json() == {"ok": True, "marked_count": 2}
+
+    body = client.get("/api/notifications").json()
+    assert body["unread_count"] == 0
+    assert all(item["is_read"] is True for item in body["items"])
+
+
+def test_delete_clears_all(client):
+    """DELETE 後 buffer 跟 _read_ids 都清空。"""
+    from web.routers.notifications import emit_notification, _read_ids
+    emit_notification("info", "notif.scanner_started")
+    client.post("/api/notifications/read")
+    assert len(_read_ids) > 0
+
+    res = client.delete("/api/notifications")
+    assert res.json()["ok"] is True
+    assert res.json()["cleared_count"] >= 1
+
+    body = client.get("/api/notifications").json()
+    assert body["items"] == []
+    assert len(_read_ids) == 0
+
+
+def test_highest_unread_level_priority(client):
+    """info + error 未讀 → highest = error；標已讀後新 warn → highest = warn。"""
+    from web.routers.notifications import emit_notification
+    emit_notification("info", "notif.scanner_started")
+    emit_notification("error", "notif.scanner_failed")
+    assert client.get("/api/notifications").json()["highest_unread_level"] == "error"
+
+    client.post("/api/notifications/read")
+    emit_notification("warn", "notif.scanner_done_with_errors")
+    assert client.get("/api/notifications").json()["highest_unread_level"] == "warn"

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -57,6 +57,9 @@ EXPECTED_TOOL_NAMES = {
     "fetch_samples",
     "list_actress_photo_candidates",
     "set_actress_photo",
+    "get_notifications",
+    "mark_notifications_read",
+    "clear_notifications",
 }
 
 REQUIRED_TOOL_FIELDS = [
@@ -103,9 +106,9 @@ class TestCapabilitiesEndpoint:
         data = client.get("/api/capabilities").json()
         assert "retry_hint" in data["error_format"]
 
-    def test_tools_count_is_29(self, client):
+    def test_tools_count_is_32(self, client):
         data = client.get("/api/capabilities").json()
-        assert len(data["tools"]) == 29
+        assert len(data["tools"]) == 32
 
     def test_all_tool_names_present(self, client):
         data = client.get("/api/capabilities").json()

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -910,23 +910,24 @@ class TestShowcaseActressState:
             "showcase/core.js _setLightboxIndex 缺少 this._videoChipsExpanded = false（reset chips）"
 
     # --- saveState / restoreState ---
+    # 53a-T2 後改用 $persist：saveState 逐欄寫入 this._persistedShowcase.X = this.X
     def test_save_state_includes_actress_mode(self):
-        """saveState 內含 showFavoriteActresses key"""
+        """saveState 內含 _persistedShowcase.showFavoriteActresses 寫入"""
         js = self._js()
-        assert "showFavoriteActresses: this.showFavoriteActresses" in js, \
-            "showcase/core.js saveState() 缺少 showFavoriteActresses key"
+        assert "_persistedShowcase.showFavoriteActresses = this.showFavoriteActresses" in js, \
+            "showcase/core.js saveState() 缺少 _persistedShowcase.showFavoriteActresses 寫入"
 
     def test_save_state_includes_actress_sort(self):
-        """saveState 內含 actressSort key"""
+        """saveState 內含 _persistedShowcase.actressSort 寫入"""
         js = self._js()
-        assert "actressSort: this.actressSort" in js, \
-            "showcase/core.js saveState() 缺少 actressSort key"
+        assert "_persistedShowcase.actressSort = this.actressSort" in js, \
+            "showcase/core.js saveState() 缺少 _persistedShowcase.actressSort 寫入"
 
     def test_save_state_includes_actress_order(self):
-        """saveState 內含 actressOrder key"""
+        """saveState 內含 _persistedShowcase.actressOrder 寫入"""
         js = self._js()
-        assert "actressOrder: this.actressOrder" in js, \
-            "showcase/core.js saveState() 缺少 actressOrder key"
+        assert "_persistedShowcase.actressOrder = this.actressOrder" in js, \
+            "showcase/core.js saveState() 缺少 _persistedShowcase.actressOrder 寫入"
 
     def test_restore_state_restores_actress_mode(self):
         """restoreState 內含 showFavoriteActresses 還原邏輯"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4783,33 +4783,31 @@ class TestPickerIntegrationGuard:
         assert re.search(r"return\s+(new\s+Promise|Promise\.resolve)", body), \
             "playPickerExitAll 必須回傳 Promise（避免 _closePicker 立即 reset 清空 _candidates）"
 
-    def test_picker_sse_handler_captures_index_before_await(self):
-        """SSE candidate handler 必須在 push 後同步 capture myIndex，再 await $nextTick。
-        否則一次連發多筆 candidate（local_crop 緊接 yield）時，所有 handler resume 後
-        看到的 _candidates.length 都是最終值，會全部 pick cards[N-1]，導致中間 candidate
-        沒有 burst（停留 opacity:0 從 CSS 預設），用戶看不到那幾張卡。
+    def test_picker_sse_candidate_handler_is_sync_push_only(self):
+        """Method B（defer-burst）：candidate handler 只做同步 push，不 await、不 burst。
+        Burst 延後到 SSE done / timeout / error 後由 _burstAllPickerCandidates 一次觸發，
+        對齊 motion-lab 模式（partial 也視覺置中、burst 飛行不受滑鼠干擾）。
+
+        舊 race-fix（myIndex capture-before-await）在 defer-burst 下已不適用：candidate
+        handler 不再呼叫 playPickerBurst，連 await $nextTick 都不需要。
         """
         js = self._core_js()
-        # 抓 _startPickerSSE 內 candidate handler 區塊
+        # 抓 _startPickerSSE 內 candidate handler 區塊（同步 callback，無 async）
         m = re.search(
-            r"sse\.addEventListener\(\s*['\"]candidate['\"]\s*,\s*async\s*\(?[^)]*\)?\s*=>\s*\{(.*?)\}\s*\)\s*;",
+            r"sse\.addEventListener\(\s*['\"]candidate['\"]\s*,\s*\(?[^)]*\)?\s*=>\s*\{(.*?)\}\s*\)\s*;",
             js, re.DOTALL,
         )
         assert m, "找不到 sse.addEventListener('candidate', ...) handler"
         body = m.group(1)
-        # 必須有 myIndex 變數
-        assert re.search(r"const\s+myIndex\s*=\s*this\._candidates\.length\s*-\s*1", body), \
-            "candidate handler 必須在 push 後同步 capture myIndex（race fix）"
-        # myIndex 必須出現在 await 之前
-        idx_pos = body.find("const myIndex")
-        await_pos = body.find("await this.$nextTick")
-        assert 0 <= idx_pos < await_pos, \
-            "myIndex capture 必須在 await this.$nextTick() 之前（race fix）"
-        # newCard 必須使用 myIndex（不能再用 this._candidates.length - 1）
-        assert re.search(r"cards\[\s*myIndex\s*\]", body), \
-            "newCard 必須使用 cards[myIndex]，不可用 cards[this._candidates.length - 1]"
-        assert "cards[this._candidates.length - 1]" not in body, \
-            "candidate handler 不可使用 cards[this._candidates.length - 1]（race bug：所有 handler 拿到同一張卡）"
+        # Method B：candidate handler 不可 await（defer-burst contract）
+        assert "await" not in body, \
+            "Method B：candidate handler 不可 await（defer-burst，burst 交給 _burstAllPickerCandidates）"
+        # candidate handler 不可自行呼叫 playPickerBurst
+        assert "playPickerBurst" not in body, \
+            "Method B：candidate handler 不可呼叫 playPickerBurst（改由 _burstAllPickerCandidates 統一觸發）"
+        # _burstAllPickerCandidates 必須定義一次 + done/timeout/error 三處呼叫（共 ≥4 次出現）
+        assert js.count("_burstAllPickerCandidates") >= 4, \
+            "_burstAllPickerCandidates 必須定義一次 + done / timeout / error 三處呼叫"
 
 
 class TestSettingsCssHardcoded:

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,0 +1,70 @@
+"""
+tests/unit/test_notifications.py — 通知 buffer 純函式邏輯測試（53b）
+
+全 mock，不啟動 FastAPI。依 CLAUDE.md 測試分層：純邏輯 → unit/。
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_buffer():
+    """每個 test 前後清空 buffer，防止狀態污染。"""
+    import web.routers.notifications as notif_mod
+    notif_mod._notifications.clear()
+    notif_mod._read_ids.clear()
+    yield
+    notif_mod._notifications.clear()
+    notif_mod._read_ids.clear()
+
+
+def test_emit_notification_basic():
+    from web.routers.notifications import emit_notification, _notifications
+    emit_notification("info", "notif.scanner_started", task_type="scanner_generate")
+    assert len(_notifications) == 1
+    assert _notifications[0]["level"] == "info"
+    assert _notifications[0]["title_key"] == "notif.scanner_started"
+    assert _notifications[0]["task_type"] == "scanner_generate"
+    assert "id" in _notifications[0]
+    assert "timestamp" in _notifications[0]
+
+
+def test_buffer_max_10():
+    from web.routers.notifications import emit_notification, _notifications
+    for i in range(11):
+        emit_notification("info", f"notif.test_{i}")
+    assert len(_notifications) == 10
+    assert _notifications[0]["title_key"] == "notif.test_10"
+    keys = [n["title_key"] for n in _notifications]
+    assert "notif.test_0" not in keys
+
+
+def test_newest_first():
+    from web.routers.notifications import emit_notification, _notifications
+    emit_notification("info", "notif.first")
+    emit_notification("error", "notif.second")
+    assert _notifications[0]["title_key"] == "notif.second"
+    assert _notifications[1]["title_key"] == "notif.first"
+
+
+def test_emit_evicts_orphan_read_id():
+    """F2 設計驗證：buffer 滿時 emit 新筆，被擠出筆的 read_id 同步從 _read_ids 清掉。"""
+    from web.routers.notifications import emit_notification, _notifications, _read_ids
+    for i in range(10):
+        emit_notification("info", f"notif.test_{i}")
+    oldest_id = _notifications[-1]["id"]
+    _read_ids.add(oldest_id)
+    emit_notification("info", "notif.test_10")
+    assert oldest_id not in _read_ids
+
+
+def test_calc_highest_unread_level_priority():
+    """直接 unit-test helper 函式，不經 API。"""
+    from web.routers.notifications import _calc_highest_unread_level
+    items = [
+        {"id": "a", "level": "info"},
+        {"id": "b", "level": "error"},
+        {"id": "c", "level": "warn"},
+    ]
+    assert _calc_highest_unread_level(items, set()) == "error"
+    assert _calc_highest_unread_level(items, {"b"}) == "warn"
+    assert _calc_highest_unread_level(items, {"a", "b", "c"}) is None

--- a/web/app.py
+++ b/web/app.py
@@ -53,6 +53,7 @@ from web.routers import capabilities as capabilities_router
 from web.routers import collection as collection_router
 from web.routers import actress as actress_router
 from web.routers import actress_alias as actress_alias_router
+from web.routers import notifications as notifications_router
 app.include_router(search_router.router)
 app.include_router(config_router.router)
 app.include_router(scraper_router.router)
@@ -68,6 +69,7 @@ app.include_router(collection_router.router)
 app.include_router(collection_router.user_tags_router)
 app.include_router(actress_router.router)
 app.include_router(actress_alias_router.router)
+app.include_router(notifications_router.router)
 
 
 @app.exception_handler(RequestValidationError)

--- a/web/routers/capabilities.py
+++ b/web/routers/capabilities.py
@@ -941,6 +941,65 @@ _TOOLS: list[dict] = [
             "-d '{{\"source\": \"graphis\", \"url\": \"https://example.com/photo.jpg\"}}'"
         ),
     },
+    {
+        "name": "get_notifications",
+        "description": "查詢 OpenAver 最近發生的事件通知（最多 10 筆），包含掃描開始/完成/失敗、批次補完等事件。可用來確認後台任務是否成功執行。只讀，不修改任何資料。",
+        "method": "GET",
+        "path": "/api/notifications",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        "output_schema": {
+            "items": "[Notification] — 通知列表，最多 10 筆，最新的排前面；每筆含 id/timestamp/level/title_key/message/task_type/is_read",
+            "unread_count": "integer — 未讀通知數量",
+            "highest_unread_level": "string | null — 未讀中最高嚴重度（info/success/warn/error），無未讀時為 null",
+        },
+        "side_effect": False,
+        "confirmation_required": False,
+        "retry_safe": True,
+        "_example_template": "curl '{base}/api/notifications'",
+    },
+    {
+        "name": "mark_notifications_read",
+        "description": "把所有通知標記為已讀。無破壞性：不刪除任何通知，只更新已讀記錄。下次查詢時 unread_count 會變 0。",
+        "method": "POST",
+        "path": "/api/notifications/read",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        "output_schema": {
+            "ok": "boolean",
+            "marked_count": "integer — 本次標記為已讀的通知數量",
+        },
+        "side_effect": True,
+        "confirmation_required": False,
+        "retry_safe": True,
+        "_example_template": "curl -X POST '{base}/api/notifications/read'",
+    },
+    {
+        "name": "clear_notifications",
+        "description": "清空所有通知記錄（包含已讀和未讀）。此操作不可逆，清空後記錄永久消失（重啟前）。AI 呼叫前必須向用戶確認。",
+        "method": "DELETE",
+        "path": "/api/notifications",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        "output_schema": {
+            "ok": "boolean",
+            "cleared_count": "integer — 刪除的通知筆數",
+        },
+        "side_effect": True,
+        "confirmation_required": True,
+        "idempotent": True,
+        "retry_safe": True,
+        "_example_template": "curl -X DELETE '{base}/api/notifications'",
+    },
 ]
 
 

--- a/web/routers/notifications.py
+++ b/web/routers/notifications.py
@@ -1,0 +1,115 @@
+"""
+通知中心後端 buffer — 53b
+
+module-level globals:
+  _notifications: deque  最多 10 筆，最新的排前面（appendleft）
+  _read_ids: set         已讀 id 集合
+
+thread safety: 所有 _notifications / _read_ids 讀寫**必須**經 _lock (RLock)
+保護。GIL 只保證單次 C-level op atomic，不保護「迭代 + membership check」「len + clear
++ clear」這類多步驟組合，也無法保證 GET handler 跟 emit 拿到一致的 snapshot
+（見 plan-53b CD-53B-1）。
+"""
+
+from collections import deque
+from typing import Optional
+import threading
+import uuid
+import time
+
+from fastapi import APIRouter
+
+from core.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api", tags=["notifications"])
+
+_lock = threading.RLock()
+_notifications: deque = deque(maxlen=10)
+_read_ids: set = set()
+
+
+def emit_notification(
+    level: str,
+    title_key: str,
+    message: str = "",
+    task_type: Optional[str] = None,
+) -> None:
+    """後端各處呼叫此函式新增一筆通知。
+    設計為極度輕量（只做 deque.appendleft），不可拋出例外。
+    level: "info" | "success" | "warn" | "error"
+    """
+    notif = {
+        "id": str(uuid.uuid4()),
+        "timestamp": time.time(),
+        "level": level,
+        "title_key": title_key,
+        "message": message,
+        "task_type": task_type,
+    }
+    with _lock:
+        if len(_notifications) == _notifications.maxlen:
+            evicted = _notifications[-1]
+            _read_ids.discard(evicted["id"])
+        _notifications.appendleft(notif)
+    logger.debug("[notif] emit level=%s title_key=%s", level, title_key)
+
+
+def _calc_highest_unread_level(items: list, read_ids: set) -> Optional[str]:
+    """計算未讀通知中最高嚴重度。"""
+    level_order = {"error": 3, "warn": 2, "success": 1, "info": 0}
+    highest = None
+    highest_score = -1
+    for item in items:
+        if item["id"] not in read_ids:
+            score = level_order.get(item["level"], 0)
+            if score > highest_score:
+                highest_score = score
+                highest = item["level"]
+    return highest
+
+
+@router.get("/notifications")
+async def get_notifications():
+    """查詢 buffer 所有通知 + 未讀摘要。"""
+    with _lock:
+        items = list(_notifications)
+        read_snapshot = set(_read_ids)
+    enriched = [
+        {**item, "is_read": item["id"] in read_snapshot}
+        for item in items
+    ]
+    unread_count = sum(1 for item in items if item["id"] not in read_snapshot)
+    highest = _calc_highest_unread_level(items, read_snapshot)
+    return {
+        "items": enriched,
+        "unread_count": unread_count,
+        "highest_unread_level": highest,
+    }
+
+
+@router.post("/notifications/read")
+async def mark_all_read():
+    """把目前 buffer 裡所有通知標為已讀。"""
+    with _lock:
+        count = 0
+        for item in _notifications:
+            if item["id"] not in _read_ids:
+                _read_ids.add(item["id"])
+                count += 1
+    return {"ok": True, "marked_count": count}
+
+
+@router.delete("/notifications")
+async def clear_notifications():
+    """清空 buffer 所有記錄，同時清空 _read_ids。
+
+    UX 註解：F6 決議——通知是 ephemeral notification buffer cleanup，
+    手機通知抽屜般直接清空，不需確認。前端 UI 不彈 confirm。
+    """
+    with _lock:
+        count = len(_notifications)
+        _notifications.clear()
+        _read_ids.clear()
+    return {"ok": True, "cleared_count": count}

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -43,6 +43,7 @@ from core.config import load_config
 from core.scraper import smart_search
 from pydantic import BaseModel
 from core.logger import get_logger
+from web.routers.notifications import emit_notification as _emit_notif
 
 logger = get_logger(__name__)
 
@@ -83,6 +84,8 @@ def generate_avlist() -> Generator[str, None, None]:
     """產生影片列表（SSE 串流）- 使用 SQLite 儲存"""
 
     try:
+        # 53b-T3: 掃描開始通知
+        _emit_notif("info", "notif.scanner_started", task_type="scanner_generate")
         # 載入設定
         config = load_config()
         gallery_config = config.get('gallery', {})
@@ -138,6 +141,7 @@ def generate_avlist() -> Generator[str, None, None]:
         total_inserted = 0
         total_updated = 0
         total_deleted = 0
+        scan_error_count = 0
         session_added_paths = []  # 追蹤本次新增/變更的影片路徑
         long_paths: list[str] = []  # a5: Windows 長路徑收集（只在 win32 填充）
 
@@ -249,6 +253,7 @@ def generate_avlist() -> Generator[str, None, None]:
                     except Exception as e:
                         logger.exception("掃描檔案失敗: %s", file_info.get('path', ''))
                         yield _sse_event({"type": "log", "level": "warn", "message": f"  [{i}] 掃描發生錯誤，已跳過"})
+                        scan_error_count += 1
 
                 # 批次寫入
                 if videos_to_upsert:
@@ -382,6 +387,20 @@ def generate_avlist() -> Generator[str, None, None]:
         _jellyfin_cache_result = None
         _jellyfin_cache_time = 0
 
+        # 53b-T3: 掃描完成通知
+        if scan_error_count > 0:
+            _emit_notif(
+                "warn", "notif.scanner_done_with_errors",
+                message=f"完成 {len(all_videos)} 部，{scan_error_count} 部失敗",
+                task_type="scanner_generate",
+            )
+        else:
+            _emit_notif(
+                "success", "notif.scanner_done",
+                message=f"完成 {len(all_videos)} 部",
+                task_type="scanner_generate",
+            )
+
         yield _sse_event({
             "type": "done",
             "video_count": len(all_videos),
@@ -401,6 +420,12 @@ def generate_avlist() -> Generator[str, None, None]:
         # global 已在 try 區塊宣告，此處直接賦值即可
         _jellyfin_cache_result = None
         _jellyfin_cache_time = 0
+        # 53b-T3: 掃描失敗通知（不洩漏 str(e) 到前端）
+        _emit_notif(
+            "error", "notif.scanner_failed",
+            message="掃描中斷，請查閱日誌",
+            task_type="scanner_generate",
+        )
         yield _sse_event({"type": "error", "message": "產生影片列表失敗"})
 
 

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -84,8 +84,6 @@ def generate_avlist() -> Generator[str, None, None]:
     """產生影片列表（SSE 串流）- 使用 SQLite 儲存"""
 
     try:
-        # 53b-T3: 掃描開始通知
-        _emit_notif("info", "notif.scanner_started", task_type="scanner_generate")
         # 載入設定
         config = load_config()
         gallery_config = config.get('gallery', {})
@@ -109,6 +107,8 @@ def generate_avlist() -> Generator[str, None, None]:
             yield _sse_event({"type": "error", "message": "未設定掃描資料夾"})
             return
 
+        # 53b-T3: 確認 directories 有值才 emit 掃描開始通知
+        _emit_notif("info", "notif.scanner_started", task_type="scanner_generate")
         logger.info(f"[Gallery] 開始生成，目錄數: {len(directories)}")
 
         # 確保輸出目錄存在

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -270,6 +270,7 @@ def generate_avlist() -> Generator[str, None, None]:
                 })
             except Exception as e:
                 logger.exception("掃描資料夾失敗: %s", directory)
+                scan_error_count += 1
                 yield _sse_event({"type": "log", "level": "error", "message": "掃描發生錯誤，已跳過此資料夾"})
 
         # 建立「當前設定資料夾」URI 集合，用於過濾 DB 記錄

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -22,6 +22,7 @@ from core.path_utils import to_file_uri, uri_to_fs_path
 from core.scraper import search_jav
 from core.logger import get_logger
 from core.config import load_config
+from web.routers.notifications import emit_notification as _emit_notif
 
 logger = get_logger(__name__)
 
@@ -234,71 +235,99 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
     async def event_generator():
         success_count = 0
         failed_count = 0
+        # 53b-T3: 補完開始通知
+        _emit_notif(
+            "info", "notif.batch_enrich_started",
+            message=f"共 {total} 部",
+            task_type="batch_enrich",
+        )
         # scraper cache：只對 refresh_full 生效（100% 需要 scraper data）
         # fill_missing 由 enrich_single 內部判斷是否需要打外站，不 pre-fetch
         # value 為 dict（成功）或 {}（search_jav 回 None，負向 cache）
         scraper_cache: dict = {}
 
-        for idx, item in enumerate(deduped_items, start=1):
-            effective_source = item.source or request.source or "auto"
-            effective_lang = item.javbus_lang or request.javbus_lang
+        try:
+            for idx, item in enumerate(deduped_items, start=1):
+                effective_source = item.source or request.source or "auto"
+                effective_lang = item.javbus_lang or request.javbus_lang
 
-            # progress 事件
-            yield f"data: {json.dumps({'type': 'progress', 'current': idx, 'total': total, 'number': item.number})}\n\n"
+                # progress 事件
+                yield f"data: {json.dumps({'type': 'progress', 'current': idx, 'total': total, 'number': item.number})}\n\n"
 
-            try:
-                loop = asyncio.get_running_loop()
+                try:
+                    loop = asyncio.get_running_loop()
 
-                # scraper cache（只對 refresh_full pre-fetch）
-                cached_data = None
-                if request.mode == "refresh_full":
-                    cache_key = (item.number.upper(), effective_source, effective_lang)
-                    if cache_key not in scraper_cache:
-                        fetched = await loop.run_in_executor(
-                            None,
-                            lambda n=item.number, es=effective_source, el=effective_lang: search_jav(
-                                n,
-                                source=es,
-                                proxy_url=proxy_url,
-                                primary_source=primary_source,
-                                javbus_lang=el,
-                            ),
-                        )
-                        # 負向 cache：search_jav 回 None → 存 {}（空 dict falsy）
-                        # enrich_single 收到 {} 時 `is None` 為 False（不再搜），
-                        # `not scraper_data` 為 True（回錯誤）
-                        scraper_cache[cache_key] = fetched if fetched else {}
-                    cached_data = scraper_cache[cache_key]
+                    # scraper cache（只對 refresh_full pre-fetch）
+                    cached_data = None
+                    if request.mode == "refresh_full":
+                        cache_key = (item.number.upper(), effective_source, effective_lang)
+                        if cache_key not in scraper_cache:
+                            fetched = await loop.run_in_executor(
+                                None,
+                                lambda n=item.number, es=effective_source, el=effective_lang: search_jav(
+                                    n,
+                                    source=es,
+                                    proxy_url=proxy_url,
+                                    primary_source=primary_source,
+                                    javbus_lang=el,
+                                ),
+                            )
+                            # 負向 cache：search_jav 回 None → 存 {}（空 dict falsy）
+                            # enrich_single 收到 {} 時 `is None` 為 False（不再搜），
+                            # `not scraper_data` 為 True（回錯誤）
+                            scraper_cache[cache_key] = fetched if fetched else {}
+                        cached_data = scraper_cache[cache_key]
 
-                result = await loop.run_in_executor(
-                    None,
-                    lambda i=item, sd=cached_data: enrich_single(
-                        file_path=i.file_path,
-                        number=i.number,
-                        mode=request.mode,
-                        write_nfo=request.write_nfo,
-                        write_cover=request.write_cover,
-                        write_extrafanart=request.write_extrafanart,
-                        overwrite_existing=request.overwrite_existing,
-                        proxy_url=proxy_url,
-                        primary_source=primary_source,
-                        source=effective_source if effective_source != "auto" else None,
-                        javbus_lang=effective_lang,
-                        scraper_data=sd,
-                    ),
-                )
-                from dataclasses import asdict
-                result_dict = asdict(result)
-                if result.success:
-                    success_count += 1
-                else:
+                    result = await loop.run_in_executor(
+                        None,
+                        lambda i=item, sd=cached_data: enrich_single(
+                            file_path=i.file_path,
+                            number=i.number,
+                            mode=request.mode,
+                            write_nfo=request.write_nfo,
+                            write_cover=request.write_cover,
+                            write_extrafanart=request.write_extrafanart,
+                            overwrite_existing=request.overwrite_existing,
+                            proxy_url=proxy_url,
+                            primary_source=primary_source,
+                            source=effective_source if effective_source != "auto" else None,
+                            javbus_lang=effective_lang,
+                            scraper_data=sd,
+                        ),
+                    )
+                    from dataclasses import asdict
+                    result_dict = asdict(result)
+                    if result.success:
+                        success_count += 1
+                    else:
+                        failed_count += 1
+                    yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, **result_dict})}\n\n"
+                except Exception:
+                    logger.exception("batch_enrich item %s 失敗", item.number)
                     failed_count += 1
-                yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, **result_dict})}\n\n"
-            except Exception:
-                logger.exception("batch_enrich item %s 失敗", item.number)
-                failed_count += 1
-                yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, 'success': False, 'error': 'enrich 處理失敗，請查閱日誌'})}\n\n"
+                    yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, 'success': False, 'error': 'enrich 處理失敗，請查閱日誌'})}\n\n"
 
-        yield f"data: {json.dumps({'type': 'done', 'summary': {'total': total, 'success': success_count, 'failed': failed_count}})}\n\n"
+            yield f"data: {json.dumps({'type': 'done', 'summary': {'total': total, 'success': success_count, 'failed': failed_count}})}\n\n"
+            # 53b-T3: 補完完成通知
+            if failed_count > 0:
+                _emit_notif(
+                    "warn", "notif.batch_enrich_done_with_errors",
+                    message=f"補完 {success_count} 部，{failed_count} 部失敗",
+                    task_type="batch_enrich",
+                )
+            else:
+                _emit_notif(
+                    "success", "notif.batch_enrich_done",
+                    message=f"補完 {success_count} 部",
+                    task_type="batch_enrich",
+                )
+        except Exception:
+            logger.exception("[notif] batch_enrich 失敗")
+            _emit_notif(
+                "error", "notif.batch_enrich_failed",
+                message="批次補完中斷，請查閱日誌",
+                task_type="batch_enrich",
+            )
+            raise
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1981,8 +1981,13 @@ body.sidebar-collapsed .showcase-footer {
 }
 
 .actress-picker-overlay .picker-candidates-grid {
-    display: flex;
-    flex-wrap: nowrap;               /* desktop ≥1280 預設單行 */
+    /* desktop ≥1280：grid 6 固定 col 取代 flex justify-content:center
+     * 理由：flex+center 在 SSE 逐筆 append 時每加一張卡 layout 重排，
+     * 已飛行中的卡 burst 目標位置漂移（位置 3→1 的位移現象）。
+     * grid 6 固定 track 從第 1 張就鎖定每 slot 座標，後到的卡填下一 col、不擾動既有卡。
+     */
+    display: grid;
+    grid-template-columns: repeat(6, 150px);
     justify-content: center;
     gap: 20px;
     overflow-x: visible;             /* 覆寫全域 overflow-x: auto */
@@ -1995,7 +2000,7 @@ body.sidebar-collapsed .showcase-footer {
     aspect-ratio: 4 / 5;             /* 188px tall on 150 wide */
     height: auto;                    /* 覆寫全域 height: 140px */
     border-radius: var(--radius-md);
-    flex: 0 0 150px;                 /* 覆寫全域 flex: 0 0 100px */
+    flex: none;                      /* grid 不需 flex，覆寫全域 flex: 0 0 100px */
 }
 
 .actress-picker-overlay .picker-candidate-img {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1981,13 +1981,14 @@ body.sidebar-collapsed .showcase-footer {
 }
 
 .actress-picker-overlay .picker-candidates-grid {
-    /* desktop ≥1280：grid 6 固定 col 取代 flex justify-content:center
-     * 理由：flex+center 在 SSE 逐筆 append 時每加一張卡 layout 重排，
-     * 已飛行中的卡 burst 目標位置漂移（位置 3→1 的位移現象）。
-     * grid 6 固定 track 從第 1 張就鎖定每 slot 座標，後到的卡填下一 col、不擾動既有卡。
+    /* desktop ≥1280：grid N 固定 col 取代 flex justify-content:center
+     * --picker-cols 由 JS 在 SSE 收齊後依實際 count 設（_burstAllPickerCandidates）
+     * fallback 6（首次 burst 前 / partial 階段）。
+     * tablet/mobile 由 media query 自行覆蓋為 repeat(3, ...)，不引用此 var，
+     * 因此 desktop→tablet resize 時 inline var 不會洩漏蓋掉媒體查詢規則。
      */
     display: grid;
-    grid-template-columns: repeat(6, 150px);
+    grid-template-columns: repeat(var(--picker-cols, 6), 150px);
     justify-content: center;
     gap: 20px;
     overflow-x: visible;             /* 覆寫全域 overflow-x: auto */

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -2381,8 +2381,14 @@
   .top-0 {
     top: calc(var(--spacing) * 0);
   }
+  .top-1 {
+    top: calc(var(--spacing) * 1);
+  }
   .right-0 {
     right: calc(var(--spacing) * 0);
+  }
+  .right-1 {
+    right: calc(var(--spacing) * 1);
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
@@ -3118,8 +3124,14 @@
       height: var(--size);
     }
   }
+  .h-2\.5 {
+    height: calc(var(--spacing) * 2.5);
+  }
   .h-14 {
     height: calc(var(--spacing) * 14);
+  }
+  .min-h-\[360px\] {
+    min-height: 360px;
   }
   .loading-sm {
     @layer daisyui.l1.l2 {
@@ -3131,11 +3143,17 @@
       width: calc(var(--size-selector, 0.25rem) * 4);
     }
   }
+  .w-2\.5 {
+    width: calc(var(--spacing) * 2.5);
+  }
   .w-10 {
     width: calc(var(--spacing) * 10);
   }
   .w-64 {
     width: calc(var(--spacing) * 64);
+  }
+  .w-80 {
+    width: calc(var(--spacing) * 80);
   }
   .w-\[100px\] {
     width: 100px;
@@ -3251,6 +3269,9 @@
   .items-center {
     align-items: center;
   }
+  .items-start {
+    align-items: flex-start;
+  }
   .items-stretch {
     align-items: stretch;
   }
@@ -3269,6 +3290,9 @@
   .gap-3 {
     gap: calc(var(--spacing) * 3);
   }
+  .gap-6 {
+    gap: calc(var(--spacing) * 6);
+  }
   .truncate {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -3280,6 +3304,9 @@
   .overflow-x-auto {
     overflow-x: auto;
   }
+  .rounded-full {
+    border-radius: calc(infinity * 1px);
+  }
   .rounded-xl {
     border-radius: var(--radius-xl);
   }
@@ -3290,6 +3317,9 @@
   .border-b {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
+  }
+  .border-base-200 {
+    border-color: var(--color-base-200);
   }
   .border-base-300 {
     border-color: var(--color-base-300);
@@ -3336,6 +3366,18 @@
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
     }
+  }
+  .bg-error {
+    background-color: var(--color-error);
+  }
+  .bg-info {
+    background-color: var(--color-info);
+  }
+  .bg-success {
+    background-color: var(--color-success);
+  }
+  .bg-warning {
+    background-color: var(--color-warning);
   }
   .loading-spinner {
     @layer daisyui.l1.l2 {
@@ -3586,6 +3628,10 @@
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .shadow-lg {
+    --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -3793,6 +3839,19 @@
     @layer daisyui.l1.l2 {
       &:is([type="checkbox"]), &:has([type="checkbox"]) {
         --size: calc(var(--size-selector, 0.25rem) * 5);
+      }
+    }
+  }
+  .last\:border-b-0 {
+    &:last-child {
+      border-bottom-style: var(--tw-border-style);
+      border-bottom-width: 0px;
+    }
+  }
+  .hover\:bg-base-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-base-200);
       }
     }
   }

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -3269,6 +3269,11 @@
   .gap-3 {
     gap: calc(var(--spacing) * 3);
   }
+  .truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .overflow-hidden {
     overflow: hidden;
   }
@@ -3621,6 +3626,11 @@
     --tw-blur: blur(8px);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
+  .drop-shadow {
+    --tw-drop-shadow-size: drop-shadow(0 1px 2px var(--tw-drop-shadow-color, rgb(0 0 0 / 0.1))) drop-shadow(0 1px 1px var(--tw-drop-shadow-color, rgb(0 0 0 / 0.06)));
+    --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow( 0 1px 1px rgb(0 0 0 / 0.06));
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
@@ -3694,6 +3704,12 @@
       --size: calc(var(--size-field, 0.25rem) * 6);
     }
   }
+  .badge-accent {
+    @layer daisyui.l1.l2 {
+      --badge-color: var(--color-accent);
+      --badge-fg: var(--color-accent-content);
+    }
+  }
   .badge-error {
     @layer daisyui.l1.l2 {
       --badge-color: var(--color-error);
@@ -3704,6 +3720,12 @@
     @layer daisyui.l1.l2 {
       --badge-color: var(--color-primary);
       --badge-fg: var(--color-primary-content);
+    }
+  }
+  .badge-secondary {
+    @layer daisyui.l1.l2 {
+      --badge-color: var(--color-secondary);
+      --badge-fg: var(--color-secondary-content);
     }
   }
   .badge-success {
@@ -4090,7 +4112,6 @@ body {
   position: absolute;
   inset: 0;
   background: oklch(0% 0 0 / 0.4);
-  backdrop-filter: blur(2px);
   opacity: 0;
   display: flex;
   align-items: center;
@@ -4604,6 +4625,10 @@ body {
 .ds-gallery-composition .flip-guard .av-card-preview:hover {
   transform: none !important;
   box-shadow: none !important;
+}
+.av-card-preview.gsap-animating {
+  pointer-events: none;
+  transition: none !important;
 }
 :is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview:hover {
   transform: translateY(-4px) scale(1.01);

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -178,7 +178,7 @@ window.SearchStateMixin_GridMode = {
                 var grid = document.querySelector('.search-grid');
                 var cardEl = grid ? grid.querySelector('[data-slot="' + closingIndex + '"]') : null;
                 if (cardEl) {
-                    window.GhostFly.playLightboxToGrid(flybackFromRect, cardEl, { coverSrc: flybackCoverSrc });
+                    window.GhostFly.playLightboxToGrid(flybackFromRect, cardEl, { coverSrc: flybackCoverSrc, fromImg: lbImg });
                 }
             });
         }

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -175,6 +175,7 @@ function showcaseState() {
         _pickerRunId: 0,
         _pickerSSE: null,
         _pickerTimeoutTimer: null,
+        _pickerBurstFired: false,        // SSE 收齊後一次 burst（防 done/timeout/error 重複觸發）
 
         // T3.3: Remove Actress fluent-modal 狀態
         removeActressModalOpen: false,
@@ -2288,12 +2289,49 @@ function showcaseState() {
         },
 
         /**
+         * SSE 收齊（done / timeout / error）後一次 burst 全部候選卡。
+         * 對齊 motion-lab 模式：所有卡同時從封面 stagger 爆射，partial 也視覺置中。
+         */
+        async _burstAllPickerCandidates(runId) {
+            if (this._pickerRunId !== runId) return;
+            if (this._candidates.length === 0) return;
+            if (this._pickerBurstFired) return;     // 防 done/timeout/error 重複觸發
+            this._pickerBurstFired = true;
+
+            await this.$nextTick();
+            if (this._pickerRunId !== runId) return;
+
+            const grid = this.$refs.pickerGrid;
+            const coverEl = this.$refs.pickerCoverImg;
+            if (!grid || !coverEl || typeof window.BurstPicker === 'undefined') return;
+
+            const cards = Array.from(grid.querySelectorAll('.picker-candidate-card'));
+            if (!cards.length) return;
+
+            // 依實際 count 縮 grid 至 N col 使 partial 視覺置中。
+            // 用 CSS custom property --picker-cols（desktop rule 引用 fallback 6），
+            // tablet/mobile media query 自有 repeat(3, ...) 不引用此 var，故 desktop→tablet
+            // resize 不會被 inline var 洩漏蓋掉媒體查詢規則。
+            grid.style.setProperty('--picker-cols', cards.length);
+
+            window.BurstPicker.playPickerBurst(cards, coverEl, _PICKER_PARAMS, {
+                streamMode: 'stagger',
+                streamInterval: 80,                  // 6×80ms = 480ms 全到位，cascade 但快
+                floatTimerSink: this._pickerFloatTweens,
+                runId: runId,
+                getRunId: () => this._pickerRunId
+            });
+        },
+
+        /**
          * 啟動 EventSource，處理 candidate / done / error 事件 + 3s no-event timeout
+         * 候選卡先收進 _candidates（保持 opacity:0），SSE 收齊後一次 burst 全部 → 視覺對稱。
          */
         _startPickerSSE(name, runId) {
             const url = `/api/actresses/${encodeURIComponent(name)}/photo-candidates`;
             const sse = new EventSource(url);
             this._pickerSSE = sse;
+            this._pickerBurstFired = false;
 
             const scheduleTimeout = () => {
                 clearTimeout(this._pickerTimeoutTimer);
@@ -2301,42 +2339,16 @@ function showcaseState() {
                     if (this._pickerRunId !== runId) return;
                     sse.close();
                     this._pickerLoading = false;
+                    this._burstAllPickerCandidates(runId);
                 }, 3000);
             };
             scheduleTimeout();
 
-            sse.addEventListener('candidate', async (e) => {
+            sse.addEventListener('candidate', (e) => {
                 if (this._pickerRunId !== runId) { sse.close(); return; }
                 try {
                     const candidate = JSON.parse(e.data);
-                    // ⚠️ Race fix：必須在 push 後同步 capture myIndex，再 await。
-                    // 否則 SSE 一次連發多筆（local_crop 緊接 yield）時，所有 handler 在
-                    // await $nextTick 後 resume 看到的 _candidates.length 都是 N（最終值），
-                    // 會全部 pick cards[N-1]，導致中間 candidate 沒有 burst（停留 opacity: 0）。
                     this._candidates = [...this._candidates, candidate];
-                    const myIndex = this._candidates.length - 1;
-                    await this.$nextTick();
-                    if (this._pickerRunId !== runId) return;
-
-                    const grid = this.$refs.pickerGrid;
-                    if (grid && typeof window.BurstPicker !== 'undefined') {
-                        const cards = grid.querySelectorAll('.picker-candidate-card');
-                        const newCard = cards[myIndex];
-                        if (newCard) {
-                            // 用 $refs.pickerCoverImg 而非 $el.querySelector：在 @click handler 內
-                            // $el 是按鈕本身、不是 component root，querySelector 會 miss → cards 留 opacity:0
-                            const coverEl = this.$refs.pickerCoverImg;
-                            if (coverEl) {
-                                window.BurstPicker.playPickerBurst([newCard], coverEl, _PICKER_PARAMS, {
-                                    streamMode: 'instant',
-                                    streamInterval: 300,
-                                    floatTimerSink: this._pickerFloatTweens,
-                                    runId: runId,
-                                    getRunId: () => this._pickerRunId
-                                });
-                            }
-                        }
-                    }
                 } catch (err) {
                     console.warn('[Picker] Failed to parse candidate:', err);
                 }
@@ -2349,6 +2361,7 @@ function showcaseState() {
                 this._pickerSSE = null;
                 this._pickerLoading = false;
                 clearTimeout(this._pickerTimeoutTimer);
+                this._burstAllPickerCandidates(runId);
             });
 
             sse.onerror = () => {
@@ -2360,6 +2373,9 @@ function showcaseState() {
                     if (typeof this.showToast === 'function') {
                         this.showToast(window.t('showcase.actress.picker.error'), 'error');
                     }
+                } else {
+                    // 已收到部分候選，仍 burst 給用戶選
+                    this._burstAllPickerCandidates(runId);
                 }
             };
         },
@@ -2563,8 +2579,12 @@ function showcaseState() {
             this._pickerSelected = false;
             this._candidates = [];
             this._pickerCurrentSource = null;
+            this._pickerBurstFired = false;
             this._pickerFloatTweens.forEach(t => t && t.kill && t.kill());
             this._pickerFloatTweens = [];
+            // 清掉 _burstAllPickerCandidates 設的 --picker-cols（防下輪 count 不同殘留）
+            const grid = this.$refs?.pickerGrid;
+            if (grid) grid.style.removeProperty('--picker-cols');
         },
 
         /**

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -1700,7 +1700,7 @@ function showcaseState() {
                 this.$nextTick(function () {
                     var cardEl = document.querySelector('[data-flip-id="' + CSS.escape(flybackFlipId) + '"]');
                     if (cardEl) {
-                        window.GhostFly.playLightboxToGrid(flybackFromRect, cardEl, { coverSrc: flybackCoverSrc });
+                        window.GhostFly.playLightboxToGrid(flybackFromRect, cardEl, { coverSrc: flybackCoverSrc, fromImg: lbImg });
                     }
                 });
             }

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -271,6 +271,8 @@ function showcaseState() {
                         if (this.lightboxCloseTimer) clearTimeout(this.lightboxCloseTimer);  // F2: cleanup delayed clear timer
                         if (this.toastTimer) clearTimeout(this.toastTimer);
                         if (this.lightboxOpen) document.body.classList.remove('overflow-hidden');
+                        this._resetPicker();                                  // 53a-T1: 清場 picker 狀態
+                        window.GhostFly?.cleanupStaleGhosts?.();              // 53a-T1: 移除殘留 ghost（沿 v0.8.1 T4 optional-chaining pattern）
                     }
                 });
             }

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -2369,6 +2369,9 @@ function showcaseState() {
          */
         _onPickerHoverIn(el, i) {
             if (this._pickerSelected) return;
+            // 飛行中（pickerSettled !== '1'）不觸發 hover scale-up，避免 burst 尾段
+            // killTweensOf 凍結卡片於中途位置
+            if (!el || el.dataset.pickerSettled !== '1') return;
             if (typeof window.BurstPicker !== 'undefined') {
                 window.BurstPicker.playPickerHoverIn(el, _PICKER_PARAMS);
             }

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -3,6 +3,18 @@
  * M2a: 基本骨架 + API 載入 + Image Grid 渲染
  */
 
+// 53a codex F3: $persist 對 localStorage 壞 JSON 沒 try/catch（會在 Alpine init 階段拋錯炸整頁），
+// 必須在 Alpine.data 註冊前先清掃壞值，讓 $persist fallback 走預設物件
+(function _safeCleanShowcaseState() {
+    try {
+        var raw = localStorage.getItem('showcase_state');
+        if (raw !== null) JSON.parse(raw);
+    } catch (e) {
+        try { localStorage.removeItem('showcase_state'); } catch (_) { /* storage unavailable */ }
+        console.warn('[Showcase] cleared corrupt showcase_state from localStorage:', e);
+    }
+})();
+
 // F1: 大陣列移出 Alpine reactive scope — Alpine 不追蹤
 var _videos = [];
 var _filteredVideos = [];

--- a/web/static/js/pages/showcase/core.js
+++ b/web/static/js/pages/showcase/core.js
@@ -100,6 +100,19 @@ function showcaseState() {
     };
 
     return {
+        // 53a-T2: 持久化容器（$persist 自動同步 localStorage 的 'showcase_state' key）
+        // sort/order/actressSort/actressOrder 用 null sentinel，讓 restoreState 走 URL > _persisted > config > fallback 優先序
+        _persistedShowcase: this.$persist({
+            sort: null,
+            order: null,
+            page: 1,
+            search: '',
+            mode: 'grid',
+            showFavoriteActresses: false,
+            actressSort: null,
+            actressOrder: null,
+        }).as('showcase_state'),
+
         // --- 狀態變數 ---
         loading: true,
         error: '',           // 錯誤訊息（API 失敗時顯示）
@@ -307,21 +320,15 @@ function showcaseState() {
             // 必須保留 numeric 0 讓下方 grid+perPage=0→120 降級邏輯有機會觸發。
             const defaultPerPage = cfg.items_per_page ?? 90;
 
-            // 2. 從 localStorage 恢復（優先於 config）
-            const saved = localStorage.getItem('showcase_state');
-            let state = {};
-            if (saved) {
-                try {
-                    state = JSON.parse(saved);
-                } catch (e) {
-                    console.warn('[Showcase] Failed to parse localStorage:', e);
-                }
-            }
+            // 2. 從 _persistedShowcase（$persist 自動讀的 localStorage 'showcase_state'）取
+            //    53a-T2: 取代手寫 localStorage.getItem + JSON.parse，格式向後相容
+            const state = this._persistedShowcase || {};
 
             // 3. 從 URL params 恢復（最高優先）
             const urlParams = new URLSearchParams(window.location.search);
 
-            // 4. 優先序：URL > localStorage > config > fallback
+            // 4. 優先序：URL > _persistedShowcase > config > fallback
+            //    sort/order/actressSort/actressOrder 在 _persisted 用 null sentinel，新用戶會透下到 config
             //    urlNum: 取 URL 數值參數，空字串視為無值（避免 parseInt("") → NaN）
             const urlNum = (key) => { const v = urlParams.get(key); return v !== null && v !== '' ? v : undefined; };
             this.sort = urlParams.get('sort') || state.sort || defaultSort;
@@ -337,7 +344,7 @@ function showcaseState() {
             if (this.mode === 'grid' && this.perPage === 0) {
                 this.perPage = 120;
             }
-            // ★ 44a: 女優模式 — 只從 localStorage，不加 URL params（避免汙染 shareable link）
+            // ★ 44a: 女優模式 — 只從 _persistedShowcase，不加 URL params（避免汙染 shareable link）
             this.showFavoriteActresses = state.showFavoriteActresses === true;  // 嚴格 === true
             this.actressSort = state.actressSort || 'video_count';
             this.actressOrder = state.actressOrder || 'desc';
@@ -345,18 +352,16 @@ function showcaseState() {
 
         // --- 狀態持久化 (M2c) ---
         saveState() {
-            const state = {
-                sort: this.sort,
-                order: this.order,
-                // T3.2 (CD-52-3): perPage 不再寫入 localStorage（每次 init 重讀 cfg.items_per_page）
-                page: this.page,
-                search: this.search,
-                mode: this.mode,
-                showFavoriteActresses: this.showFavoriteActresses,  // ★ 44a
-                actressSort: this.actressSort,                      // ★ 44a
-                actressOrder: this.actressOrder,                    // ★ 44a
-            };
-            localStorage.setItem('showcase_state', JSON.stringify(state));
+            // 53a-T2: 寫入 reactive _persistedShowcase，$persist 自動同步 localStorage 'showcase_state'
+            // T3.2 (CD-52-3): perPage 不寫入（每次 init 重讀 cfg.items_per_page）
+            this._persistedShowcase.sort = this.sort;
+            this._persistedShowcase.order = this.order;
+            this._persistedShowcase.page = this.page;
+            this._persistedShowcase.search = this.search;
+            this._persistedShowcase.mode = this.mode;
+            this._persistedShowcase.showFavoriteActresses = this.showFavoriteActresses;  // ★ 44a
+            this._persistedShowcase.actressSort = this.actressSort;                      // ★ 44a
+            this._persistedShowcase.actressOrder = this.actressOrder;                    // ★ 44a
 
             // 同步到 URL（方便分享連結）
             const params = new URLSearchParams();

--- a/web/static/js/shared/ghost-fly.js
+++ b/web/static/js/shared/ghost-fly.js
@@ -174,7 +174,7 @@
          * Lightbox → Grid ghost fly-back
          * @param {DOMRect} fromRect - lightbox 封面的 bounding rect（lightboxOpen = false 前捕獲）
          * @param {Element} targetCardEl - 目標 grid 卡片元素
-         * @param {object} [options] - { coverSrc }
+         * @param {object} [options] - { coverSrc, fromImg }
          * @returns {null} fire-and-forget
          */
         playLightboxToGrid: function (fromRect, targetCardEl, options) {
@@ -184,6 +184,10 @@
             if (window.OpenAver && window.OpenAver.prefersReducedMotion) return null;
 
             if (!fromRect.width || fromRect.width === 0) return null;
+
+            // 隱藏 lightbox 大圖，避免 ghost 縮回過程與原位大圖疊圖（lightbox CSS fade-out 250ms）
+            var fromImg = options.fromImg || document.querySelector('.lightbox-cover img');
+            if (fromImg) gsap.set(fromImg, { opacity: 0 });
 
             // 判斷目標卡片是否在 viewport 內
             var targetImg = targetCardEl.querySelector('.av-card-preview-img img, .actress-card-photo img');

--- a/web/static/js/shared/ghost-fly.js
+++ b/web/static/js/shared/ghost-fly.js
@@ -189,12 +189,17 @@
             var fromImg = options.fromImg || document.querySelector('.lightbox-cover img');
             if (fromImg) gsap.set(fromImg, { opacity: 0 });
 
+            function abort() {
+                if (fromImg) gsap.set(fromImg, { opacity: 1 });
+                return null;
+            }
+
             // 判斷目標卡片是否在 viewport 內
             var targetImg = targetCardEl.querySelector('.av-card-preview-img img, .actress-card-photo img');
-            if (!targetImg) return null;
+            if (!targetImg) return abort();
 
             var toRect = targetImg.getBoundingClientRect();
-            if (!toRect || toRect.width === 0) return null;
+            if (!toRect || toRect.width === 0) return abort();
 
             var viewportH = window.innerHeight;
             var viewportW = window.innerWidth;
@@ -205,7 +210,7 @@
 
             if (!inViewport) {
                 // 退化：直接 fade-out（不強制 scroll）
-                return null;
+                return abort();
             }
 
             var coverSrc = options.coverSrc || targetImg.src;

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -268,6 +268,43 @@
             width: 24px;
             margin-right: 0.5rem;
         }
+
+        /* 53b-T4: sidebar 通知鈴鐺（語義為 button，繼承 nav-link 視覺但非切頁） */
+        .sidebar .nav-link--bell {
+            background: none;
+            border: none;
+            cursor: pointer;
+            font: inherit;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.5rem 0.75rem;
+            width: 100%;
+            text-align: left;
+            border-radius: var(--fluent-radius-md, 8px);
+            color: inherit;
+            transition: background var(--fluent-duration-fast, 167ms) var(--fluent-ease, linear);
+        }
+        .sidebar .nav-link--bell:hover {
+            background: var(--fluent-subtle-fill-secondary, rgba(0,0,0,0.04));
+        }
+        .sidebar .nav-link--bell.is-open {
+            background: var(--fluent-subtle-fill-secondary, rgba(0,0,0,0.06));
+        }
+        /* 紅點：絕對定位於 icon 右上，sidebar collapsed 時仍可見 */
+        .sidebar .nav-link__unread-dot {
+            position: absolute;
+            top: 8px;
+            left: 28px;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            border: 1.5px solid var(--sidebar-bg, transparent);
+        }
+        .sidebar .nav-link__unread-dot.is-info    { background: hsl(var(--in)); }
+        .sidebar .nav-link__unread-dot.is-success { background: hsl(var(--su)); }
+        .sidebar .nav-link__unread-dot.is-warn    { background: hsl(var(--wa)); }
+        .sidebar .nav-link__unread-dot.is-error   { background: hsl(var(--er)); }
     </style>
 
     {% block extra_css %}{% endblock %}
@@ -302,7 +339,61 @@
             event.preventDefault();
         }
     },
-    sampleGalleryOpen: false, sampleGalleryImages: [], sampleGalleryIndex: 0
+    sampleGalleryOpen: false, sampleGalleryImages: [], sampleGalleryIndex: 0,
+    notifBell: {
+        items: [],
+        unreadCount: 0,
+        highestLevel: null,
+        drawerOpen: false,
+        _pollTimer: null,
+        _FAST_INTERVAL: 2000,
+        _SLOW_INTERVAL: 5000,
+        _anchorEl: null,
+        _mediaQuery: null,
+    },
+    init() {
+        this.notifBell._pollTimer = setInterval(() => { this._pollNotifications(); }, this.notifBell._SLOW_INTERVAL);
+        this._pollNotifications();
+        this.notifBell._mediaQuery = window.matchMedia('(min-width: 1024px)');
+        const mqHandler = () => { if (this.notifBell.drawerOpen) this.closeDrawer(); };
+        if (this.notifBell._mediaQuery.addEventListener) {
+            this.notifBell._mediaQuery.addEventListener('change', mqHandler);
+        } else {
+            this.notifBell._mediaQuery.addListener(mqHandler);
+        }
+        window.addEventListener('beforeunload', () => { clearInterval(this.notifBell._pollTimer); });
+    },
+    async _pollNotifications() {
+        try {
+            const res = await fetch('/api/notifications');
+            if (!res.ok) return;
+            const data = await res.json();
+            this.notifBell.items = data.items ?? [];
+            this.notifBell.unreadCount = data.unread_count ?? 0;
+            this.notifBell.highestLevel = data.highest_unread_level ?? null;
+        } catch (_) {}
+    },
+    async toggleDrawer(anchorEl) {
+        if (this.notifBell.drawerOpen) { return this.closeDrawer(); }
+        this.notifBell._anchorEl = anchorEl;
+        this.notifBell.drawerOpen = true;
+        clearInterval(this.notifBell._pollTimer);
+        this.notifBell._pollTimer = setInterval(() => { this._pollNotifications(); }, this.notifBell._FAST_INTERVAL);
+        await fetch('/api/notifications/read', { method: 'POST' });
+        await this._pollNotifications();
+    },
+    closeDrawer() {
+        this.notifBell.drawerOpen = false;
+        clearInterval(this.notifBell._pollTimer);
+        this.notifBell._pollTimer = setInterval(() => { this._pollNotifications(); }, this.notifBell._SLOW_INTERVAL);
+    },
+    async clearNotifications() {
+        await fetch('/api/notifications', { method: 'DELETE' });
+        await this._pollNotifications();
+    },
+    formatTimestamp(ts) {
+        return new Date(ts * 1000).toLocaleString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+    }
 }"
      x-init="$watch('sidebarCollapsed', configSync('sidebar_collapsed'))"
      :class="{ 'sidebar-collapsed': sidebarCollapsed }"
@@ -326,7 +417,25 @@
             </span>
         </div>
         <div class="navbar-end">
-            <span class="w-10"></span>
+            <!-- 53b-T4: mobile 鈴鐺 -->
+            <button x-ref="mobileBellBtn"
+                    @click.stop="toggleDrawer($refs.mobileBellBtn)"
+                    type="button"
+                    class="btn btn-ghost btn-sm relative"
+                    :aria-label="notifBell.drawerOpen ? (window.t ? window.t('notif.close') : '關閉通知') : (window.t ? window.t('notif.open') : '開啟通知')"
+                    aria-haspopup="true"
+                    :aria-expanded="notifBell.drawerOpen.toString()">
+                <i :class="notifBell.unreadCount > 0 ? 'bi bi-bell-fill' : 'bi bi-bell'" class="text-xl"></i>
+                <template x-if="notifBell.highestLevel">
+                    <span class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full"
+                          :class="{
+                            'bg-info': notifBell.highestLevel === 'info',
+                            'bg-success': notifBell.highestLevel === 'success',
+                            'bg-warning': notifBell.highestLevel === 'warn',
+                            'bg-error': notifBell.highestLevel === 'error'
+                          }"></span>
+                </template>
+            </button>
         </div>
     </nav>
 
@@ -446,6 +555,31 @@
                     <span class="nav-text">{{ t('nav.showcase') }}</span>
                 </a>
             </li>
+            <!-- 53b-T4: desktop 鈴鐺（sidebar 內 help 上方，不是切頁 nav-item） -->
+            <li class="nav-item">
+                <button x-ref="desktopBellBtn"
+                        @click.stop="toggleDrawer($refs.desktopBellBtn)"
+                        type="button"
+                        class="nav-link nav-link--bell relative w-full text-left"
+                        :class="{ 'is-open': notifBell.drawerOpen }"
+                        :title="notifBell.unreadCount > 0 ? ((window.t ? window.t('notif.title') : '通知') + ' (' + notifBell.unreadCount + ')') : (window.t ? window.t('notif.title') : '通知')"
+                        :aria-label="notifBell.drawerOpen ? (window.t ? window.t('notif.close') : '關閉通知') : (window.t ? window.t('notif.open') : '開啟通知')"
+                        aria-haspopup="dialog"
+                        :aria-expanded="notifBell.drawerOpen.toString()">
+                    <i :class="notifBell.unreadCount > 0 ? 'bi bi-bell-fill' : 'bi bi-bell'"></i>
+                    <span class="nav-text" x-text="window.t ? window.t('notif.title') : '通知'"></span>
+                    <template x-if="notifBell.highestLevel">
+                        <span class="nav-link__unread-dot"
+                              :class="{
+                                'is-info':    notifBell.highestLevel === 'info',
+                                'is-success': notifBell.highestLevel === 'success',
+                                'is-warn':    notifBell.highestLevel === 'warn',
+                                'is-error':   notifBell.highestLevel === 'error'
+                              }"
+                              aria-hidden="true"></span>
+                    </template>
+                </button>
+            </li>
             <li class="nav-item mt-auto">
                 <a class="nav-link {% if page == 'help' %}active{% endif %}" href="/help" title="{{ t('nav.help_title') }}"
                    @click="handleNavClick($event, $el.href)">
@@ -493,12 +627,67 @@
     <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.15.12/dist/cdn.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.15.12/dist/cdn.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.15.12/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/anchor@3.15.12/dist/cdn.min.js"></script>
     <!-- Alpine Core -->
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js"></script>
     <!-- Tutorial JS -->
     <script src="/static/js/components/tutorial.js"></script>
 
     {% block extra_js %}{% endblock %}
+
+    <!-- 53b-T4: 通知抽屜（單例，fixed 浮動，anchor 由 toggleDrawer 決定） -->
+    <div x-show="notifBell.drawerOpen"
+         x-cloak
+         x-anchor.right-start.offset.8="notifBell._anchorEl || $el"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0 -translate-x-2"
+         x-transition:enter-end="opacity-100 translate-x-0"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-start="opacity-100 translate-x-0"
+         x-transition:leave-end="opacity-0 -translate-x-2"
+         x-trap.inert="notifBell.drawerOpen"
+         @click.outside="closeDrawer()"
+         @keydown.escape.window="if (notifBell.drawerOpen) closeDrawer()"
+         class="w-80 bg-base-100 border border-base-300 rounded-xl shadow-lg"
+         style="z-index: 1010; position: fixed;"
+         role="dialog"
+         :aria-label="window.t ? window.t('notif.dialog_label') : '通知中心'">
+        <div class="flex items-center justify-between px-4 py-2 border-b border-base-300">
+            <span class="font-semibold text-sm" x-text="window.t ? window.t('notif.title') : '通知'"></span>
+            <button @click="clearNotifications()"
+                    class="btn btn-ghost btn-xs text-base-content/60"
+                    x-text="window.t ? window.t('notif.clear_all') : '全部清空'"></button>
+        </div>
+        <div class="max-h-80 overflow-y-auto">
+            <template x-if="notifBell.items.length === 0">
+                <div class="px-4 py-6 text-center text-base-content/40 text-sm"
+                     x-text="window.t ? window.t('notif.empty') : '目前沒有通知'"></div>
+            </template>
+            <template x-for="item in notifBell.items" :key="item.id">
+                <div class="px-4 py-3 border-b border-base-200"
+                     :class="item.is_read ? 'opacity-60' : ''">
+                    <div class="flex items-start gap-2">
+                        <span class="text-xs mt-0.5 flex-shrink-0"
+                              :class="{
+                                'text-info': item.level === 'info',
+                                'text-success': item.level === 'success',
+                                'text-warning': item.level === 'warn',
+                                'text-error': item.level === 'error'
+                              }">●</span>
+                        <div class="flex-1 min-w-0">
+                            <div class="text-sm font-medium leading-tight"
+                                 x-text="window.t ? window.t(item.title_key) : item.title_key"></div>
+                            <template x-if="item.message">
+                                <div class="text-xs text-base-content/60 mt-0.5" x-text="item.message"></div>
+                            </template>
+                            <div class="text-xs text-base-content/40 mt-0.5"
+                                 x-text="formatTimestamp(item.timestamp)"></div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -488,11 +488,13 @@
     <!-- Burst Picker — shared photo-picker animation module (49b-T4a) -->
     <script defer src="/static/js/shared/burst-picker.js"></script>
 
-    <!-- Alpine Plugins (must load before Alpine Core) -->
-    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
+    <!-- Alpine Plugins (must load before Alpine Core) — 53a: 釘版 3.15.12，新增 focus + intersect -->
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.15.12/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.15.12/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.15.12/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/intersect@3.15.12/dist/cdn.min.js"></script>
     <!-- Alpine Core -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js"></script>
     <!-- Tutorial JS -->
     <script src="/static/js/components/tutorial.js"></script>
 

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -269,21 +269,16 @@
             margin-right: 0.5rem;
         }
 
-        /* 53b-T4: sidebar 通知鈴鐺（語義為 button，繼承 nav-link 視覺但非切頁） */
+        /* 53b-T7: sidebar 通知鈴鐺：只保留 button reset，版面對齊繼承 .nav-link */
         .sidebar .nav-link--bell {
+            appearance: none;
             background: none;
             border: none;
             cursor: pointer;
             font: inherit;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 0.5rem 0.75rem;
-            width: 100%;
             text-align: left;
-            border-radius: var(--fluent-radius-md, 8px);
-            color: inherit;
-            transition: background var(--fluent-duration-fast, 167ms) var(--fluent-ease, linear);
+            width: -webkit-fill-available; /* 讓 button 像 <a> 撐滿 <li> 可用寬，消除 icon 右偏 */
+            width: stretch;                /* 標準草案等效值（Chromium 已支援） */
         }
         .sidebar .nav-link--bell:hover {
             background: var(--fluent-subtle-fill-secondary, rgba(0,0,0,0.04));
@@ -301,10 +296,10 @@
             border-radius: 50%;
             border: 1.5px solid var(--sidebar-bg, transparent);
         }
-        .sidebar .nav-link__unread-dot.is-info    { background: hsl(var(--in)); }
-        .sidebar .nav-link__unread-dot.is-success { background: hsl(var(--su)); }
-        .sidebar .nav-link__unread-dot.is-warn    { background: hsl(var(--wa)); }
-        .sidebar .nav-link__unread-dot.is-error   { background: hsl(var(--er)); }
+        .sidebar .nav-link__unread-dot.is-info    { background: var(--color-info); }
+        .sidebar .nav-link__unread-dot.is-success { background: var(--color-success); }
+        .sidebar .nav-link__unread-dot.is-warn    { background: var(--color-warning); }
+        .sidebar .nav-link__unread-dot.is-error   { background: var(--color-error); }
     </style>
 
     {% block extra_css %}{% endblock %}
@@ -555,12 +550,12 @@
                     <span class="nav-text">{{ t('nav.showcase') }}</span>
                 </a>
             </li>
-            <!-- 53b-T4: desktop 鈴鐺（sidebar 內 help 上方，不是切頁 nav-item） -->
-            <li class="nav-item">
+            <!-- 53b-T7: desktop 鈴鐺在底部組最上方（mt-auto 推至底，Bell → Help → Settings） -->
+            <li class="nav-item mt-auto">
                 <button x-ref="desktopBellBtn"
                         @click.stop="toggleDrawer($refs.desktopBellBtn)"
                         type="button"
-                        class="nav-link nav-link--bell relative w-full text-left"
+                        class="nav-link nav-link--bell relative"
                         :class="{ 'is-open': notifBell.drawerOpen }"
                         :title="notifBell.unreadCount > 0 ? ((window.t ? window.t('notif.title') : '通知') + ' (' + notifBell.unreadCount + ')') : (window.t ? window.t('notif.title') : '通知')"
                         :aria-label="notifBell.drawerOpen ? (window.t ? window.t('notif.close') : '關閉通知') : (window.t ? window.t('notif.open') : '開啟通知')"
@@ -580,7 +575,7 @@
                     </template>
                 </button>
             </li>
-            <li class="nav-item mt-auto">
+            <li class="nav-item">
                 <a class="nav-link {% if page == 'help' %}active{% endif %}" href="/help" title="{{ t('nav.help_title') }}"
                    @click="handleNavClick($event, $el.href)">
                     <i class="bi bi-question-circle"></i>

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -50,6 +50,7 @@
         <a href="#ds-feedback">Feedback</a>
         <a href="#ds-showcase-elements">Showcase Elements</a>
         <a href="#ds-search-elements">Search Elements</a>
+        <a href="#ds-notif-center">Notification Center</a>
     </nav>
 
     <!-- 右側內容 -->
@@ -3059,6 +3060,136 @@
                 </p>
             </div>
 
+        </section>
+
+        <!-- Notification Center (53b-T1 demo) -->
+        <section id="ds-notif-center" class="ds-section glass"
+                 x-data="{
+                     demoDrawerOpen: true,  /* TODO 53b-T4: 接 toggle，本 demo 永遠展開 */
+                     demoItemsFull: [],
+                     demoItems: [],
+                     fakeDataMode: 'has_items',
+                     init() {
+                         var now = Date.now() / 1000;
+                         this.demoItemsFull = [
+                             { id: '1', level: 'error',   title_key: 'notif.scanner_failed',                 message: '掃描中斷：找不到資料夾', timestamp: now - 120 },
+                             { id: '2', level: 'warn',    title_key: 'notif.batch_enrich_done_with_errors',  message: '補完 48 部，2 部失敗',    timestamp: now - 300 },
+                             { id: '3', level: 'success', title_key: 'notif.scanner_done',                   message: '完成 1247 部',            timestamp: now - 600 },
+                             { id: '4', level: 'info',    title_key: 'notif.batch_enrich_started',           message: '共 50 部',                timestamp: now - 660 }
+                         ];
+                         this.demoItems = [...this.demoItemsFull];
+                     },
+                     toggleFakeData() {
+                         this.fakeDataMode = this.fakeDataMode === 'has_items' ? 'empty' : 'has_items';
+                         this.demoItems = this.fakeDataMode === 'has_items' ? [...this.demoItemsFull] : [];
+                     },
+                     clearAll() { this.demoItems = []; this.fakeDataMode = 'empty'; }
+                 }">
+            <h2>Notification Center</h2>
+            <p class="ds-note">53b-T1 靜態 demo — 鈴鐺 4 狀態 + 抽屜 4 嚴重度通知樣本。實際 poll / 已讀邏輯 / anchor 定位 / focus trap 在 T2-T5 接入 base.html。</p>
+
+            <!-- Subsection 1: 鈴鐺 4 狀態並排 -->
+            <div class="ds-subsection">
+                <h3>Bell States</h3>
+                <p class="ds-desc">鈴鐺 4 狀態（idle / info / warn / error），DaisyUI semantic color 自動跟主題（CD-53B-9）。</p>
+                <div class="flex items-center gap-6">
+                    <div class="flex flex-col items-center gap-1">
+                        <button class="btn btn-ghost btn-sm" type="button" aria-label="idle bell">
+                            <i class="bi bi-bell text-xl"></i>
+                        </button>
+                        <span class="text-xs text-base-content/60">idle</span>
+                    </div>
+                    <div class="flex flex-col items-center gap-1">
+                        <div class="relative inline-flex">
+                            <button class="btn btn-ghost btn-sm" type="button" aria-label="info bell">
+                                <i class="bi bi-bell-fill text-info text-xl"></i>
+                            </button>
+                            <span class="absolute top-1 right-1 w-2.5 h-2.5 rounded-full bg-info"></span>
+                        </div>
+                        <span class="text-xs text-base-content/60">INFO</span>
+                    </div>
+                    <div class="flex flex-col items-center gap-1">
+                        <div class="relative inline-flex">
+                            <button class="btn btn-ghost btn-sm" type="button" aria-label="warn bell">
+                                <i class="bi bi-bell-fill text-warning text-xl"></i>
+                            </button>
+                            <span class="absolute top-1 right-1 w-2.5 h-2.5 rounded-full bg-warning"></span>
+                        </div>
+                        <span class="text-xs text-base-content/60">WARN</span>
+                    </div>
+                    <div class="flex flex-col items-center gap-1">
+                        <div class="relative inline-flex">
+                            <button class="btn btn-ghost btn-sm" type="button" aria-label="error bell">
+                                <i class="bi bi-bell-fill text-error text-xl"></i>
+                            </button>
+                            <span class="absolute top-1 right-1 w-2.5 h-2.5 rounded-full bg-error"></span>
+                        </div>
+                        <span class="text-xs text-base-content/60">ERROR</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Subsection 2: 抽屜展開靜態樣本 -->
+            <div class="ds-subsection">
+                <h3>Drawer (Expanded Sample)</h3>
+                <p class="ds-desc">抽屜展開狀態，4 個嚴重度通知樣本。實際 anchor 定位 / 開關動畫 / focus trap 在 T4 接入。</p>
+                <div class="relative min-h-[360px]">
+                    <div class="w-80 bg-base-100 border border-base-300 rounded-xl shadow-lg">
+                        <div class="flex items-center justify-between px-4 py-2 border-b border-base-300">
+                            <span class="font-semibold text-sm" x-text="window.t('notif.title')"></span>
+                            <button class="btn btn-ghost btn-xs" type="button"
+                                    @click="clearAll()"
+                                    x-text="window.t('notif.clear_all')"></button>
+                        </div>
+                        <template x-if="demoItems.length === 0">
+                            <div class="p-6 text-center text-sm text-base-content/60"
+                                 x-text="window.t('notif.empty')"></div>
+                        </template>
+                        <template x-for="item in demoItems" :key="item.id">
+                            <div class="px-4 py-3 border-b border-base-200 last:border-b-0 hover:bg-base-200">
+                                <div class="flex items-start gap-2">
+                                    <span class="text-xs mt-0.5"
+                                          :class="{
+                                              'text-info':    item.level==='info',
+                                              'text-success': item.level==='success',
+                                              'text-warning': item.level==='warn',
+                                              'text-error':   item.level==='error'
+                                          }">●</span>
+                                    <div class="flex-1 min-w-0">
+                                        <div class="text-sm font-medium" x-text="window.t(item.title_key)"></div>
+                                        <div class="text-xs text-base-content/60" x-text="item.message"></div>
+                                        <div class="text-xs text-base-content/40 mt-1"
+                                             x-text="new Date(item.timestamp * 1000).toLocaleString('zh-TW')"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Subsection 3: 互動 -->
+            <div class="ds-subsection">
+                <h3>Demo Controls</h3>
+                <p class="ds-desc">切換假資料 / 全部清空（demo 階段為 no-op：直接清空 demoItems，T5 才接 confirm）。</p>
+                <div class="flex items-center gap-3">
+                    <button class="btn btn-sm" type="button" @click="toggleFakeData()">
+                        切換假資料（目前：<span x-text="fakeDataMode === 'has_items' ? '有通知' : '空抽屜'"></span>）
+                    </button>
+                    <button class="btn btn-sm btn-ghost" type="button" @click="clearAll()">
+                        清空（demo no-op）
+                    </button>
+                </div>
+            </div>
+
+            <!-- 技術細節 -->
+            <div class="ds-note">
+                <strong>技術細節：</strong>
+                嚴重度顏色用 DaisyUI semantic（<code>bg-info</code> / <code>bg-success</code> / <code>bg-warning</code> / <code>bg-error</code>），跟主題自動切換（CD-53B-9）。
+                抽屜 panel 用 <code>bg-base-100</code> + <code>shadow-lg</code> + <code>rounded-xl</code>，T4 整合 base.html 時再對齊 §2 玻璃階。
+                T1 demo <strong>不引入</strong> <code>@alpinejs/anchor</code>、<code>@alpinejs/focus</code>、<code>x-collapse</code>，皆留 T4 / T5 處理。
+                <br><strong>Demo Controls 文案 i18n 例外</strong>：「切換假資料 / 有通知 / 空抽屜 / 清空 (demo no-op)」為 design-system 內部開發者用文案，沿 ds-desc 中文慣例不抽 i18n。
+            </div>
         </section>
     </div>
 </div>

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -257,16 +257,24 @@
 
     <!-- Actress Alias Management -->
     <div class="actress-alias-card" id="actressAliasCard">
-        <div class="actress-alias-header">
+        <!-- 53a-T5fix: header 整列點擊展開（對齊 settings collapsible-trigger pattern） -->
+        <div class="actress-alias-header"
+             role="button"
+             tabindex="0"
+             :aria-expanded="(!aliasCardCollapsed).toString()"
+             title="{{ t('scanner.alias.collapse_title') }}"
+             @click="toggleAliasCard()"
+             @keydown.enter.prevent="toggleAliasCard()"
+             @keydown.space.prevent="toggleAliasCard()">
             <div class="title">
                 <i class="bi bi-person-circle"></i> <span>{{ t('scanner.alias.section_title') }}</span>
             </div>
-            <button class="btn-icon btn-collapse" @click="toggleAliasCard()" title="{{ t('scanner.alias.collapse_title') }}">
+            <span class="btn-collapse" aria-hidden="true">
                 <i class="bi" :class="aliasCardCollapsed ? 'bi-chevron-down' : 'bi-chevron-up'"></i>
-            </button>
+            </span>
         </div>
 
-        <div class="actress-alias-body" x-show="!aliasCardCollapsed">
+        <div class="actress-alias-body" x-show="!aliasCardCollapsed" x-collapse>
             <!-- 單一輸入框：篩選 + 新增 -->
             <div class="alias-toolbar">
                 <div class="alias-input-wrap">

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -390,7 +390,7 @@
                             <i class="bi bi-chevron-down" :class="{ 'rotate-180': expanded }"></i>
                         </span>
                     </button>
-                    <div x-show="expanded" x-transition class="collapsible-content" id="scraperAdvanced">
+                    <div x-show="expanded" x-collapse class="collapsible-content" id="scraperAdvanced">
 
                     <!-- 版本標記 -->
                     <div class="settings-form-row">
@@ -619,7 +619,7 @@
                             <i class="bi bi-chevron-down" :class="{ 'rotate-180': expanded }"></i>
                         </span>
                     </button>
-                    <div x-show="expanded" x-transition class="collapsible-content" id="galleryAdvanced">
+                    <div x-show="expanded" x-collapse class="collapsible-content" id="galleryAdvanced">
                     <div class="settings-form-row">
                         <label class="row-label">{{ t('settings.gallery.default_mode_label') }}</label>
                         <select class="select select-bordered select-sm" id="avlistMode"

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -512,7 +512,7 @@
         <!-- Lightbox (M3a) -->
         <div class="showcase-lightbox"
              :class="{ 'show': lightboxOpen }"
-             x-trap.inert="lightboxOpen"
+             x-trap.inert="lightboxOpen && !sampleGalleryOpen && !removeActressModalOpen"
              @click="handleLightboxBackdropClick($event)">
 
             <div class="lightbox-content" @click.stop>

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -512,6 +512,7 @@
         <!-- Lightbox (M3a) -->
         <div class="showcase-lightbox"
              :class="{ 'show': lightboxOpen }"
+             x-trap.inert="lightboxOpen"
              @click="handleLightboxBackdropClick($event)">
 
             <div class="lightbox-content" @click.stop>

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -797,7 +797,10 @@
                         </div>
                     </template>
                 </div>
-                <div x-show="_pickerLoading && _candidates.length === 0" class="picker-loading">
+                <!-- Method B（defer-burst）：loading 條件改用 _pickerBurstFired，避免第 1 張 candidate
+                     到達就隱藏 spinner、但 cards 仍 opacity:0（CSS 預設）造成空白 picker（cloud SSE
+                     可達 5s）。Empty 與 refresh 同步用 _pickerBurstFired 為基準。 -->
+                <div x-show="_pickerLoading && !_pickerBurstFired" class="picker-loading">
                     <i class="bi bi-hourglass-split"></i>
                     <span x-text="t('showcase.actress.picker.loading')"></span>
                 </div>
@@ -807,7 +810,7 @@
                     <p class="picker-empty-hint" x-text="t('showcase.actress.picker.empty_hint')"></p>
                 </div>
                 <button class="picker-refresh-btn"
-                        x-show="_candidates.length > 0"
+                        x-show="_pickerBurstFired"
                         @click.stop="openActressPicker()"
                         :disabled="_pickerLoading"
                         :title="t('showcase.actress.change_photo')"


### PR DESCRIPTION
## Summary

- **53a Alpine 輕量升級包**：Alpine 釘版 3.15.12 + 官方插件導入（focus / intersect / collapse / persist / anchor），showcase Lightbox 焦點鎖、切頁狀態保留、settings 平滑展開、showcase 切頁不殘留鬼影
- **53b 通知中心**：sidebar 鈴鐺 + 抽屜，Scanner / batch-enrich 事件即時可見（跨頁、跨裝置），後端 deque buffer + 3 個 REST 端點 + Capabilities 3 新 tool
- **Bug fixes**：ghost-fly 疊圖、photo picker burst、鈴鐺 icon 對齊（Playwright 測量 diff=0）

## Test plan

- [x] 全套測試 2822 passed, 0 failed（`pytest tests/ --ignore=tests/smoke --ignore=tests/e2e`）
- [x] unit test_notifications.py 5 tests — buffer 邏輯、evict orphan read_id、最高嚴重度計算
- [x] integration test_notifications_api.py 6 tests — GET / POST /read / DELETE 端點、priority 排序
- [x] Codex review ×3 輪，所有 P2 findings 已修正
- [x] Playwright 實測 bell icon 對齊（icon left diff = 0 vs 其他 nav icon）
- [x] 敏感資訊掃描 CLEAN、打包完整性 PASS
- [ ] milestone 前補齊 en / zh_CN / ja notif.* 翻譯 key（3 warnings，非阻擋）

🤖 Generated with [Claude Code](https://claude.com/claude-code)