### PR TITLE
v0.9.6 — Cover Loading UX & Showcase Console Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **搜尋頁/設計系統頁封面隱形回歸（Codex 二次審核發現）**：封面淡入的 `opacity:0` 預設規則因共用 scope 洩漏到同樣載入 showcase.css 的 `/search` 與 `/design-system`（兩頁的卡片 img 無淡入機制），會讓搜尋結果封面與元件展示 demo 整片隱形；改用 compound `.showcase-container` scope 收斂，只命中 showcase 頁。
 - **Hero 無女優照片時的空白框**：最愛女優若無照片，`<img src="">` 不觸發 load/error 而顯空白；改為無照片直接顯破圖 icon（與 grid 一致）。
+- **bfcache cleanup 回歸（Codex 二次審核發現）**：`unload`→`pagehide` 後，頁面進 back/forward cache 時 `pagehide` 以 `persisted=true` 觸發會誤跑一次性 cleanup（拆 SSE/abort/resize listener），按 Back 還原（不重跑 init）後頁面缺資源；改為僅在真正丟棄（`persisted=false`）才 cleanup。僅瀏覽器存取會踩，PyWebView 桌面端無此路徑。
 
 ### Added（守衛 / Guards）
 - `tests/unit/test_frontend_lint.py::TestCoverLoadingUx67Guard`：HTML/CSS 三態契約守衛（SVG 無 `<template>`、12 組靜態 rail/sweep id、grid/hero `@load` 綁定、淡入不掛 GSAP 專屬容器、reduced-motion 退化、淡入 scope 收斂於 `.showcase-container`）；`eslint.config.mjs` 加 `addEventListener('unload')` 禁令。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-06-06
+
+本版單一主軸：**封面載入體感優化（Cover Loading UX）+ Showcase Console 清零**，純前端、零後端、零新依賴。兩條正交軌。**Track A**：封面在 NAS(HDD) 上一頁 90 張陸續慢慢冒，過去圖沒到是空白、到了「啪」一下出現；本版讓每張 grid 卡片與 Hero card 在等待時顯示 skeleton/shimmer、圖到淡入、抓不到顯示業界標準破圖 icon——把 HDD 喚醒/seek 的等待填上「正在載入」的視覺。**不縮短實際載入**（那是縮圖快取的事），只解「等待時看到什麼」。**Track B**：清掉 `/showcase` 開 F12 固定噴的 4 條 console 紅字——SVG namespace 下誤放 `<template x-for>`（3 條）+ 過時的 `unload` 事件（1 條，site-wide）；修好 SVG bug 後相似探索的連接線也恢復顯示（原被 bug 壓住從未畫出）。
+
+*This release has one theme: **Cover Loading UX + Showcase console cleanup** — pure frontend, zero backend, zero new deps, two orthogonal tracks. **Track A**: covers on a NAS HDD trickle in (≈90/page); previously the wait was blank then a hard "pop". Now each grid card and the Hero card shows a skeleton/shimmer while waiting, fades the cover in on load, and shows an industry-standard broken-image icon when there's no cover — filling the HDD spin-up/seek wait with a "loading" visual. It does not speed up actual loading (that's the thumbnail cache's job); it only fixes "what you see while waiting." **Track B**: clears the 4 console errors on `/showcase` — a `<template x-for>` mistakenly placed inside an SVG namespace (3) + a deprecated site-wide `unload` listener (1); fixing the SVG bug also restores the similar-explore connector lines (previously never drawn, suppressed by the bug).*
+
+### Added
+#### 🎴 封面三態（grid + Hero）/ Cover three-state
+- **Showcase grid 每張卡片**：載入中 skeleton + shimmer → `@load` 淡入封面 → 無封面/抓不到顯破圖 icon。首屏前 8 張封面 `loading=eager` + `fetchpriority=high`（最先看到的先到），其餘維持 `lazy`。
+- **Hero card**（最愛女優精準命中時最上方那張大圖）：補齊到與 grid 一致的三態（獨立旗標，因 Hero 是女優照片非影片封面）。
+- 卡片以 `aspect-ratio` 佔位，圖到不位移（無 layout shift）；尊重系統「減少動態」（shimmer/淡入退化為靜態）。
+
+#### 🔇 Showcase console 清零 / Console cleanup
+- 相似探索的 rail/sweep 連接線從「永遠畫不出來」恢復為正常渲染（修好 SVG bug 的附帶效果）。
+
+### Changed
+- 相似探索 stage 的 SVG 連接線由 Alpine `<template x-for>` 動態產生改為 12 組靜態 `<line>`（鏡射 motion-lab 既有無錯寫法），根除 SVG namespace 下 `<template>` 無 `.content` 的 console error。
+- 頁面卸載 cleanup 由 `unload` 事件改用 bfcache-safe 的 `pagehide`（新版 Chrome 以 Permissions-Policy 封鎖 `unload`）。
+
+### Fixed
+- **搜尋頁/設計系統頁封面隱形回歸（Codex 二次審核發現）**：封面淡入的 `opacity:0` 預設規則因共用 scope 洩漏到同樣載入 showcase.css 的 `/search` 與 `/design-system`（兩頁的卡片 img 無淡入機制），會讓搜尋結果封面與元件展示 demo 整片隱形；改用 compound `.showcase-container` scope 收斂，只命中 showcase 頁。
+- **Hero 無女優照片時的空白框**：最愛女優若無照片，`<img src="">` 不觸發 load/error 而顯空白；改為無照片直接顯破圖 icon（與 grid 一致）。
+
+### Added（守衛 / Guards）
+- `tests/unit/test_frontend_lint.py::TestCoverLoadingUx67Guard`：HTML/CSS 三態契約守衛（SVG 無 `<template>`、12 組靜態 rail/sweep id、grid/hero `@load` 綁定、淡入不掛 GSAP 專屬容器、reduced-motion 退化、淡入 scope 收斂於 `.showcase-container`）；`eslint.config.mjs` 加 `addEventListener('unload')` 禁令。
+  - 註：HTML/CSS 守衛走 pytest 而非 eslint/stylelint，因 eslint 不解析 Jinja `.html`、選擇器歸屬無法用 stylelint 表達（CD-67-8 既定例外）；可 eslint 化的 `unload` 禁令已在 eslint。屬永久守衛（HTML binding / 架構契約），非 transient。
+
+### Non-Goals（明確不做）
+- 不縮短實際載入時間（縮圖快取押後）、不做伺服端 HDD 狀態偵測、不導 HTMX、不重做 Search 頁、不做 Lightbox 大圖載入態（同封面 URL 已快取、秒開無等待）。
+
+### 測試
+- 全套 pytest **3538 passed, 2 skipped**（unit + integration，排除 smoke/e2e）+ `npm run lint`（eslint + stylelint）綠。
+- CDP 終驗（含生產環境 NAS HDD 實機）：`/showcase` console 0 error、相似探索 rail+sweep 24 條渲染、grid 三態（skeleton 淡入實況）、首屏 eager+high、`/search` 與 `/design-system` 封面可見。
+
 ## [0.9.5] - 2026-06-06
 
 本版單一主軸：**把所有「在 `async def` 路由裡裸跑、會打慢 I/O（NAS 檔案 stat / HDD 上的 sqlite / config 檔 / 同步 HTTP）的同步呼叫」移出 event loop**，讓載圖／播放／切頁／任一慢請求不再互相凍住整個 app。純後端技術收斂，**無新 UI、無新設定、無新端點、零新依賴、零 ZIP 影響**；既有功能行為與輸出 byte 級不變。根因：FastAPI 對 `def` 路由會自動丟 threadpool，但 `async def` 路由的函式體直接跑在 event loop 上——裡面任何同步阻塞呼叫都會卡住整個 loop，連帶讓別的請求（含切到新頁的 HTML/API）排不進 loop，畫面就凍住。手段二選一：body 無 `await` → 直接改宣告為 `def`（最便宜，Starlette 自動 threadpool）；body 必須保留 `await` → 把阻塞段包進 `await asyncio.to_thread(...)`。逐處人工確認、不全域 sed。新增 AST 回歸守衛永久防止新路由再犯。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **搜尋頁/設計系統頁封面隱形回歸（Codex 二次審核發現）**：封面淡入的 `opacity:0` 預設規則因共用 scope 洩漏到同樣載入 showcase.css 的 `/search` 與 `/design-system`（兩頁的卡片 img 無淡入機制），會讓搜尋結果封面與元件展示 demo 整片隱形；改用 compound `.showcase-container` scope 收斂，只命中 showcase 頁。
 - **Hero 無女優照片時的空白框**：最愛女優若無照片，`<img src="">` 不觸發 load/error 而顯空白；改為無照片直接顯破圖 icon（與 grid 一致）。
 - **bfcache cleanup 回歸（Codex 二次審核發現）**：`unload`→`pagehide` 後，頁面進 back/forward cache 時 `pagehide` 以 `persisted=true` 觸發會誤跑一次性 cleanup（拆 SSE/abort/resize listener），按 Back 還原（不重跑 init）後頁面缺資源；改為僅在真正丟棄（`persisted=false`）才 cleanup。僅瀏覽器存取會踩，PyWebView 桌面端無此路徑。
+- **stale/404 封面 fallback 可見性硬化（Codex 二次審核發現）**：grid 封面 stale/搬移導致 404 時，`handleCoverError` 換 placeholder 後封面可見性原本只依賴 placeholder 二次 `@load` 觸發 `_imgLoaded`（實測 Chromium 會觸發、可見，但屬脆弱隱性依賴）；改為 `handleCoverError` 直接設 `_imgLoaded=true`，破圖 placeholder 確定性顯示、不再依賴 `@load`。僅影響 showcase grid（table/list 無封面、hero/search/lightbox 走各自路徑）。
 
 ### Added（守衛 / Guards）
 - `tests/unit/test_frontend_lint.py::TestCoverLoadingUx67Guard`：HTML/CSS 三態契約守衛（SVG 無 `<template>`、12 組靜態 rail/sweep id、grid/hero `@load` 綁定、淡入不掛 GSAP 專屬容器、reduced-motion 退化、淡入 scope 收斂於 `.showcase-container`）；`eslint.config.mjs` 加 `addEventListener('unload')` 禁令。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 VERSION = __version__
 
 # 版本資訊

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,18 @@ const SEL_FILTER_BRIGHTNESS = {
     "filter: brightness() 在 56c-T4fix7 後禁用，hover dim 改用 --slot-dim-opacity CSS var tween（v0.8.6 取代 TestClipStageGuard pytest 守衛遷移到 eslint）。",
 };
 
+// ── 67-B2 (CD-67-7) unload listener ban（共用，所有 JS 檔案）────
+// 新版 Chrome 以 Permissions-Policy 預設封鎖 'unload' → listener 靜默不註冊 + console 報錯。
+// 一律改用 bfcache-safe 的 'pagehide'（page-lifecycle.js 已遷移）。與 SEL_WINDOW_CONFIRM 同為
+// universal ban：flat config 同 rule 後者整段 replace 不 merge，故須加進每個 group 的清單（不能用
+// 獨立 global block，會覆蓋各 group 的完整 selector）。
+const SEL_NO_UNLOAD_LISTENER = {
+  selector:
+    "CallExpression[callee.property.name='addEventListener'][arguments.0.value='unload']",
+  message:
+    "addEventListener('unload', …) 已禁用（67-B2/CD-67-7）：新版 Chrome 以 Permissions-Policy 封鎖 'unload'，listener 靜默不註冊 + console 報錯。改用 bfcache-safe 的 'pagehide'（page-lifecycle.js 的 _doCleanup 有 _cleanedUp one-shot guard，pagehide + leavePage 雙觸發安全）。",
+};
+
 export default [
   // ── 全域基礎設定 ──────────────────────────────────────────────
   {
@@ -129,6 +141,7 @@ export default [
         SEL_CREATE_ELEMENT,
         SEL_SHOW_MODAL,
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         SEL_BREATHING_MANAGER_NEW,
         SEL_STARSETTLE_LITERAL,
       ],
@@ -146,6 +159,7 @@ export default [
         "error",
         SEL_CREATE_ELEMENT,
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         SEL_BREATHING_MANAGER_NEW,
         SEL_STARSETTLE_LITERAL,
         {
@@ -169,7 +183,7 @@ export default [
     files: ["web/static/js/**/*.js"],
     ignores: ["web/static/js/pages/**/state/**/*.js"],
     rules: {
-      "no-restricted-syntax": ["error", SEL_WINDOW_CONFIRM],
+      "no-restricted-syntax": ["error", SEL_WINDOW_CONFIRM, SEL_NO_UNLOAD_LISTENER],
     },
   },
 
@@ -185,6 +199,7 @@ export default [
       "no-restricted-syntax": [
         "error",
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         SEL_BREATHING_MANAGER_NEW,
         {
           selector:
@@ -224,6 +239,7 @@ export default [
       "no-restricted-syntax": [
         "error",
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         {
           selector: "Property[key.name='drawSVG']",
           message:
@@ -306,6 +322,7 @@ export default [
       "no-restricted-syntax": [
         "error",
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         SEL_STARSETTLE_LITERAL,
         // 56c-T4fix7：filter: brightness() ban（host 內 hover dim 改 CSS var tween）
         SEL_FILTER_BRIGHTNESS,
@@ -337,6 +354,7 @@ export default [
       "no-restricted-syntax": [
         "error",
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         SEL_BREATHING_MANAGER_NEW,
         SEL_STARSETTLE_LITERAL,
         {
@@ -379,6 +397,7 @@ export default [
       "no-restricted-syntax": [
         "error",
         SEL_WINDOW_CONFIRM,
+        SEL_NO_UNLOAD_LISTENER,
         SEL_BREATHING_MANAGER_NEW,
         SEL_STARSETTLE_LITERAL,
         {

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9682,3 +9682,15 @@ class TestCoverLoadingUx67Guard:
             "page-lifecycle.js 缺 addEventListener('pagehide')"
         assert "addEventListener('unload'" not in src, \
             "page-lifecycle.js 仍有 addEventListener('unload')（應改 pagehide）"
+
+    def test_pagehide_skips_cleanup_on_bfcache_persist(self):
+        """Codex P2 (bfcache): pagehide handler 須在 event.persisted（進 bfcache）時跳過 cleanup，
+        否則 Back 還原（不重跑 module init）後頁面缺 SSE/abort/resize listener。抽 pagehide handler
+        callback body 再斷言含 persisted 短路，不整檔裸 grep。"""
+        src = PAGE_LIFECYCLE_JS.read_text(encoding="utf-8")
+        m = re.search(r"addEventListener\('pagehide',\s*function\s*\([^)]*\)\s*\{(.*?)\}\s*\)", src, re.S)
+        assert m, "page-lifecycle.js: 找不到 pagehide handler callback"
+        body = m.group(1)
+        assert "persisted" in body, \
+            ("pagehide handler 未檢查 event.persisted（Codex P2 bfcache）：進 bfcache 時無條件 cleanup "
+             "會讓 Back 還原的頁面缺 listener/resource。需 `if (e.persisted) return;`")

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9494,3 +9494,165 @@ class TestSettingsDmmProxyContract:
         metatube_toggle_pos = html.index('id="metatubeEnableToggle"')
         assert sec_search_pos < proxy_model_pos < metatube_toggle_pos, \
             "64e-3 違規：proxy row 應在 id=\"sec-search\" 之後、id=\"metatubeEnableToggle\" 之前（搬至 metatube toggle 正上方）"
+
+
+SHOWCASE_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "showcase.css"
+PAGE_LIFECYCLE_JS = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "components" / "page-lifecycle.js"
+
+
+class TestCoverLoadingUx67Guard:
+    """67 Cover Loading UX + Showcase Console 清零 守衛（HTML/CSS contract；JS 字串守衛走 eslint，CD-67-8）。
+
+    全部依 G5：先 regex 抽出目標 tag/區塊再斷言其內容，不整檔裸 grep（showcase.html 別處仍有
+    合法 <template x-for> 與多個 <img>）。每條皆可 RED→GREEN（破壞 contract 跑 RED、還原 GREEN）。
+    """
+
+    def _html(self):
+        return SHOWCASE_HTML.read_text(encoding="utf-8")
+
+    def _css(self):
+        return SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def _grid_img(self):
+        """抽出 grid 卡片封面 <img>（唯一含 :src="video.cover_url" 的 img tag）"""
+        html = self._html()
+        m = re.search(r'<img :src="video\.cover_url".*?>', html, re.S)
+        assert m, "showcase.html: grid 封面 <img :src=\"video.cover_url\"> 不存在"
+        return m.group(0)
+
+    def _hero_img(self):
+        """抽出 hero 卡片 <img>（含 _matchedActress?.photo_url 的 img tag）"""
+        html = self._html()
+        m = re.search(r"<img :src=\"_matchedActress\?\.photo_url \|\| ''\".*?>", html, re.S)
+        assert m, "showcase.html: hero <img :src=\"_matchedActress?.photo_url || ''\"> 不存在"
+        return m.group(0)
+
+    def _rails_svg(self):
+        """抽出相似 stage rails <svg class=\"similar-stage-rails\">…</svg> 區塊"""
+        html = self._html()
+        m = re.search(r'<svg class="similar-stage-rails".*?</svg>', html, re.S)
+        assert m, "showcase.html: <svg class=\"similar-stage-rails\"> 區塊不存在"
+        return m.group(0)
+
+    # ---- Track B: SVG 靜態化（B1）----
+
+    def test_rails_svg_has_no_template(self):
+        """B-2: rails <svg> 內不得有 <template>（SVG namespace 下無 .content → Alpine x-for 丟錯）"""
+        block = self._rails_svg()
+        assert "<template" not in block, \
+            "showcase.html rails <svg class=\"similar-stage-rails\"> 內仍有 <template>（SVG x-for bug 回退；改靜態 <line>）"
+
+    def test_rails_svg_has_12_static_rail_and_sweep_ids(self):
+        """B-2/B-3: rails <svg> 含 12 組靜態 similar-rail-NN + similar-sweep-NN（防漏組/補錯位數）"""
+        block = self._rails_svg()
+        for nn in range(1, 13):
+            rail = f'id="similar-rail-{nn:02d}"'
+            sweep = f'id="similar-sweep-{nn:02d}"'
+            assert rail in block, f"showcase.html rails <svg> 缺靜態 {rail}"
+            assert sweep in block, f"showcase.html rails <svg> 缺靜態 {sweep}"
+
+    # ---- Track A: grid 卡片三態（A2）----
+
+    def test_grid_img_has_load_and_imgloaded_fade(self):
+        """A2/DoD A-1: grid <img> 含 @load 旗標 + .cover-loaded 淡入 class（綁在 img 上）"""
+        img = self._grid_img()
+        assert '@load="video._imgLoaded = true"' in img, \
+            "grid <img> 缺 @load=\"video._imgLoaded = true\"（三態的 loaded 觸發）"
+        assert ":class=\"{ 'cover-loaded': video._imgLoaded }\"" in img, \
+            "grid <img> 缺 :class 淡入綁定（.cover-loaded by _imgLoaded）"
+
+    def test_grid_img_first_screen_fetchpriority(self):
+        """A2/DoD A-5: grid <img> 首屏前 8 張 eager+high（不可 lazy+high 並存）"""
+        img = self._grid_img()
+        assert ":loading=\"index < 8 ? 'eager' : 'lazy'\"" in img, \
+            "grid <img> 缺首屏 :loading 綁定（index<8 eager 其餘 lazy）"
+        assert ":fetchpriority=\"index < 8 ? 'high' : 'auto'\"" in img, \
+            "grid <img> 缺 :fetchpriority 綁定（index<8 high 其餘 auto）"
+        assert 'loading="lazy"' not in img, \
+            "grid <img> 仍有寫死 loading=\"lazy\"（應改 :loading 綁定）"
+
+    def test_grid_has_no_cover_div(self):
+        """A2/CD-67-3 (a): grid 含 no-cover div x-show=\"!video.cover_url\"（DB 缺封面空白 img）"""
+        html = self._html()
+        assert 'x-show="!video.cover_url"' in html, \
+            "showcase.html grid 缺 no-cover div（x-show=\"!video.cover_url\"，DB 缺封面 fallback）"
+
+    # ---- Track A: hero 卡片三態（A3）----
+
+    def test_hero_img_has_load_and_heroloaded_fade(self):
+        """A3/CD-67-4: hero <img> 含 @load=_heroCardImageLoaded（獨立旗標，不混 video _imgLoaded）"""
+        img = self._hero_img()
+        assert '@load="_heroCardImageLoaded = true"' in img, \
+            "hero <img> 缺 @load=\"_heroCardImageLoaded = true\""
+        assert ":class=\"{ 'cover-loaded': _heroCardImageLoaded }\"" in img, \
+            "hero <img> 缺 :class 淡入綁定（.cover-loaded by _heroCardImageLoaded）"
+        assert 'fetchpriority="high"' in img and 'loading="eager"' in img, \
+            "hero <img> 缺首屏 eager+high（CD-67-5）"
+
+    def test_actress_js_declares_and_resets_heroloaded(self):
+        """A3/CD-67-4: state-actress.js 宣告 _heroCardImageLoaded + 兩處 lifecycle 重置"""
+        src = SHOWCASE_ACTRESS_JS.read_text(encoding="utf-8")
+        assert "_heroCardImageLoaded: false" in src, \
+            "state-actress.js 缺 _heroCardImageLoaded 宣告"
+        n = src.count("this._heroCardImageLoaded = false")
+        assert n >= 2, \
+            f"state-actress.js _heroCardImageLoaded 重置須 ≥2 處（_clearPreciseMatch + _checkPreciseActressMatch），實際 {n}"
+
+    # ---- Track A: JS 旗標初始化/重置（A2）----
+
+    def test_imgloaded_initialized_in_fetchvideos(self):
+        """A2: state-videos.js fetchVideos 初始化 _imgLoaded（唯一來源，涵蓋所有 grid render）"""
+        src = SHOWCASE_VIDEOS_JS.read_text(encoding="utf-8")
+        assert "_imgLoaded === undefined" in src and "_imgLoaded = false" in src, \
+            "state-videos.js fetchVideos 缺 _imgLoaded:false 初始化"
+
+    def test_refreshvideodata_resets_imgloaded_before_assign(self):
+        """A2/CD-67-3b: refreshVideoData 在 Object.assign 前 reset _imgLoaded（補封面重走三態）"""
+        src = SHOWCASE_LIGHTBOX_JS.read_text(encoding="utf-8")
+        m = re.search(r"video\._imgLoaded = false;.*?Object\.assign\(video, data\.video\)", src, re.S)
+        assert m, \
+            "state-lightbox.js refreshVideoData 須在 Object.assign(video, data.video) 前 reset video._imgLoaded=false"
+
+    # ---- Track A: CSS 淡入歸屬 + PRM 退化（A1，DoD A-3/A-4）----
+
+    def test_fade_not_on_card_preview_container(self):
+        """A1/DoD A-3: per-image 淡入 opacity transition 不得掛 .av-card-preview 容器（GSAP playEntry 專屬）。
+
+        負向：任何 bare `.av-card-preview {…}` 規則 body 不得同時含 transition + opacity。
+        （`.av-card-preview-img …` 因後接 `-img` 不符 `\\.av-card-preview\\s*\\{`，不誤判。）"""
+        css = self._css()
+        for m in re.finditer(r'\.av-card-preview\s*\{([^}]*)\}', css):
+            body = m.group(1)
+            assert not ("transition" in body and "opacity" in body), \
+                "DoD A-3 違規：.av-card-preview 容器帶 opacity transition；淡入須掛 .av-card-preview-img img（GSAP playEntry 動容器 opacity，不可共存 CSS transition）"
+
+    def test_fade_rule_on_img_layer_default_hidden(self):
+        """A1/DoD A-3: 存在 .av-card-preview-img img 的淡入規則（opacity:0 預設 + transition）"""
+        css = self._css()
+        rules = re.findall(r'\.av-card-preview-img img\s*\{([^}]*)\}', css)
+        assert any("opacity: 0" in b and "transition" in b and "opacity" in b for b in rules), \
+            "showcase.css 缺 .av-card-preview-img img 淡入規則（opacity:0 預設 + opacity transition）"
+
+    def test_prm_degrades_shimmer_and_fade(self):
+        """A1/DoD A-4: reduced-motion 下 shimmer animation:none + 淡入 transition:none/opacity:1 皆退化"""
+        css = self._css()
+        assert "prefers-reduced-motion: reduce" in css, \
+            "showcase.css 缺 @media (prefers-reduced-motion: reduce) guard"
+        shimmer_rules = re.findall(r'(?<![\w-])\.shimmer\s*\{([^}]*)\}', css)
+        assert any("animation: shimmer" in b for b in shimmer_rules), \
+            "showcase.css 缺 .shimmer 基礎 animation"
+        assert any("animation: none" in b for b in shimmer_rules), \
+            "showcase.css PRM 缺 .shimmer { animation: none }（DoD A-4）"
+        fade_rules = re.findall(r'\.av-card-preview-img img\s*\{([^}]*)\}', css)
+        assert any("transition: none" in b and "opacity: 1" in b for b in fade_rules), \
+            "showcase.css PRM 缺淡入退化（.av-card-preview-img img { transition: none; opacity: 1 }，DoD A-4）"
+
+    # ---- Track B: unload 已遷 pagehide（B2，eslint 也擋；此處正向確認 pagehide 在位）----
+
+    def test_page_lifecycle_uses_pagehide_not_unload(self):
+        """B-4/CD-67-7: page-lifecycle.js 用 pagehide、無 unload listener（eslint SEL_NO_UNLOAD_LISTENER 同擋）"""
+        src = PAGE_LIFECYCLE_JS.read_text(encoding="utf-8")
+        assert "addEventListener('pagehide'" in src, \
+            "page-lifecycle.js 缺 addEventListener('pagehide')"
+        assert "addEventListener('unload'" not in src, \
+            "page-lifecycle.js 仍有 addEventListener('unload')（應改 pagehide）"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9617,6 +9617,19 @@ class TestCoverLoadingUx67Guard:
         assert "_imgLoaded === undefined" in src and "_imgLoaded = false" in src, \
             "state-videos.js fetchVideos 缺 _imgLoaded:false 初始化"
 
+    def test_handle_cover_error_marks_loaded(self):
+        """Codex P2 (broken cover): handleCoverError 須同時設 has_cover=false 且 _imgLoaded=true，
+        讓 stale/404 封面換 placeholder 後確定性顯示（grid 淡入規則使 img 預設 opacity:0；不可只依賴
+        placeholder 二次 @load 觸發 _imgLoaded）。抽 handleCoverError body 再斷言，非整檔裸 grep。"""
+        src = SHOWCASE_BASE_JS.read_text(encoding="utf-8")
+        m = re.search(r"handleCoverError\(video, event\)\s*\{(.*?)\n\s*\},", src, re.S)
+        assert m, "state-base.js: 找不到 handleCoverError(video, event) method"
+        body = m.group(1)
+        assert "has_cover = false" in body, "handleCoverError 須設 video.has_cover = false"
+        assert "_imgLoaded = true" in body, \
+            ("handleCoverError 須設 video._imgLoaded = true（Codex P2 broken-cover）：否則 stale/404 封面"
+             "在 grid opacity:0 淡入規則下停在隱形、no-cover 也不顯 → 空白卡")
+
     def test_refreshvideodata_resets_imgloaded_before_assign(self):
         """A2/CD-67-3b: refreshVideoData 在 Object.assign 前 reset _imgLoaded（補封面重走三態）"""
         src = SHOWCASE_LIGHTBOX_JS.read_text(encoding="utf-8")

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9589,6 +9589,17 @@ class TestCoverLoadingUx67Guard:
         assert 'fetchpriority="high"' in img and 'loading="eager"' in img, \
             "hero <img> 缺首屏 eager+high（CD-67-5）"
 
+    def test_hero_img_xshow_gated_on_photo_url(self):
+        """Codex P2#2: hero <img> x-show 須 gate by _matchedActress?.photo_url（空 photo_url 的 src=""
+        不觸發 @load/@error；若 x-show 只看 !_heroCardImageError 會顯空白框）。no-cover div 對應 gate
+        !photo_url || error 顯破圖 icon（與 grid no-cover 一致）。"""
+        img = self._hero_img()
+        assert 'x-show="_matchedActress?.photo_url && !_heroCardImageError"' in img, \
+            "hero <img> x-show 須含 _matchedActress?.photo_url（防空 photo_url 顯空白框回退，Codex P2#2）"
+        html = self._html()
+        assert "!_matchedActress.photo_url || _heroCardImageError" in html, \
+            "hero no-cover div x-show 須含 !_matchedActress.photo_url || _heroCardImageError（空 photo 或 error 皆顯破圖 icon）"
+
     def test_actress_js_declares_and_resets_heroloaded(self):
         """A3/CD-67-4: state-actress.js 宣告 _heroCardImageLoaded + 兩處 lifecycle 重置"""
         src = SHOWCASE_ACTRESS_JS.read_text(encoding="utf-8")
@@ -9632,6 +9643,21 @@ class TestCoverLoadingUx67Guard:
         rules = re.findall(r'\.av-card-preview-img img\s*\{([^}]*)\}', css)
         assert any("opacity: 0" in b and "transition" in b and "opacity" in b for b in rules), \
             "showcase.css 缺 .av-card-preview-img img 淡入規則（opacity:0 預設 + opacity transition）"
+
+    def test_fade_rule_scoped_to_showcase_container(self):
+        """Codex P2#1: 淡入 opacity:0 規則必須 compound .showcase-container scope（防洩漏到 search.html /
+        design-system.html——兩頁也載 showcase.css + 共用 ds scope 但無 .cover-loaded 機制，洩漏會讓搜尋
+        封面/demo 整片隱形）。抓含 opacity:0 的淡入規則整條 selector，斷言含 .showcase-container。"""
+        css = self._css()
+        # 先剝除 /* */ 註解（否則 [^{}]*? 會吃進前面提及 .showcase-container 的註解 → 假 GREEN）
+        css_nc = re.sub(r'/\*.*?\*/', '', css, flags=re.S)
+        # 抓 opacity:0 淡入 base 規則的完整 selector（含前綴）
+        m = re.search(r'([^{}]*?\.av-card-preview-img img)\s*\{[^}]*opacity:\s*0[^}]*\}', css_nc)
+        assert m, "showcase.css 找不到 opacity:0 的 .av-card-preview-img img 淡入規則"
+        selector = m.group(1)
+        assert ".showcase-container" in selector, \
+            ("淡入 opacity:0 規則未 compound .showcase-container（Codex P2#1）：會洩漏到 search.html / "
+             f"design-system.html 讓封面隱形。實際 selector: {selector.strip()!r}")
 
     def test_prm_degrades_shimmer_and_fade(self):
         """A1/DoD A-4: reduced-motion 下 shimmer animation:none + 淡入 transition:none/opacity:1 皆退化"""

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -2900,3 +2900,58 @@ body.sidebar-collapsed .showcase-footer {
 @media (max-width: 959px) {
     .similar-stage-inner { display: none; }
 }
+
+/* ==================== 67-A1: Cover Loading UX — skeleton/shimmer + per-image 淡入 + PRM guard ==================== */
+/* skeleton/shimmer 複製自 search.css:682-702，補 overlay 定位：showcase 的封面 img 淡入時 opacity:0
+   仍佔 flow（CD-67-3 用 x-show=cover_url + _imgLoaded 淡入，非互斥 x-show）→ skeleton 須 absolute overlay。
+   容器 aspect-ratio:3/2 由 theme.css:1017 提供、img height:100% 撐滿 → A1 不重複宣告（G1：無 height 互斥、不需 height:auto）。
+   容器 position:relative（theme.css:1016）+ overflow:hidden（:1018）→ overlay 定位 context + 圓角裁切皆現成。 */
+.av-card-preview-img .skeleton-cover {
+    position: absolute;
+    inset: 0;
+    background: var(--color-base-300);
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+
+.shimmer {
+    background: linear-gradient(
+        90deg,
+        var(--color-base-300) 25%,
+        var(--color-base-200) 50%,
+        var(--color-base-300) 75%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+/* per-image 淡入（CSS transition，不用 GSAP — CD-67-1/G3）：掛 img 層；
+   .av-card-preview 容器 opacity 由 GSAP playEntry 專屬（animations.js:142/177/193），此處零容器 transition。
+   ⚠️ 選擇器須對齊 theme.css:1022 的 :is(#ds-gallery-components,.ds-gallery-composition) scope（specificity 1,1,1）——
+   否則裸 .av-card-preview-img img(0,1,1) 的 transition:opacity 蓋不過 theme 的 transition:transform → 淡入失效。
+   合併保留 transform transition（hover-zoom 過渡不回歸）。 */
+:is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-img img {
+    opacity: 0;
+    transition:
+        opacity var(--fluent-duration-fast) var(--fluent-ease-standard),
+        transform var(--fluent-duration-slow) var(--fluent-ease-standard);
+}
+:is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-img img.cover-loaded {
+    opacity: 1;
+}
+
+/* reduced-motion：shimmer + 淡入皆退化靜態（per-rule，可被 inspection/lint 驗證；DoD A-4）。
+   兩條都要——只 guard .shimmer 不夠，淡入也是動畫。 */
+@media (prefers-reduced-motion: reduce) {
+    .shimmer {
+        animation: none;
+    }
+    :is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-img img {
+        transition: none;
+        opacity: 1;
+    }
+}

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -2931,16 +2931,20 @@ body.sidebar-collapsed .showcase-footer {
 
 /* per-image 淡入（CSS transition，不用 GSAP — CD-67-1/G3）：掛 img 層；
    .av-card-preview 容器 opacity 由 GSAP playEntry 專屬（animations.js:142/177/193），此處零容器 transition。
-   ⚠️ 選擇器須對齊 theme.css:1022 的 :is(#ds-gallery-components,.ds-gallery-composition) scope（specificity 1,1,1）——
-   否則裸 .av-card-preview-img img(0,1,1) 的 transition:opacity 蓋不過 theme 的 transition:transform → 淡入失效。
+   ⚠️ 選擇器須對齊 theme.css:1022 的 :is(#ds-gallery-components,.ds-gallery-composition) scope，否則裸
+   .av-card-preview-img img(0,1,1) 的 transition:opacity 蓋不過 theme 的 transition:transform → 淡入失效。
+   ⚠️ Codex P2#1 修正：再 compound .showcase-container（showcase.html:16 同元素同時帶兩 class）——showcase.css
+   也被 search.html / design-system.html 載入且共用 ds scope，但那兩頁的卡 img 無 .cover-loaded 機制；若不
+   收斂，opacity:0 會讓 search 搜尋封面整片隱形、design-system demo 隱形。compound 後 specificity (1,2,1)>theme
+   (1,1,1) 仍贏，且只命中 showcase 頁（search/design-system 容器無 .showcase-container）。
    合併保留 transform transition（hover-zoom 過渡不回歸）。 */
-:is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-img img {
+:is(#ds-gallery-components, .ds-gallery-composition).showcase-container .av-card-preview-img img {
     opacity: 0;
     transition:
         opacity var(--fluent-duration-fast) var(--fluent-ease-standard),
         transform var(--fluent-duration-slow) var(--fluent-ease-standard);
 }
-:is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-img img.cover-loaded {
+:is(#ds-gallery-components, .ds-gallery-composition).showcase-container .av-card-preview-img img.cover-loaded {
     opacity: 1;
 }
 
@@ -2950,7 +2954,7 @@ body.sidebar-collapsed .showcase-footer {
     .shimmer {
         animation: none;
     }
-    :is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-img img {
+    :is(#ds-gallery-components, .ds-gallery-composition).showcase-container .av-card-preview-img img {
         transition: none;
         opacity: 1;
     }

--- a/web/static/js/components/page-lifecycle.js
+++ b/web/static/js/components/page-lifecycle.js
@@ -9,7 +9,7 @@
  *
  * 兩條離頁路徑：
  *   路徑 A（sidebar）：beforeLeave → cleanup → 頁面卸載
- *   路徑 B（tab close）：onBeforeUnload → [原生提示] → unload 事件 → cleanup
+ *   路徑 B（tab close）：onBeforeUnload → [原生提示] → pagehide 事件 → cleanup
  */
 var _handlers = { beforeLeave: null, onBeforeUnload: null, cleanup: null };
 var _cleanedUp = false;
@@ -30,8 +30,10 @@ if (_handlers.onBeforeUnload) {
 }
 });
 
-// unload：頁面確定要卸載了，best-effort cleanup
-window.addEventListener('unload', function () {
+// pagehide：頁面確定要卸載了，best-effort cleanup
+// （新版 Chrome 以 Permissions-Policy 預設封鎖 'unload' → 改用 bfcache-safe 的 'pagehide'，
+//  涵蓋 tab-close/reload/nav；_doCleanup 的 _cleanedUp one-shot guard 保證與 leavePage 雙觸發安全）
+window.addEventListener('pagehide', function () {
 _doCleanup();
 });
 

--- a/web/static/js/components/page-lifecycle.js
+++ b/web/static/js/components/page-lifecycle.js
@@ -33,7 +33,12 @@ if (_handlers.onBeforeUnload) {
 // pagehide：頁面確定要卸載了，best-effort cleanup
 // （新版 Chrome 以 Permissions-Policy 預設封鎖 'unload' → 改用 bfcache-safe 的 'pagehide'，
 //  涵蓋 tab-close/reload/nav；_doCleanup 的 _cleanedUp one-shot guard 保證與 leavePage 雙觸發安全）
-window.addEventListener('pagehide', function () {
+// ⚠️ bfcache：persisted=true 表頁面進 back/forward cache、之後可能被 Back 還原且「不重跑 module init」。
+//    此時若 cleanup（拆 SSE/abort/resize/GSAP ctx），還原後頁面缺 listener/resource → 壞掉。
+//    故只有真正丟棄（persisted=false：tab-close/reload/discard）才 cleanup；進 bfcache 跳過、整頁凍結還原即可用。
+//    （有活躍 SSE 的頁本就 bfcache-ineligible → persisted=false → 照常 cleanup。）
+window.addEventListener('pagehide', function (e) {
+if (e.persisted) return;
 _doCleanup();
 });
 

--- a/web/static/js/pages/showcase/state-actress.js
+++ b/web/static/js/pages/showcase/state-actress.js
@@ -39,6 +39,7 @@ export function stateActress() {
         _preciseMatchSource: null,
         _favoriteHeartLoading: false,
         _heroCardImageError: false,
+        _heroCardImageLoaded: false,   // 67-A3: hero actress photo 載入旗標（獨立於 video _imgLoaded，CD-67-4）
         _fetchSamplesLoading: false,
         _fetchSamplesFailed: {},
 
@@ -60,6 +61,7 @@ export function stateActress() {
             this._preciseMatchSource = null;
             this._favoriteHeartLoading = false;
             this._heroCardImageError = false;
+            this._heroCardImageLoaded = false;   // 67-A3: 換命中對象要重現 skeleton
         },
 
         async _checkPreciseActressMatch(term, source) {
@@ -69,6 +71,7 @@ export function stateActress() {
             }
             if (this.search.trim() !== capturedTerm) return;
             this._heroCardImageError = false;
+            this._heroCardImageLoaded = false;   // 67-A3: 換命中對象要重現 skeleton
             var found = _actresses.find(function(a) {
                 var group = _nameToGroup[a.name] || [a.name];
                 return group.indexOf(capturedTerm) !== -1;

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -334,6 +334,10 @@ export function stateBase() {
         handleCoverError(video, event) {
             if (!video) return;
             video.has_cover = false;  // 觸發 reactive — enrich icon 自動出現 + missing-cover class 套用
+            // 67/Codex P2（broken cover）：grid 三態淡入讓 .av-card-preview-img img 預設 opacity:0、靠
+            // .cover-loaded(=_imgLoaded) 才可見。stale/404 換 placeholder 後，可見性原本只依賴 placeholder
+            // 二次 @load 觸發（脆弱）→ 直接設 _imgLoaded=true，確定性顯示 placeholder（不依賴 @load）。
+            video._imgLoaded = true;
             event.target.onerror = null;  // 防止 placeholder 失敗無限迴圈
             event.target.src = _NO_COVER_PLACEHOLDER;
         },

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -745,6 +745,9 @@ export function stateLightbox() {
                     if (data.video.cover_url) {
                         data.video.cover_url = data.video.cover_url + '&t=' + Date.now();
                     }
+                    // 67-A2/CD-67-3b: data.video 不帶 _imgLoaded → 舊 true 殘留會讓新封面跳過 skeleton/fade。
+                    // Object.assign 前 reset，讓補封面/重抓的新 cover_url（含上面 &t= cache-bust）重走 skeleton→@load→淡入。
+                    if (data.video.cover_url) video._imgLoaded = false;
                     Object.assign(video, data.video);
                 }
             } catch (e) {

--- a/web/static/js/pages/showcase/state-videos.js
+++ b/web/static/js/pages/showcase/state-videos.js
@@ -38,6 +38,10 @@ export function stateVideos() {
                 // (core.js uses direct assignment; ESM re-exports work because we read
                 // _videos/_filteredVideos at call time, not at import time)
                 var vids = data.videos || [];
+                // 67-A2: per-card 三態旗標。video 物件由此唯一來源流穿整條 render 鏈
+                // （_videos → _filteredVideos → paginatedVideos slice，皆同 ref），故初始化一處即涵蓋
+                // 初次載入/retry/翻頁/搜尋/排序；後端不回此欄位。補封面走 refreshVideoData reset。
+                vids.forEach(function (v) { if (v._imgLoaded === undefined) v._imgLoaded = false; });
                 _setVideos(vids);
                 this.videoCount = _videos.length;
                 _setFilteredVideos(_videos);

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -307,10 +307,25 @@
                      :style="`--card-index: ${index}`"
                      :data-flip-id="video.path">
                     <div class="av-card-preview-img">
+                        <!-- 67-A2: 三態（CD-67-3）。保留單一 <img> 沿用 handleCoverError 換圖；
+                             淡入靠 _imgLoaded 的 .cover-loaded class（A1 CSS）；首屏前 8 張 eager+high（CD-67-5，不可 lazy+high 並存） -->
                         <img :src="video.cover_url"
                              :alt="video.number"
-                             loading="lazy"
+                             :loading="index < 8 ? 'eager' : 'lazy'"
+                             :fetchpriority="index < 8 ? 'high' : 'auto'"
+                             x-show="video.cover_url"
+                             :class="{ 'cover-loaded': video._imgLoaded }"
+                             @load="video._imgLoaded = true"
                              @error="handleCoverError(video, $event)">
+                        <!-- 67-A2: skeleton overlay（pending 時，gate 含 has_cover → stale @error 後 has_cover=false 自動退出）-->
+                        <div class="skeleton-cover shimmer"
+                             x-show="video.cover_url && video.has_cover && !video._imgLoaded"></div>
+                        <!-- 67-A2: no-cover（CD-67-3 (a)：DB 缺封面 cover_url="" 空白 img 不發請求；鏡射 hero :272-276）。
+                             與 stale-@error 換 placeholder 路徑互斥（stale 時 cover_url 仍非空 → 不顯示，不雙重渲染）-->
+                        <div x-show="!video.cover_url" class="av-card-no-cover">
+                          <i class="bi bi-image"></i>
+                          <span x-text="t('common.no_image')"></span>
+                        </div>
                         <div class="av-card-preview-overlay">
                             <button class="btn-glass-circle"
                                     @click.stop="playVideo(video.path)"

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -264,11 +264,18 @@
                  x-cloak
                  @click="openHeroCardLightbox()">
               <div class="av-card-preview-img">
+                <!-- 67-A3: hero 三態（actress photo，獨立 _heroCardImageLoaded，CD-67-4）。首屏 eager+high -->
                 <img :src="_matchedActress?.photo_url || ''"
                      :alt="_matchedActress?.name"
-                     loading="lazy"
+                     loading="eager"
+                     fetchpriority="high"
                      x-show="_matchedActress && !_heroCardImageError"
+                     :class="{ 'cover-loaded': _heroCardImageLoaded }"
+                     @load="_heroCardImageLoaded = true"
                      @error="if (_matchedActress?.photo_url) _heroCardImageError = true">
+                <!-- 67-A3: skeleton overlay。gate 含 photo_url（空 photo 的 img src="" 不觸發 @load/@error → 不卡 shimmer，鏡射 grid cover_url gate）-->
+                <div class="skeleton-cover shimmer"
+                     x-show="_matchedActress?.photo_url && !_heroCardImageError && !_heroCardImageLoaded"></div>
                 <div x-show="_matchedActress && _heroCardImageError"
                      class="av-card-no-cover">
                   <i class="bi bi-image"></i>

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1094,12 +1094,31 @@
 
             <!-- SVG rails 12 條 + 12 sweep lines（id 對映 similar-rail-XX / similar-sweep-XX） -->
             <svg class="similar-stage-rails" viewBox="0 0 960 620" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <template x-for="anchor in SIMILAR_ANCHORS" :key="anchor.id">
-                    <g>
-                        <line :id="'similar-rail-' + anchor.idShort" class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
-                        <line :id="'similar-sweep-' + anchor.idShort" class="similar-rail-sweep" x1="480" y1="310" x2="480" y2="310" />
-                    </g>
-                </template>
+                <!-- 靜態 12 組 rail + sweep（鏡射 motion_lab.html 無錯 precedent；id 對映 state-similar.js 消費端 'similar-rail-'+idShort / 'similar-sweep-'+idShort，runtime setRailCoords 覆蓋座標，初始為退化點 480,310） -->
+                <line id="similar-rail-01"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-01" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-02"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-02" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-03"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-03" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-04"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-04" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-05"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-05" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-06"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-06" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-07"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-07" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-08"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-08" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-09"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-09" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-10"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-10" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-11"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-11" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-rail-12"  class="similar-rail rail--hidden" x1="480" y1="310" x2="480" y2="310" />
+                <line id="similar-sweep-12" class="similar-rail-sweep"        x1="480" y1="310" x2="480" y2="310" />
             </svg>
 
             <!-- 56c-T4: main image visual center anchor — single source of truth

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -269,14 +269,15 @@
                      :alt="_matchedActress?.name"
                      loading="eager"
                      fetchpriority="high"
-                     x-show="_matchedActress && !_heroCardImageError"
+                     x-show="_matchedActress?.photo_url && !_heroCardImageError"
                      :class="{ 'cover-loaded': _heroCardImageLoaded }"
                      @load="_heroCardImageLoaded = true"
                      @error="if (_matchedActress?.photo_url) _heroCardImageError = true">
                 <!-- 67-A3: skeleton overlay。gate 含 photo_url（空 photo 的 img src="" 不觸發 @load/@error → 不卡 shimmer，鏡射 grid cover_url gate）-->
                 <div class="skeleton-cover shimmer"
                      x-show="_matchedActress?.photo_url && !_heroCardImageError && !_heroCardImageLoaded"></div>
-                <div x-show="_matchedActress && _heroCardImageError"
+                <!-- 67/Codex P2#2: 空 photo_url（src="" 不觸發 @error）或 404 error 皆顯破圖 icon；img x-show 同步 gate photo_url，不顯空白框（鏡射 grid no-cover）-->
+                <div x-show="_matchedActress && (!_matchedActress.photo_url || _heroCardImageError)"
                      class="av-card-no-cover">
                   <i class="bi bi-image"></i>
                   <span x-text="t('common.no_image')"></span>


### PR DESCRIPTION
## 概要 / Summary

純前端兩軌（zero backend / zero new deps）。**Track A** — 封面載入體感：Showcase grid 卡片 + Hero card 三態（載入中 skeleton/shimmer → `@load` 淡入 → 無封面破圖 icon），把 NAS HDD 載圖的等待填上「正在載入」視覺；**不縮短實際載速**，只解「等待時看到什麼」。**Track B** — 清掉 `/showcase` 固定 4 條 console 紅字（SVG 內誤放 `<template x-for>` ×3 + site-wide `unload` ×1），並恢復相似探索連接線。

*Pure frontend, two orthogonal tracks. Track A fills the NAS-HDD cover-loading wait with skeleton/shimmer → fade-in → broken-image icon (does not speed up loading, only fixes the wait visual). Track B clears the 4 `/showcase` console errors (mis-placed SVG `<template x-for>` ×3 + deprecated `unload` ×1) and restores the similar-explore connector lines.*

## 變更 / Changes

**Track A**
- Grid 每張卡片 + Hero card 三態（`_imgLoaded` / `_heroCardImageLoaded` `@load` 旗標 + `.cover-loaded` CSS 淡入）
- 首屏前 8 張 `loading=eager` + `fetchpriority=high`，其餘 `lazy`
- `aspect-ratio` 佔位消 layout shift；`prefers-reduced-motion` 退化為靜態
- 淡入掛 `<img>` 層，不與 GSAP `playEntry`（容器 opacity）衝突；補封面/重抓後重走三態

**Track B**
- 相似 stage SVG 連接線：`<template x-for>` → 12 組靜態 `<line>`（鏡射 motion-lab），`state-similar.js` 零改動
- `page-lifecycle.js`：`unload` → bfcache-safe `pagehide`

**Codex 二次審核修正（P2）**
- 淡入 `opacity:0` scope 洩漏到 `/search` + `/design-system`（會讓搜尋封面/demo 整片隱形）→ compound `.showcase-container` 收斂（specificity (1,2,1) > theme (1,1,1) 仍贏，僅命中 showcase）
- Hero 無女優照片時的空白框 → 無照片直接顯破圖 icon（鏡射 grid）

**守衛 / Guards**
- `TestCoverLoadingUx67Guard`（HTML/CSS 契約，CD-67-8 既定例外：eslint 不解析 Jinja `.html`）
- `eslint.config.mjs` 加 `addEventListener('unload')` 禁令

## 驗證 / Verification
- 全套 pytest **3538 passed, 2 skipped**；`npm run lint`（eslint + stylelint）綠
- 守衛 RED→GREEN；敏感掃描 / 打包 / Capabilities 皆 PASS
- CDP 終驗（含生產環境 NAS HDD 實機）：`/showcase` console 0 error、rail+sweep 24 條、grid 三態 skeleton→淡入實況、首屏 eager+high、`/search` + `/design-system` 封面可見

## ⚠️ 部署注意 / Deploy note
靜態資源無 `Cache-Control` + 檔名無 hash → 重新部署後瀏覽器會吃舊快取，需 hard-reload 才看得到 Track A。屬既有 infra gap（非本 PR 引入），建議後續加資源 cache-busting。

## Non-Goals
不縮短實際載速（縮圖快取押後）、不做伺服端 HDD 偵測、不導 HTMX、不重做 Search 頁、不做 Lightbox 大圖載入態。

🤖 Generated with [Claude Code](https://claude.com/claude-code)