### PR TITLE
v0.9.5 — Async Offload: move slow I/O off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.5] - 2026-06-05
+## [0.9.5] - 2026-06-06
 
 本版單一主軸：**把所有「在 `async def` 路由裡裸跑、會打慢 I/O（NAS 檔案 stat / HDD 上的 sqlite / config 檔 / 同步 HTTP）的同步呼叫」移出 event loop**，讓載圖／播放／切頁／任一慢請求不再互相凍住整個 app。純後端技術收斂，**無新 UI、無新設定、無新端點、零新依賴、零 ZIP 影響**；既有功能行為與輸出 byte 級不變。根因：FastAPI 對 `def` 路由會自動丟 threadpool，但 `async def` 路由的函式體直接跑在 event loop 上——裡面任何同步阻塞呼叫都會卡住整個 loop，連帶讓別的請求（含切到新頁的 HTML/API）排不進 loop，畫面就凍住。手段二選一：body 無 `await` → 直接改宣告為 `def`（最便宜，Starlette 自動 threadpool）；body 必須保留 `await` → 把阻塞段包進 `await asyncio.to_thread(...)`。逐處人工確認、不全域 sed。新增 AST 回歸守衛永久防止新路由再犯。
 
@@ -31,12 +31,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **守衛強化**：下潛巢狀 async generator（跑在 loop 上）、per-file 推斷「含阻塞 I/O 的 sync helper」並抓其裸呼叫、排除 generator function（呼叫只建物件、body 由 threadpool 迭代）
 - `jellyfin_image_check` 的 `get_db_path`（含 mkdir I/O）一併折進 helper，該路由 body 全乾淨
 
+#### 🔒 並發硬化（plan-66b 後續收斂）— 補回 offload 拆掉的隱式序列化
+async-offload 把 `async def`（無 await）改 `def`（Starlette threadpool ~40 並發）/ 加 `to_thread` 後，**拆掉了 event loop 對 handler 的隱式互斥**；凡「pre-branch 靠 loop 序列化才安全」的共享可變資源（config.json RMW / metatube runtime state / cold-start 單例 / 非-config 檔案寫入），offload 後變真並發 → lost-update / TOCTOU。全庫 5-subagent 稽核 + Codex review 後逐處補回協調機制：
+- **config.json 寫入序列化 + 原子寫（T1，最大）**：`core/config.py` 加 process-wide `threading.Lock`（非 asyncio.Lock——def 路由跑 threadpool thread），public-locked + private-unlocked 分層 + 原子寫（`tempfile.mkstemp`+`os.replace`）；新增 `mutate_config(mutator)` 把整個 load→改→save 收進單一 critical section。修掉「並切 theme+font（150ms debounce）靜默 lost-update」（每用戶會中）；config 三 RMW 路由 + metatube `_connect_sync`/`_persist_allow_lan` + `get_common_context` locale 首寫全遷移至 `mutate_config`，delete 走 `reset_config_file`（消 exists/unlink TOCTOU）
+- **metatube startup generation 帶回（T2）**：lifespan 不再於 `await` 後重讀 `state.generation`（與已修的 `/connect` race 同型 TOCTOU），`startup_reconnect` 回傳 `(names, gen)`；連線臨界段共用 `_connect_lock`
+- **metatube `/test` 原子 snapshot（T3）**：新增 `state.probe_snapshot()` 單鎖內取 `(names, gen, base_url, token)`，消「分 4 次讀夾出不一致組合」（names 仍沿用 `_availability` keys，行為不變）
+- **translate 單例 init 鎖（T4）**：`get_translate_service` double-checked locking，消 threadpool 並發冷啟動 double-init
+- **actress photo 檔寫競態（T4b）**：`_write_actress_photo` 改 `unlink(missing_ok=True)` + temp/`os.replace` 原子寫，消同 actress 並發 local_crop 的 glob/unlink TOCTOU（500）與 torn 檔
+- **守衛擴充（T5）**：`test_async_offload_guard.py` 新增 AST 守衛——`web/routers/*.py` + `web/app.py` 禁裸呼 `save_config`（唯一白名單 = `config.py::update_config` full-replace），新路由再犯即報錯
+
+*Concurrency hardening (plan-66b): the offload removed the event loop's implicit serialization, so shared mutable resources that were "safe only because the loop serialized them" became truly concurrent. Re-added coordination per path: a process-wide `threading.Lock` + atomic write + `mutate_config()` RMW helper in `core/config.py` (fixes the silent theme+font lost-update every user hits); metatube startup generation carry-back + shared `_connect_lock`; an atomic `/test` `probe_snapshot()`; a double-checked translate-singleton lock; lock-free atomic actress-photo write (`unlink(missing_ok)` + `os.replace`); and an AST guard banning bare `save_config` outside the `update_config` whitelist across routers + `web/app.py`. Pure backend, zero new deps, byte-identical behavior aside from the added coordination.*
+
 ### Non-Goals（明確不做）
 - 不導 HTMX（卡死根源在後端 loop，非前端換頁）、不做縮圖/WebP/快取（thumbnail-cache 押後）、不解單請求自身慢（HDD 喚醒/seek 的單張延遲）、不換 aiosqlite、不調 threadpool limiter
 
 ### 測試
-- 全套 pytest **3496 passed, 2 skipped**（unit + integration，排除 smoke / e2e）+ `npm run lint`（eslint + stylelint）綠
+- 全套 pytest **3523 passed, 2 skipped**（unit + integration，排除 smoke / e2e）+ `npm run lint`（eslint + stylelint）綠
 - 守衛 RED→GREEN 驗證 + 5 種 control（bare-helper / sync-generator / async-gen 內阻塞 / to_thread 包裝 / async-gen 內 bare-helper）全對
+- 並發硬化（plan-66b）每處皆**確定性測試**（`threading.Barrier`/`Event`/`lock.locked()` 斷言，非真 race flaky）：no-lost-update / atomic-no-temp-leftover / migration-no-deadlock / startup-generation-carry-back / probe-snapshot / singleton-init-once / actress-photo-atomic / save_config 守衛 RED-check
 
 ## [0.9.4] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-06-05
+
+本版單一主軸：**把所有「在 `async def` 路由裡裸跑、會打慢 I/O（NAS 檔案 stat / HDD 上的 sqlite / config 檔 / 同步 HTTP）的同步呼叫」移出 event loop**，讓載圖／播放／切頁／任一慢請求不再互相凍住整個 app。純後端技術收斂，**無新 UI、無新設定、無新端點、零新依賴、零 ZIP 影響**；既有功能行為與輸出 byte 級不變。根因：FastAPI 對 `def` 路由會自動丟 threadpool，但 `async def` 路由的函式體直接跑在 event loop 上——裡面任何同步阻塞呼叫都會卡住整個 loop，連帶讓別的請求（含切到新頁的 HTML/API）排不進 loop，畫面就凍住。手段二選一：body 無 `await` → 直接改宣告為 `def`（最便宜，Starlette 自動 threadpool）；body 必須保留 `await` → 把阻塞段包進 `await asyncio.to_thread(...)`。逐處人工確認、不全域 sed。新增 AST 回歸守衛永久防止新路由再犯。
+
+*This release has one theme: **move every synchronous slow-I/O call (NAS file stat / sqlite on HDD / config files / sync HTTP) that was bare-running inside an `async def` route off the event loop**, so loading covers / playback / pagination / any slow request no longer freeze the whole app for each other. Pure backend convergence — no new UI/settings/endpoints, zero new deps, zero ZIP impact; existing behavior is byte-identical. Root cause: FastAPI auto-threadpools `def` routes, but an `async def` route body runs directly on the event loop, so any synchronous blocking call there stalls the entire loop (including the HTML/API for switching pages). Two fixes: no `await` in body → convert to `def` (Starlette auto-threadpools); must keep `await` → wrap the blocking segment in `await asyncio.to_thread(...)`. Done per-call by hand, no global sed. A new AST regression guard permanently prevents new routes from reintroducing the bug.*
+
+### Changed
+
+#### ⚡ async def → def（body 無 await，Starlette 自動 threadpool）
+- **止血 hot path**：`get_image` / `get_video`（封面/影片代理）轉 def，一次涵蓋 realpath/exists/getsize/load_config 全部裸跑 stat（每張封面 = 多次 NAS stat，HDD 喚醒時單次可達數百 ms～數秒）
+- **純讀 DB 路由 11 處**轉 def：scanner `get_stats`/`clear_cache`/`check_update`/`check_missing`/`view_list`/`get_actress_stats`、showcase `get_videos`/`get_video`、search `get_favorite_files`/`get_local_status`、`motion_lab_data`
+- **config/設定檔 I/O 路由 9 處**轉 def：config 7 路由 + `get_scraper_sources` + `get_favorite_scanner_link`（load_config/save_config 移出 loop）
+
+#### 🧵 必留 async → to_thread 包阻塞段
+- **翻譯/AI 路由 5 處**：gemini/openai/translate/ollama 測試與翻譯端點的 `load_config` 包 `await asyncio.to_thread(...)`（body 有 httpx await，不能轉 def）
+- **半套 offload 補齊**：actress 照片 3 路由 / `jellyfin_image_check` / metatube `connect` 先前只 to_thread 了重活，同 body 的 `init_db`/`repo.*`/`load_config`/`save_config`/同步 HTTP 仍裸跑 → 抽 helper（`_check_cover_path`/`_load_actress`/`_connect_sync` 等）一併移出 loop
+- **SSE 外層 + 檔案走訪**：`search_stream`/`batch_enrich`/`list_photo_candidates` 的 pre-stream load_config/DB、`filter_files` 的整段 exists/stat/iterdir 檔案走訪移出 loop（內層 generator 維持原樣）
+
+### Added
+- **`tests/integration/test_async_offload_guard.py`**：AST 靜態守衛掃 `web/routers/*.py`，斷言每個 `async def` 路由（含巢狀 async generator）的 body 不得裸跑慢 I/O（直接呼叫或經「含阻塞 I/O 的 sync helper」間接呼叫皆抓）；並正斷言 T1–T3 轉 def 的 24 個 handler 維持 `def`，防回退。新路由自動納入掃描。
+
+### Fixed / Internal
+- **Codex review 補三處二階卡 loop**：`search_stream` 內層 async generator 裸呼 `_fetch_actress_profile_with_db`（init_db/repo + DB-miss 同步 scraper HTTP）、metatube `connect` dedup path 裸呼 `_persist_allow_lan`（load/save_config）、`translate_title`/`translate_batch` 裸呼 `get_translate_service`（冷啟動 load_config）全補 to_thread
+- **守衛強化**：下潛巢狀 async generator（跑在 loop 上）、per-file 推斷「含阻塞 I/O 的 sync helper」並抓其裸呼叫、排除 generator function（呼叫只建物件、body 由 threadpool 迭代）
+- `jellyfin_image_check` 的 `get_db_path`（含 mkdir I/O）一併折進 helper，該路由 body 全乾淨
+
+### Non-Goals（明確不做）
+- 不導 HTMX（卡死根源在後端 loop，非前端換頁）、不做縮圖/WebP/快取（thumbnail-cache 押後）、不解單請求自身慢（HDD 喚醒/seek 的單張延遲）、不換 aiosqlite、不調 threadpool limiter
+
+### 測試
+- 全套 pytest **3496 passed, 2 skipped**（unit + integration，排除 smoke / e2e）+ `npm run lint`（eslint + stylelint）綠
+- 守衛 RED→GREEN 驗證 + 5 種 control（bare-helper / sync-generator / async-gen 內阻塞 / to_thread 包裝 / async-gen 內 bare-helper）全對
+
 ## [0.9.4] - 2026-06-04
 
 本版單一主軸：讓「掃描來源」頁的 **Active Row 拖曳順序成為所有搜尋路由的唯一真理**，徹底移除 `primary_source` 概念。改完後邏輯收斂成一句話：**順序就是一切**。先前搜尋路由其實有兩套真理在打架——拖曳順序（auto 合併早已照它走）vs. 殘留的 `primary_source` 欄位（Settings 底部那塊標「已停用設定」的 radio，但對精準 DMM 短路與模糊 routing 仍暗中 live）。本版把這個會誤導人的隱性 gap 連根拔除：**精準搜尋**拔掉 DMM 整包短路（Rule 4a）、封面改跟 Active Row 順序（移除 hardcode 反浮水印優先序）、只用啟用中來源；**模糊搜尋**（女優名/關鍵字）從寫死 dmm/javbus 改成照 Active Row 順序的 fallback 鏈（循序試、命中即停、always-on 無視啟用），候選池實測收斂為 javbus + dmm（jav321 keyword 恆回空、javdb 連續模糊呼叫會被 Cloudflare ban）；**進階搜尋**（picker 單源覆寫）維持原樣不動。`primary_source` 從 schema 欄位、config 預設、no-op 傳遞點、Settings radio UI 到舊 config key 全清（含一次性 strip migration），Help 補一句說明「模糊鏈 always-on：停用的來源仍會被模糊搜尋用到」。

--- a/core/config.py
+++ b/core/config.py
@@ -9,8 +9,11 @@ core/config.py — 設定載入 / 儲存 / 遷移邏輯
 """
 
 import json
+import os
+import tempfile
+import threading
 from pathlib import Path
-from typing import Literal, Optional, List
+from typing import Callable, Literal, Optional, List
 
 from pydantic import BaseModel, Field
 
@@ -24,6 +27,14 @@ logger = get_logger(__name__)
 _PROJECT_ROOT = Path(__file__).parent.parent
 CONFIG_PATH = _PROJECT_ROOT / "web" / "config.json"
 CONFIG_DEFAULT_PATH = _PROJECT_ROOT / "web" / "config.default.json"
+
+# 66 TASK-66b-T1（CD-66b-1）：process-wide config.json 寫入序列化鎖。
+# async-offload 把 def 路由移到 threadpool thread 後，event loop 的隱式互斥消失，
+# load_config→mutate→save_config 的 RMW 變成真並發 → lost-update（Race A）。
+# 必須是 threading.Lock（非 asyncio.Lock）：def 路由跑在 threadpool thread，
+# asyncio.Lock 保護不到；且 plain Lock（非 RLock）—— public locked / private
+# unlocked 嚴格分層，鎖內絕不二次 acquire（mutator 契約禁呼 public API）。
+_config_write_lock = threading.Lock()
 
 
 # ============ Pydantic Schema ============
@@ -146,8 +157,12 @@ class AppConfig(BaseModel):
 
 # ============ 載入 / 儲存 ============
 
-def load_config() -> dict:
-    """載入設定，包含自動遷移邏輯和首次啟動初始化"""
+def _load_config_unlocked() -> dict:
+    """載入設定（含 migration / first-init），**不取鎖** —— caller 須已持有 _config_write_lock。
+
+    migration 的寫回必須走 _save_config_unlocked（同樣不取鎖），否則在已持鎖的
+    critical section 內再 acquire 同一 threading.Lock → 自我死鎖（CD-66b-1）。
+    """
     # 首次啟動：從 config.default.json 初始化
     if not CONFIG_PATH.exists() and CONFIG_DEFAULT_PATH.exists():
         import shutil
@@ -354,16 +369,67 @@ def load_config() -> dict:
                 raw_config['sources'] = []
             need_save = True
 
-        # Save migrated config
+        # Save migrated config（已持鎖 → 用 unlocked 版避免自我死鎖）
         if need_save:
-            save_config(raw_config)
+            _save_config_unlocked(raw_config)
 
         return raw_config
     # 返回預設設定（沒有 default 檔案時）
     return AppConfig().model_dump()
 
 
+def load_config() -> dict:
+    """載入設定，包含自動遷移邏輯和首次啟動初始化（process-wide 序列化）"""
+    with _config_write_lock:
+        return _load_config_unlocked()
+
+
+def _save_config_unlocked(config: dict) -> None:
+    """原子寫 config.json，**不取鎖** —— caller 須已持有 _config_write_lock。
+
+    tempfile.mkstemp 在 CONFIG_PATH 同目錄（同卷）建臨時檔 → fd 寫完關閉後
+    os.replace（POSIX/Windows 皆原子）。任何例外都清掉 temp 殘檔後 re-raise，
+    避免半寫的 *.tmp 殘留。fd 必須在 os.replace 前關閉（Windows file-lock）。
+    """
+    fd, tmp = tempfile.mkstemp(dir=CONFIG_PATH.parent, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(config, f, indent=2, ensure_ascii=False)
+        # fd 已由 with 區塊關閉 → 安全 replace
+        os.replace(tmp, CONFIG_PATH)
+    except Exception:
+        # 清掉殘留 temp（best-effort）後 re-raise
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 def save_config(config: dict) -> None:
-    """儲存設定"""
-    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
-        json.dump(config, f, indent=2, ensure_ascii=False)
+    """儲存設定（原子寫 + process-wide 序列化）"""
+    with _config_write_lock:
+        _save_config_unlocked(config)
+
+
+def mutate_config(mutator: Callable[[dict], None]) -> None:
+    """在單一 critical section 內 read-modify-write config.json（消除 RMW 競態）。
+
+    load → mutator(cfg)（原地修改 dict）→ save 全程持 _config_write_lock，
+    兩個並發 mutate_config 不再讀到同一 v0 → 無 lost-update（Race A）。
+
+    mutator 契約：`mutator(cfg: dict) -> None`，僅做純記憶體 dict 操作；
+    **不得**呼叫任何 public locked API（load_config / save_config /
+    mutate_config / reset_config_file）—— 會在已持鎖時二次 acquire → 自我死鎖。
+    """
+    with _config_write_lock:
+        cfg = _load_config_unlocked()
+        mutator(cfg)
+        _save_config_unlocked(cfg)
+
+
+def reset_config_file() -> None:
+    """刪除 config.json（恢復原廠）—— 在鎖內檢查 + 刪除，無 exists/unlink TOCTOU。"""
+    with _config_write_lock:
+        if CONFIG_PATH.exists():
+            CONFIG_PATH.unlink()

--- a/core/metatube/state.py
+++ b/core/metatube/state.py
@@ -50,7 +50,7 @@ class MetatubeConnectionState:
     # Mutations
     # ------------------------------------------------------------------
 
-    def connect(self, base_url: str, token: str, provider_names: list[str]) -> None:
+    def connect(self, base_url: str, token: str, provider_names: list[str]) -> int:
         """Mark as connected and bulk-set all named providers to available.
 
         Repeated connect rebuilds availability from scratch: _availability is
@@ -64,6 +64,13 @@ class MetatubeConnectionState:
             token:    API token (empty string means no auth required).
             provider_names: Raw provider names WITHOUT 'metatube:' prefix
                             (e.g. ['FANZA', 'HEYZO']).
+
+        Returns:
+            The generation counter this connect set (captured under the lock).
+            Callers that fire a generation-fenced probe AFTER an await/threadpool
+            boundary MUST use this returned value rather than re-reading
+            `state.generation` later — a concurrent connect/disconnect could have
+            advanced the global generation in between (66 Codex P2 race).
         """
         with self._lock:
             self._availability = {}  # clear stale keys before rebuilding
@@ -74,10 +81,12 @@ class MetatubeConnectionState:
             for name in provider_names:
                 self._availability[f'metatube:{name}'] = True
             self._generation += 1
+            gen = self._generation  # capture while lock held — atomic with the bump
         logger.debug(
             'MetatubeConnectionState.connect: base_url=%r providers=%r',
             base_url, provider_names,
         )
+        return gen
 
     def disconnect(self) -> None:
         """Mark as disconnected; bulk-set all known providers to unavailable.

--- a/core/metatube/state.py
+++ b/core/metatube/state.py
@@ -190,6 +190,23 @@ class MetatubeConnectionState:
         with self._lock:
             return self._availability.get(source_id, False)
 
+    def probe_snapshot(self) -> tuple[list[str], int, str, str]:
+        """Atomically snapshot (names, generation, base_url, token) for firing a probe.
+
+        Single _lock acquisition so /test cannot dance with a concurrent
+        connect/disconnect across separate reads (CD-66b-3). `names` is sourced
+        from `_availability` keys (stripped of the 'metatube:' prefix) — NOT
+        `_providers` — to preserve the existing behaviour that /test still lists
+        previously-known providers after a disconnect (which clears _providers but
+        keeps _availability keys set False).
+        """
+        with self._lock:
+            names = [k.split(":", 1)[1] for k in self._availability]
+            gen = self._generation
+            base_url = self.base_url or ""
+            token = self.token or ""
+            return names, gen, base_url, token
+
     # ------------------------------------------------------------------
     # Read-only properties
     # ------------------------------------------------------------------

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/integration/test_api_actress.py
+++ b/tests/integration/test_api_actress.py
@@ -562,12 +562,10 @@ class TestSetActressPhoto:
         video_uri = f"file://{video_path}"
         fake_jpeg = b"\xff\xd8\xff\xe0FAKE_CROP_JPEG"
 
+        gfriends = tmp_path / "gfriends"
+        gfriends.mkdir()
         with patch("web.routers.actress.crop_video_cover", return_value=fake_jpeg), \
-             patch("web.routers.actress.GFRIENDS_DIR") as mock_dir:
-            # mock GFRIENDS_DIR to write into tmp_path
-            mock_dir.__truediv__ = lambda self, other: tmp_path / other
-            mock_dir.mkdir = lambda **kw: None
-            mock_dir.glob = lambda pattern: []
+             patch("web.routers.actress.GFRIENDS_DIR", gfriends):
             resp = client.post(
                 f"/api/actresses/{ACTRESS_NAME}/photo",
                 json={"source": "local_crop", "video_path": video_uri},
@@ -577,6 +575,10 @@ class TestSetActressPhoto:
         data = resp.json()
         assert data["photo_source"] == "local_crop"
         assert "?t=" in data["photo_url"]
+        # file was actually written
+        written = list(gfriends.glob("*.jpg"))
+        assert len(written) == 1
+        assert written[0].read_bytes() == fake_jpeg
 
     # ---- 錯誤處理 ----
 
@@ -760,11 +762,10 @@ class TestSetActressPhoto:
             VideoRepository().upsert(vid)
             video_uri = f"file://{video_path}"
 
+            gfriends = Path(td) / "gfriends"
+            gfriends.mkdir()
             with patch("web.routers.actress.crop_video_cover", return_value=fake_jpeg), \
-                 patch("web.routers.actress.GFRIENDS_DIR") as mock_dir:
-                mock_dir.__truediv__ = lambda self, other: Path(td) / other
-                mock_dir.mkdir = lambda **kw: None
-                mock_dir.glob = lambda pattern: []
+                 patch("web.routers.actress.GFRIENDS_DIR", gfriends):
                 resp2 = client.post(
                     f"/api/actresses/{ACTRESS_NAME}/photo",
                     json={"source": "local_crop", "video_path": video_uri},
@@ -854,11 +855,10 @@ class TestSetActressPhoto:
         video_uri, cover_uri, video_path, cover_path = self._save_video_with_uri_path(tmp_path)
         fake_jpeg = b"\xff\xd8\xff\xe0FAKE_URI_CROP"
 
+        gfriends = tmp_path / "gfriends"
+        gfriends.mkdir()
         with patch("web.routers.actress.crop_video_cover", return_value=fake_jpeg), \
-             patch("web.routers.actress.GFRIENDS_DIR") as mock_dir:
-            mock_dir.__truediv__ = lambda self, other: tmp_path / other
-            mock_dir.mkdir = lambda **kw: None
-            mock_dir.glob = lambda pattern: []
+             patch("web.routers.actress.GFRIENDS_DIR", gfriends):
             resp = client.post(
                 f"/api/actresses/{ACTRESS_NAME}/photo",
                 json={"source": "local_crop", "video_path": video_uri},
@@ -868,3 +868,66 @@ class TestSetActressPhoto:
         data = resp.json()
         assert data["photo_source"] == "local_crop"
         assert "?t=" in data["photo_url"]
+
+
+# ---------------------------------------------------------------------------
+# _write_actress_photo — lock-free atomic write (66b-T4b)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteActressPhoto:
+    """確定性測試 _write_actress_photo 的 lock-free 原子寫語意（不需真並發）。"""
+
+    def test_write_actress_photo_atomic_last_wins(self, tmp_path):
+        """序列兩次同 actress 寫入 → 終態 = 後者 bytes，且只剩一個 jpg（舊檔已取代）。"""
+        from web.routers.actress import _write_actress_photo
+        from core.organizer import sanitize_filename
+
+        gfriends = tmp_path / "gfriends"
+        with patch("web.routers.actress.GFRIENDS_DIR", gfriends):
+            _write_actress_photo("Some Name", b"AAA")
+            _write_actress_photo("Some Name", b"BBB")
+
+            safe = sanitize_filename("Some Name")
+            dest = gfriends / f"{safe}.jpg"
+            assert dest.exists()
+            assert dest.read_bytes() == b"BBB"
+            # 只剩一個此 actress 的 jpg（無 temp 殘留、舊檔已取代）
+            assert list(gfriends.glob(f"{safe}.*")) == [dest]
+            assert list(gfriends.glob("tmp*")) == []
+
+    def test_write_actress_photo_unlink_race_missing_ok(self, tmp_path):
+        """模擬 unlink race：glob 回傳一個已被刪除的舊檔 → unlink(missing_ok=True) 不拋。"""
+        from web.routers.actress import _write_actress_photo
+        from core.organizer import sanitize_filename
+
+        gfriends = tmp_path / "gfriends"
+        gfriends.mkdir()
+        safe = sanitize_filename("Race Name")
+
+        # 先寫一個舊檔再刪掉，模擬「另一 writer 已 unlink 同檔」的競態
+        stale = gfriends / f"{safe}.png"
+        stale.write_bytes(b"OLD")
+        stale.unlink()  # 已不存在
+
+        with patch("web.routers.actress.GFRIENDS_DIR", gfriends), \
+             patch.object(type(gfriends), "glob", lambda self, pat: [stale]):
+            # glob 回傳已刪除的 stale → 不應拋 FileNotFoundError
+            _write_actress_photo("Race Name", b"NEW")
+
+        dest = gfriends / f"{safe}.jpg"
+        assert dest.exists()
+        assert dest.read_bytes() == b"NEW"
+
+    def test_write_actress_photo_no_temp_leftover_on_error(self, tmp_path):
+        """os.replace 拋 OSError → 重新拋出，且不留 tmp* 殘檔。"""
+        from web.routers.actress import _write_actress_photo
+
+        gfriends = tmp_path / "gfriends"
+        with patch("web.routers.actress.GFRIENDS_DIR", gfriends), \
+             patch("web.routers.actress.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError):
+                _write_actress_photo("Err Name", b"DATA")
+
+        # 例外後不留 temp 殘檔
+        assert list(gfriends.glob("tmp*")) == []

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -412,10 +412,17 @@ class TestJellyfinCheck:
         assert data['error'] == '檢查 Jellyfin 圖片狀態失敗'
 
     def test_jellyfin_check_uses_to_thread(self):
-        """靜態掃描確認 scanner.py 使用 asyncio.to_thread 包裝同步呼叫"""
+        """靜態掃描確認 scanner.py 使用 asyncio.to_thread 包裝 _check_jellyfin_needed helper，
+        且 helper 內含 db_path.exists、VideoRepository、check_jellyfin_images_needed"""
         import pathlib
         scanner_src = (pathlib.Path(__file__).parents[2] / 'web' / 'routers' / 'scanner.py').read_text(encoding='utf-8')
-        assert 'asyncio.to_thread(check_jellyfin_images_needed' in scanner_src
+        # helper 函式透過 to_thread 包裝
+        assert 'asyncio.to_thread(_check_jellyfin_needed' in scanner_src
+        # helper 函式 body 包含三個被 offload 的呼叫
+        assert 'def _check_jellyfin_needed(' in scanner_src
+        assert 'db_path.exists()' in scanner_src
+        assert 'VideoRepository(db_path)' in scanner_src
+        assert 'check_jellyfin_images_needed(repo)' in scanner_src
 
     # ---- T3(40c): TTL 快取相關測試 ----
 

--- a/tests/integration/test_api_translate.py
+++ b/tests/integration/test_api_translate.py
@@ -1,6 +1,8 @@
 """
 翻譯 API 日文跳過邏輯測試
 """
+import threading
+
 import httpx
 import pytest
 from fastapi.testclient import TestClient
@@ -131,3 +133,74 @@ class TestTranslateDisabled:
         data = response.json()
         assert data["success"] is False
         assert "翻譯功能未啟用" in data["error"]
+
+
+class TestTranslateServiceSingletonLock:
+    """CD-66b-5：translate service 單例 cold-start init 鎖（double-checked locking）"""
+
+    def test_concurrent_cold_start_inits_once(self):
+        """並發 cold-start：create_translate_service 只被呼叫一次、兩執行緒拿同一物件。
+
+        確定性（非靠時序碰運氣）：
+        - 兩執行緒先各自 barrier.wait() 在 Barrier(2) 會合，被同時釋放後
+          才呼叫 get_translate_service()，保證兩者「同時」進入 fast-path 的
+          `is None` 區域。
+        - barrier 放在 get 呼叫「之前」（不放在 create 內），因為有鎖時只有
+          一個執行緒會進 create，若把 Barrier(2) 放 create 內第二方永不到達
+          → 死鎖。
+        - 有鎖時：先進臨界區的執行緒 init，第二個阻塞於鎖，取得鎖後 re-check
+          見非 None → 跳過 create。故 create 只被呼叫一次。
+        """
+        from web.routers import translate as translate_mod
+
+        translate_mod._translate_service = None
+        try:
+            barrier = threading.Barrier(2)
+            sentinel = object()  # create 的唯一回傳值（單例）
+
+            def fake_create(translate_config, locale):
+                return sentinel
+
+            mock_create = patch(
+                "web.routers.translate.create_translate_service",
+                side_effect=fake_create,
+            )
+            mock_load = patch(
+                "web.routers.translate.load_config",
+                return_value={"translate": {}, "general": {"locale": "zh-TW"}},
+            )
+
+            results = {}
+
+            def worker(idx):
+                barrier.wait()  # 兩執行緒在此會合，同時被釋放
+                results[idx] = translate_mod.get_translate_service()
+
+            with mock_load, mock_create as m_create:
+                t0 = threading.Thread(target=worker, args=(0,))
+                t1 = threading.Thread(target=worker, args=(1,))
+                t0.start()
+                t1.start()
+                t0.join(timeout=5)
+                t1.join(timeout=5)
+
+                assert not t0.is_alive() and not t1.is_alive(), "執行緒未在時限內結束（疑似死鎖）"
+                # 鎖讓 init 只發生一次
+                assert m_create.call_count == 1
+                # 兩執行緒拿到同一單例物件
+                assert results[0] is sentinel
+                assert results[1] is sentinel
+                assert results[0] is results[1]
+        finally:
+            translate_mod._translate_service = None
+
+    def test_reset_under_lock(self):
+        """reset_translate_service 在鎖內把單例設回 None。"""
+        from web.routers import translate as translate_mod
+
+        try:
+            translate_mod._translate_service = object()
+            translate_mod.reset_translate_service()
+            assert translate_mod._translate_service is None
+        finally:
+            translate_mod._translate_service = None

--- a/tests/integration/test_async_offload_guard.py
+++ b/tests/integration/test_async_offload_guard.py
@@ -1,0 +1,292 @@
+"""
+Async-offload 回歸守衛（feature/66 T5）
+
+AST-based 靜態掃描 web/routers/*.py：
+  1. 每個 async def 路由的「直接 body」不得裸跑偵測清單中的阻塞慢 I/O 呼叫
+     （直接 body = 不下潛 nested FunctionDef / AsyncFunctionDef；
+      已包在 await asyncio.to_thread(...) 內的呼叫天然不算裸呼叫，
+      因為 to_thread 的 target 是 Name 節點而非 Call 節點）
+  2. T1–T3 轉 def 的 handler 確認為 FunctionDef（非 AsyncFunctionDef），
+     防止 refactoring 意外把它們改回 async def 而重新卡 event loop
+
+CD-66-5：本守衛屬 pytest C 類（Python API contract / 行為），不走 eslint。
+形式參考：tests/integration/test_api_scanner.py::test_jellyfin_check_uses_to_thread
+"""
+import ast
+import pathlib
+from typing import Optional
+
+ROUTERS_DIR = pathlib.Path(__file__).parents[2] / "web" / "routers"
+
+
+# ============================================================
+# 偵測清單
+# ============================================================
+
+# 直接函式名（ast.Name 的 id，或 ast.Attribute 的 attr）
+BLOCKING_FUNC_NAMES = frozenset({
+    # File I/O
+    "realpath", "getsize", "open",
+    # DB
+    "init_db", "get_db_path", "VideoRepository", "ActressRepository",
+    # Config
+    "load_config", "save_config",
+    # Sync HTTP（metatube）
+    "MetatubeHttpClient", "list_providers", "_verify_token_canary",
+})
+
+# Attribute-call 後綴（接在任意物件後 .exists() / .stat() / .iterdir() / .save()）
+BLOCKING_ATTR_CALL_NAMES = frozenset({
+    "exists", "stat", "iterdir", "save",
+})
+
+# 白名單：{(file_stem, func_name)} — 豁免整個函式。
+# 目前為空：偵測清單夠精確（只命中具名慢 I/O / repo.* / 檔案 stat），
+# in-memory state 操作（state.disconnect / status_dict / _fire_probe）天然不命中，
+# 無需豁免。刻意保持空集合 → 連 settings_metatube 的 in-memory 路由都受保護：
+# 若它們未來新增裸 load_config/repo 呼叫，守衛會立即報錯而非被白名單放生。
+# 只有「確實會命中偵測、但刻意留 loop」的路由才該加入（並附理由）。
+WHITELIST: frozenset = frozenset()
+
+
+# ============================================================
+# AST 工具
+# ============================================================
+
+def _is_route_handler(node: ast.AsyncFunctionDef) -> bool:
+    """確認 node 有 @router.<method>(...) 裝飾器。"""
+    for dec in node.decorator_list:
+        # @router.get(...) / @router.post(...) 等
+        if isinstance(dec, ast.Call) and isinstance(dec.func, ast.Attribute):
+            if isinstance(dec.func.value, ast.Name) and dec.func.value.id == "router":
+                return True
+        # @router.get（無括號，防禦）
+        if isinstance(dec, ast.Attribute):
+            if isinstance(dec.value, ast.Name) and dec.value.id == "router":
+                return True
+    return False
+
+
+def _collect_direct_calls(func_node: ast.AsyncFunctionDef) -> list:
+    """收集 func_node 直接 body 的所有 Call 節點。
+
+    「直接 body」= 不下潛 nested FunctionDef / AsyncFunctionDef
+    （nested 函式不是 to_thread target 就是內層 SSE generator，CD-66-3 不在範圍）。
+    """
+    calls = []
+
+    def _walk(nodes):
+        for node in nodes:
+            if isinstance(node, ast.Call):
+                calls.append(node)
+            # 停止條件：遇到巢狀函式定義即不下潛
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            _walk(ast.iter_child_nodes(node))
+
+    _walk(ast.iter_child_nodes(func_node))
+    return calls
+
+
+def _call_name(call: ast.Call) -> Optional[str]:
+    """取 Call node 的「函式名」用於偵測：
+    - ast.Name      → .id    (e.g. load_config())
+    - ast.Attribute → .attr  (e.g. db_path.exists(), repo.save())
+    """
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _is_blocking_call(call: ast.Call) -> bool:
+    """判斷 call 是否為偵測清單中的裸阻塞呼叫。"""
+    name = _call_name(call)
+    if name is None:
+        return False
+
+    # 直接函式名 / Attribute attr 命中
+    if name in BLOCKING_FUNC_NAMES:
+        return True
+    # Attribute-call 後綴命中（.exists / .stat / .iterdir / .save）
+    if name in BLOCKING_ATTR_CALL_NAMES:
+        return True
+    # repo.* / *_repo.* pattern：value 是 Name 且 id == "repo" 或結尾 "_repo"
+    if isinstance(call.func, ast.Attribute):
+        val = call.func.value
+        if isinstance(val, ast.Name) and (val.id == "repo" or val.id.endswith("_repo")):
+            return True
+    return False
+
+
+def _iter_async_route_handlers():
+    """yield (py_file, AsyncFunctionDef) for every async route handler in web/routers/*.py."""
+    for py_file in sorted(ROUTERS_DIR.glob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and _is_route_handler(node):
+                yield py_file, node
+
+
+# ============================================================
+# 守衛測試
+# ============================================================
+
+class TestAsyncOffloadGuard:
+    """AST 回歸守衛：async def 路由直接 body 不得裸跑慢 I/O。"""
+
+    def test_no_bare_blocking_in_async_routes(self):
+        """主守衛：掃 web/routers/*.py 每個 async 路由，直接 body 不得有裸阻塞呼叫。"""
+        violations = []
+        for py_file, node in _iter_async_route_handlers():
+            if (py_file.stem, node.name) in WHITELIST:
+                continue
+            for call in _collect_direct_calls(node):
+                if _is_blocking_call(call):
+                    violations.append(
+                        f"{py_file.name}:{node.name}() — bare blocking call: {_call_name(call)}()"
+                    )
+        assert not violations, (
+            "Async route handlers have bare blocking calls on the event loop "
+            "(wrap in `await asyncio.to_thread(...)` or convert to `def`):\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )
+
+    def test_whitelist_entries_exist(self):
+        """白名單防腐：每個白名單條目對應的函式必須真實存在（避免殭屍豁免）。"""
+        found = {(py.stem, n.name) for py, n in _iter_async_route_handlers()}
+        missing = [w for w in WHITELIST if w not in found]
+        assert not missing, f"WHITELIST 指向不存在的 async 路由（應清理）: {missing}"
+
+
+class TestConvertedHandlersAreDef:
+    """正斷言：T1–T3 轉 def 的 handler 確認為同步 def（不可回退 async def）。"""
+
+    @staticmethod
+    def _func_type(filename: str, func_name: str) -> type:
+        py_file = ROUTERS_DIR / filename
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+                return type(node)
+        raise AssertionError(f"{filename}:{func_name} not found")
+
+    # T1 — hot path
+    def test_t1_get_image_is_def(self):
+        assert self._func_type("scanner.py", "get_image") is ast.FunctionDef
+
+    def test_t1_get_video_is_def(self):
+        assert self._func_type("scanner.py", "get_video") is ast.FunctionDef
+
+    # T2 — 純讀 DB 路由
+    def test_t2_get_stats_is_def(self):
+        assert self._func_type("scanner.py", "get_stats") is ast.FunctionDef
+
+    def test_t2_clear_cache_is_def(self):
+        assert self._func_type("scanner.py", "clear_cache") is ast.FunctionDef
+
+    def test_t2_check_update_is_def(self):
+        assert self._func_type("scanner.py", "check_update") is ast.FunctionDef
+
+    def test_t2_check_missing_is_def(self):
+        assert self._func_type("scanner.py", "check_missing") is ast.FunctionDef
+
+    def test_t2_view_list_is_def(self):
+        assert self._func_type("scanner.py", "view_list") is ast.FunctionDef
+
+    def test_t2_get_actress_stats_is_def(self):
+        assert self._func_type("scanner.py", "get_actress_stats") is ast.FunctionDef
+
+    def test_t2_showcase_get_videos_is_def(self):
+        assert self._func_type("showcase.py", "get_videos") is ast.FunctionDef
+
+    def test_t2_showcase_get_video_is_def(self):
+        assert self._func_type("showcase.py", "get_video") is ast.FunctionDef
+
+    def test_t2_get_favorite_files_is_def(self):
+        assert self._func_type("search.py", "get_favorite_files") is ast.FunctionDef
+
+    def test_t2_get_local_status_is_def(self):
+        assert self._func_type("search.py", "get_local_status") is ast.FunctionDef
+
+    def test_t2_motion_lab_data_is_def(self):
+        assert self._func_type("motion_lab.py", "motion_lab_data") is ast.FunctionDef
+
+    # T3 — config / 設定檔 I/O 路由
+    def test_t3_get_config_is_def(self):
+        assert self._func_type("config.py", "get_config") is ast.FunctionDef
+
+    def test_t3_update_config_is_def(self):
+        assert self._func_type("config.py", "update_config") is ast.FunctionDef
+
+    def test_t3_reset_config_is_def(self):
+        assert self._func_type("config.py", "reset_config") is ast.FunctionDef
+
+    def test_t3_get_tutorial_status_is_def(self):
+        assert self._func_type("config.py", "get_tutorial_status") is ast.FunctionDef
+
+    def test_t3_mark_tutorial_completed_is_def(self):
+        assert self._func_type("config.py", "mark_tutorial_completed") is ast.FunctionDef
+
+    def test_t3_reset_tutorial_is_def(self):
+        assert self._func_type("config.py", "reset_tutorial") is ast.FunctionDef
+
+    def test_t3_update_general_field_is_def(self):
+        assert self._func_type("config.py", "update_general_field") is ast.FunctionDef
+
+    def test_t3_get_scraper_sources_is_def(self):
+        assert self._func_type("scraper_sources.py", "get_scraper_sources") is ast.FunctionDef
+
+    def test_t3_get_favorite_scanner_link_is_def(self):
+        assert self._func_type("settings_link.py", "get_favorite_scanner_link") is ast.FunctionDef
+
+
+class TestT4OffloadHousePattern:
+    """T4 to_thread 包裝的 house-pattern substring 守衛（延續既有 test_jellyfin_check_uses_to_thread）。"""
+
+    @staticmethod
+    def _src(filename: str) -> str:
+        return (ROUTERS_DIR / filename).read_text(encoding="utf-8")
+
+    def test_jellyfin_check_uses_to_thread_helper(self):
+        src = self._src("scanner.py")
+        assert "asyncio.to_thread(_check_jellyfin_needed" in src
+        assert "def _check_jellyfin_needed(" in src
+        assert "db_path.exists()" in src
+        assert "VideoRepository(db_path)" in src
+        assert "check_jellyfin_images_needed(repo)" in src
+
+    def test_connect_uses_to_thread_helper(self):
+        src = self._src("settings_metatube.py")
+        assert "asyncio.to_thread(_connect_sync" in src
+        assert "def _connect_sync(" in src
+        assert "MetatubeHttpClient" in src
+        assert "_verify_token_canary" in src
+
+    def test_actress_crop_uses_to_thread(self):
+        src = self._src("actress.py")
+        assert "asyncio.to_thread(_check_cover_path" in src
+        assert "asyncio.to_thread(crop_video_cover" in src
+
+    def test_set_actress_photo_uses_to_thread(self):
+        src = self._src("actress.py")
+        assert "asyncio.to_thread(_load_actress" in src
+        assert "asyncio.to_thread(_get_actress_videos" in src
+        assert "asyncio.to_thread(_write_actress_photo" in src
+
+    def test_search_stream_load_config_offloaded(self):
+        assert "await asyncio.to_thread(load_config)" in self._src("search.py")
+
+    def test_filter_files_uses_to_thread(self):
+        src = self._src("search.py")
+        assert "asyncio.to_thread(_filter_files_sync" in src
+        assert "def _filter_files_sync(" in src
+
+    def test_batch_enrich_load_config_offloaded(self):
+        assert "await asyncio.to_thread(load_config)" in self._src("scraper.py")
+
+    def test_translate_routes_load_config_offloaded(self):
+        assert "await asyncio.to_thread(load_config)" in self._src("translate.py")

--- a/tests/integration/test_async_offload_guard.py
+++ b/tests/integration/test_async_offload_guard.py
@@ -390,18 +390,26 @@ def _find_save_config_callers(tree: ast.Module) -> list:
     return callers
 
 
+# 守衛掃描範圍：web/routers/*.py + web/app.py（後者的 get_common_context 在
+# loop thread 上做 locale 首寫 RMW，與 threadpool config 寫入交錯會 lost-update，
+# 故一併納入掃描，Codex P2）。
+_WEB_DIR = ROUTERS_DIR.parent
+SAVE_CONFIG_SCAN_FILES = tuple(sorted(ROUTERS_DIR.glob("*.py")) + [_WEB_DIR / "app.py"])
+
+
 class TestConfigWriteSerializationGuard:
-    """66b-T5：web/routers/*.py 不得裸呼 save_config（除 update_config 白名單）。
+    """66b-T5：web/routers/*.py + web/app.py 不得裸呼 save_config（除 update_config 白名單）。
 
     根據 CD-66b-1 / plan-66b T5：T1 把所有 config RMW caller 遷移到 mutate_config /
     reset_config_file（core/config.py 內單一 _config_write_lock 序列化 + 原子寫）後，
-    router 內唯一合法的直接 save_config 呼叫只剩 config.py::update_config（full-replace）。
-    新 router 若裸呼 save_config 做 RMW → 重新引入 lost-update 競態 → 守衛報錯。
+    唯一合法的直接 save_config 呼叫只剩 config.py::update_config（full-replace）。
+    其餘 router 或 web/app.py 若裸呼 save_config 做 RMW → 重新引入 lost-update 競態
+    → 守衛報錯（Codex P2：含 web/app.py get_common_context 的 locale 首寫）。
     """
 
     def test_no_bare_save_config_outside_whitelist(self):
         violations = []
-        for py_file in sorted(ROUTERS_DIR.glob("*.py")):
+        for py_file in SAVE_CONFIG_SCAN_FILES:
             if py_file.name == "__init__.py":
                 continue
             tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))

--- a/tests/integration/test_async_offload_guard.py
+++ b/tests/integration/test_async_offload_guard.py
@@ -355,3 +355,77 @@ class TestT4OffloadHousePattern:
 
     def test_translate_routes_load_config_offloaded(self):
         assert "await asyncio.to_thread(load_config)" in self._src("translate.py")
+
+
+# ============================================================
+# 66b-T5：config 寫入序列化守衛
+# ============================================================
+
+# 唯一白名單：config.py::update_config 是 full-replace（client 送完整 AppConfig），
+# 已走 public locked+atomic save_config，非 unlocked-RMW 反模式 → 允許直接呼叫。
+# 其餘 router 一律不得裸呼 save_config：RMW 走 core.config.mutate_config（鎖內
+# load→mutate→save），delete 走 reset_config_file（鎖內 exists/unlink）。
+WHITELIST_SAVE_CONFIG: frozenset = frozenset({("config", "update_config")})
+
+
+def _find_save_config_callers(tree: ast.Module) -> list:
+    """回傳 [(enclosing_func_name_or_None)] for every direct `save_config(...)` call.
+
+    用最近的具名 enclosing function 標記每個 save_config 呼叫（含 nested def）。
+    module-level 呼叫 → None。`_call_name` 同時涵蓋 `save_config()`（Name）與
+    `core.config.save_config()`（Attribute.attr）。
+    """
+    callers = []
+
+    def _walk(node, func_stack):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                _walk(child, func_stack + [child.name])
+            else:
+                if isinstance(child, ast.Call) and _call_name(child) == "save_config":
+                    callers.append(func_stack[-1] if func_stack else None)
+                _walk(child, func_stack)
+
+    _walk(tree, [])
+    return callers
+
+
+class TestConfigWriteSerializationGuard:
+    """66b-T5：web/routers/*.py 不得裸呼 save_config（除 update_config 白名單）。
+
+    根據 CD-66b-1 / plan-66b T5：T1 把所有 config RMW caller 遷移到 mutate_config /
+    reset_config_file（core/config.py 內單一 _config_write_lock 序列化 + 原子寫）後，
+    router 內唯一合法的直接 save_config 呼叫只剩 config.py::update_config（full-replace）。
+    新 router 若裸呼 save_config 做 RMW → 重新引入 lost-update 競態 → 守衛報錯。
+    """
+
+    def test_no_bare_save_config_outside_whitelist(self):
+        violations = []
+        for py_file in sorted(ROUTERS_DIR.glob("*.py")):
+            if py_file.name == "__init__.py":
+                continue
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+            for func_name in _find_save_config_callers(tree):
+                if (py_file.stem, func_name) in WHITELIST_SAVE_CONFIG:
+                    continue
+                violations.append(
+                    f"{py_file.name}:{func_name}() — bare save_config() call"
+                )
+        assert not violations, (
+            "Routers must not call save_config() directly (RMW lost-update risk): "
+            "use core.config.mutate_config() for RMW or reset_config_file() for delete. "
+            "Only config.py::update_config (full-replace) is whitelisted:\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )
+
+    def test_whitelisted_update_config_still_calls_save_config(self):
+        """白名單防腐：update_config 必須真的存在且真的呼叫 save_config（避免殭屍白名單）。"""
+        tree = ast.parse(
+            (ROUTERS_DIR / "config.py").read_text(encoding="utf-8"),
+            filename="config.py",
+        )
+        callers = _find_save_config_callers(tree)
+        assert "update_config" in callers, (
+            "config.py::update_config 不再直接呼叫 save_config —— 白名單已過時，應清理 "
+            "WHITELIST_SAVE_CONFIG"
+        )

--- a/tests/integration/test_async_offload_guard.py
+++ b/tests/integration/test_async_offload_guard.py
@@ -68,10 +68,16 @@ def _is_route_handler(node: ast.AsyncFunctionDef) -> bool:
 
 
 def _collect_direct_calls(func_node: ast.AsyncFunctionDef) -> list:
-    """收集 func_node 直接 body 的所有 Call 節點。
+    """收集 func_node 在「event loop 上執行的 body」的所有 Call 節點。
 
-    「直接 body」= 不下潛 nested FunctionDef / AsyncFunctionDef
-    （nested 函式不是 to_thread target 就是內層 SSE generator，CD-66-3 不在範圍）。
+    下潛規則（Codex review 修正）：
+    - **停在巢狀同步 `FunctionDef`**：sync def 不是 to_thread target 就是
+      Starlette 在 threadpool 迭代的 sync generator —— 皆不在 loop，不掃。
+    - **下潛巢狀 `AsyncFunctionDef`**：SSE async generator（如 event_generator）
+      由 Starlette 在 event loop 上迭代 → 其 body 的裸阻塞呼叫一樣卡 loop，必須掃。
+
+    註：`await asyncio.to_thread(fn, ...)` 的 fn 是 args 裡的 Name 節點、非 Call，
+    天然不會被當成裸呼叫——已正確包裝者不會誤報。
     """
     calls = []
 
@@ -79,13 +85,66 @@ def _collect_direct_calls(func_node: ast.AsyncFunctionDef) -> list:
         for node in nodes:
             if isinstance(node, ast.Call):
                 calls.append(node)
-            # 停止條件：遇到巢狀函式定義即不下潛
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # 只在「同步」巢狀 def 停（threadpool-safe）；async def 繼續下潛
+            if isinstance(node, ast.FunctionDef):
                 continue
             _walk(ast.iter_child_nodes(node))
 
     _walk(ast.iter_child_nodes(func_node))
     return calls
+
+
+def _is_generator_def(func_node) -> bool:
+    """func_node 是否為 generator function（自身 body 直接含 yield / yield from，
+    不含 nested 函式內的 yield）。
+
+    關鍵：呼叫一個 sync generator function 只會「建立」generator 物件、**不執行 body**；
+    其 body 在被迭代時才跑（StreamingResponse 的 sync generator 由 Starlette 在
+    threadpool 迭代，不在 loop）。故 generator function 不算「呼叫即阻塞」的 helper。
+    """
+    found = False
+
+    def _walk(nodes):
+        nonlocal found
+        for node in nodes:
+            if found:
+                return
+            if isinstance(node, (ast.Yield, ast.YieldFrom)):
+                found = True
+                return
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue  # 不下潛 nested 函式
+            _walk(ast.iter_child_nodes(node))
+
+    _walk(ast.iter_child_nodes(func_node))
+    return found
+
+
+def _collect_blocking_local_helpers(tree: ast.Module) -> frozenset:
+    """回傳「module-level 同步 def 且 body 含已知阻塞呼叫」的 helper 名稱集合。
+
+    用途：抓「裸呼叫一個本檔 sync helper，而該 helper 內部裹著 load_config /
+    init_db / repo.* 等阻塞 I/O」的二階卡 loop（Codex P1/P2：`_persist_allow_lan`、
+    `get_translate_service`、`_fetch_actress_profile_with_db`）。
+
+    只看 module-level `FunctionDef`（async def 是路由或 coroutine，不算 helper；
+    nested def 是 to_thread target）。**排除 generator function**：呼叫它只建立
+    generator 物件、body 不在 call site 執行（sync generator 給 StreamingResponse
+    由 Starlette threadpool 迭代）—— 否則會誤報 generate_avlist 等。
+    一層偵測即足夠涵蓋本 codebase 的 helper pattern。
+    註：`await asyncio.to_thread(helper)` 的 helper 是 Name arg、非 Call → 不誤報。
+    """
+    helpers = set()
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if _is_generator_def(node):
+            continue  # sync generator：呼叫不執行 body，threadpool 迭代
+        for child in ast.walk(node):
+            if isinstance(child, ast.Call) and _is_blocking_call(child):
+                helpers.add(node.name)
+                break
+    return frozenset(helpers)
 
 
 def _call_name(call: ast.Call) -> Optional[str]:
@@ -121,14 +180,18 @@ def _is_blocking_call(call: ast.Call) -> bool:
 
 
 def _iter_async_route_handlers():
-    """yield (py_file, AsyncFunctionDef) for every async route handler in web/routers/*.py."""
+    """yield (py_file, AsyncFunctionDef, blocking_helpers) for every async route handler.
+
+    blocking_helpers = 本檔 module-level sync helper 中含阻塞 I/O 者（per-file 推斷）。
+    """
     for py_file in sorted(ROUTERS_DIR.glob("*.py")):
         if py_file.name == "__init__.py":
             continue
         tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        blocking_helpers = _collect_blocking_local_helpers(tree)
         for node in ast.walk(tree):
             if isinstance(node, ast.AsyncFunctionDef) and _is_route_handler(node):
-                yield py_file, node
+                yield py_file, node, blocking_helpers
 
 
 # ============================================================
@@ -141,13 +204,15 @@ class TestAsyncOffloadGuard:
     def test_no_bare_blocking_in_async_routes(self):
         """主守衛：掃 web/routers/*.py 每個 async 路由，直接 body 不得有裸阻塞呼叫。"""
         violations = []
-        for py_file, node in _iter_async_route_handlers():
+        for py_file, node, blocking_helpers in _iter_async_route_handlers():
             if (py_file.stem, node.name) in WHITELIST:
                 continue
             for call in _collect_direct_calls(node):
-                if _is_blocking_call(call):
+                name = _call_name(call)
+                # 直接命中偵測清單，或裸呼叫本檔含阻塞 I/O 的 sync helper
+                if _is_blocking_call(call) or (name is not None and name in blocking_helpers):
                     violations.append(
-                        f"{py_file.name}:{node.name}() — bare blocking call: {_call_name(call)}()"
+                        f"{py_file.name}:{node.name}() — bare blocking call: {name}()"
                     )
         assert not violations, (
             "Async route handlers have bare blocking calls on the event loop "
@@ -157,7 +222,7 @@ class TestAsyncOffloadGuard:
 
     def test_whitelist_entries_exist(self):
         """白名單防腐：每個白名單條目對應的函式必須真實存在（避免殭屍豁免）。"""
-        found = {(py.stem, n.name) for py, n in _iter_async_route_handlers()}
+        found = {(py.stem, n.name) for py, n, _ in _iter_async_route_handlers()}
         missing = [w for w in WHITELIST if w not in found]
         assert not missing, f"WHITELIST 指向不存在的 async 路由（應清理）: {missing}"
 

--- a/tests/integration/test_settings_metatube.py
+++ b/tests/integration/test_settings_metatube.py
@@ -1160,3 +1160,60 @@ class TestConnectSerialization:
         assert r1["ok"] is True and r2["ok"] is True
         assert state.base_url == "http://8.8.8.8:8080"
         assert saved[-1]["metatube"]["url"] == "http://8.8.8.8:8080"
+
+    def test_disconnect_holds_connect_lock(self, client, reset_state):
+        """disconnect 路由經 _connect_lock 序列化：state.disconnect() 在鎖內執行。"""
+        from web.routers.settings_metatube import _connect_lock
+
+        held = []
+        orig = state.disconnect
+
+        def _spy():
+            held.append(_connect_lock.locked())
+            orig()
+
+        with patch.object(state, "disconnect", side_effect=_spy):
+            resp = client.post("/api/settings/metatube/disconnect")
+
+        assert resp.json()["success"] is True
+        assert held == [True], "state.disconnect() 必須在 _connect_lock 持有時執行"
+
+    def test_disconnect_waits_for_inflight_connect_then_wins(self, reset_state):
+        """在途 connect 持鎖時 disconnect 必須等待，鎖釋放後斷線（last-action-wins）。
+
+        確定性：用 Barrier/Event 強制順序，不依賴 timing。
+        """
+        import threading
+        import time
+        from web.routers.settings_metatube import _disconnect_sync, _connect_lock
+
+        barrier = threading.Barrier(2)
+        release = threading.Event()
+
+        def _hold_lock():
+            with _connect_lock:
+                barrier.wait()            # 通知「已持鎖」
+                release.wait(timeout=2.0)  # 持鎖直到被釋放
+
+        holder = threading.Thread(target=_hold_lock, daemon=True)
+        holder.start()
+        barrier.wait()                     # 等 holder 拿到鎖
+
+        state.connect("http://8.8.8.8:8080", "", ["FANZA"])
+        assert state.is_connected is True
+
+        result = []
+
+        def _run_disconnect():
+            _disconnect_sync()
+            result.append(state.is_connected)
+
+        t = threading.Thread(target=_run_disconnect, daemon=True)
+        t.start()
+
+        time.sleep(0.05)
+        assert state.is_connected is True, "鎖被持有時 disconnect 必須仍在等待"
+
+        release.set()
+        t.join(timeout=2.0)
+        assert result == [False], "鎖釋放後 disconnect 應使狀態變為斷線"

--- a/tests/integration/test_settings_metatube.py
+++ b/tests/integration/test_settings_metatube.py
@@ -1075,3 +1075,88 @@ class TestStartupReconnect:
 
         assert resp.json()["success"] is False
         assert resp.json()["error"] == "設定儲存失敗，請重試。"
+
+
+# ======================================================================
+# 66 Codex P2 (round 2): connect 序列化鎖 — 防並發 connect 交錯
+# clobber config/runtime 或 rollback 拆別人連線
+# ======================================================================
+
+class TestConnectSerialization:
+    """確定性測試（無真 race）：_connect_lock 在臨界段持有 + 序列結果一致。"""
+
+    def test_connect_lock_is_threading_lock(self):
+        import threading
+        from web.routers.settings_metatube import _connect_lock
+        assert isinstance(_connect_lock, type(threading.Lock()))
+
+    def test_connect_sync_holds_lock_during_save_config(self, reset_state):
+        """save_config 被呼叫時 _connect_lock 必須持有（臨界段涵蓋 save）。"""
+        from web.routers.settings_metatube import _connect_sync, _connect_lock
+
+        held = []
+
+        def _fake_save(cfg):
+            held.append(_connect_lock.locked())
+
+        with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
+             patch("web.routers.settings_metatube.load_config", return_value=_fresh_config()), \
+             patch("web.routers.settings_metatube.save_config", side_effect=_fake_save):
+            mock_inst = MagicMock()
+            mock_inst.list_providers.return_value = {"FANZA": _PUBLIC_URL}
+            mock_inst.search.return_value = []
+            MockClient.return_value = mock_inst
+
+            result = _connect_sync(_PUBLIC_URL, "", True)
+
+        assert result["ok"] is True
+        assert held and all(held), "save_config 必須在 _connect_lock 持有時被呼叫"
+
+    def test_persist_allow_lan_holds_lock_during_save_config(self, reset_state):
+        """_persist_allow_lan 的 save_config 也在 _connect_lock 內。"""
+        from web.routers.settings_metatube import _persist_allow_lan, _connect_lock
+
+        held = []
+
+        def _fake_save(cfg):
+            held.append(_connect_lock.locked())
+
+        cfg = {"metatube": {"url": _PUBLIC_URL, "token": "tok", "allow_lan": False}}
+        with patch("web.routers.settings_metatube.load_config", return_value=cfg), \
+             patch("web.routers.settings_metatube.save_config", side_effect=_fake_save):
+            ok = _persist_allow_lan(_PUBLIC_URL, "tok", True)
+
+        assert ok is True
+        assert held and all(held), "_persist_allow_lan 的 save 必須在 _connect_lock 內"
+
+    def test_sequential_connects_leave_config_consistent(self, reset_state):
+        """兩次連續 connect 後 config 與 runtime state 皆指向最後一次（B）。
+
+        序列代理並發 clobber 場景：序列化下，config 永遠反映最後一次 connect，
+        不會殘留前一台 server 的 URL。
+        """
+        import copy
+        from web.routers.settings_metatube import _connect_sync
+
+        saved = []
+
+        def _fake_load():
+            return copy.deepcopy(saved[-1]) if saved else _fresh_config()
+
+        def _fake_save(cfg):
+            saved.append(copy.deepcopy(cfg))
+
+        with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
+             patch("web.routers.settings_metatube.load_config", side_effect=_fake_load), \
+             patch("web.routers.settings_metatube.save_config", side_effect=_fake_save):
+            mock_inst = MagicMock()
+            mock_inst.list_providers.return_value = {"FANZA": _PUBLIC_URL}
+            mock_inst.search.return_value = []
+            MockClient.return_value = mock_inst
+
+            r1 = _connect_sync("http://8.8.4.4:8080", "", True)
+            r2 = _connect_sync("http://8.8.8.8:8080", "", True)
+
+        assert r1["ok"] is True and r2["ok"] is True
+        assert state.base_url == "http://8.8.8.8:8080"
+        assert saved[-1]["metatube"]["url"] == "http://8.8.8.8:8080"

--- a/tests/integration/test_settings_metatube.py
+++ b/tests/integration/test_settings_metatube.py
@@ -833,8 +833,10 @@ class TestStartupReconnect:
             result = startup_reconnect(cfg)
 
         assert state.is_connected is True
-        assert isinstance(result, list)
-        assert len(result) > 0
+        names, gen = result
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert isinstance(gen, int)
 
     # ------------------------------------------------------------------
     # (a-5) list_providers raises MetatubeError → no connect
@@ -898,7 +900,8 @@ class TestStartupReconnect:
 
         assert state.is_connected is True
         assert result is not None
-        assert isinstance(result, list)
+        names, gen = result
+        assert isinstance(names, list)
 
     # ------------------------------------------------------------------
     # (a-8) happy path (public URL) → connected + list returned
@@ -922,8 +925,8 @@ class TestStartupReconnect:
         assert state.is_connected is True
         avail = state.availability_map()
         assert len(avail) > 0
-        assert isinstance(result, list)
-        assert set(result) == {"FANZA", "HEYZO", "MGS"}
+        names, gen = result
+        assert set(names) == {"FANZA", "HEYZO", "MGS"}
 
     # ------------------------------------------------------------------
     # (a-9) config has no 'metatube' key → walks enabled=False path
@@ -940,9 +943,9 @@ class TestStartupReconnect:
         MockClient.assert_not_called()
 
     # ------------------------------------------------------------------
-    # (a-10) return value is list[str]
+    # (a-10) return value is tuple[list[str], int]
     # ------------------------------------------------------------------
-    def test_return_value_is_list_of_str(self, reset_state):
+    def test_return_value_is_tuple_of_names_and_gen(self, reset_state):
         from web.routers.settings_metatube import startup_reconnect
 
         cfg = _startup_config()
@@ -957,8 +960,65 @@ class TestStartupReconnect:
 
             result = startup_reconnect(cfg)
 
-        assert isinstance(result, list)
-        assert all(isinstance(n, str) for n in result)
+        names, gen = result
+        assert isinstance(names, list)
+        assert all(isinstance(n, str) for n in names)
+        assert isinstance(gen, int)
+
+    # ------------------------------------------------------------------
+    # (a-11) returned generation == the gen state.connect set (B1, CD-66b-2)
+    # ------------------------------------------------------------------
+    def test_returns_generation(self, reset_state):
+        from web.routers.settings_metatube import startup_reconnect
+
+        cfg = _startup_config()
+        with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient:
+            mock_instance = MagicMock()
+            mock_instance.list_providers.return_value = {
+                "FANZA": _PUBLIC_URL,
+                "HEYZO": _PUBLIC_URL,
+            }
+            mock_instance.search.return_value = []
+            MockClient.return_value = mock_instance
+
+            result = startup_reconnect(cfg)
+
+        assert result is not None
+        names, gen = result
+        # The carried-back generation matches what state.connect set.
+        assert gen == state.generation
+
+    # ------------------------------------------------------------------
+    # (a-12) connect-critical section runs while _connect_lock is held (B3)
+    # ------------------------------------------------------------------
+    def test_holds_connect_lock_during_connect(self, reset_state):
+        from web.routers import settings_metatube
+        from web.routers.settings_metatube import startup_reconnect
+
+        names = ["FANZA", "HEYZO"]
+        observed = {}
+
+        def _fake_connect(url, token, provider_names):
+            # state.connect is called inside the connect-critical section,
+            # which must be holding _connect_lock.
+            observed["locked"] = settings_metatube._connect_lock.locked()
+            return 7
+
+        cfg = _startup_config()
+        with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
+             patch.object(settings_metatube.state, "connect", side_effect=_fake_connect) as mock_connect:
+            mock_instance = MagicMock()
+            mock_instance.list_providers.return_value = {n: _PUBLIC_URL for n in names}
+            mock_instance.search.return_value = []
+            MockClient.return_value = mock_instance
+
+            result = startup_reconnect(cfg)
+
+        mock_connect.assert_called_once()
+        assert observed.get("locked") is True
+        assert result == (names, 7)
+        # Lock released after the function returns.
+        assert settings_metatube._connect_lock.locked() is False
 
     # ------------------------------------------------------------------
     # (b) Lifespan glue layer — TestClient context manager triggers lifespan
@@ -989,7 +1049,7 @@ class TestStartupReconnect:
              patch("web.app._fire_probe") as mock_probe:
 
             mock_load.return_value = _startup_config()
-            mock_sr.return_value = names
+            mock_sr.return_value = (names, 1)
 
             with TestClient(app):
                 pass
@@ -1009,6 +1069,24 @@ class TestStartupReconnect:
                 pass
 
         mock_probe.assert_not_called()
+
+    def test_lifespan_uses_returned_generation(self, reset_state):
+        """lifespan passes the generation RETURNED by startup_reconnect to
+        _fire_probe — it does NOT re-read state.generation (CD-66b-2 / B1)."""
+        with patch("web.app.load_config") as mock_load, \
+             patch("web.app.startup_reconnect") as mock_sr, \
+             patch("web.app._fire_probe") as mock_probe:
+
+            mock_load.return_value = _startup_config()
+            # state.generation here is unrelated (0); the returned 42 must win.
+            mock_sr.return_value = (["FANZA"], 42)
+
+            with TestClient(app):
+                pass
+
+        mock_probe.assert_called_once()
+        # generation is the last positional arg of _fire_probe(base, token, names, gen)
+        assert mock_probe.call_args.args[-1] == 42
 
     # ------------------------------------------------------------------
     # (c) connect dedup persist — allow_lan updated in config after dedup hit

--- a/tests/integration/test_settings_metatube.py
+++ b/tests/integration/test_settings_metatube.py
@@ -90,6 +90,14 @@ class _ConfigStore:
         self.data = copy.deepcopy(cfg)
         self.saved.append(copy.deepcopy(cfg))
 
+    def mutate(self, mutator):
+        """Mirror core.config.mutate_config: load → mutator(cfg) → save (RMW)."""
+        import copy
+        cfg = copy.deepcopy(self.data)
+        mutator(cfg)
+        self.data = copy.deepcopy(cfg)
+        self.saved.append(copy.deepcopy(cfg))
+
 
 def _make_config_patches(initial: dict | None = None):
     """Return (store, patch_load, patch_save) context managers."""
@@ -106,8 +114,7 @@ def test_connect_success(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all") as mock_probe, \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {
@@ -175,8 +182,7 @@ def test_connect_unavailable(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.side_effect = MetatubeUnavailable("connection refused")
@@ -208,8 +214,7 @@ def test_connect_auth_error(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.side_effect = MetatubeAuthError("401 Unauthorized")
@@ -240,8 +245,7 @@ def test_connect_order_offset(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {
@@ -285,8 +289,7 @@ def test_disconnect(client):
     # First connect
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {"FANZA": "http://mt:8080"}
@@ -306,15 +309,15 @@ def test_disconnect(client):
     save_count_before = len(store.saved)
 
     # Disconnect inside its own patch scope so save_count assertion is meaningful
-    with patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+    with patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
         resp = client.post("/api/settings/metatube/disconnect")
 
     assert resp.status_code == 200
     assert resp.json()["success"] is True
     assert state.is_connected is False
 
-    # save_config must NOT be called by disconnect
-    assert len(store.saved) == save_count_before, "disconnect must not call save_config"
+    # disconnect must NOT write config (no mutate_config call)
+    assert len(store.saved) == save_count_before, "disconnect must not write config"
 
     # In-memory config metatube url/token must still be the values set by connect
     assert store.data["metatube"]["url"] == "http://192.168.1.10:8080"
@@ -331,8 +334,7 @@ def test_status_during_probe(client):
     # Connect first so state.is_connected is True
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {
@@ -431,8 +433,7 @@ def test_connect_preserves_enabled(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {
@@ -521,8 +522,7 @@ def test_connect_preserves_metatube_enabled_flag(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {
@@ -559,8 +559,7 @@ def test_connect_persistence_failure_rollback(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all") as mock_probe, \
-         patch("web.routers.settings_metatube.load_config", return_value=_fresh_config()), \
-         patch("web.routers.settings_metatube.save_config", side_effect=OSError("disk full")):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=OSError("disk full")):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = {
@@ -619,8 +618,7 @@ def test_canary_search_auth_error_blocks_connect(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all") as mock_probe, \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = _canary_providers()
@@ -652,8 +650,7 @@ def test_canary_search_unavailable_does_not_block_connect(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = _canary_providers()
@@ -677,8 +674,7 @@ def test_canary_search_not_found_does_not_block_connect(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = _canary_providers()
@@ -701,8 +697,7 @@ def test_canary_search_success_allows_connect(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = _canary_providers()
@@ -726,8 +721,7 @@ def test_canary_skipped_when_no_canary_provider_in_list(client):
 
     with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
          patch("web.routers.settings_metatube.probe_all"), \
-         patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-         patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+         patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
         mock_instance = MagicMock()
         mock_instance.list_providers.return_value = _no_canary_providers()
@@ -1035,8 +1029,7 @@ class TestStartupReconnect:
         # Second connect: same url+token, but allow_lan=True
         with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
              patch("web.routers.settings_metatube.probe_all"), \
-             patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-             patch("web.routers.settings_metatube.save_config", side_effect=store.save):
+             patch("web.routers.settings_metatube.mutate_config", side_effect=store.mutate):
 
             mock_instance = MagicMock()
             mock_instance.list_providers.return_value = {"FANZA": _LAN_URL}
@@ -1064,8 +1057,7 @@ class TestStartupReconnect:
 
         with patch("web.routers.settings_metatube.MetatubeHttpClient"), \
              patch("web.routers.settings_metatube.probe_all"), \
-             patch("web.routers.settings_metatube.load_config", side_effect=store.load), \
-             patch("web.routers.settings_metatube.save_config",
+             patch("web.routers.settings_metatube.mutate_config",
                    side_effect=OSError("disk full")):
 
             resp = tc.post(
@@ -1091,17 +1083,21 @@ class TestConnectSerialization:
         assert isinstance(_connect_lock, type(threading.Lock()))
 
     def test_connect_sync_holds_lock_during_save_config(self, reset_state):
-        """save_config 被呼叫時 _connect_lock 必須持有（臨界段涵蓋 save）。"""
+        """config 寫入時 _connect_lock 必須持有（臨界段涵蓋 mutate_config）。
+
+        mutate_config 在 _connect_lock 內被呼叫（鎖序：外 _connect_lock → 內
+        _config_write_lock），語意等價於「save 時 _connect_lock 持有」。
+        """
         from web.routers.settings_metatube import _connect_sync, _connect_lock
 
         held = []
 
-        def _fake_save(cfg):
+        def _fake_mutate(mutator):
             held.append(_connect_lock.locked())
+            mutator(_fresh_config())
 
         with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
-             patch("web.routers.settings_metatube.load_config", return_value=_fresh_config()), \
-             patch("web.routers.settings_metatube.save_config", side_effect=_fake_save):
+             patch("web.routers.settings_metatube.mutate_config", side_effect=_fake_mutate):
             mock_inst = MagicMock()
             mock_inst.list_providers.return_value = {"FANZA": _PUBLIC_URL}
             mock_inst.search.return_value = []
@@ -1110,24 +1106,23 @@ class TestConnectSerialization:
             result = _connect_sync(_PUBLIC_URL, "", True)
 
         assert result["ok"] is True
-        assert held and all(held), "save_config 必須在 _connect_lock 持有時被呼叫"
+        assert held and all(held), "mutate_config 必須在 _connect_lock 持有時被呼叫"
 
     def test_persist_allow_lan_holds_lock_during_save_config(self, reset_state):
-        """_persist_allow_lan 的 save_config 也在 _connect_lock 內。"""
+        """_persist_allow_lan 的 config 寫入也在 _connect_lock 內。"""
         from web.routers.settings_metatube import _persist_allow_lan, _connect_lock
 
         held = []
 
-        def _fake_save(cfg):
+        def _fake_mutate(mutator):
             held.append(_connect_lock.locked())
+            mutator({"metatube": {"url": _PUBLIC_URL, "token": "tok", "allow_lan": False}})
 
-        cfg = {"metatube": {"url": _PUBLIC_URL, "token": "tok", "allow_lan": False}}
-        with patch("web.routers.settings_metatube.load_config", return_value=cfg), \
-             patch("web.routers.settings_metatube.save_config", side_effect=_fake_save):
+        with patch("web.routers.settings_metatube.mutate_config", side_effect=_fake_mutate):
             ok = _persist_allow_lan(_PUBLIC_URL, "tok", True)
 
         assert ok is True
-        assert held and all(held), "_persist_allow_lan 的 save 必須在 _connect_lock 內"
+        assert held and all(held), "_persist_allow_lan 的寫入必須在 _connect_lock 內"
 
     def test_sequential_connects_leave_config_consistent(self, reset_state):
         """兩次連續 connect 後 config 與 runtime state 皆指向最後一次（B）。
@@ -1140,15 +1135,13 @@ class TestConnectSerialization:
 
         saved = []
 
-        def _fake_load():
-            return copy.deepcopy(saved[-1]) if saved else _fresh_config()
-
-        def _fake_save(cfg):
+        def _fake_mutate(mutator):
+            cfg = copy.deepcopy(saved[-1]) if saved else _fresh_config()
+            mutator(cfg)
             saved.append(copy.deepcopy(cfg))
 
         with patch("web.routers.settings_metatube.MetatubeHttpClient") as MockClient, \
-             patch("web.routers.settings_metatube.load_config", side_effect=_fake_load), \
-             patch("web.routers.settings_metatube.save_config", side_effect=_fake_save):
+             patch("web.routers.settings_metatube.mutate_config", side_effect=_fake_mutate):
             mock_inst = MagicMock()
             mock_inst.list_providers.return_value = {"FANZA": _PUBLIC_URL}
             mock_inst.search.return_value = []

--- a/tests/unit/test_core_config.py
+++ b/tests/unit/test_core_config.py
@@ -802,3 +802,92 @@ class TestConfigDefaultSchemaParity:
         default = self._default()
         schema_sources = AppConfig().model_dump()["sources"]
         assert default["sources"] == schema_sources
+
+
+# ============ TASK-66b-T1：寫入序列化 + 原子寫 + mutate_config ============
+
+class TestMutateConfigAndAtomicWrite:
+    """CD-66b-1：_config_write_lock 序列化 + 原子寫 + mutate_config RMW（確定性，非真 race）。"""
+
+    def _patch_paths(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.json"
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+        return config_path
+
+    def test_mutate_config_no_lost_update(self, tmp_path, monkeypatch):
+        """兩次序列 mutate_config（不同欄位）→ 兩者皆持久化（RMW 在單一 critical section）。"""
+        config_path = self._patch_paths(tmp_path, monkeypatch)
+        save_config({"general": {}})
+
+        core_config.mutate_config(
+            lambda cfg: cfg.setdefault("general", {}).__setitem__("theme", "dark")
+        )
+        core_config.mutate_config(
+            lambda cfg: cfg.setdefault("general", {}).__setitem__("font_size", "lg")
+        )
+
+        result = load_config()
+        assert result["general"]["theme"] == "dark"
+        assert result["general"]["font_size"] == "lg"
+
+    def test_save_config_atomic_no_temp_leftover(self, tmp_path, monkeypatch):
+        """json.dump 拋例外 → _save_config_unlocked re-raise 且不留 *.tmp 殘檔。"""
+        config_path = self._patch_paths(tmp_path, monkeypatch)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("dump failed")
+
+        monkeypatch.setattr(core_config.json, "dump", _boom)
+
+        with pytest.raises(RuntimeError, match="dump failed"):
+            core_config._save_config_unlocked({"general": {}})
+
+        leftover = list(config_path.parent.glob("*.tmp"))
+        assert leftover == [], f"原子寫失敗後不應殘留 temp: {leftover}"
+        assert not config_path.exists(), "寫入失敗不應產生 config.json"
+
+    def test_mutate_config_holds_lock(self, tmp_path, monkeypatch):
+        """mutator 執行時 _config_write_lock 必須持有（確定性斷言，CD-66b-6）。"""
+        self._patch_paths(tmp_path, monkeypatch)
+        save_config({"general": {}})
+
+        seen = []
+
+        def _mut(cfg):
+            seen.append(core_config._config_write_lock.locked())
+            cfg.setdefault("general", {})["theme"] = "dark"
+
+        core_config.mutate_config(_mut)
+        assert seen == [True], "mutator 執行時 _config_write_lock 必須為 locked"
+
+    def test_reset_config_file(self, tmp_path, monkeypatch):
+        """存在 → 刪除；不存在 → no-op 不拋（無 TOCTOU）。"""
+        config_path = self._patch_paths(tmp_path, monkeypatch)
+        save_config({"general": {}})
+        assert config_path.exists()
+
+        core_config.reset_config_file()
+        assert not config_path.exists()
+
+        # 再次呼叫不應拋例外
+        core_config.reset_config_file()
+        assert not config_path.exists()
+
+    def test_load_config_migration_no_deadlock(self, tmp_path, monkeypatch):
+        """觸發 migration（primary_source strip）→ load_config() 不死鎖且寫回。
+
+        migration save 走 _save_config_unlocked（已持鎖），若誤用 save_config 會
+        二次 acquire 同一 threading.Lock → 永久死鎖。此測試在無 hang 下完成即證明。
+        """
+        config_path = self._patch_paths(tmp_path, monkeypatch)
+        _write_config(config_path, {"search": {"primary_source": "javdb"}})
+
+        result = load_config()  # 不得 hang
+
+        assert "primary_source" not in result.get("search", {})
+        # migration 已持久化（檔案內也無 primary_source）
+        persisted = _read_config(config_path)
+        assert "primary_source" not in persisted.get("search", {})
+        # 鎖已釋放（load_config 結束後不應仍持有）
+        assert core_config._config_write_lock.locked() is False

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4997,7 +4997,9 @@ class TestVideoPlaybackGuard:
             ),
             (
                 PROJECT_ROOT / "web" / "routers" / "scanner.py",
-                ['async def get_video(', 'async def video_player(', 'os.path.normpath',
+                # 66-T1: get_video async→def（移出 event loop，Starlette 自動 threadpool）；
+                # video_player 維持 async。security 守衛字串不變。
+                ['def get_video(', 'async def video_player(', 'os.path.normpath',
                  'get_proxy_extensions', 'is_path_under_dir'],
             ),
         ]:

--- a/tests/unit/test_metatube_state.py
+++ b/tests/unit/test_metatube_state.py
@@ -345,6 +345,34 @@ def test_connect_bumps_generation(state):
     assert state.generation == gen_before + 1
 
 
+def test_connect_returns_new_generation(state):
+    """66 Codex P2: connect() 必須回傳它所設的 generation（lock 內原子取得）。
+
+    這是 _connect_sync 的契約——它把此值帶給 _fire_probe，避免在 await 後重讀
+    state.generation 而拿到並發 connect/disconnect 推進後的錯誤值。
+    """
+    gen0 = state.generation
+    returned = state.connect('http://host', 'tok', ['FANZA'])
+    assert returned == gen0 + 1
+    assert returned == state.generation  # 單執行緒測試下與 property 一致
+
+
+def test_returned_generation_fences_superseded_probe(state):
+    """66 Codex P2: 用 connect() 回傳的 generation 帶探測，被後續 connect 取代時
+    其寫入會被 generation guard 正確擋下（不污染現役連線的 availability）。"""
+    # 模擬請求 A connect，捕捉回傳 generation
+    gen_a = state.connect('http://serverA', 'tokA', ['HEYZO'])
+    # 模擬並發請求 B 取代 A
+    gen_b = state.connect('http://serverB', 'tokB', ['HEYZO'])
+    assert gen_b > gen_a
+    # A 的 stale 探測（帶 gen_a）對現役 B 連線的寫入應被擋下
+    state.mark_failed('metatube:HEYZO', generation=gen_a)
+    assert state.is_available('metatube:HEYZO') is True  # 未被 A 污染
+    # B 自己的探測（帶 gen_b，當前 generation）正常生效
+    state.mark_failed('metatube:HEYZO', generation=gen_b)
+    assert state.is_available('metatube:HEYZO') is False
+
+
 def test_disconnect_bumps_generation(state):
     """disconnect() must increment _generation."""
     state.connect('http://host', 'tok', ['FANZA'])

--- a/tests/unit/test_metatube_state.py
+++ b/tests/unit/test_metatube_state.py
@@ -495,3 +495,50 @@ def test_mark_no_generation_arg_backward_compatible(state):
     assert state.is_available('metatube:FANZA') is False
     state.mark_available('metatube:FANZA')  # no generation arg
     assert state.is_available('metatube:FANZA') is True
+
+
+# ===========================================================================
+# CD-66b-3: probe_snapshot() — atomic (names, gen, base_url, token)
+# ===========================================================================
+
+def test_probe_snapshot_after_connect(state):
+    """probe_snapshot() returns connected names/gen/url/token in one atomic read."""
+    state.connect('http://host:8080', 'tok', ['FANZA', 'HEYZO'])
+    names, gen, url, token = state.probe_snapshot()
+    assert set(names) == {'FANZA', 'HEYZO'}
+    assert gen == state.generation
+    assert url == 'http://host:8080'
+    assert token == 'tok'
+
+
+def test_probe_snapshot_none_to_empty_string(state):
+    """Fresh state (no connect): base_url/token None map to '', names empty, gen 0."""
+    names, gen, url, token = state.probe_snapshot()
+    assert names == []
+    assert url == ''
+    assert token == ''
+    assert gen == 0
+
+
+def test_probe_snapshot_names_from_availability_not_providers(state):
+    """CD-66b-3: after disconnect, names still come from _availability keys.
+
+    disconnect() clears _providers but keeps _availability keys (set False), so
+    /test must still list previously-known providers. base_url/token are cleared.
+    """
+    state.connect('http://host:8080', 'tok', ['FANZA', 'HEYZO'])
+    state.disconnect()
+    names, gen, url, token = state.probe_snapshot()
+    # _providers is now empty, but _availability keys are preserved
+    assert set(names) == {'FANZA', 'HEYZO'}
+    # disconnect cleared base_url/token → ''
+    assert url == ''
+    assert token == ''
+
+
+def test_probe_snapshot_names_stripped_prefix(state):
+    """names are stripped of the 'metatube:' prefix."""
+    state.connect('http://host:8080', 'tok', ['FANZA'])
+    names, _gen, _url, _token = state.probe_snapshot()
+    assert 'metatube:FANZA' not in names
+    assert 'FANZA' in names

--- a/web/app.py
+++ b/web/app.py
@@ -20,7 +20,7 @@ setup_logging()
 
 logger = get_logger(__name__)
 
-from core.config import load_config, save_config
+from core.config import load_config
 from core.database import VideoRepository, init_db
 from core.metatube.state import metatube_state as _mt_startup_state
 
@@ -139,7 +139,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 def get_common_context(request: Request) -> dict:
     """取得共用的模板 Context (包含設定)"""
-    from core.config import load_config, save_config
+    from core.config import load_config, mutate_config
     from core.i18n import t as _t, get_merged_translations, detect_locale_from_accept_language
     config = load_config()
 
@@ -158,8 +158,14 @@ def get_common_context(request: Request) -> dict:
         try:
             if 'general' not in config:
                 config['general'] = {}
-            config['general']['locale'] = locale
-            save_config(config)
+            config['general']['locale'] = locale  # 本地副本供 template context 用
+            # 66b（Codex P2）：get_common_context 跑在 event loop thread，舊裸 RMW
+            # （load_config→mutate→save_config）跨兩次 lock，會與 threadpool 上的
+            # config/metatube 寫入交錯 → lost-update。改 mutate_config 在單一
+            # critical section 內「只設 locale」於 fresh-load 的 cfg，不蓋他人欄位。
+            def _persist_locale(cfg):
+                cfg.setdefault('general', {})['locale'] = locale
+            mutate_config(_persist_locale)
         except Exception as e:
             logger.warning("[i18n] 首次偵測語系寫入 config 失敗: %s", e)
 

--- a/web/app.py
+++ b/web/app.py
@@ -45,9 +45,15 @@ async def lifespan(app: FastAPI):
         import asyncio as _asyncio
         _config = load_config()
         _loop = _asyncio.get_event_loop()
-        _names = await _loop.run_in_executor(None, lambda: startup_reconnect(_config))
-        if _names:
-            _gen = _mt_startup_state.generation
+        _res = await _loop.run_in_executor(None, lambda: startup_reconnect(_config))
+        if _res:
+            # Use the generation returned by startup_reconnect (captured under
+            # state's lock at connect time) — never re-read state.generation
+            # after the await/executor boundary (CD-66b-2). base_url/token are
+            # still read from state; a concurrent connect that advanced the
+            # generation makes this probe's writes stale, which the
+            # mark_available/failed generation guard drops harmlessly.
+            _names, _gen = _res
             _fire_probe(_mt_startup_state.base_url, _mt_startup_state.token, _names, _gen)
     except Exception:
         logger.warning("lifespan: startup_reconnect failed unexpectedly", exc_info=True)

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -467,6 +467,37 @@ async def list_photo_candidates(name: str):
 # NOTE：必須定義在 GET /{name} 之前！
 # ---------------------------------------------------------------------------
 
+def _check_cover_path(fs_path: str) -> bool:
+    """Threadpool helper: init DB + check cover path is known (防任意檔案讀取)."""
+    init_db()
+    return VideoRepository().is_known_cover_path(fs_path)
+
+
+def _load_actress(name: str):
+    """Threadpool helper: init DB + load ActressRepository + fetch actress by name.
+
+    Returns (repo, actress) tuple so the caller can reuse the same repo instance
+    for repo.save() later, preserving original semantics.
+    """
+    init_db()
+    repo = ActressRepository()
+    return repo, repo.get_by_name(name)
+
+
+def _get_actress_videos(name: str) -> list:
+    """Threadpool helper: fetch videos for actress (init_db already ran in _load_actress)."""
+    return VideoRepository().get_videos_by_actress(name)
+
+
+def _write_actress_photo(name: str, crop_bytes: bytes) -> None:
+    """Threadpool helper: write crop_bytes to GFRIENDS_DIR, replacing old files."""
+    safe = sanitize_filename(name)
+    GFRIENDS_DIR.mkdir(parents=True, exist_ok=True)
+    for old in GFRIENDS_DIR.glob(f"{safe}.*"):
+        old.unlink()
+    (GFRIENDS_DIR / f"{safe}.jpg").write_bytes(crop_bytes)
+
+
 @router.get("/actress-crop")
 async def actress_crop(path: str, spec: str = "v1"):
     """
@@ -477,9 +508,8 @@ async def actress_crop(path: str, spec: str = "v1"):
     # Fix 2 (T2): uri_to_fs_path 已 idempotent（非 URI 直接 normalize_path），直接呼叫
     fs_path = uri_to_fs_path(path)
     # Security: cover_path 必須是 DB 中某個 video 的 cover_path（防任意檔案讀取）
-    init_db()
-    video_repo = VideoRepository()
-    if not video_repo.is_known_cover_path(fs_path):
+    allowed = await asyncio.to_thread(_check_cover_path, fs_path)
+    if not allowed:
         return Response(b"", status_code=403)
     result = await asyncio.to_thread(crop_video_cover, fs_path, spec)
     if result is None:
@@ -504,9 +534,7 @@ async def set_actress_photo(name: str, req: SetActressPhotoRequest):
     覆蓋時先 glob 刪舊副檔名，再寫入新圖。
     更新 DB photo_source 欄位，回傳帶 cache-bust timestamp 的新 photo_url。
     """
-    init_db()
-    repo = ActressRepository()
-    actress = repo.get_by_name(name)
+    repo, actress = await asyncio.to_thread(_load_actress, name)
     if actress is None:
         return JSONResponse(status_code=404, content={"error": "not_found"})
 
@@ -526,8 +554,7 @@ async def set_actress_photo(name: str, req: SetActressPhotoRequest):
         # file:/// URI → FS path（禁止手動 strip）
         video_fs_path = uri_to_fs_path(req.video_path)
         # 從 DB 取該影片的 cover_path
-        video_repo = VideoRepository()
-        videos = video_repo.get_videos_by_actress(name)
+        videos = await asyncio.to_thread(_get_actress_videos, name)
         # Fix 3 (T3): v.path 在 DB 存 file:/// URI（gallery_scanner 用 to_file_uri 寫入），
         # 比對前雙邊都正規化為 FS path，避免 URI vs FS path 永遠 fail
         match = next(
@@ -547,15 +574,11 @@ async def set_actress_photo(name: str, req: SetActressPhotoRequest):
         if crop_bytes is None:
             return JSONResponse(status_code=500, content={"error": "crop_failed"})
         # glob 刪舊副檔名 + 寫入
-        safe = sanitize_filename(name)
-        GFRIENDS_DIR.mkdir(parents=True, exist_ok=True)
-        for old in GFRIENDS_DIR.glob(f"{safe}.*"):
-            old.unlink()
-        (GFRIENDS_DIR / f"{safe}.jpg").write_bytes(crop_bytes)
+        await asyncio.to_thread(_write_actress_photo, name, crop_bytes)
 
     # 更新 photo_source + 回傳
     actress.photo_source = req.source
-    repo.save(actress)
+    await asyncio.to_thread(repo.save, actress)
 
     t = int(time.time())
     photo_url = f"/api/actresses/photo/{quote(name)}?t={t}"

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -12,8 +12,10 @@
 
 import asyncio
 import json
+import os
 import random
 import re
+import tempfile
 import time
 from typing import Optional, List
 from urllib.parse import quote
@@ -488,12 +490,28 @@ def _get_actress_videos(name: str) -> list:
 
 
 def _write_actress_photo(name: str, crop_bytes: bytes) -> None:
-    """Threadpool helper: write crop_bytes to GFRIENDS_DIR, replacing old files."""
+    """Threadpool helper: atomically write crop_bytes to GFRIENDS_DIR, replacing old files.
+
+    Lock-free: same-actress concurrent writers are last-writer-wins (acceptable).
+    unlink(missing_ok=True) avoids the glob/unlink TOCTOU 500; temp+os.replace
+    avoids torn reads (66b-T4b).
+    """
     safe = sanitize_filename(name)
     GFRIENDS_DIR.mkdir(parents=True, exist_ok=True)
     for old in GFRIENDS_DIR.glob(f"{safe}.*"):
-        old.unlink()
-    (GFRIENDS_DIR / f"{safe}.jpg").write_bytes(crop_bytes)
+        old.unlink(missing_ok=True)
+    dest = GFRIENDS_DIR / f"{safe}.jpg"
+    fd, tmp = tempfile.mkstemp(dir=GFRIENDS_DIR, suffix=".jpg")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(crop_bytes)
+        os.replace(tmp, dest)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 @router.get("/actress-crop")

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -385,9 +385,7 @@ async def list_photo_candidates(name: str):
     雲端 0–3 張並行抓取 + 本機影片封面 crop 補足至 6 張。
     actress 不存在 → JSONResponse 404。
     """
-    init_db()
-    repo = ActressRepository()
-    actress = repo.get_by_name(name)
+    _, actress = await asyncio.to_thread(_load_actress, name)
     if actress is None:
         return JSONResponse(
             status_code=404,

--- a/web/routers/config.py
+++ b/web/routers/config.py
@@ -18,6 +18,7 @@
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+import asyncio
 import httpx
 
 from core.logger import get_logger
@@ -208,7 +209,7 @@ async def test_ollama_model(request: OllamaTestRequest) -> dict:
     try:
         url = request.url.rstrip('/')
 
-        config = load_config()
+        config = await asyncio.to_thread(load_config)
         locale = config.get("general", {}).get("locale", "zh-TW")
         lang_config = LANGUAGE_PROMPTS.get(locale, LANGUAGE_PROMPTS["zh-TW"])
         lang_name = lang_config["name"]

--- a/web/routers/config.py
+++ b/web/routers/config.py
@@ -50,13 +50,13 @@ def _reset_translate_service():
 
 
 @router.get("/config")
-async def get_config() -> dict:
+def get_config() -> dict:
     """取得所有設定"""
     return {"success": True, "data": load_config()}
 
 
 @router.put("/config")
-async def update_config(config: AppConfig) -> dict:
+def update_config(config: AppConfig) -> dict:
     """更新所有設定"""
     # Cap 守衛（CD-61-16，endpoint-level；非 model_validator）：
     # 同時啟用且非 manual_only 的來源數不得超過 MAX_ENABLED_SOURCES。
@@ -77,7 +77,7 @@ async def update_config(config: AppConfig) -> dict:
 
 
 @router.delete("/config")
-async def reset_config() -> dict:
+def reset_config() -> dict:
     """恢復原廠設定 - 刪除 config.json"""
     try:
         if _core_config.CONFIG_PATH.exists():
@@ -90,7 +90,7 @@ async def reset_config() -> dict:
 
 
 @router.get("/tutorial-status")
-async def get_tutorial_status() -> dict:
+def get_tutorial_status() -> dict:
     """取得新手引導完成狀態"""
     config = load_config()
     completed = config.get("general", {}).get("tutorial_completed", False)
@@ -98,7 +98,7 @@ async def get_tutorial_status() -> dict:
 
 
 @router.post("/tutorial-completed")
-async def mark_tutorial_completed() -> dict:
+def mark_tutorial_completed() -> dict:
     """標記新手引導已完成（僅在點擊完成時呼叫）"""
     config = load_config()
     if "general" not in config:
@@ -109,7 +109,7 @@ async def mark_tutorial_completed() -> dict:
 
 
 @router.post("/tutorial-reset")
-async def reset_tutorial() -> dict:
+def reset_tutorial() -> dict:
     """重置新手引導狀態（供設定頁使用）"""
     config = load_config()
     if "general" not in config:
@@ -124,7 +124,7 @@ class GeneralFieldRequest(BaseModel):
 
 
 @router.put("/config/general/{field}")
-async def update_general_field(field: str, request: GeneralFieldRequest) -> dict:
+def update_general_field(field: str, request: GeneralFieldRequest) -> dict:
     """更新 general 區塊單一欄位（輕量端點，供 UI toggle 即時同步）"""
     allowed = {"sidebar_collapsed", "theme", "font_size", "locale"}
     if field not in allowed:

--- a/web/routers/config.py
+++ b/web/routers/config.py
@@ -22,7 +22,6 @@ import asyncio
 import httpx
 
 from core.logger import get_logger
-from core import config as _core_config
 from core.config import (
     AppConfig,
     ScraperConfig,
@@ -35,6 +34,8 @@ from core.config import (
     GeneralConfig,
     load_config,
     save_config,
+    mutate_config,
+    reset_config_file,
 )
 from core.source_config import MAX_ENABLED_SOURCES
 from core.translate_service import LANGUAGE_PROMPTS
@@ -81,8 +82,7 @@ def update_config(config: AppConfig) -> dict:
 def reset_config() -> dict:
     """恢復原廠設定 - 刪除 config.json"""
     try:
-        if _core_config.CONFIG_PATH.exists():
-            _core_config.CONFIG_PATH.unlink()
+        reset_config_file()  # 鎖內 exists/unlink，無 TOCTOU（CD-66b-1）
         _reset_translate_service()  # 清除舊服務實例
         return {"success": True, "message": "已恢復預設設定"}
     except Exception as e:
@@ -101,22 +101,18 @@ def get_tutorial_status() -> dict:
 @router.post("/tutorial-completed")
 def mark_tutorial_completed() -> dict:
     """標記新手引導已完成（僅在點擊完成時呼叫）"""
-    config = load_config()
-    if "general" not in config:
-        config["general"] = {}
-    config["general"]["tutorial_completed"] = True
-    save_config(config)
+    def _mut(cfg):
+        cfg.setdefault("general", {})["tutorial_completed"] = True
+    mutate_config(_mut)
     return {"success": True}
 
 
 @router.post("/tutorial-reset")
 def reset_tutorial() -> dict:
     """重置新手引導狀態（供設定頁使用）"""
-    config = load_config()
-    if "general" not in config:
-        config["general"] = {}
-    config["general"]["tutorial_completed"] = False
-    save_config(config)
+    def _mut(cfg):
+        cfg.setdefault("general", {})["tutorial_completed"] = False
+    mutate_config(_mut)
     return {"success": True}
 
 
@@ -131,14 +127,15 @@ def update_general_field(field: str, request: GeneralFieldRequest) -> dict:
     if field not in allowed:
         return {"success": False, "error": f"不允許更新欄位: {field}"}
     try:
-        config = load_config()
-        if "general" not in config:
-            config["general"] = {}
+        # locale 驗證在 mutate 前（保留既有順序：驗證 → 寫入 → translate reset）
         if field == "locale" and request.value not in ("zh-TW", "zh-CN", "ja", "en"):
             logger.warning("嘗試設定不支援的語系: %s", request.value)
             return {"success": False, "error": "不支援的語系"}
-        config["general"][field] = request.value
-        save_config(config)
+
+        def _mut(cfg):
+            cfg.setdefault("general", {})[field] = request.value
+        mutate_config(_mut)
+
         if field == "locale":
             _reset_translate_service()
         return {"success": True}

--- a/web/routers/gemini.py
+++ b/web/routers/gemini.py
@@ -11,6 +11,7 @@ from core.translate_service import LANGUAGE_PROMPTS
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+import asyncio
 import httpx
 from typing import List
 
@@ -162,7 +163,7 @@ async def test_gemini_translate(request: TestTranslateRequest):
     # 使用安全的測試標題（不會觸發內容過濾）
     test_title = "新人女優デビュー"
 
-    config = load_config()
+    config = await asyncio.to_thread(load_config)
     locale = config.get("general", {}).get("locale", "zh-TW")
     lang_config = LANGUAGE_PROMPTS.get(locale, LANGUAGE_PROMPTS["zh-TW"])
     lang_name = lang_config["name"]

--- a/web/routers/motion_lab.py
+++ b/web/routers/motion_lab.py
@@ -28,7 +28,7 @@ async def motion_lab_page(request: Request):
 
 
 @router.get("/api/motion-lab/data")
-async def motion_lab_data():
+def motion_lab_data():
     """取得前 30 筆影片資料（用於 Motion Lab 沙盒頁）"""
     try:
         db_path = get_db_path()

--- a/web/routers/openai_translate.py
+++ b/web/routers/openai_translate.py
@@ -12,6 +12,7 @@ from core.translate_service import LANGUAGE_PROMPTS
 
 from fastapi import APIRouter
 from pydantic import BaseModel
+import asyncio
 import httpx
 from typing import List, Optional
 
@@ -127,7 +128,7 @@ async def test_openai_translate(request: TestTranslateRequest):
     # 使用安全的測試標題（與 gemini.py 行 191 相同）
     test_title = "新人女優デビュー"
 
-    config = load_config()
+    config = await asyncio.to_thread(load_config)
     locale = config.get("general", {}).get("locale", "zh-TW")
 
     # F2: ja short-circuit — 與 translate_service.py 的行為保持一致

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -1038,12 +1038,13 @@ def generate_jellyfin_images_stream() -> Generator[str, None, None]:
         yield _sse_event({"type": "error", "message": "產生 Jellyfin 圖片失敗"})
 
 
-def _check_jellyfin_needed(db_path) -> dict | None:
-    """Threadpool helper: check DB existence + open repo + run jellyfin check.
+def _check_jellyfin_needed() -> dict | None:
+    """Threadpool helper: get_db_path + check DB existence + open repo + run jellyfin check.
 
     Returns None if DB does not exist (caller handles as need_update=0 early return).
     Returns the result dict from check_jellyfin_images_needed otherwise.
     """
+    db_path = get_db_path()
     if not db_path.exists():
         return None
     repo = VideoRepository(db_path)
@@ -1055,16 +1056,15 @@ async def jellyfin_image_check():
     """檢查多少影片需要補齊 Jellyfin 圖片"""
     global _jellyfin_cache_result, _jellyfin_cache_time
     try:
-        db_path = get_db_path()
-
-        # T3(40c): TTL 快取命中
-        # T4b(66): db_path.exists() 併入 _check_jellyfin_needed helper（NAS stat 移出
-        # loop），故 exists 檢查現在排在 TTL 快取之後。副作用：DB 在 60s TTL 窗內被刪除
-        # 時，warm cache 會回舊值而非 0（pathological，無 workflow 觸發）；屬刻意取捨。
+        # T3(40c): TTL 快取命中（純記憶體，命中時 zero-threadpool）
+        # T4b(66): get_db_path（含 mkdir）+ db_path.exists() + repo 全併入
+        # _check_jellyfin_needed helper 移出 loop，故 DB 偵測現在排在 TTL 快取之後。
+        # 副作用：DB 在 60s TTL 窗內被刪除時，warm cache 會回舊值而非 0
+        # （pathological，無 workflow 觸發）；屬刻意取捨。
         if _jellyfin_cache_result is not None and time.time() - _jellyfin_cache_time < 60:
             return {"success": True, "data": {"need_update": _jellyfin_cache_result['need_update']}}
 
-        result = await asyncio.to_thread(_check_jellyfin_needed, db_path)
+        result = await asyncio.to_thread(_check_jellyfin_needed)
 
         if result is None:
             return {"success": True, "data": {"need_update": 0}}

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -1038,21 +1038,36 @@ def generate_jellyfin_images_stream() -> Generator[str, None, None]:
         yield _sse_event({"type": "error", "message": "產生 Jellyfin 圖片失敗"})
 
 
+def _check_jellyfin_needed(db_path) -> dict | None:
+    """Threadpool helper: check DB existence + open repo + run jellyfin check.
+
+    Returns None if DB does not exist (caller handles as need_update=0 early return).
+    Returns the result dict from check_jellyfin_images_needed otherwise.
+    """
+    if not db_path.exists():
+        return None
+    repo = VideoRepository(db_path)
+    return check_jellyfin_images_needed(repo)
+
+
 @router.get("/jellyfin-check")
 async def jellyfin_image_check():
     """檢查多少影片需要補齊 Jellyfin 圖片"""
     global _jellyfin_cache_result, _jellyfin_cache_time
     try:
         db_path = get_db_path()
-        if not db_path.exists():
-            return {"success": True, "data": {"need_update": 0}}
 
         # T3(40c): TTL 快取命中
+        # T4b(66): db_path.exists() 併入 _check_jellyfin_needed helper（NAS stat 移出
+        # loop），故 exists 檢查現在排在 TTL 快取之後。副作用：DB 在 60s TTL 窗內被刪除
+        # 時，warm cache 會回舊值而非 0（pathological，無 workflow 觸發）；屬刻意取捨。
         if _jellyfin_cache_result is not None and time.time() - _jellyfin_cache_time < 60:
             return {"success": True, "data": {"need_update": _jellyfin_cache_result['need_update']}}
 
-        repo = VideoRepository(db_path)
-        result = await asyncio.to_thread(check_jellyfin_images_needed, repo)
+        result = await asyncio.to_thread(_check_jellyfin_needed, db_path)
+
+        if result is None:
+            return {"success": True, "data": {"need_update": 0}}
 
         # T3(40c): 更新快取
         _jellyfin_cache_result = result

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -445,7 +445,7 @@ async def generate():
 
 
 @router.get("/stats")
-async def get_stats():
+def get_stats():
     """取得 Scanner 統計資訊（從 SQLite 讀取）"""
     try:
         db_path = get_db_path()
@@ -471,7 +471,7 @@ async def get_stats():
 
 
 @router.delete("/cache")
-async def clear_cache():  # noqa: ranker-invalidate (DELETE FROM videos only in docstring; actual deletion delegates to repo.clear_all() which already calls SimilarRankerCache.invalidate())
+def clear_cache():  # noqa: ranker-invalidate (DELETE FROM videos only in docstring; actual deletion delegates to repo.clear_all() which already calls SimilarRankerCache.invalidate())
     """清除所有影片快取（DELETE FROM videos）"""
     try:
         db_path = get_db_path()
@@ -492,7 +492,7 @@ async def clear_cache():  # noqa: ranker-invalidate (DELETE FROM videos only in 
 
 
 @router.get("/update-check")
-async def check_update():
+def check_update():
     """檢查需要更新的影片數量（從 SQLite 讀取）"""
     try:
         db_path = get_db_path()
@@ -544,7 +544,7 @@ async def check_update():
 
 
 @router.get("/missing-check")
-async def check_missing():
+def check_missing():
     """T10: 檢查 DB 中缺少 NFO 或封面的影片數量與清單"""
     try:
         db_path = get_db_path()
@@ -672,7 +672,7 @@ async def run_update():
 
 
 @router.get("/view")
-async def view_list():
+def view_list():
     """取得產生的 HTML 列表檔案（修改圖片路徑為 API 代理）"""
     try:
         config = load_config()
@@ -931,7 +931,7 @@ async def video_player(path: str = Query(..., description="影片路徑（file:/
 
 
 @router.get("/actress-stats")
-async def get_actress_stats(name: str = Query(..., description="女優名稱")):
+def get_actress_stats(name: str = Query(..., description="女優名稱")):
     """查詢某名字的片數"""
     try:
         db_path = get_db_path()

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -722,7 +722,7 @@ async def view_list():
 
 
 @router.get("/image")
-async def get_image(path: str = Query(..., description="圖片路徑")):
+def get_image(path: str = Query(..., description="圖片路徑")):
     """代理圖片請求，解決 file:// 在 iframe 中無法載入的問題"""
     from urllib.parse import unquote
     from core.path_utils import normalize_path
@@ -787,7 +787,7 @@ async def get_image(path: str = Query(..., description="圖片路徑")):
 
 
 @router.get("/video")
-async def get_video(request: Request, path: str = Query(..., description="影片路徑（file:/// URI 或 FS 路徑）")):
+def get_video(request: Request, path: str = Query(..., description="影片路徑（file:/// URI 或 FS 路徑）")):
     """代理影片請求，解決瀏覽器無法開啟 file:/// URI 的問題"""
     # URL decode
     path = unquote(path)

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -280,7 +280,7 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
     if len(request.items) > 20:
         raise HTTPException(status_code=422, detail="items 上限為 20 筆")
 
-    config = load_config()
+    config = await asyncio.to_thread(load_config)
     search_cfg = config.get("search", {})
     proxy_url = search_cfg.get("proxy_url", "")
 

--- a/web/routers/scraper_sources.py
+++ b/web/routers/scraper_sources.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/api", tags=["scraper-sources"])
 
 
 @router.get("/scraper-sources")
-async def get_scraper_sources() -> dict:
+def get_scraper_sources() -> dict:
     """查詢目前 auto 搜尋實際 fan-out 的啟用來源清單。
 
     過濾 = Rule 3：enabled=True AND is_beta=False AND manual_only=False

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -523,7 +523,7 @@ async def search_stream(
 
     # 讀取設定（無碼模式 + proxy）
     from core.config import load_config
-    config = load_config()
+    config = await asyncio.to_thread(load_config)
     uncensored_mode = is_uncensored_mode_effective(config)
     proxy_url = config.get('search', {}).get('proxy_url', '')
 
@@ -761,26 +761,13 @@ def get_favorite_files() -> dict:
     }
 
 
-@router.post("/search/filter-files")
-async def filter_files(request: Request) -> dict:
-    """過濾檔案列表：移除非影片檔與過小檔案
+def _filter_files_sync(paths: list) -> dict:
+    """Threadpool helper（CD-66-3 外層）：load_config + 檔案走訪（exists/stat/iterdir）。
 
-    Args:
-        request: {"paths": ["/path/to/file1.mp4", "C:\\path\\to\\file2.txt", ...]}
-
-    Returns:
-        {
-            "success": True,
-            "files": ["filtered paths"],
-            "rejected": {"extension": 0, "size": 0, "not_found": 0},
-            "total_rejected": 0
-        }
+    整段同步阻塞 I/O，由 filter_files 經 await asyncio.to_thread 移出 event loop。
     """
     from core.config import load_config
     from core.path_utils import normalize_path
-
-    data = await request.json()
-    paths = data.get("paths", [])
 
     # 載入設定
     config = load_config()
@@ -841,6 +828,26 @@ async def filter_files(request: Request) -> dict:
         "rejected": rejected,
         "total_rejected": sum(rejected.values())
     }
+
+
+@router.post("/search/filter-files")
+async def filter_files(request: Request) -> dict:
+    """過濾檔案列表：移除非影片檔與過小檔案
+
+    Args:
+        request: {"paths": ["/path/to/file1.mp4", "C:\\path\\to\\file2.txt", ...]}
+
+    Returns:
+        {
+            "success": True,
+            "files": ["filtered paths"],
+            "rejected": {"extension": 0, "size": 0, "not_found": 0},
+            "total_rejected": 0
+        }
+    """
+    data = await request.json()
+    paths = data.get("paths", [])
+    return await asyncio.to_thread(_filter_files_sync, paths)
 
 
 @router.get("/search/local-status")

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -676,7 +676,7 @@ async def get_sources() -> dict:
 
 
 @router.get("/search/favorite-files")
-async def get_favorite_files() -> dict:
+def get_favorite_files() -> dict:
     """取得我的最愛資料夾的檔案列表（已過濾）
 
     Returns:
@@ -844,7 +844,7 @@ async def filter_files(request: Request) -> dict:
 
 
 @router.get("/search/local-status")
-async def get_local_status(numbers: str = Query(..., description="逗號分隔的番號列表")) -> dict:
+def get_local_status(numbers: str = Query(..., description="逗號分隔的番號列表")) -> dict:
     """查詢番號在本地庫的存在狀態
 
     Args:

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -605,7 +605,11 @@ async def search_stream(
                     top_actor = _analyze_top_actor(results, threshold=0.8, min_samples=3)
                     if top_actor:
                         logger.info(f"[Actress Profile] Fetching profile for: {top_actor}")
-                        actress_profile = _fetch_actress_profile_with_db(top_actor, _extract_top_makers(results))
+                        # 66 Codex P1：event_generator 是 async generator、跑在 event loop 上，
+                        # 此 helper 做 init_db/repo + DB-miss 時同步 scraper HTTP → 必須 to_thread
+                        actress_profile = await asyncio.to_thread(
+                            _fetch_actress_profile_with_db, top_actor, _extract_top_makers(results)
+                        )
                         if not actress_profile:
                             logger.info(f"[Actress Profile] Not found for: {top_actor}")
 

--- a/web/routers/settings_link.py
+++ b/web/routers/settings_link.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/api/settings", tags=["settings-link"])
 
 
 @router.get("/favorite-scanner-link")
-async def get_favorite_scanner_link(
+def get_favorite_scanner_link(
     favorite: str = Query(default="", description="最愛資料夾路徑（input 即時值）"),
 ) -> dict:
     """

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -8,6 +8,7 @@ Endpoints (prefix /api/settings/metatube):
   POST /test       — re-probe all known providers in background
 """
 import asyncio
+import threading
 
 from fastapi import APIRouter
 from pydantic import BaseModel
@@ -24,6 +25,13 @@ from core.source_config import build_metatube_sources
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api/settings/metatube", tags=["settings-metatube"])
+
+# 66 Codex P2 (round 2)：connect 序列化鎖。offload 後 _connect_sync 跑在 threadpool
+# thread、兩個並發 /connect 會交錯各自的 state.connect()/save_config()/rollback
+# （config↔runtime 不一致、rollback 拆掉別人的連線）。pre-branch event loop 隱式序列
+# 化了這段；此鎖在 threadpool thread 上阻塞（不卡 event loop）以還原該序列化。
+# connect/persist-allow-lan 皆罕見管理動作，序列化其慢 I/O 可接受。
+_connect_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -79,18 +87,23 @@ def _persist_allow_lan(url: str, token: str, allow_lan: bool) -> bool:
     Returns True on success (or no-op when url/token don't match), False if the
     config write fails — caller must surface the failure rather than reporting
     success, otherwise the LAN opt-in is silently lost (Codex P2).
+
+    66 Codex P2 (round 2)：與 _connect_sync 共用 _connect_lock —— 兩個並發
+    dedup-save，或 dedup-save 與 full-connect-save 競爭同一個 config.json，會互相
+    clobber。序列化即可避免。
     """
-    try:
-        config = load_config()
-        mt = config.get("metatube") or {}
-        if mt.get("url") == url and mt.get("token") == token:
-            mt["allow_lan"] = allow_lan
-            config["metatube"] = mt
-            save_config(config)
-        return True
-    except Exception:
-        logger.exception("_persist_allow_lan: failed to update allow_lan in config")
-        return False
+    with _connect_lock:
+        try:
+            config = load_config()
+            mt = config.get("metatube") or {}
+            if mt.get("url") == url and mt.get("token") == token:
+                mt["allow_lan"] = allow_lan
+                config["metatube"] = mt
+                save_config(config)
+            return True
+        except Exception:
+            logger.exception("_persist_allow_lan: failed to update allow_lan in config")
+            return False
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +203,18 @@ def _fire_probe(base_url: str, token: str, names: list[str], generation: int) ->
 # ---------------------------------------------------------------------------
 
 def _connect_sync(url: str, token: str, allow_lan: bool) -> dict:
+    """Threadpool entry for /connect — serializes via _connect_lock then delegates.
+
+    66 Codex P2 (round 2)：整個連線臨界段（Step3–5 + rollback）在 _connect_lock 內
+    執行，避免兩個並發 connect 交錯（config↔runtime 不一致、rollback 拆別人連線）。
+    鎖在 threadpool thread 上阻塞、不卡 event loop。_fire_probe 仍在外層 async
+    handler（需 running loop），不在此鎖內。
+    """
+    with _connect_lock:
+        return _connect_sync_impl(url, token, allow_lan)
+
+
+def _connect_sync_impl(url: str, token: str, allow_lan: bool) -> dict:
     """Threadpool helper: Step3 list_providers + Step3b canary + Step4 state.connect
     + Step5 load_config / merge / save_config (+ rollback state.disconnect on failure).
 

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -236,7 +236,10 @@ def _connect_sync(url: str, token: str, allow_lan: bool) -> dict:
         )
 
     # Step 4: update runtime state (thread-safe: metatube_state uses threading.Lock)
-    state.connect(url, token, names)
+    # 66 Codex P2：capture THIS connect 設的 generation 一路帶回給 _fire_probe，
+    # 不可在 await 後重讀 state.generation（並發 connect/disconnect 會推進它 → 探測
+    # 會用錯的 generation 蓋掉現役連線的 availability）
+    gen = state.connect(url, token, names)
 
     # Step 5: persist to config.json (CD-63b-3 merge)
     try:
@@ -288,7 +291,7 @@ def _connect_sync(url: str, token: str, allow_lan: bool) -> dict:
         state.disconnect()  # rollback — don't stay connected with unsaved config
         return {"ok": False, "error": "設定儲存失敗，請重試。"}
 
-    return {"ok": True, "names": names}
+    return {"ok": True, "names": names, "generation": gen}
 
 
 @router.post("/connect")
@@ -320,8 +323,9 @@ async def connect(req: ConnectRequest):
         return {"success": False, "error": result["error"]}
 
     # Step 6: fire background probe (must stay on loop — uses asyncio.get_running_loop())
-    gen = state.generation
-    _fire_probe(req.url, req.token, result["names"], gen)
+    # 66 Codex P2：用 _connect_sync 回傳的 generation（此次 connect 設的），不重讀
+    # state.generation（avoid stale/superseded generation under concurrent connects）
+    _fire_probe(req.url, req.token, result["names"], result["generation"])
 
     return {"success": True, "provider_count": len(result["names"])}
 

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -107,6 +107,25 @@ def _persist_allow_lan(url: str, token: str, allow_lan: bool) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Sync helper: disconnect serialized against in-flight connect — Codex P2
+# ---------------------------------------------------------------------------
+
+def _disconnect_sync() -> None:
+    """Acquire _connect_lock then state.disconnect().
+
+    66 Codex P2：序列化 disconnect 對在途的 _connect_sync —— 連線 HTTP/config I/O
+    執行期間送出的 disconnect 會等該 connect 完成後才斷線，確保 last-action-wins，
+    避免 connect worker 在使用者已 disconnect 後又把 connected 設回 True。
+    連線完成後 disconnect 把 generation 推進 → connect 的 stale 探測被 generation
+    guard 擋下（探測本就不會動 connected）。
+    必須經 asyncio.to_thread 呼叫：在 event loop thread 上直接 acquire 已被持有的
+    threading.Lock 會卡死整個 loop。
+    """
+    with _connect_lock:
+        state.disconnect()
+
+
+# ---------------------------------------------------------------------------
 # Sync: startup reconnect — TASK-63e-1
 # ---------------------------------------------------------------------------
 
@@ -365,8 +384,11 @@ async def disconnect():
 
     URL/token are NOT cleared from config.json so they can prefill the
     next connect dialog.  Source enabled flags are also untouched.
+
+    66 Codex P2：經 _connect_lock 序列化（via to_thread），等在途 connect 完成後
+    才斷線 → last-action-wins，不會被 connect worker 的晚到完成蓋回 connected。
     """
-    state.disconnect()
+    await asyncio.to_thread(_disconnect_sync)
     return {"success": True}
 
 

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -189,35 +189,27 @@ def _fire_probe(base_url: str, token: str, names: list[str], generation: int) ->
 # POST /connect
 # ---------------------------------------------------------------------------
 
-@router.post("/connect")
-async def connect(req: ConnectRequest):
-    """Connect to a metatube HTTP server.
+def _connect_sync(url: str, token: str, allow_lan: bool) -> dict:
+    """Threadpool helper: Step3 list_providers + Step3b canary + Step4 state.connect
+    + Step5 load_config / merge / save_config (+ rollback state.disconnect on failure).
 
-    Validates URL (SSRF guard), fetches provider list, persists config,
-    and fires a background probe of all providers.
+    Returns:
+        {"ok": True,  "names": [...]}
+        {"ok": False, "error": "<exact error string>"}
+
+    Error-string / catch-order is preserved exactly as the original connect() body:
+      - Step3 MetatubeError (catches MetatubeAuthError subclass too) → "無法連線..."
+      - Step3b MetatubeAuthError → "Token 錯誤..."
+      - Step3b non-401 MetatubeError → log only, continue
+      - Step5 Exception → state.disconnect() rollback → "設定儲存失敗，請重試。"
     """
-    # Step 1: SSRF validation
-    err = validate_metatube_url(req.url, req.allow_lan)
-    if err:
-        return {"success": False, "error": err}
-
-    # Step 2: dedup — already connected to same URL and token.
-    # Even on dedup hit we still need to persist allow_lan in case the user
-    # changed it (Codex P2: _persist_allow_lan updates config without re-connecting).
-    if state.is_connected and state.base_url == req.url and state.token == req.token:
-        if not _persist_allow_lan(req.url, req.token, req.allow_lan):
-            # Mirror Step5 semantics: don't report success if the opt-in wasn't
-            # persisted, otherwise the restart bug silently returns (Codex P2).
-            return {"success": False, "error": "設定儲存失敗，請重試。"}
-        return {"success": True, "provider_count": state.provider_count}
-
     # Step 3: fetch provider list from the metatube server
     try:
-        providers = MetatubeHttpClient(req.url, req.token).list_providers()
+        providers = MetatubeHttpClient(url, token).list_providers()
     except MetatubeError:
-        logger.exception("metatube connect: list_providers failed for url=%r", req.url)
+        logger.exception("metatube connect: list_providers failed for url=%r", url)
         return {
-            "success": False,
+            "ok": False,
             "error": "無法連線到 metatube server，請確認 URL 與 token",
         }
 
@@ -229,10 +221,10 @@ async def connect(req: ConnectRequest):
     # _verify_token_canary: 401 → MetatubeAuthError; non-401 MetatubeError → re-raised;
     # no canary provider in list → returns (skip, treat as pass).
     try:
-        _verify_token_canary(req.url, req.token, providers)
+        _verify_token_canary(url, token, providers)
     except MetatubeAuthError:
         return {
-            "success": False,
+            "ok": False,
             "error": "Token 錯誤或缺少：無法通過 metatube server 驗證，請確認 Bearer Token",
         }
     except MetatubeError as e:
@@ -243,8 +235,8 @@ async def connect(req: ConnectRequest):
             type(e).__name__,
         )
 
-    # Step 4: update runtime state
-    state.connect(req.url, req.token, names)
+    # Step 4: update runtime state (thread-safe: metatube_state uses threading.Lock)
+    state.connect(url, token, names)
 
     # Step 5: persist to config.json (CD-63b-3 merge)
     try:
@@ -255,9 +247,9 @@ async def connect(req: ConnectRequest):
         # state must survive.  allow_lan is stored so startup_reconnect can honour
         # the user's LAN opt-in when re-connecting after a restart (TASK-63e-1).
         mt = config.get("metatube") or {}
-        mt["url"] = req.url
-        mt["token"] = req.token
-        mt["allow_lan"] = req.allow_lan
+        mt["url"] = url
+        mt["token"] = token
+        mt["allow_lan"] = allow_lan
         config["metatube"] = mt
 
         # Merge metatube sources (preserve existing enabled flags)
@@ -294,13 +286,43 @@ async def connect(req: ConnectRequest):
     except Exception:
         logger.exception("metatube connect: failed to persist config")
         state.disconnect()  # rollback — don't stay connected with unsaved config
-        return {"success": False, "error": "設定儲存失敗，請重試。"}
+        return {"ok": False, "error": "設定儲存失敗，請重試。"}
 
-    # Step 6: fire background probe
+    return {"ok": True, "names": names}
+
+
+@router.post("/connect")
+async def connect(req: ConnectRequest):
+    """Connect to a metatube HTTP server.
+
+    Validates URL (SSRF guard), fetches provider list, persists config,
+    and fires a background probe of all providers.
+    """
+    # Step 1: SSRF validation
+    err = validate_metatube_url(req.url, req.allow_lan)
+    if err:
+        return {"success": False, "error": err}
+
+    # Step 2: dedup — already connected to same URL and token.
+    # Even on dedup hit we still need to persist allow_lan in case the user
+    # changed it (Codex P2: _persist_allow_lan updates config without re-connecting).
+    if state.is_connected and state.base_url == req.url and state.token == req.token:
+        if not _persist_allow_lan(req.url, req.token, req.allow_lan):
+            # Mirror Step5 semantics: don't report success if the opt-in wasn't
+            # persisted, otherwise the restart bug silently returns (Codex P2).
+            return {"success": False, "error": "設定儲存失敗，請重試。"}
+        return {"success": True, "provider_count": state.provider_count}
+
+    # Step 3–5: run blocking I/O (HTTP + config) in threadpool
+    result = await asyncio.to_thread(_connect_sync, req.url, req.token, req.allow_lan)
+    if not result["ok"]:
+        return {"success": False, "error": result["error"]}
+
+    # Step 6: fire background probe (must stay on loop — uses asyncio.get_running_loop())
     gen = state.generation
-    _fire_probe(req.url, req.token, names, gen)
+    _fire_probe(req.url, req.token, result["names"], gen)
 
-    return {"success": True, "provider_count": len(names)}
+    return {"success": True, "provider_count": len(result["names"])}
 
 
 # ---------------------------------------------------------------------------

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -423,7 +423,6 @@ async def status():
 @router.post("/test")
 async def test_connection():
     """Re-probe all currently known providers in the background."""
-    names = [k.split(":", 1)[1] for k in state.availability_map()]
-    gen = state.generation
-    _fire_probe(state.base_url or "", state.token or "", names, gen)
+    names, gen, base_url, token = state.probe_snapshot()
+    _fire_probe(base_url, token, names, gen)
     return {"success": True, "message": "probe started"}

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -131,7 +131,7 @@ def _disconnect_sync() -> None:
 # Sync: startup reconnect — TASK-63e-1
 # ---------------------------------------------------------------------------
 
-def startup_reconnect(config: dict) -> list[str] | None:
+def startup_reconnect(config: dict) -> tuple[list[str], int] | None:
     """Re-establish metatube connection from persisted config at startup.
 
     Reads the metatube section of *config* (a raw dict as returned by
@@ -139,8 +139,13 @@ def startup_reconnect(config: dict) -> list[str] | None:
     token via canary, then calls state.connect().
 
     Returns:
-        list[str]  — provider names if successfully reconnected.
-        None       — if reconnect was skipped or failed (state stays disconnected).
+        tuple[list[str], int]  — (provider names, generation set by state.connect)
+                                  if successfully reconnected. The generation is
+                                  captured under state's lock and carried back so
+                                  the caller never re-reads state.generation after
+                                  the await/executor boundary (CD-66b-2).
+        None                   — if reconnect was skipped or failed (state stays
+                                  disconnected).
 
     This function is intentionally synchronous so it can be called from
     lifespan via loop.run_in_executor() without any async context dependency.
@@ -165,32 +170,37 @@ def startup_reconnect(config: dict) -> list[str] | None:
         logger.warning("startup_reconnect: SSRF blocked for stored URL: %s", err)
         return None
 
-    # Fetch provider list
-    try:
-        providers = MetatubeHttpClient(url, token).list_providers()
-    except MetatubeError:
-        logger.warning("startup_reconnect: list_providers failed for url=%r", url)
-        return None
+    # Connect-critical section — serialised via _connect_lock (CD-66b-4), shared
+    # with _connect_sync / _disconnect_sync so startup cannot interleave with an
+    # early-arriving /connect (test env). Held across HTTP I/O on the executor
+    # thread — blocks the threadpool thread, not the event loop.
+    with _connect_lock:
+        # Fetch provider list
+        try:
+            providers = MetatubeHttpClient(url, token).list_providers()
+        except MetatubeError:
+            logger.warning("startup_reconnect: list_providers failed for url=%r", url)
+            return None
 
-    # Token canary (Codex P1) — same semantics as connect endpoint
-    try:
-        _verify_token_canary(url, token, providers)
-    except MetatubeAuthError:
-        logger.warning(
-            "startup_reconnect: token rejected (401) — not reconnecting"
-        )
-        return None
-    except MetatubeError:
-        # Non-401: transient / canary issue — log and continue (same as connect)
-        logger.info(
-            "startup_reconnect: canary non-401 error, continuing with reconnect"
-        )
+        # Token canary (Codex P1) — same semantics as connect endpoint
+        try:
+            _verify_token_canary(url, token, providers)
+        except MetatubeAuthError:
+            logger.warning(
+                "startup_reconnect: token rejected (401) — not reconnecting"
+            )
+            return None
+        except MetatubeError:
+            # Non-401: transient / canary issue — log and continue (same as connect)
+            logger.info(
+                "startup_reconnect: canary non-401 error, continuing with reconnect"
+            )
 
-    # Reconnect runtime state
-    names = list(providers.keys())
-    state.connect(url, token, names)
-    logger.info("startup_reconnect: reconnected to %r with %d providers", url, len(names))
-    return names
+        # Reconnect runtime state — capture the generation set under state's lock
+        names = list(providers.keys())
+        gen = state.connect(url, token, names)
+        logger.info("startup_reconnect: reconnected to %r with %d providers", url, len(names))
+        return names, gen
 
 
 # ---------------------------------------------------------------------------

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -13,7 +13,7 @@ import threading
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from core.config import load_config, save_config
+from core.config import mutate_config
 from core.logger import get_logger
 from core.metatube.client import MetatubeHttpClient
 from core.metatube.errors import MetatubeAuthError, MetatubeError
@@ -92,14 +92,16 @@ def _persist_allow_lan(url: str, token: str, allow_lan: bool) -> bool:
     dedup-save，或 dedup-save 與 full-connect-save 競爭同一個 config.json，會互相
     clobber。序列化即可避免。
     """
+    # 鎖序：外 _connect_lock → 內 _config_write_lock（經 mutate_config）。
     with _connect_lock:
         try:
-            config = load_config()
-            mt = config.get("metatube") or {}
-            if mt.get("url") == url and mt.get("token") == token:
-                mt["allow_lan"] = allow_lan
-                config["metatube"] = mt
-                save_config(config)
+            def _mut(config):
+                mt = config.get("metatube") or {}
+                if mt.get("url") == url and mt.get("token") == token:
+                    mt["allow_lan"] = allow_lan
+                    config["metatube"] = mt
+                # url/token 不符 → 不改 cfg（mutate_config 仍會 byte-identical 重存，可接受）
+            mutate_config(_mut)
             return True
         except Exception:
             logger.exception("_persist_allow_lan: failed to update allow_lan in config")
@@ -286,9 +288,9 @@ def _connect_sync_impl(url: str, token: str, allow_lan: bool) -> dict:
     gen = state.connect(url, token, names)
 
     # Step 5: persist to config.json (CD-63b-3 merge)
-    try:
-        config = load_config()
-
+    # 鎖序：caller _connect_sync 已持 _connect_lock（外）→ mutate_config 取
+    # _config_write_lock（內）。整個 load+merge 在 mutator 內、單一 critical section。
+    def _merge_mutator(config):
         # Persist metatube URL + token + allow_lan, preserving existing `enabled`
         # flag (CD-63b-3).  Do NOT wipe `enabled` on reconnect — user's toggle
         # state must survive.  allow_lan is stored so startup_reconnect can honour
@@ -329,7 +331,9 @@ def _connect_sync_impl(url: str, token: str, allow_lan: bool) -> dict:
                 merged_mt.append(s)
 
         config["sources"] = non_mt + merged_mt
-        save_config(config)
+
+    try:
+        mutate_config(_merge_mutator)
     except Exception:
         logger.exception("metatube connect: failed to persist config")
         state.disconnect()  # rollback — don't stay connected with unsaved config

--- a/web/routers/settings_metatube.py
+++ b/web/routers/settings_metatube.py
@@ -307,7 +307,8 @@ async def connect(req: ConnectRequest):
     # Even on dedup hit we still need to persist allow_lan in case the user
     # changed it (Codex P2: _persist_allow_lan updates config without re-connecting).
     if state.is_connected and state.base_url == req.url and state.token == req.token:
-        if not _persist_allow_lan(req.url, req.token, req.allow_lan):
+        # 66 Codex P1：dedup path 也跑在 loop，_persist_allow_lan 做 load/save_config → to_thread
+        if not await asyncio.to_thread(_persist_allow_lan, req.url, req.token, req.allow_lan):
             # Mirror Step5 semantics: don't report success if the opt-in wasn't
             # persisted, otherwise the restart bug silently returns (Codex P2).
             return {"success": False, "error": "設定儲存失敗，請重試。"}

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -73,7 +73,7 @@ def _get_configured_dirs(config: dict) -> tuple[set, dict]:
 
 
 @router.get("/videos")
-async def get_videos():
+def get_videos():
     """取得所有影片資料（用於 Showcase 頁面客戶端渲染）"""
     try:
         db_path = get_db_path()
@@ -115,7 +115,7 @@ async def get_videos():
 
 
 @router.get("/video")
-async def get_video(path: str = Query(..., description="file:/// URI")):
+def get_video(path: str = Query(..., description="file:/// URI")):
     """取得單筆影片資料（用於 T3 refreshVideoData enrich 後刷新卡片）"""
     try:
         db_path = get_db_path()

--- a/web/routers/translate.py
+++ b/web/routers/translate.py
@@ -9,6 +9,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 from typing import Optional, List
+import asyncio
 import httpx
 
 from core.config import load_config
@@ -68,7 +69,7 @@ async def translate_title(request: TranslateRequest) -> dict:
     """翻譯或優化標題（支援 Ollama/Gemini）"""
     import re
 
-    config = load_config()
+    config = await asyncio.to_thread(load_config)
     translate_config = config.get("translate", {})
 
     if not translate_config.get("enabled", False):
@@ -215,7 +216,7 @@ async def translate_batch(request: BatchTranslateRequest):
         translate_service = get_translate_service()
 
         # 獲取配置的批次大小（預留：可從 config 讀取默認值）
-        config = load_config()
+        config = await asyncio.to_thread(load_config)
         default_batch_size = config.get("translate", {}).get("batch_size", 10)
 
         # 限制批次大小（防止超時），優先使用請求參數

--- a/web/routers/translate.py
+++ b/web/routers/translate.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel, Field
 from typing import Optional, List
 import asyncio
+import threading
 import httpx
 
 from core.config import load_config
@@ -38,6 +39,11 @@ class BatchTranslateRequest(BaseModel):
 
 # 全局翻譯服務實例（單例模式）
 _translate_service = None
+# CD-66b-5：get_translate_service 現經 await asyncio.to_thread(...) 在 threadpool
+# thread 上呼叫（66 async-offload），cold-start init 失去 event loop 隱式互斥，
+# 兩個並發冷啟動可同時看到 None → double-init。用 Lock 包 init + reset 消窗口。
+# 鎖只保護 init / reset 兩個 critical section，不鎖 service 物件的使用期。
+_translate_service_lock = threading.Lock()
 
 
 def get_translate_service():
@@ -46,22 +52,31 @@ def get_translate_service():
 
     locale 變更時由 config router 呼叫 reset_translate_service() 重建。
 
+    Double-checked locking（CD-66b-5）：fast-path 無鎖讀，僅 None 時進鎖
+    再 re-check，確保 threadpool 並發 cold-start 只 init 一次。
+
     Returns:
         TranslateService 實例
     """
     global _translate_service
-    if _translate_service is None:
-        config = load_config()
-        translate_config = config.get("translate", {})
-        locale = config.get("general", {}).get("locale", "zh-TW")
-        _translate_service = create_translate_service(translate_config, locale)
+    if _translate_service is None:                    # fast path, no lock
+        with _translate_service_lock:
+            if _translate_service is None:            # double-check under lock
+                config = load_config()
+                translate_config = config.get("translate", {})
+                locale = config.get("general", {}).get("locale", "zh-TW")
+                _translate_service = create_translate_service(translate_config, locale)
     return _translate_service
 
 
 def reset_translate_service():
-    """重置翻譯服務實例（配置改變時調用）"""
+    """重置翻譯服務實例（配置改變時調用）
+
+    在 _translate_service_lock 內設 None（CD-66b-5），避免 reset×get 交錯回半建狀態。
+    """
     global _translate_service
-    _translate_service = None
+    with _translate_service_lock:
+        _translate_service = None
 
 
 @router.post("/translate")

--- a/web/routers/translate.py
+++ b/web/routers/translate.py
@@ -87,7 +87,8 @@ async def translate_title(request: TranslateRequest) -> dict:
     # === translate 模式：使用 translate service（支援 Ollama/Gemini）===
     if request.mode == "translate":
         try:
-            translate_service = get_translate_service()
+            # 66 Codex P2：get_translate_service 冷啟動會同步 load_config → to_thread
+            translate_service = await asyncio.to_thread(get_translate_service)
             context = {
                 "actors": request.actors or [],
                 "number": request.number or ""
@@ -213,7 +214,8 @@ async def translate_batch(request: BatchTranslateRequest):
     """
     try:
         # 獲取翻譯服務（單例）
-        translate_service = get_translate_service()
+        # 66 Codex P2：get_translate_service 冷啟動會同步 load_config → to_thread
+        translate_service = await asyncio.to_thread(get_translate_service)
 
         # 獲取配置的批次大小（預留：可從 config 讀取默認值）
         config = await asyncio.to_thread(load_config)


### PR DESCRIPTION
## 一句話 / TL;DR

把所有「在 `async def` 路由裡裸跑、會打慢 I/O（NAS 檔案 stat / HDD 上的 sqlite / config 檔 / 同步 HTTP）的同步呼叫」移出 event loop，讓**載圖／播放／切頁／任一慢請求不再互相凍住整個 app**。純後端、**無新 UI/設定/端點、零新依賴、零 ZIP 影響**、行為 byte 級不變。

*Moves every synchronous slow-I/O call that was bare-running inside an `async def` route off the event loop. Pure backend; byte-identical behavior.*

> **更新（PR 開出後追加）：** 原始 PR 只含 async-offload（plan-66）。後續追加 **plan-66b 並發硬化**——offload 拆掉了 event loop 的隱式序列化，需在所有碰共享資源的路徑補回協調機制。詳見下方「追加：並發硬化」段。
> *Update: this PR originally covered only the async-offload (plan-66). It was later extended with **plan-66b concurrency hardening** — the offload removed the loop's implicit serialization, so coordination had to be re-added on every shared-resource path. See the "Added: concurrency hardening" section below.*

## 根因

FastAPI 對 `def` 路由自動丟 threadpool，但 `async def` 路由的函式體**直接跑在 event loop 上**——裡面任何同步阻塞呼叫卡住整個 loop，連帶讓別的請求（含切頁的 HTML/API）排不進 loop，畫面就凍住。

## 手段（二選一，逐處人工確認、不全域 sed）

- **body 無 `await` → 改宣告 `def`**（最便宜，Starlette 自動 threadpool）
- **body 必須留 `await` → `await asyncio.to_thread(...)` 包阻塞段**

## 變更（task 分解）

| Task | 內容 |
|------|------|
| T1 | `get_image`/`get_video` 轉 def（止血 hot path：realpath/exists/getsize/load_config 全裸跑 stat） |
| T2 | 純讀 DB async 路由 11 處轉 def |
| T3 | config/設定檔 I/O 路由 9 處轉 def |
| T4a | 翻譯/AI 路由 5 處 `load_config` 包 to_thread |
| T4b | 半套 offload 補齊（actress×2 / jellyfin_check / metatube connect 抽 helper） |
| T4c | SSE 外層 + `filter_files` 檔案走訪移出 loop |
| T5 | 新增 AST 回歸守衛 + 全套回歸 |
| Codex fix | 補三處二階卡 loop（search_stream 內層 async gen / metatube dedup / get_translate_service 冷啟動）+ 守衛強化 |

## 守衛（防回退）

新增 `tests/integration/test_async_offload_guard.py`：AST 掃 `web/routers/*.py`，斷言每個 `async def` 路由（**含巢狀 async generator**）body 不得裸跑慢 I/O（直接或經「含阻塞 I/O 的 sync helper」間接皆抓；排除 generator function；to_thread 包裝天然不誤報）；並正斷言 T1–T3 轉 def 的 24 handler 維持 `def`。

---

## 追加：並發硬化（plan-66b）/ Added: concurrency hardening

PR 開出後追加。async-offload 把 `async def`（無 await）改 `def`（threadpool ~40 並發）/ 加 `to_thread` 後，**拆掉了 event loop 對 handler 的隱式互斥**；凡「pre-branch 靠 loop 序列化才安全」的共享可變資源（config.json RMW / metatube runtime state / cold-start 單例 / 非-config 檔案寫入）offload 後變真並發 → lost-update / TOCTOU。全庫 5-subagent 稽核 + Codex plan-review 後逐處補回協調機制（皆只加協調、不改語意）：

| Task | 內容 |
|------|------|
| 66b-T1 | **config.json 寫入序列化 + 原子寫**：`core/config.py` 加 process-wide `threading.Lock`（非 asyncio.Lock——def 路由跑 threadpool thread），public-locked + private-unlocked 分層 + `tempfile.mkstemp`/`os.replace`；新增 `mutate_config(mutator)` 把整個 load→改→save 收進單一 critical section。修「並切 theme+font（150ms debounce）靜默 lost-update」（每用戶會中）；config 三 RMW 路由 + metatube `_connect_sync`/`_persist_allow_lan` 全遷移，delete 走 `reset_config_file`（消 TOCTOU） |
| 66b-T2 | **metatube startup generation 帶回**：lifespan 不再於 `await` 後重讀 `state.generation`（與已修 `/connect` race 同型 TOCTOU），`startup_reconnect` 回傳 `(names, gen)`；連線臨界段共用 `_connect_lock` |
| 66b-T3 | **metatube `/test` 原子 snapshot**：`state.probe_snapshot()` 單鎖內取 `(names, gen, base_url, token)`，消「分 4 次讀夾出不一致」（names 仍沿用 `_availability` keys，行為不變） |
| 66b-T4 | **translate 單例 init 鎖**：`get_translate_service` double-checked locking，消 threadpool 並發冷啟動 double-init |
| 66b-T4b | **actress photo 檔寫競態**：`_write_actress_photo` 改 `unlink(missing_ok=True)` + temp/`os.replace` 原子寫，消同 actress 並發 local_crop 的 glob/unlink TOCTOU（500）與 torn 檔 |
| 66b-T5 | **守衛擴充**：`test_async_offload_guard.py` 加 AST 守衛——`web/routers/*.py` + `web/app.py` 禁裸呼 `save_config`（唯一白名單 = `config.py::update_config` full-replace） |
| Codex P2 | `web/app.py` `get_common_context` locale 首寫改 `mutate_config`（它跑在 loop thread，但 racer 本 branch 已移到 threadpool → loop 端裸 RMW 會與 threadpool 寫入 lost-update） |

每處皆**確定性測試**（`threading.Barrier`/`Event`/`lock.locked()` 斷言，非真 race flaky）。純後端、零新依賴、行為 byte 級不變。

*Concurrency hardening: the offload removed the loop's implicit serialization, so shared mutable state became truly concurrent. Re-added coordination per path — a process-wide `threading.Lock` + atomic write + `mutate_config()` RMW helper in `core/config.py` (fixes the silent theme+font lost-update every user hits); metatube startup-generation carry-back + shared `_connect_lock`; an atomic `/test` `probe_snapshot()`; a double-checked translate-singleton lock; lock-free atomic actress-photo write; and an AST guard banning bare `save_config` outside the `update_config` whitelist across routers + `web/app.py`. All with deterministic (non-flaky) tests.*

## 測試

- 全套 pytest **3523 passed, 2 skipped**（排除 smoke/e2e）+ `npm run lint`（eslint + stylelint）綠
- 守衛 RED→GREEN + 5 種 control 驗證；並發硬化每處確定性測試

## Non-Goals

不導 HTMX、不做縮圖/快取、不換 aiosqlite、不調 threadpool limiter、不解單請求自身慢（thumbnail-cache 押後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
