### PR TITLE
v0.9.7 - VR projection-tag preservation + auto VR tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-本版單一修正：**`/static` 靜態資源現在一律回傳 `Cache-Control: no-cache`**，根治瀏覽器 heuristic caching 導致「重新部署後同檔名仍吃舊 JS/CSS」的問題。純後端、零新依賴、不觸碰任何模板或 ESM import map。
+本版兩處小修正：**(1) `/static` 靜態資源現在一律回傳 `Cache-Control: no-cache`**，根治瀏覽器 heuristic caching 導致「重新部署後同檔名仍吃舊 JS/CSS」的問題（純後端、零新依賴、不觸碰任何模板或 ESM import map）；**(2)「Jellyfin 圖片模式」正名為「Jellyfin / Emby 圖片模式」**並把 hint 寫清楚：poster 與 NFO 兩家通吃、fanart 僅 Jellyfin 讀取（Emby 不支援 `{stem}-fanart.jpg` 命名）——純 i18n 文字 + README，不動 `jellyfin_mode` 配置欄位、零行為變化。
 
-*Single-fix patch: `/static` now always sends `Cache-Control: no-cache`, eliminating browser heuristic caching that served stale JS/CSS after redeploy when filenames didn't change.*
+*Two small fixes: (1) `/static` now always sends `Cache-Control: no-cache`, eliminating browser heuristic caching that served stale JS/CSS after redeploy when filenames didn't change; (2) "Jellyfin Image Mode" renamed to "Jellyfin / Emby Image Mode" with the hint clarified — poster and NFO work with both Jellyfin and Emby, fanart is Jellyfin-only (Emby doesn't read the `{stem}-fanart.jpg` naming) — pure i18n text + README, no change to the `jellyfin_mode` config field or behavior.*
 
 ### Fixed
 - **`/static` heuristic stale cache**：以 `NoCacheStaticFiles(StaticFiles)` 子類替換 `web/app.py:75` 的原生 `StaticFiles` mount。override `file_response`，在 `super().file_response()` 回傳後對已建好的 response 物件做 post-construction headers mutation（`response.headers["Cache-Control"] = "no-cache"`），200 `FileResponse` 與 304 `NotModifiedResponse` 兩條路徑均有效。ETag / Last-Modified / 304 機制完整保留（同檔案未變回 304 空 body，有變才回 200 新版，免 hard-reload）。封面圖代理的 24h 強快取（`scanner.py get_image`）與影片 Range streaming 完全不受影響（不經此 mount）。
   - **桌面端（PyWebView）零副作用**：`webview.start()` 預設 `private_mode=True, storage_path=None`（pywebview ≥ 6.0 的 `start()` 參數，非 `create_window()` 參數）→ 非持久 WebView2 profile，每次啟動空快取；`no-cache` 對它只是 in-session localhost 多一次可忽略的重驗（< 1ms）。
   - **真正受益者**：`feature/epic-synology.md` 的 Server / NAS(.spk) / Docker 模式——client 端持久瀏覽器快取在 server 更新（換檔 + 重啟）後本不清除，此修正確保下次載入必重驗並取到新版。
+
+### Changed
+- **「Jellyfin 圖片模式」→「Jellyfin / Emby 圖片模式」**：label 與 hint 文案修正（`settings.scraper.jellyfin_mode_{label,hint}`，4 語系 zh_TW/zh_CN/en/ja）+ README / README_EN feature 條目。澄清相容性事實——`{stem}-poster.jpg` 與 Kodi-style NFO 兩者 Emby 與 Jellyfin 皆可讀（親核 Emby 官方 `Movie-Naming.md` 確認支援 `{name}-poster.ext`），`{stem}-fanart.jpg` 僅 Jellyfin 讀取（Emby backdrop/fanart 不支援 `{name}-` 前綴命名，只認 standalone `fanart.jpg`）。**刻意不**額外產生 standalone `fanart.jpg`：用戶若關閉資料夾模式（多片同目錄）會撞檔。配置欄位 `jellyfin_mode` 維持不變、無 migration、無行為變化。
 
 ### 測試
 - 新增 `tests/integration/test_static_cache_headers.py`：兩條契約測試（200 帶 `cache-control: no-cache` + `etag`；304 仍帶 `cache-control: no-cache`）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+本版單一修正：**`/static` 靜態資源現在一律回傳 `Cache-Control: no-cache`**，根治瀏覽器 heuristic caching 導致「重新部署後同檔名仍吃舊 JS/CSS」的問題。純後端、零新依賴、不觸碰任何模板或 ESM import map。
+
+*Single-fix patch: `/static` now always sends `Cache-Control: no-cache`, eliminating browser heuristic caching that served stale JS/CSS after redeploy when filenames didn't change.*
+
+### Fixed
+- **`/static` heuristic stale cache**：以 `NoCacheStaticFiles(StaticFiles)` 子類替換 `web/app.py:75` 的原生 `StaticFiles` mount。override `file_response`，在 `super().file_response()` 回傳後對已建好的 response 物件做 post-construction headers mutation（`response.headers["Cache-Control"] = "no-cache"`），200 `FileResponse` 與 304 `NotModifiedResponse` 兩條路徑均有效。ETag / Last-Modified / 304 機制完整保留（同檔案未變回 304 空 body，有變才回 200 新版，免 hard-reload）。封面圖代理的 24h 強快取（`scanner.py get_image`）與影片 Range streaming 完全不受影響（不經此 mount）。
+  - **桌面端（PyWebView）零副作用**：`webview.start()` 預設 `private_mode=True, storage_path=None`（pywebview ≥ 6.0 的 `start()` 參數，非 `create_window()` 參數）→ 非持久 WebView2 profile，每次啟動空快取；`no-cache` 對它只是 in-session localhost 多一次可忽略的重驗（< 1ms）。
+  - **真正受益者**：`feature/epic-synology.md` 的 Server / NAS(.spk) / Docker 模式——client 端持久瀏覽器快取在 server 更新（換檔 + 重啟）後本不清除，此修正確保下次載入必重驗並取到新版。
+
+### 測試
+- 新增 `tests/integration/test_static_cache_headers.py`：兩條契約測試（200 帶 `cache-control: no-cache` + `etag`；304 仍帶 `cache-control: no-cache`）。
+- `pytest tests/integration/ -q` 全綠（含既有 `test_async_offload_guard.py` 34 條不回歸）。
+
 ## [0.9.6] - 2026-06-06
 
 本版單一主軸：**封面載入體感優化（Cover Loading UX）+ Showcase Console 清零**，純前端、零後端、零新依賴。兩條正交軌。**Track A**：封面在 NAS(HDD) 上一頁 90 張陸續慢慢冒，過去圖沒到是空白、到了「啪」一下出現；本版讓每張 grid 卡片與 Hero card 在等待時顯示 skeleton/shimmer、圖到淡入、抓不到顯示業界標準破圖 icon——把 HDD 喚醒/seek 的等待填上「正在載入」的視覺。**不縮短實際載入**（那是縮圖快取的事），只解「等待時看到什麼」。**Track B**：清掉 `/showcase` 開 F12 固定噴的 4 條 console 紅字——SVG namespace 下誤放 `<template x-for>`（3 條）+ 過時的 `unload` 事件（1 條，site-wide）；修好 SVG bug 後相似探索的連接線也恢復顯示（原被 bug 壓住從未畫出）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-本版兩處小修正：**(1) `/static` 靜態資源現在一律回傳 `Cache-Control: no-cache`**，根治瀏覽器 heuristic caching 導致「重新部署後同檔名仍吃舊 JS/CSS」的問題（純後端、零新依賴、不觸碰任何模板或 ESM import map）；**(2)「Jellyfin 圖片模式」正名為「Jellyfin / Emby 圖片模式」**並把 hint 寫清楚：poster 與 NFO 兩家通吃、fanart 僅 Jellyfin 讀取（Emby 不支援 `{stem}-fanart.jpg` 命名）——純 i18n 文字 + README，不動 `jellyfin_mode` 配置欄位、零行為變化。
+## [0.9.7] - 2026-06-06
 
-*Two small fixes: (1) `/static` now always sends `Cache-Control: no-cache`, eliminating browser heuristic caching that served stale JS/CSS after redeploy when filenames didn't change; (2) "Jellyfin Image Mode" renamed to "Jellyfin / Emby Image Mode" with the hint clarified — poster and NFO work with both Jellyfin and Emby, fanart is Jellyfin-only (Emby doesn't read the `{stem}-fanart.jpg` naming) — pure i18n text + README, no change to the `jellyfin_mode` config field or behavior.*
+本版主軸：**VR 投影標籤保留 + 自動 VR tag**（feature/68），純後端、單檔 `core/organizer.py`、零新依賴、零 ZIP 影響、零 i18n、零 UI。問題根因：頭顯 App（DeoVR / HereSphere / Skybox / Pigasus）100% 靠「**檔名 token**」判斷 VR 投影/立體格式（`_180_LR` / `_3dh` / `mkx200`…），不讀 NFO；而 OpenAver 改名是用模板從頭重組檔名，原檔名的 VR token **不會被帶過來** → 改名後 VR 檔在頭顯 App 變成平面 2D 播放。本版讓改名時偵測原檔名的 VR token 並**原樣保留**到輸出檔名尾端，同時在 NFO 加一個 `VR` tag/genre。**無 toggle、無需用戶輸入；檔名無 VR token 時輸出 byte 級零變化**（2D 轉檔 / 一般片完全不受影響）。同梱兩處先前的小修正：`/static` no-cache 根治 stale cache、「Jellyfin / Emby 圖片模式」正名。
+
+*This release's main theme: **VR projection-tag preservation + automatic VR tag** (feature/68) — pure backend, single file `core/organizer.py`, zero new deps, zero ZIP impact, zero i18n, zero UI. Root cause: VR headset apps (DeoVR / HereSphere / Skybox / Pigasus) decide projection/stereo format 100% from the **filename token** (`_180_LR` / `_3dh` / `mkx200`…), not from NFO; but OpenAver's rename rebuilds the filename from a template, so the original VR token was dropped → renamed VR files played flat 2D in the headset. Now the rename detects the original filename's VR token and **preserves it verbatim** at the end of the output filename, and adds a `VR` tag/genre to the NFO. **No toggle, no user input; output is byte-identical when there's no VR token** (2D transcodes / ordinary files are wholly unaffected). Also bundles two earlier small fixes: `/static` no-cache, and the "Jellyfin / Emby Image Mode" rename.*
+
+### Added
+#### 🥽 VR 投影標籤保留 + 自動 VR tag / VR projection tag preservation
+- **檔名 VR token 偵測 + 原樣保留**：改名時偵測原檔名的 VR 投影/立體 token（投影 `180`/`360`/`180x180`/`EAC360`、鏡頭 `MKX200`/`VRCA220`/`FISHEYE`、立體 `3DH`/`SBS`/`LR`/`TB`…），把「首個~末個 VR token 的 raw 子字串」原樣（不正規化、不砍、保大小寫）接到輸出檔名尾端。sidecar（poster/fanart/NFO）跟隨同 stem 命名不破。
+- **自動 VR tag**：偵測到 VR token 的影片，NFO 加 `<tag>VR</tag>` + `<genre>VR</genre>`（固定英文，技術標籤不 i18n），供 Emby/Jellyfin 過濾分類。
+- **高精準偵測（零誤判導向）**：唯一字串 token（`MKX200`/`180x180`/`3DH`…，無真番號長這樣）單獨成立；高誤判 token（裸 `180`/`360`/`LR`/`SBS`…）須**同一連續 cluster 內共現**才算數——孤立的 `MIRD-180`/`REBD-360`/`title_LR` 等真番號 → 不算 VR、檔名零變化。
+
+### Changed
+- **「Jellyfin 圖片模式」→「Jellyfin / Emby 圖片模式」**：label 與 hint 文案修正（`settings.scraper.jellyfin_mode_{label,hint}`，4 語系 zh_TW/zh_CN/en/ja）+ README / README_EN feature 條目。澄清相容性事實——`{stem}-poster.jpg` 與 Kodi-style NFO 兩者 Emby 與 Jellyfin 皆可讀（親核 Emby 官方 `Movie-Naming.md` 確認支援 `{name}-poster.ext`），`{stem}-fanart.jpg` 僅 Jellyfin 讀取（Emby backdrop/fanart 不支援 `{name}-` 前綴命名，只認 standalone `fanart.jpg`）。**刻意不**額外產生 standalone `fanart.jpg`：用戶若關閉資料夾模式（多片同目錄）會撞檔。配置欄位 `jellyfin_mode` 維持不變、無 migration、無行為變化。
 
 ### Fixed
 - **`/static` heuristic stale cache**：以 `NoCacheStaticFiles(StaticFiles)` 子類替換 `web/app.py:75` 的原生 `StaticFiles` mount。override `file_response`，在 `super().file_response()` 回傳後對已建好的 response 物件做 post-construction headers mutation（`response.headers["Cache-Control"] = "no-cache"`），200 `FileResponse` 與 304 `NotModifiedResponse` 兩條路徑均有效。ETag / Last-Modified / 304 機制完整保留（同檔案未變回 304 空 body，有變才回 200 新版，免 hard-reload）。封面圖代理的 24h 強快取（`scanner.py get_image`）與影片 Range streaming 完全不受影響（不經此 mount）。
   - **桌面端（PyWebView）零副作用**：`webview.start()` 預設 `private_mode=True, storage_path=None`（pywebview ≥ 6.0 的 `start()` 參數，非 `create_window()` 參數）→ 非持久 WebView2 profile，每次啟動空快取；`no-cache` 對它只是 in-session localhost 多一次可忽略的重驗（< 1ms）。
   - **真正受益者**：`feature/epic-synology.md` 的 Server / NAS(.spk) / Docker 模式——client 端持久瀏覽器快取在 server 更新（換檔 + 重啟）後本不清除，此修正確保下次載入必重驗並取到新版。
 
-### Changed
-- **「Jellyfin 圖片模式」→「Jellyfin / Emby 圖片模式」**：label 與 hint 文案修正（`settings.scraper.jellyfin_mode_{label,hint}`，4 語系 zh_TW/zh_CN/en/ja）+ README / README_EN feature 條目。澄清相容性事實——`{stem}-poster.jpg` 與 Kodi-style NFO 兩者 Emby 與 Jellyfin 皆可讀（親核 Emby 官方 `Movie-Naming.md` 確認支援 `{name}-poster.ext`），`{stem}-fanart.jpg` 僅 Jellyfin 讀取（Emby backdrop/fanart 不支援 `{name}-` 前綴命名，只認 standalone `fanart.jpg`）。**刻意不**額外產生 standalone `fanart.jpg`：用戶若關閉資料夾模式（多片同目錄）會撞檔。配置欄位 `jellyfin_mode` 維持不變、無 migration、無行為變化。
+### Internal
+- **VR 偵測「先切 token 再分類 + 連續 run 共現」演算法**（`_detect_vr_cluster`）：切詞法天然繞掉 monolithic regex 的 `_LR` 底線邊界 bug；共現限定在連續 VR-token run 內（中間夾 non-VR token 即斷開），避免散落 token 跨任意文字誤共現。截斷保護新建獨立 budget path（VR cluster 不被 `max_filename_length` 切掉）；NFO VR tag 對 `<tag>`/`<genre>` 各做 case-insensitive 去重（scraper 已給 VR 不重複）。VR token 全程不進任何 strip 路徑（與「中字」偵測後移除標記相反），並剝除 extracted_title 尾端殘留以免與尾端保留雙寫。
+
+### Non-Goals（明確不做）
+- 不做 toggle / 用戶自訂 token 清單（自動偵測）、不做 token 正規化（降低相容性）、不保留解析度/裝置 token（`8K`/`60fps`/`samsung`）、不碰影片轉碼、不做 VR poster 不裁切（issue #6 獨立）、不串接 Emby/DeoVR/DLNA（用戶端的事）。enricher / nfo_updater 不改名路徑不在範圍（VR 偵測是 organize_file 職責）。
 
 ### 測試
+- 新增 `tests/unit/test_organizer.py` VR 測試（5 class、46+ case）：偵測層全 DoD 表（命中/None/混大小寫/bracket-paren/誤判防護 `1080`/`color`/`SIVR-999`）+ 檔名組裝（suffix×VR 順序 / 超長截斷保護 / 零變化）+ NFO 去重（scraper VR 不重複 / has_vr 兩條分切 / 中字共存 / byte-identical）+ 端到端 wiring + Codex 兩輪 review 回歸（連續 run / 雙寫 / bracket 雙寫 / 多 confirmed run）。
 - 新增 `tests/integration/test_static_cache_headers.py`：兩條契約測試（200 帶 `cache-control: no-cache` + `etag`；304 仍帶 `cache-control: no-cache`）。
-- `pytest tests/integration/ -q` 全綠（含既有 `test_async_offload_guard.py` 34 條不回歸）。
+- 全套 pytest **3588 passed, 2 skipped**（unit + integration，排除 smoke / e2e）+ `npm run lint`（eslint + stylelint）綠。
 
 ## [0.9.6] - 2026-06-06
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ irm https://raw.githubusercontent.com/slive777/OpenAver/main/install.ps1 | iex
 - **多語系 UI**：繁中 / 简中 / 日文 / 英文，即時切換。
 - **路徑管理**：靈活設定輸出路徑與檔案命名規則，支援 `{suffix}` 格式變數。
 - **我的最愛資料夾**：設定常用資料夾，一鍵載入並自動搜尋。
-- **Jellyfin 圖片模式**：自動生成 poster / fanart 供 Jellyfin / Emby 使用。
+- **Jellyfin / Emby 圖片模式**：自動生成 poster + NFO（Jellyfin 與 Emby 皆相容），並額外生成 fanart 供 Jellyfin（Emby 不支援此 fanart 命名）。
 - **靜態 HTML 匯出**：生成獨立 HTML 索引檔，不需部署伺服器也能離線瀏覽。
 
 ### 🔌 刮削來源擴充：Metatube 聯邦（進階選配）

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ irm https://raw.githubusercontent.com/slive777/OpenAver/main/install.ps1 | iex
 - **女優別名管理**：用 GUI 即時新增、編輯別名（不用手改設定檔或 XML），搜尋時自動展開同一人的所有藝名與退休名。
 - **Tag 別名管理 chip 牆**：跨語言同義詞集中管理，搜尋框與 Showcase chip 在搜尋時自動展開（中日英，如「女僕＝Maid＝メイド」）。
 - **字幕偵測**：影片搬移時自動偵測並搬移同目錄字幕檔。
+- **VR 檔名標籤保留**：整理 VR 影片時自動保留原檔名的投影/立體標籤（如 `_180_LR`、`_3dh`、`mkx200`），讓 VR 頭顯播放器（Skybox / DeoVR / HereSphere 等）正確識別投影格式。
 
 ### ⚡ Search → Showcase 即時化
 - **同名 NFO 跳過**：最愛資料夾若同目錄已有 `.nfo`，視為已整理不重打 scraper（避免重複外部請求）。

--- a/README_EN.md
+++ b/README_EN.md
@@ -148,7 +148,7 @@ On first launch, a built-in setup wizard walks you through folder configuration 
 - **Multi-Language UI**: Traditional Chinese, Simplified Chinese, Japanese, English — instant switch.
 - **Path & Naming Rules**: Flexible output path configuration with `{suffix}` variable support.
 - **Favorites Folders**: Save frequently used folders for one-click batch loading.
-- **Jellyfin Image Mode**: Auto-generates `poster` and `fanart` in the format Jellyfin / Emby expects.
+- **Jellyfin / Emby Image Mode**: Auto-generates a `poster` + NFO (read by both Jellyfin and Emby), plus a Jellyfin `fanart` (Emby doesn't support this fanart filename).
 - **Static HTML Export**: Generates a standalone HTML index file — viewable offline without a server.
 
 ### 🔌 Scrape-Source Expansion: Metatube Federation (advanced, optional)

--- a/README_EN.md
+++ b/README_EN.md
@@ -130,6 +130,7 @@ On first launch, a built-in setup wizard walks you through folder configuration 
 - **Actress Alias Management**: Add and edit aliases live through the GUI (no editing config files or XML) — searches automatically expand to all of a person's stage names and post-retirement names.
 - **Tag Alias Management chip wall**: Manage cross-language synonyms in one place; the search box and Showcase chips auto-expand them at query time (Chinese/Japanese/English, e.g. "Maid＝メイド＝女僕").
 - **Subtitle Detection**: Automatically detects and moves subtitle files in the same folder when relocating videos.
+- **VR Filename Tag Preservation**: When organizing VR videos, automatically preserves the original filename's projection/stereo tags (e.g. `_180_LR`, `_3dh`, `mkx200`) so VR headset players (Skybox / DeoVR / HereSphere, etc.) detect the projection format correctly.
 
 ### ⚡ Search → Showcase, Made Instant
 - **Same-Name NFO Skip**: If your favorites folder already has a `.nfo` next to the video, it's treated as organized and the scraper is skipped (avoids redundant external requests).

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -737,6 +737,11 @@ def organize_file(
         filename_base = truncate_to_chars(filename_base, max(0, max_chars - reserve))
     # VR tail 永遠最後接（CD-68-6）；vr_tail='' 時零變化（CD-68-9）
     filename_base = filename_base + vr_tail
+    # 最終長度上限保護（Codex PR P2）：即使退化情形也不突破 max_filename_length。
+    # 正常/spec 情形 reserve 已預留 → base+vr_tail == max_chars → 此為 no-op、VR tail 完整；
+    # 僅 max_filename_length 被設到連 ext+VR cluster 都裝不下（低於 UI 下限的 config/API 值）時才作用，
+    # 鏡射 suffix 路徑的 truncate_to_chars(suffix, max_chars) 上限語意。
+    filename_base = truncate_to_chars(filename_base, max_chars)
 
     new_filename = filename_base + original_ext
     target_path = os.path.join(target_dir, new_filename)

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -595,6 +595,11 @@ def organize_file(
     suffix = _detect_suffixes(original_filename, suffix_keywords)
     format_data['suffix'] = suffix
 
+    # 偵測 VR cluster（CD-68-5/6/7）：算一次，作用域涵蓋組裝段與 nfo 呼叫（GA）
+    vr_cluster = _detect_vr_cluster(original_filename)
+    vr_tail = f'_{vr_cluster}' if vr_cluster else ''
+    reserve = len(vr_tail)  # 兩分支共用 budget，CD-68-7
+
     # 記錄哪些欄位實際用了 fallback（僅資料夾層級會觸發 fallback）
     used_fallbacks = []
     if config.get('create_folder', True):
@@ -659,18 +664,20 @@ def organize_file(
 
     suffix = format_data.get('suffix', '')
     if suffix and '{suffix}' in filename_template:
-        # 先用空 suffix 產生 base，截斷後再接回 suffix
+        # 先用空 suffix 產生 base，截斷後再接回 suffix；base_budget 扣 reserve（CD-68-5/7）
         no_suffix_data = dict(format_data, suffix='')
         base_without_suffix = format_string(filename_template, no_suffix_data)
-        base_budget = max(0, max_chars - len(suffix))
+        base_budget = max(0, max_chars - len(suffix) - reserve)
         if base_budget == 0:
-            filename_base = truncate_to_chars(suffix, max_chars)
+            filename_base = truncate_to_chars(suffix, max(0, max_chars - reserve))
         else:
             base_without_suffix = truncate_to_chars(base_without_suffix, base_budget)
             filename_base = base_without_suffix + suffix
     else:
         filename_base = format_string(filename_template, format_data)
-        filename_base = truncate_to_chars(filename_base, max_chars)
+        filename_base = truncate_to_chars(filename_base, max(0, max_chars - reserve))
+    # VR tail 永遠最後接（CD-68-6）；vr_tail='' 時零變化（CD-68-9）
+    filename_base = filename_base + vr_tail
 
     new_filename = filename_base + original_ext
     target_path = os.path.join(target_dir, new_filename)

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -167,28 +167,69 @@ _VR_AMBIGUOUS: frozenset = frozenset({
 
 def _detect_vr_cluster(filename: str) -> Optional[str]:
     """
-    偵測檔名中的 VR 投影 token cluster，回傳首個~末個 VR token 之間的 raw 子字串。
+    偵測檔名中的 VR 投影 token cluster，回傳首個~末個 confirmed run 的 raw 子字串。
     無 VR token 或不滿足共現條件時回傳 None（守零變化）。
 
-    演算法（CD-68-1/2/3）：
+    演算法（CD-68-1/2/3，Codex P2 修正）：
     1. 去副檔名取 stem
     2. 以 [_.-空格[]()] 為分隔符切詞，取 (token, start, end) 序列
-    3. 逐 token lower-case 比對 _VR_UNIQUE / _VR_AMBIGUOUS 分類
-    4. 共現判定：unique 非空 OR len(ambiguous)>=2
-    5. 取確認 token 的 start/end span，回傳 stem[start:end]（raw，保大小寫）
+    3. 逐 token 分類：unique / ambiguous / none
+    4. 將連續的 VR token（unique 或 ambiguous，中間無 none token）聚成 maximal run。
+       遇到 none token 立即斷開當前 run。
+    5. 每個 run 的「confirmed」條件：含 ≥1 unique 或 ≥2 ambiguous。
+       單一孤立 ambiguous 自成一 run，不 confirmed。
+    6. 無任何 confirmed run → return None。
+    7. 有 confirmed run → 回傳「第一個 confirmed run 的首 token start」到
+       「最後一個 confirmed run 的末 token end」之間的 raw 子字串（stem[start:end]）。
+
+    共現限定在連續 run 內（high-precision「same cluster」契約），
+    取代原 whole-stem min/max（Codex P2 修正）。
     """
     stem = os.path.splitext(filename)[0]
     tokens = [(m.group(), m.start(), m.end()) for m in re.finditer(r'[^_.\-\s\[\]()]+', stem)]
-    unique = [(tok, s, e) for tok, s, e in tokens if tok.lower() in _VR_UNIQUE]
-    ambiguous = [(tok, s, e) for tok, s, e in tokens if tok.lower() in _VR_AMBIGUOUS]
-    if unique:
-        confirmed = unique + ambiguous
-    elif len(ambiguous) >= 2:
-        confirmed = ambiguous
-    else:
+
+    # 建立每個 token 的 VR 類別
+    classified = []  # (tok, s, e, kind)  kind: 'unique' | 'ambiguous' | 'none'
+    for tok, s, e in tokens:
+        low = tok.lower()
+        if low in _VR_UNIQUE:
+            classified.append((tok, s, e, 'unique'))
+        elif low in _VR_AMBIGUOUS:
+            classified.append((tok, s, e, 'ambiguous'))
+        else:
+            classified.append((tok, s, e, 'none'))
+
+    # 聚成 maximal 連續 VR run（none token 斷開）
+    runs = []  # list of [(tok, s, e, kind), ...]
+    current_run = []
+    for entry in classified:
+        _, _, _, kind = entry
+        if kind != 'none':
+            current_run.append(entry)
+        else:
+            if current_run:
+                runs.append(current_run)
+                current_run = []
+    if current_run:
+        runs.append(current_run)
+
+    # 判斷每個 run 是否 confirmed
+    confirmed_runs = []
+    for run in runs:
+        has_unique = any(kind == 'unique' for _, _, _, kind in run)
+        ambiguous_count = sum(1 for _, _, _, kind in run if kind == 'ambiguous')
+        if has_unique or ambiguous_count >= 2:
+            confirmed_runs.append(run)
+
+    if not confirmed_runs:
         return None
-    start = min(s for _, s, _ in confirmed)
-    end = max(e for _, _, e in confirmed)
+
+    # 只取第一個 confirmed run（避免兩個被 non-VR token 隔開的 confirmed run
+    # 被 span 在一起、把中間非 VR 文字包進 cluster，Codex P3）。
+    # 真實 VR 命名 cluster 為單一連續 run；多 confirmed run 屬非常規命名。
+    first_run = confirmed_runs[0]
+    start = first_run[0][1]    # 首 token start
+    end = first_run[-1][2]     # 末 token end
     return stem[start:end]
 
 
@@ -569,6 +610,12 @@ def organize_file(
     original_ext = os.path.splitext(file_path)[1]
     original_filename = os.path.basename(file_path)
 
+    # 偵測 VR cluster（CD-68-5/6/7）：算一次，作用域涵蓋 title 剝除、組裝段與 nfo 呼叫（GA）
+    # 上移至 extract_chinese_title 之前，用於剝除 extracted_title 尾端的 VR token（Codex P2）
+    vr_cluster = _detect_vr_cluster(original_filename)
+    vr_tail = f'_{vr_cluster}' if vr_cluster else ''
+    reserve = len(vr_tail)  # 兩分支共用 budget，CD-68-7
+
     # 準備格式化資料
     actors = metadata.get('actors', [])
 
@@ -576,6 +623,16 @@ def organize_file(
     original_title = metadata.get('title', '')  # 日文原始標題
     translated_title = metadata.get('translated_title', '')  # LLM 翻譯/優化的標題
     extracted_title = extract_chinese_title(original_filename, number, actors)
+
+    # 剝除 extracted_title 尾端的 VR cluster（含可選 bracket/paren 包裝，Codex P2 二次修正）
+    # _detect_vr_cluster 把 []() 當分隔符 → cluster 不含 bracket，但 extracted_title 保留 bracket，
+    # 故需匹配可選的開/閉 bracket/paren 包裝；否則 _[180_LR] 不被剝 → 與尾端 vr_tail 雙寫。
+    if vr_cluster and extracted_title:
+        _vr_tail_re = re.compile(r'[\[(]?' + re.escape(vr_cluster) + r'[\])]?[\s_.\-]*$')
+        _m = _vr_tail_re.search(extracted_title)
+        if _m:
+            _trimmed = extracted_title[:_m.start()].rstrip('_-. ')
+            extracted_title = _trimmed or extracted_title
 
     # 決定最終使用的標題
     if translated_title:
@@ -601,11 +658,6 @@ def organize_file(
     suffix_keywords = config.get('suffix_keywords', [])
     suffix = _detect_suffixes(original_filename, suffix_keywords)
     format_data['suffix'] = suffix
-
-    # 偵測 VR cluster（CD-68-5/6/7）：算一次，作用域涵蓋組裝段與 nfo 呼叫（GA）
-    vr_cluster = _detect_vr_cluster(original_filename)
-    vr_tail = f'_{vr_cluster}' if vr_cluster else ''
-    reserve = len(vr_tail)  # 兩分支共用 budget，CD-68-7
 
     # 記錄哪些欄位實際用了 fallback（僅資料夾層級會觸發 fallback）
     used_fallbacks = []

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -153,6 +153,45 @@ def _detect_suffixes(filename: str, keywords: list) -> str:
     return ''.join(matched)
 
 
+_VR_UNIQUE: frozenset = frozenset({
+    'mkx200', 'mkx220', 'vrca220', 'rf52', 'fisheye190', 'fisheye',
+    'f180', '180f', '180x180', 'eac360', '360eac', 'mono180', '180mono',
+    'mono360', '360mono', '3dh', '3dv', 'lrf', 'sbsf', 'fsbs', 'hsbs',
+    'tbf', 'ftab', 'htab',
+})
+
+_VR_AMBIGUOUS: frozenset = frozenset({
+    '180', '360', 'sbs', 'lr', 'rl', 'tb', 'bt', 'ou',
+})
+
+
+def _detect_vr_cluster(filename: str) -> Optional[str]:
+    """
+    偵測檔名中的 VR 投影 token cluster，回傳首個~末個 VR token 之間的 raw 子字串。
+    無 VR token 或不滿足共現條件時回傳 None（守零變化）。
+
+    演算法（CD-68-1/2/3）：
+    1. 去副檔名取 stem
+    2. 以 [_.-空格[]()] 為分隔符切詞，取 (token, start, end) 序列
+    3. 逐 token lower-case 比對 _VR_UNIQUE / _VR_AMBIGUOUS 分類
+    4. 共現判定：unique 非空 OR len(ambiguous)>=2
+    5. 取確認 token 的 start/end span，回傳 stem[start:end]（raw，保大小寫）
+    """
+    stem = os.path.splitext(filename)[0]
+    tokens = [(m.group(), m.start(), m.end()) for m in re.finditer(r'[^_.\-\s\[\]()]+', stem)]
+    unique = [(tok, s, e) for tok, s, e in tokens if tok.lower() in _VR_UNIQUE]
+    ambiguous = [(tok, s, e) for tok, s, e in tokens if tok.lower() in _VR_AMBIGUOUS]
+    if unique:
+        confirmed = unique + ambiguous
+    elif len(ambiguous) >= 2:
+        confirmed = ambiguous
+    else:
+        return None
+    start = min(s for _, s, _ in confirmed)
+    end = max(e for _, _, e in confirmed)
+    return stem[start:end]
+
+
 FALLBACKS = {
     'actor':  '未知女優',
     'actors': '未知女優',

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -359,6 +359,7 @@ def generate_nfo(
     maker: str = '',
     url: str = '',
     has_subtitle: bool = False,
+    has_vr: bool = False,
     output_path: str = '',
     has_poster: bool = False,
     has_fanart: bool = False,
@@ -447,6 +448,9 @@ def generate_nfo(
     if has_subtitle:
         nfo_content += '  <tag>中文字幕</tag>\n'
 
+    if has_vr and not any(t.strip().lower() == 'vr' for t in tags):
+        nfo_content += '  <tag>VR</tag>\n'
+
     # 用戶自訂標籤（獨立於 scraper tags，其他平台忽略）
     for ut in user_tags:
         nfo_content += f'  <user_tag>{html.escape(ut)}</user_tag>\n'
@@ -457,6 +461,9 @@ def generate_nfo(
 
     if has_subtitle:
         nfo_content += '  <genre>中文字幕</genre>\n'
+
+    if has_vr and not any(t.strip().lower() == 'vr' for t in tags):
+        nfo_content += '  <genre>VR</genre>\n'
 
     nfo_content += f'''  <num>{html.escape(number)}</num>
   <release>{html.escape(date)}</release>
@@ -769,6 +776,7 @@ def organize_file(
             maker=metadata.get('maker', ''),
             url=metadata.get('url', ''),
             has_subtitle=has_subtitle,
+            has_vr=(vr_cluster is not None),
             output_path=nfo_path,
             has_poster=bool(result.get('poster_path')),
             has_fanart=bool(result.get('fanart_path')),

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/en.json
+++ b/locales/en.json
@@ -309,8 +309,8 @@
       "path_length_help_line4": "macOS / Linux have no such limit, but long filenames generated on macOS/Linux may still fail on Windows without LongPathsEnabled.",
       "video_extensions_label": "Video Extensions",
       "video_extensions_hint": "Comma-separated",
-      "jellyfin_mode_label": "Jellyfin Image Mode",
-      "jellyfin_mode_hint": "Auto-generate {stem}-poster.jpg + {stem}-fanart.jpg (for Jellyfin library)",
+      "jellyfin_mode_label": "Jellyfin / Emby Image Mode",
+      "jellyfin_mode_hint": "Auto-generate {stem}-poster.jpg + {stem}-fanart.jpg; poster and NFO work with both Jellyfin and Emby, fanart is Jellyfin-only (Emby doesn't read this filename)",
       "download_sample_images_label": "Download Stills (extrafanart)",
       "download_sample_images_hint": "Download stills to extrafanart/ during organize (requires Create Folder enabled)"
     },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -309,8 +309,8 @@
       "path_length_help_line4": "macOS / Linux にはこの制限はありませんが、macOS/Linux で生成した長いファイル名を LongPathsEnabled が無効な Windows に移動すると失敗する場合があります。",
       "video_extensions_label": "動画拡張子",
       "video_extensions_hint": "カンマ区切り",
-      "jellyfin_mode_label": "Jellyfin 画像モード",
-      "jellyfin_mode_hint": "{stem}-poster.jpg + {stem}-fanart.jpg を自動生成（Jellyfin ライブラリ用）",
+      "jellyfin_mode_label": "Jellyfin / Emby 画像モード",
+      "jellyfin_mode_hint": "{stem}-poster.jpg + {stem}-fanart.jpg を自動生成。poster と NFO は Jellyfin / Emby 両対応、fanart は Jellyfin のみ（Emby はこの命名に非対応）",
       "download_sample_images_label": "サンプル画像をダウンロード（extrafanart）",
       "download_sample_images_hint": "整理時にスクリーンショットを extrafanart/ にダウンロード（「フォルダー作成」が必要）"
     },

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -309,8 +309,8 @@
       "path_length_help_line4": "macOS / Linux 不受此限制，但从 macOS/Linux 生成的长文件名移至未启用 LongPathsEnabled 的 Windows 仍可能失败。",
       "video_extensions_label": "视频扩展名",
       "video_extensions_hint": "以逗号分隔",
-      "jellyfin_mode_label": "Jellyfin 图片模式",
-      "jellyfin_mode_hint": "自动生成 {stem}-poster.jpg + {stem}-fanart.jpg（Jellyfin 图库用）",
+      "jellyfin_mode_label": "Jellyfin / Emby 图片模式",
+      "jellyfin_mode_hint": "自动生成 {stem}-poster.jpg + {stem}-fanart.jpg；poster 与 NFO 同时兼容 Jellyfin 与 Emby，fanart 仅 Jellyfin 读取（Emby 不支持此命名）",
       "download_sample_images_label": "下载剧照（extrafanart）",
       "download_sample_images_hint": "整理时自动下载剧照至 extrafanart/ 子目录（需启用「建立文件夹」）"
     },

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -315,8 +315,8 @@
       "path_length_help_line4": "macOS / Linux 不受此限制，但從 macOS/Linux 產生的長檔名搬到未啟用 LongPathsEnabled 的 Windows 仍可能失敗。",
       "video_extensions_label": "影片副檔名",
       "video_extensions_hint": "以逗號分隔",
-      "jellyfin_mode_label": "Jellyfin 圖片模式",
-      "jellyfin_mode_hint": "自動產生 {stem}-poster.jpg + {stem}-fanart.jpg（Jellyfin 圖庫用）",
+      "jellyfin_mode_label": "Jellyfin / Emby 圖片模式",
+      "jellyfin_mode_hint": "自動產生 {stem}-poster.jpg + {stem}-fanart.jpg；poster 與 NFO 同時相容 Jellyfin 與 Emby，fanart 僅 Jellyfin 讀取（Emby 不支援此命名）",
       "download_sample_images_label": "下載劇照",
       "download_sample_images_hint": "整理時自動下載劇照至 extrafanart/ 子目錄（需啟用「建立資料夾」）"
     },

--- a/tests/integration/test_static_cache_headers.py
+++ b/tests/integration/test_static_cache_headers.py
@@ -1,0 +1,21 @@
+# tests/integration/test_static_cache_headers.py
+"""
+契約測試：/static mount 的 Cache-Control: no-cache + ETag-based revalidation。
+
+依 CLAUDE.md「Lint 守衛規則」：此為「mount ↔ response header API contract」→ pytest 正確，非 eslint 範疇。
+"""
+
+
+def test_static_css_has_no_cache(client):
+    resp = client.get("/static/css/theme.css")
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "no-cache"
+    assert "etag" in resp.headers  # ETag-based revalidation 仍在
+
+
+def test_static_304_keeps_no_cache(client):
+    first = client.get("/static/css/theme.css")
+    etag = first.headers["etag"]
+    second = client.get("/static/css/theme.css", headers={"If-None-Match": etag})
+    assert second.status_code == 304
+    assert second.headers["cache-control"] == "no-cache"

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -2322,6 +2322,51 @@ class TestOrganizeVrFilename:
         assert "_180" not in name1 and "_LR" not in name1, f"CD1 意外多了 VR tail：{name1}"
         assert "_180" not in name2 and "_LR" not in name2, f"CD2 意外多了 VR tail：{name2}"
 
+    # ---- Codex PR P2 回歸：退化 config 最終長度上限保護 ----
+
+    def test_degenerate_max_len_vr_tail_bounded(self, tmp_path):
+        """退化 config（max_filename_length < ext + vr_tail）最終檔名不得超出上限。
+
+        SIVR-1_180_3dh_LR.mp4：
+          vr_tail = _180_3dh_LR（11 chars）
+          ext     = .mp4（4 chars）
+          vr_tail + ext = 15 chars
+          max_filename_length = 10 < 15  → 退化（連 ext+vr_tail 都裝不下）
+
+        修前行為：filename_base = '' + '_180_3dh_LR' = '_180_3dh_LR'（11）
+                  new_filename  = '_180_3dh_LR.mp4'（15）> 10  → overflow
+        修後行為：最終 cap 截到 max_chars=6 → len(new_filename) <= 10
+        """
+        src = tmp_path / "SIVR-1_180_3dh_LR.mp4"
+        src.write_bytes(b"degenerate vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 10,   # < ext(4) + vr_tail(11) = 15 → 退化
+            "suffix_keywords": ["-cd1", "-cd2"],
+        }
+        metadata = {
+            "number": "SIVR-1",
+            "title": "Title",
+            "actors": [],
+            "tags": [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        assert len(new_name) <= 10, (
+            f"退化 config overflow 未被 cap：len={len(new_name)}，filename={new_name!r}"
+        )
+
 
 # ============ generate_nfo() VR tag/genre 去重測試 (T3) ============
 

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -1984,3 +1984,295 @@ class TestDetectVrCluster:
     def test_duplicate_ambiguous_satisfies_cooccurrence(self):
         """兩個相同 ambiguous token（len(ambiguous)>=2）→ 成立"""
         assert _detect_vr_cluster("NAME_180_180") == "180_180"
+
+
+# ============ organize_file() VR 檔名端到端測試 ============
+
+class TestOrganizeVrFilename:
+    """organize_file() VR tail 端到端測試（TDD-lite，T2 DoD）
+
+    驗證：
+    - VR cluster 正確接到檔名尾（_{cluster}）
+    - suffix × VR 順序 = base + suffix + _vr
+    - 超長截斷時 VR cluster 完整不被切
+    - 無 VR token 檔案 byte 級零變化（reserve=0）
+    - 一般 2D 檔 byte 級零變化
+    - 既有 suffix 路徑不回歸（-cd1/-cd2，無 VR，reserve=0 不影響）
+    """
+
+    # ---- DoD Row 1: VR 檔名尾正確接 _{cluster} ----
+
+    def test_vr_tail_appended_no_suffix(self, tmp_path):
+        """NAME_180_LR.mp4（無 suffix keyword）→ filename 尾帶 _180_LR"""
+        src = tmp_path / "NAME_180_LR.mp4"
+        src.write_bytes(b"vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 60,
+            "suffix_keywords": ["-cd1", "-cd2", "-4k", "-uc"],
+        }
+        metadata = {
+            "number": "VR-001",
+            "title": "VR Test Title",
+            "actors": [],
+            "tags": [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        assert new_name.endswith("_180_LR.mp4"), (
+            f"VR tail _180_LR 未接到尾：{new_name}"
+        )
+
+    # ---- DoD Row 2: suffix × VR 順序（base + suffix + _vr） ----
+
+    def test_suffix_before_vr_tail(self, tmp_path):
+        """MOVIE-4k_180_3dh_LR.mp4（suffix=-4k, VR cluster=180_3dh_LR）
+        → 輸出順序 = base + -4k + _180_3dh_LR（suffix 在 VR 之前）"""
+        src = tmp_path / "MOVIE-4k_180_3dh_LR.mp4"
+        src.write_bytes(b"vr 4k content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 80,
+            "suffix_keywords": ["-4k", "-cd1", "-uc"],
+        }
+        metadata = {
+            "number": "MOVIE-001",
+            "title": "Some Title",
+            "actors": [],
+            "tags": [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        stem = Path(new_name).stem  # 不含副檔名
+
+        # suffix -4k 必須出現
+        assert "-4k" in stem, f"suffix -4k 未在檔名中：{new_name}"
+        # VR tail _180_3dh_LR 必須在最後
+        assert stem.endswith("_180_3dh_LR"), (
+            f"VR tail _180_3dh_LR 未在 stem 最尾：{stem}"
+        )
+        # 順序：-4k 出現位置在 _180 之前
+        idx_suffix = stem.index("-4k")
+        idx_vr = stem.index("_180_3dh_LR")
+        assert idx_suffix < idx_vr, (
+            f"suffix(-4k) 應在 VR tail(_180_3dh_LR) 之前：{stem}"
+        )
+
+    # ---- DoD Row 3: 超長截斷 VR cluster 完整不被切 ----
+
+    def test_long_title_vr_cluster_preserved(self, tmp_path):
+        """超長 title + _180_3dh_LR.mp4：base 被 max_filename_length 截，VR cluster 完整"""
+        src = tmp_path / "VR-999_180_3dh_LR.mp4"
+        src.write_bytes(b"long vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 30,  # 故意很短，迫使截斷
+            "suffix_keywords": ["-4k"],
+        }
+        metadata = {
+            "number": "VR-999",
+            "title": "超級無敵長的標題名稱會被截斷但VR尾應完整保留",
+            "actors": [],
+            "tags": [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        stem = Path(new_name).stem
+        # VR cluster 必須完整保留（_180_3dh_LR 原樣）
+        assert stem.endswith("_180_3dh_LR"), (
+            f"VR cluster _180_3dh_LR 被截斷：{stem}"
+        )
+        # 核心：reserve budget 真的生效——整個檔名（含 ext）不得超出 max_filename_length。
+        # 沒有這行，「不扣 reserve 直接 overflow」也會讓上面的 endswith 通過（假測試）。
+        assert len(new_name) <= 30, (
+            f"reserve budget 未生效，檔名 {len(new_name)} 字超出 max_filename_length=30：{new_name!r}"
+        )
+        # base 確實被壓縮：超長標題不可能完整出現（證明 reserve 扣掉了 base 預算）
+        assert "超級無敵長的標題名稱會被截斷但VR尾應完整保留" not in stem, (
+            f"base 未被截斷，reserve 未壓縮 base：{stem}"
+        )
+
+    def test_vr_cluster_preserved_when_base_budget_zero(self, tmp_path):
+        """退化邊界（CD-68-7 base_budget==0）：max_filename_length 短到 base 預算歸零，
+        VR cluster 仍完整保留、檔名不超限（reserve 在 base_budget==0 子分支也生效）"""
+        src = tmp_path / "VR-1_180_3dh_LR.mp4"
+        src.write_bytes(b"x")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 16,  # ext(.mp4=4)+vr_tail(_180_3dh_LR=11)=15，base 預算 ~1
+            "suffix_keywords": ["-4k"],
+        }
+        metadata = {
+            "number": "VR-1",
+            "title": "X" * 80,
+            "actors": [], "tags": [], "maker": "M", "date": "2024-01-15",
+            "cover": "", "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        assert Path(new_name).stem.endswith("_180_3dh_LR"), (
+            f"VR cluster 在 base_budget==0 退化時被切：{new_name}"
+        )
+        assert len(new_name) <= 16, (
+            f"base_budget==0 子分支 reserve 未生效，超限：{new_name!r}"
+        )
+
+    # ---- DoD Row 4: 無 VR token，byte 級零變化（SIVR-999.mp4，else 分支） ----
+
+    def test_no_vr_token_byte_identical(self, tmp_path):
+        """SIVR-999.mp4（無 VR token、無 suffix）→ reserve=0，
+        輸出名與未改動前完全相同（byte 級零變化）"""
+        src = tmp_path / "SIVR-999.mp4"
+        src.write_bytes(b"no vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 60,
+            "suffix_keywords": ["-cd1", "-cd2", "-4k"],
+        }
+        metadata = {
+            "number": "SIVR-999",
+            "title": "Some Title",
+            "actors": [],
+            "tags": [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        # reserve=0 → 與 T2 改動前的預期完全相同（byte-identical path）
+        # expected = "[{num}] {title}" truncated to max_chars, no vr_tail
+        expected_stem = truncate_to_chars("[SIVR-999] Some Title", 60 - len(".mp4"))
+        expected_name = expected_stem + ".mp4"
+        assert new_name == expected_name, (
+            f"零變化失敗：got {new_name!r}, expected {expected_name!r}"
+        )
+
+    # ---- DoD Row 5: 一般 2D 檔 byte 級零變化 ----
+
+    def test_2d_file_byte_identical(self, tmp_path):
+        """一般 2D 檔（無 VR token）→ reserve=0，輸出名與改動前完全相同"""
+        src = tmp_path / "ABP-123.mp4"
+        src.write_bytes(b"2d content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 60,
+            "suffix_keywords": ["-cd1", "-4k"],
+        }
+        metadata = {
+            "number": "ABP-123",
+            "title": "Normal Title",
+            "actors": [],
+            "tags": [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+        new_name = Path(result["new_filename"]).name
+        expected_stem = truncate_to_chars("[ABP-123] Normal Title", 60 - len(".mp4"))
+        expected_name = expected_stem + ".mp4"
+        assert new_name == expected_name, (
+            f"2D 零變化失敗：got {new_name!r}, expected {expected_name!r}"
+        )
+
+    # ---- DoD Row 6: 既有 suffix 路徑不回歸（無 VR，reserve=0） ----
+
+    def test_existing_suffix_no_regression(self, tmp_path):
+        """既有 -cd1/-cd2 suffix（無 VR）→ reserve=0，行為完全不回歸"""
+        cd1 = tmp_path / "SONE-205-CD1.mp4"
+        cd1.write_bytes(b"cd1 content")
+        cd2 = tmp_path / "SONE-205-CD2.mp4"
+        cd2.write_bytes(b"cd2 content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": 60,
+            "suffix_keywords": ["-cd1", "-cd2", "-4k"],
+        }
+        metadata = {
+            "number": "SONE-205",
+            "title": "Test Title",
+            "actors": [],
+            "tags": [],
+            "maker": "S1",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result1 = organize_file(str(cd1), metadata, config)
+        result2 = organize_file(str(cd2), metadata, config)
+
+        assert result1["success"] is True, f"CD1 失敗: {result1.get('error')}"
+        assert result2["success"] is True, f"CD2 失敗: {result2.get('error')}"
+
+        name1 = Path(result1["new_filename"]).name
+        name2 = Path(result2["new_filename"]).name
+
+        # suffix 保留
+        assert "-cd1" in name1, f"CD1 suffix 消失：{name1}"
+        assert "-cd2" in name2, f"CD2 suffix 消失：{name2}"
+        # 沒有意外 VR tail（無 VR token）
+        assert "_180" not in name1 and "_LR" not in name1, f"CD1 意外多了 VR tail：{name1}"
+        assert "_180" not in name2 and "_LR" not in name2, f"CD2 意外多了 VR tail：{name2}"

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -1985,6 +1985,51 @@ class TestDetectVrCluster:
         """兩個相同 ambiguous token（len(ambiguous)>=2）→ 成立"""
         assert _detect_vr_cluster("NAME_180_180") == "180_180"
 
+    # ---- Codex P2 修正（Finding 2）：連續 run 偵測 ----
+
+    def test_none_scattered_ambiguous_across_words(self):
+        """TITLE_180_some_words_LR.mp4 → None
+        （散落 ambiguous 被 non-VR token 隔開，不構成連續 run，不應共現）"""
+        result = _detect_vr_cluster("TITLE_180_some_words_LR.mp4")
+        assert result is None, (
+            f"散落 ambiguous 跨文字不共現，應為 None，實際：{result!r}"
+        )
+
+    def test_none_ambiguous_with_nonvr_between(self):
+        """MOVIE_180_4k_LR.mp4 → None
+        （4k 是 non-VR token，夾在 180 與 LR 之間斷開 run；散落不共現）"""
+        result = _detect_vr_cluster("MOVIE_180_4k_LR.mp4")
+        assert result is None, (
+            f"non-VR token（4k）夾斷 run，兩端散落 ambiguous 不共現，應為 None，實際：{result!r}"
+        )
+
+    def test_partial_run_unique_isolated_lr(self):
+        """A_180x180_word_LR → 180x180
+        （unique 180x180 自成一個 confirmed run；孤立 LR 因中間夾了 non-VR 'word' 不在同 run）"""
+        result = _detect_vr_cluster("A_180x180_word_LR")
+        assert result == "180x180", (
+            f"只有 unique 180x180 那個 run confirmed，孤立 LR 跨字不算，期望 '180x180'，實際：{result!r}"
+        )
+
+    # ---- Codex P2 二次修正（Finding 2, P3）：多 confirmed run 只取第一個 ----
+
+    def test_multiple_confirmed_runs_returns_first(self):
+        """A_180_LR_title_3dh → '180_LR'（只取第一個 confirmed run，不跨 non-VR title 到第二 run）
+
+        Repro：run1=[180,LR]（ambiguous×2，confirmed），non-VR token 'title' 斷開，
+        run2=[3dh]（unique，confirmed）；舊邏輯跨 span → '180_LR_title_3dh'（含 junk）。
+        修正後只取 first confirmed run → '180_LR'。
+        """
+        result = _detect_vr_cluster("A_180_LR_title_3dh")
+        assert result == "180_LR", (
+            f"多個 confirmed run 應只取第一個，期望 '180_LR'，實際：{result!r}"
+        )
+        # 含副檔名同結果
+        result_ext = _detect_vr_cluster("A_180_LR_title_3dh.mp4")
+        assert result_ext == "180_LR", (
+            f"含副檔名：多個 confirmed run 應只取第一個，期望 '180_LR'，實際：{result_ext!r}"
+        )
+
 
 # ============ organize_file() VR 檔名端到端測試 ============
 
@@ -2579,6 +2624,205 @@ class TestVrEndToEnd:
         )
         assert "<genre>VR</genre>" not in nfo_content, (
             f"SIVR-999（無 VR token）NFO 不應含 canonical <genre>VR</genre>"
+        )
+
+    # ---- Codex P2 修正（Finding 1）：中文標題 VR token 雙寫 ----
+
+    def test_chinese_title_vr_no_double_write(self, tmp_path):
+        """ABC-123 中文標題_180_LR.mp4 + create_nfo=True + extracted_title 路徑
+        → 檔名 stem 僅有單一 _180_LR（不雙寫 _180_LR_180_LR）
+        且 NFO sidecar stem 也單一 tail、<tag>VR</tag> count==1。
+
+        Codex P2（Finding 1）：extract_chinese_title 保留 VR token 在 title，
+        之後 vr_tail 再接一次 → _180_LR_180_LR 雙寫。
+        """
+        src = tmp_path / "ABC-123 中文標題_180_LR.mp4"
+        src.write_bytes(b"zh title vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": True,
+            "max_title_length": 50,
+            "max_filename_length": 80,
+            "suffix_keywords": [],
+        }
+        # metadata title 空字串 → 迫使走 extracted_title 路徑（title_source=='extracted'）
+        metadata = {
+            "number": "ABC-123",
+            "title": "",         # 空 → 不走 original 路徑
+            "translated_title": "",  # 空 → 不走 translated 路徑
+            "actors": [],
+            "tags": ["單體"],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        # title_source 應為 extracted（確認走了 extract 路徑）
+        assert result.get("title_source") == "extracted", (
+            f"應走 extracted 路徑，實際 title_source={result.get('title_source')!r}"
+        )
+
+        new_path = Path(result["new_filename"])
+        stem = new_path.stem
+
+        # 關鍵斷言：stem 中 _180_LR 恰好出現一次（不雙寫）
+        assert stem.count("_180_LR") == 1, (
+            f"_180_LR 應恰好出現 1 次（不雙寫），實際 stem：{stem!r}，count={stem.count('_180_LR')}"
+        )
+        # stem 應以 _180_LR 結尾
+        assert stem.endswith("_180_LR"), (
+            f"VR tail 應在 stem 最末，實際 stem：{stem!r}"
+        )
+
+        # NFO sidecar：stem 對齊 + <tag>VR</tag> count==1
+        nfo_path = result.get("nfo_path")
+        assert nfo_path is not None, "create_nfo=True 時 nfo_path 不應為 None"
+        nfo_content = Path(nfo_path).read_text(encoding="utf-8")
+        nfo_stem = Path(nfo_path).stem
+        assert nfo_stem == stem, (
+            f"NFO sidecar stem({nfo_stem!r}) 應與影片 stem({stem!r}) 對齊"
+        )
+        assert nfo_stem.count("_180_LR") == 1, (
+            f"NFO sidecar stem _180_LR 也應單一，實際：{nfo_stem!r}"
+        )
+        assert nfo_content.count("<tag>VR</tag>") == 1, (
+            f"NFO <tag>VR</tag> 應恰一個，count={nfo_content.count('<tag>VR</tag>')}"
+        )
+
+    # ---- Codex P2 二次修正（Finding 1, P2）：bracket/paren 包 cluster 不雙寫 ----
+
+    def test_chinese_title_bracket_vr_no_double_write(self, tmp_path):
+        """ABC-123 中文標題_[180_LR].mp4 + create_nfo=True + extracted_title 路徑
+        → 檔名 stem 僅有單一 _180_LR（不雙寫 _[180_LR]_180_LR）
+        且 stem 中不含 '[180_LR]'、NFO <tag>VR</tag> count==1。
+
+        Codex P2 二次修正（Finding 1, P2）：_detect_vr_cluster 回傳 '180_LR'（不含 bracket），
+        但 extract_chinese_title 萃取的 title 保留 '[180_LR]'，舊 endswith 不命中 →
+        bracket 殘留在 title + vr_tail 再接 → 雙寫。
+        修正：regex 匹配可選 bracket 包裝。
+        """
+        src = tmp_path / "ABC-123 中文標題_[180_LR].mp4"
+        src.write_bytes(b"zh bracket vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": True,
+            "max_title_length": 50,
+            "max_filename_length": 80,
+            "suffix_keywords": [],
+        }
+        metadata = {
+            "number": "ABC-123",
+            "title": "",
+            "translated_title": "",
+            "actors": [],
+            "tags": ["單體"],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        assert result.get("title_source") == "extracted", (
+            f"應走 extracted 路徑，實際 title_source={result.get('title_source')!r}"
+        )
+
+        stem = Path(result["new_filename"]).stem
+
+        # 關鍵：stem 中 _180_LR 恰一次（不雙寫）
+        assert stem.count("_180_LR") == 1, (
+            f"_180_LR 應恰好出現 1 次（不雙寫），實際 stem：{stem!r}"
+        )
+        # stem 中不應含原始 bracket 形式
+        assert "[180_LR]" not in stem, (
+            f"stem 中不應含 '[180_LR]'（bracket 殘留），實際 stem：{stem!r}"
+        )
+        # 不應有雙寫形式
+        assert "_180_LR_180_LR" not in stem, (
+            f"stem 中不應有 _180_LR_180_LR（雙寫），實際 stem：{stem!r}"
+        )
+        # stem 以 _180_LR 結尾
+        assert stem.endswith("_180_LR"), (
+            f"VR tail 應在 stem 最末，實際 stem：{stem!r}"
+        )
+
+        nfo_path = result.get("nfo_path")
+        assert nfo_path is not None, "create_nfo=True 時 nfo_path 不應為 None"
+        nfo_content = Path(nfo_path).read_text(encoding="utf-8")
+        assert nfo_content.count("<tag>VR</tag>") == 1, (
+            f"NFO <tag>VR</tag> 應恰一個，count={nfo_content.count('<tag>VR</tag>')}"
+        )
+
+    def test_chinese_title_paren_vr_no_double_write(self, tmp_path):
+        """ABC-123 中文標題_(180_LR).mp4 + create_nfo=True + extracted_title 路徑
+        → 檔名 stem 僅有單一 _180_LR（不雙寫 _(180_LR)_180_LR）
+        且 stem 中不含 '(180_LR)'、NFO <tag>VR</tag> count==1。
+
+        Codex P2 二次修正（Finding 1, P2）：同 bracket case，paren 版本。
+        """
+        src = tmp_path / "ABC-123 中文標題_(180_LR).mp4"
+        src.write_bytes(b"zh paren vr content")
+
+        config = {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": True,
+            "max_title_length": 50,
+            "max_filename_length": 80,
+            "suffix_keywords": [],
+        }
+        metadata = {
+            "number": "ABC-123",
+            "title": "",
+            "translated_title": "",
+            "actors": [],
+            "tags": ["單體"],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        assert result.get("title_source") == "extracted", (
+            f"應走 extracted 路徑，實際 title_source={result.get('title_source')!r}"
+        )
+
+        stem = Path(result["new_filename"]).stem
+
+        assert stem.count("_180_LR") == 1, (
+            f"_180_LR 應恰好出現 1 次（不雙寫），實際 stem：{stem!r}"
+        )
+        assert "(180_LR)" not in stem, (
+            f"stem 中不應含 '(180_LR)'（paren 殘留），實際 stem：{stem!r}"
+        )
+        assert "_180_LR_180_LR" not in stem, (
+            f"stem 中不應有 _180_LR_180_LR（雙寫），實際 stem：{stem!r}"
+        )
+        assert stem.endswith("_180_LR"), (
+            f"VR tail 應在 stem 最末，實際 stem：{stem!r}"
+        )
+
+        nfo_path = result.get("nfo_path")
+        assert nfo_path is not None, "create_nfo=True 時 nfo_path 不應為 None"
+        nfo_content = Path(nfo_path).read_text(encoding="utf-8")
+        assert nfo_content.count("<tag>VR</tag>") == 1, (
+            f"NFO <tag>VR</tag> 應恰一個，count={nfo_content.count('<tag>VR</tag>')}"
         )
 
 

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 from PIL import Image
 
-from core.organizer import _detect_suffixes, format_string, organize_file, crop_to_poster, generate_nfo, extract_chinese_title, download_image, truncate_to_chars, truncate_title
+from core.organizer import _detect_suffixes, format_string, organize_file, crop_to_poster, generate_nfo, extract_chinese_title, download_image, truncate_to_chars, truncate_title, _detect_vr_cluster
 
 
 # ============ _detect_suffixes() 測試 ============
@@ -1869,3 +1869,118 @@ class TestTruncateWindowsTrailingDot:
             if len(text) > limit and limit > 3:
                 assert not r.endswith('.') and not r.endswith(' '), \
                     f"limit={limit}: got {r!r}"
+
+
+# ============ _detect_vr_cluster() 測試 ============
+
+class TestDetectVrCluster:
+    """_detect_vr_cluster() 的單元測試（TDD-lite RED→GREEN）
+
+    命中列：回傳 raw 子字串（原樣大小寫）
+    None 列：回傳 None（守零變化）
+    """
+
+    # ---- 命中列（unique 單獨成立）----
+
+    def test_hit_unique_plus_ambiguous_full(self):
+        """SIVR-123_8K_60fps_180_180x180_3dh_LR → 180_180x180_3dh_LR（unique 3dh + ambiguous 180/LR 共存）"""
+        result = _detect_vr_cluster("SIVR-123_8K_60fps_180_180x180_3dh_LR")
+        assert result == "180_180x180_3dh_LR"
+
+    def test_hit_mkx200_lr(self):
+        """KAVR-001_mkx200_LR → mkx200_LR（unique mkx200 + ambiguous LR）"""
+        result = _detect_vr_cluster("KAVR-001_mkx200_LR")
+        assert result == "mkx200_LR"
+
+    def test_hit_180_sbs(self):
+        """WAVR-456_4096x2048_180_sbs → 180_sbs（ambiguous ×2 共現）"""
+        result = _detect_vr_cluster("WAVR-456_4096x2048_180_sbs")
+        assert result == "180_sbs"
+
+    def test_hit_180_lr(self):
+        """NAME_180_LR → 180_LR（最主流：ambiguous ×2 共現）"""
+        result = _detect_vr_cluster("NAME_180_LR")
+        assert result == "180_LR"
+
+    def test_hit_mixed_case(self):
+        """KAVR-001_MKX200_lr → MKX200_lr（混大小寫原樣回傳，不正規化）"""
+        result = _detect_vr_cluster("KAVR-001_MKX200_lr")
+        assert result == "MKX200_lr"
+
+    def test_hit_4k_nonvr_prefix_excluded(self):
+        """MOVIE-4k_180_3dh_LR → 180_3dh_LR（4k 非 VR token，cluster 從 180 起）"""
+        result = _detect_vr_cluster("MOVIE-4k_180_3dh_LR")
+        assert result == "180_3dh_LR"
+
+    def test_hit_bracket_square(self):
+        """NAME_[180_LR] → 180_LR（bracket 當分隔符，cluster 不含外圍括號）"""
+        result = _detect_vr_cluster("NAME_[180_LR]")
+        assert result == "180_LR"
+
+    def test_hit_bracket_paren(self):
+        """KAVR-001_(mkx200_lr) → mkx200_lr（paren 當分隔符，cluster 不含外圍括號）"""
+        result = _detect_vr_cluster("KAVR-001_(mkx200_lr)")
+        assert result == "mkx200_lr"
+
+    # ---- None 列（守零變化）----
+
+    def test_none_isolated_180(self):
+        """MIRD-180 → None（孤立裸 180，真番號，無共現 VR token）"""
+        result = _detect_vr_cluster("MIRD-180")
+        assert result is None
+
+    def test_none_isolated_360(self):
+        """REBD-360 → None（孤立裸 360，真番號）"""
+        result = _detect_vr_cluster("REBD-360")
+        assert result is None
+
+    def test_none_isolated_lr(self):
+        """title_LR → None（孤立裸 LR，無共現）"""
+        result = _detect_vr_cluster("title_LR")
+        assert result is None
+
+    def test_none_vr_num_no_token(self):
+        """SIVR-999 → None（VR 番號但無 VR token；SIVR/999 皆非集合成員）"""
+        result = _detect_vr_cluster("SIVR-999")
+        assert result is None
+
+    def test_none_color_edition_no_false_lr(self):
+        """ABP-123 [color edition] → None（不誤中 lr：color 非 VR 成員）"""
+        result = _detect_vr_cluster("ABP-123 [color edition]")
+        assert result is None
+
+    def test_none_1080_not_180(self):
+        """STARS-1080 → None（不誤中 180：1080 是獨立 token，exact match 不命中）"""
+        result = _detect_vr_cluster("STARS-1080")
+        assert result is None
+
+    def test_none_bare_vr_tag(self):
+        """[VR] → None（裸 vr 不是訊號；嚴禁進集合）"""
+        result = _detect_vr_cluster("[VR]")
+        assert result is None
+
+    # ---- 含副檔名也應一致 ----
+
+    def test_with_extension_mp4(self):
+        """NAME_180_LR.mp4（含副檔名）→ 180_LR（splitext 去掉 ext）"""
+        result = _detect_vr_cluster("NAME_180_LR.mp4")
+        assert result == "180_LR"
+
+    def test_none_with_extension(self):
+        """MIRD-180.mp4（含副檔名）→ None"""
+        result = _detect_vr_cluster("MIRD-180.mp4")
+        assert result is None
+
+    # --- 防禦性 / branch 補洞（review advisory）---
+    def test_empty_string(self):
+        """空字串 → None（splitext('') → finditer 無命中 → 不炸）"""
+        assert _detect_vr_cluster("") is None
+
+    def test_unique_only_no_ambiguous(self):
+        """單一 unique token、零 ambiguous（unique-only branch）→ 原樣保留"""
+        assert _detect_vr_cluster("fisheye") == "fisheye"
+        assert _detect_vr_cluster("KAVR-001_mkx200") == "mkx200"
+
+    def test_duplicate_ambiguous_satisfies_cooccurrence(self):
+        """兩個相同 ambiguous token（len(ambiguous)>=2）→ 成立"""
+        assert _detect_vr_cluster("NAME_180_180") == "180_180"

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -2276,3 +2276,167 @@ class TestOrganizeVrFilename:
         # 沒有意外 VR tail（無 VR token）
         assert "_180" not in name1 and "_LR" not in name1, f"CD1 意外多了 VR tail：{name1}"
         assert "_180" not in name2 and "_LR" not in name2, f"CD2 意外多了 VR tail：{name2}"
+
+
+# ============ generate_nfo() VR tag/genre 去重測試 (T3) ============
+
+class TestGenerateNfoVrTagDedup:
+    """generate_nfo() has_vr 參數 + tag/genre VR 去重邏輯測試（TASK-68-T3）
+
+    邊界條件來源：68-T3.md 邊界條件表 + plan-68.md CD-68-8/9
+    """
+
+    def test_has_vr_true_no_vr_in_tags_adds_canonical(self, tmp_path):
+        """has_vr=True + tags 無 VR → 補 canonical <tag>VR</tag> + <genre>VR</genre>（各恰一個）"""
+        nfo_path = tmp_path / "SIVR-123.nfo"
+        result = generate_nfo(
+            number="SIVR-123",
+            title="テスト",
+            tags=["巨乳", "單體"],
+            output_path=str(nfo_path),
+            has_vr=True,
+        )
+        assert result is True
+        content = nfo_path.read_text(encoding="utf-8")
+        assert content.count("<tag>VR</tag>") == 1, \
+            f"has_vr=True + 無 VR tags → 應含恰一個 <tag>VR</tag>，content={content!r}"
+        assert content.count("<genre>VR</genre>") == 1, \
+            f"has_vr=True + 無 VR tags → 應含恰一個 <genre>VR</genre>，content={content!r}"
+
+    def test_has_vr_true_scraper_already_has_vr_no_duplicate(self, tmp_path):
+        """has_vr=True + scraper tags 已有 VR → 不重複補 canonical（各恰一個）"""
+        nfo_path = tmp_path / "KAVR-001.nfo"
+        result = generate_nfo(
+            number="KAVR-001",
+            title="テスト",
+            tags=["VR", "單體"],
+            output_path=str(nfo_path),
+            has_vr=True,
+        )
+        assert result is True
+        content = nfo_path.read_text(encoding="utf-8")
+        assert content.count("<tag>VR</tag>") == 1, \
+            f"scraper 已有 VR + has_vr=True → 應仍只有一個 <tag>VR</tag>（不重複）"
+        assert content.count("<genre>VR</genre>") == 1, \
+            f"scraper 已有 VR + has_vr=True → 應仍只有一個 <genre>VR</genre>（不重複）"
+
+    def test_has_vr_true_lowercase_space_variant_no_duplicate(self, tmp_path):
+        """has_vr=True + tags=[' vr ','x']（小寫+空白變體）→ case-insensitive 去重，不補 canonical"""
+        nfo_path = tmp_path / "WAVR-456.nfo"
+        result = generate_nfo(
+            number="WAVR-456",
+            title="テスト",
+            tags=[" vr ", "x"],
+            output_path=str(nfo_path),
+            has_vr=True,
+        )
+        assert result is True
+        content = nfo_path.read_text(encoding="utf-8")
+        # 不可額外補 canonical VR，count 不爆（tag 與 genre 各最多一個 VR 相關 entry）
+        # ` vr ` 由 tags 迴圈寫出（html.escape 後原樣），不補第二個 <tag>VR</tag>
+        assert content.count("<tag>VR</tag>") == 0, \
+            f"小寫/空白 vr 已在 tags → 不應額外補 canonical <tag>VR</tag>"
+        assert content.count("<genre>VR</genre>") == 0, \
+            f"小寫/空白 vr 已在 tags → 不應額外補 canonical <genre>VR</genre>"
+        # 正向：scraper 原始變體仍原樣由 tags 迴圈寫出（去重只擋 canonical，不吞 scraper 條目）
+        assert "<tag> vr </tag>" in content, \
+            "scraper 原始 ' vr ' 變體應原樣寫出（spec §3 邊界表：該變體由 tags 迴圈寫出）"
+        assert "<genre> vr </genre>" in content, \
+            "scraper 原始 ' vr ' 變體 genre 應原樣寫出"
+
+    def test_has_vr_false_no_vr_in_tags_no_vr_written(self, tmp_path):
+        """has_vr=False + tags 無 VR → NFO 完全無 VR tag/genre（不多補）"""
+        nfo_path = tmp_path / "ABP-123.nfo"
+        result = generate_nfo(
+            number="ABP-123",
+            title="テスト",
+            tags=["巨乳"],
+            output_path=str(nfo_path),
+            has_vr=False,
+        )
+        assert result is True
+        content = nfo_path.read_text(encoding="utf-8")
+        assert "<tag>VR</tag>" not in content, \
+            "has_vr=False + 無 VR tags → NFO 不應含 <tag>VR</tag>"
+        assert "<genre>VR</genre>" not in content, \
+            "has_vr=False + 無 VR tags → NFO 不應含 <genre>VR</genre>"
+
+    def test_has_vr_false_scraper_vr_preserved(self, tmp_path):
+        """has_vr=False + scraper tags 含 VR → scraper VR 照寫（不可斷言『無 VR』）"""
+        nfo_path = tmp_path / "STARS-999.nfo"
+        result = generate_nfo(
+            number="STARS-999",
+            title="テスト",
+            tags=["VR", "x"],
+            output_path=str(nfo_path),
+            has_vr=False,
+        )
+        assert result is True
+        content = nfo_path.read_text(encoding="utf-8")
+        # scraper 給的 VR 必須照 tags 路徑寫出（各一）
+        assert content.count("<tag>VR</tag>") == 1, \
+            "has_vr=False + scraper VR → scraper VR tag 應照寫"
+        assert content.count("<genre>VR</genre>") == 1, \
+            "has_vr=False + scraper VR → scraper VR genre 應照寫"
+
+    def test_has_vr_true_with_subtitle_coexist(self, tmp_path):
+        """has_vr=True + has_subtitle=True → VR 與中文字幕 tag/genre 共存（互不干擾）"""
+        nfo_path = tmp_path / "SIVR-VR-C.nfo"
+        result = generate_nfo(
+            number="SIVR-VR-C",
+            title="VR 中字",
+            tags=["巨乳"],
+            output_path=str(nfo_path),
+            has_vr=True,
+            has_subtitle=True,
+        )
+        assert result is True
+        content = nfo_path.read_text(encoding="utf-8")
+        assert content.count("<tag>VR</tag>") == 1, \
+            "has_vr=True + has_subtitle=True → 應含恰一個 <tag>VR</tag>"
+        assert content.count("<genre>VR</genre>") == 1, \
+            "has_vr=True + has_subtitle=True → 應含恰一個 <genre>VR</genre>"
+        assert "<tag>中文字幕</tag>" in content, \
+            "has_subtitle=True 時 <tag>中文字幕</tag> 應仍存在（VR 不干擾中字）"
+        assert "<genre>中文字幕</genre>" in content, \
+            "has_subtitle=True 時 <genre>中文字幕</genre> 應仍存在"
+
+    def test_has_vr_false_no_vr_nfo_byte_identical(self, tmp_path):
+        """has_vr=False（預設）一般檔 → NFO 與未加 has_vr 前 byte 完全相同（CD-68-9）
+
+        兩次呼叫使用同一 output_path（basename 相同），保證 <poster>/<thumb>/<fanart> 不因
+        檔名不同而差異——此測試純粹驗證 has_vr=False 不在 NFO 內容裡新增任何 VR 相關行。
+        """
+        dir_before = tmp_path / "before"
+        dir_after = tmp_path / "after"
+        dir_before.mkdir()
+        dir_after.mkdir()
+        # 兩次用同一 NFO 檔名（basename 相同 → poster/thumb/fanart tag 相同）
+        nfo_path_before = dir_before / "ABP-555.nfo"
+        nfo_path_after = dir_after / "ABP-555.nfo"
+
+        # 「未加 has_vr 前」：不傳 has_vr（使用預設值）
+        generate_nfo(
+            number="ABP-555",
+            title="一般標題",
+            tags=["巨乳", "OL"],
+            actors=["女優A"],
+            date="2024-03-01",
+            maker="Studio",
+            output_path=str(nfo_path_before),
+        )
+        # 「加了 has_vr=False」：明確傳 False
+        generate_nfo(
+            number="ABP-555",
+            title="一般標題",
+            tags=["巨乳", "OL"],
+            actors=["女優A"],
+            date="2024-03-01",
+            maker="Studio",
+            output_path=str(nfo_path_after),
+            has_vr=False,
+        )
+        content_before = nfo_path_before.read_text(encoding="utf-8")
+        content_after = nfo_path_after.read_text(encoding="utf-8")
+        assert content_before == content_after, \
+            f"has_vr=False 應與不傳時完全相同（零變化）\nbefore={content_before!r}\nafter={content_after!r}"

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -2440,3 +2440,216 @@ class TestGenerateNfoVrTagDedup:
         content_after = nfo_path_after.read_text(encoding="utf-8")
         assert content_before == content_after, \
             f"has_vr=False 應與不傳時完全相同（零變化）\nbefore={content_before!r}\nafter={content_after!r}"
+
+
+# ============ organize_file() VR 端到端串接測試 (T4) ============
+
+class TestVrEndToEnd:
+    """organize_file(create_nfo=True) 端到端 wiring 測試（TASK-68-T4）
+
+    核心 gap：T2 用 create_nfo=False，T3 直呼 generate_nfo——
+    未有任何測試同時驗「VR tail 檔名」+「NFO 恰一個 <tag>VR</tag>」。
+
+    本 class 補上這條端到端鏈路：一次 organize_file 呼叫，
+    同時斷言 (a) 檔名 stem tail、(b) NFO VR tag count==1 + genre count==1、
+    (c) NFO sidecar 檔名 stem 與影片對齊（GB sidecar 跟隨）。
+    """
+
+    # ---- 共用 helper ----
+
+    def _base_config(self, tmp_path=None, max_filename_length=60, suffix_keywords=None):
+        return {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": True,
+            "max_title_length": 50,
+            "max_filename_length": max_filename_length,
+            "suffix_keywords": suffix_keywords or [],
+        }
+
+    def _base_metadata(self, number, title, tags=None):
+        return {
+            "number": number,
+            "title": title,
+            "actors": [],
+            "tags": tags or [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+    # ---- T4 DoD: VR 檔（KAVR-001_mkx200_LR.mp4）端到端 ----
+
+    def test_vr_file_filename_tail_and_nfo_vr_tag(self, tmp_path):
+        """KAVR-001_mkx200_LR.mp4 + tags=['單體']（無 VR）→
+        (a) 檔名 stem 結尾 _mkx200_LR
+        (b) NFO 含恰一個 <tag>VR</tag> + 一個 <genre>VR</genre>
+        (c) NFO sidecar 檔名 stem 與影片 stem 對齊（prove GB sidecar 跟隨）
+        """
+        src = tmp_path / "KAVR-001_mkx200_LR.mp4"
+        src.write_bytes(b"vr content")
+
+        config = self._base_config(tmp_path)
+        metadata = self._base_metadata("KAVR-001", "VR Test Title", tags=["單體"])
+
+        result = organize_file(str(src), metadata, config)
+
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        # (a) 檔名 stem 結尾 _mkx200_LR
+        new_path = Path(result["new_filename"])
+        stem = new_path.stem
+        assert stem.endswith("_mkx200_LR"), (
+            f"VR tail _mkx200_LR 未接到 stem 尾：{stem!r}"
+        )
+
+        # (b) NFO 含恰一個 <tag>VR</tag> + 一個 <genre>VR</genre>
+        nfo_path = result.get("nfo_path")
+        assert nfo_path is not None, "create_nfo=True 時 nfo_path 不應為 None"
+        assert Path(nfo_path).exists(), f"NFO 檔不存在：{nfo_path}"
+        nfo_content = Path(nfo_path).read_text(encoding="utf-8")
+        assert nfo_content.count("<tag>VR</tag>") == 1, (
+            f"NFO 應含恰一個 <tag>VR</tag>，count={nfo_content.count('<tag>VR</tag>')}"
+        )
+        assert nfo_content.count("<genre>VR</genre>") == 1, (
+            f"NFO 應含恰一個 <genre>VR</genre>，count={nfo_content.count('<genre>VR</genre>')}"
+        )
+
+        # (c) NFO sidecar 檔名 stem 與影片 stem 對齊（VR tail 隨行，prove GB）
+        nfo_stem = Path(nfo_path).stem
+        assert nfo_stem == stem, (
+            f"NFO sidecar stem({nfo_stem!r}) 應與影片 stem({stem!r}) 完全對齊"
+        )
+        assert nfo_stem.endswith("_mkx200_LR"), (
+            f"NFO sidecar stem 應帶 VR tail：{nfo_stem!r}"
+        )
+
+    def test_vr_file_scraper_already_has_vr_no_duplicate(self, tmp_path):
+        """KAVR-001_mkx200_LR.mp4 + scraper tags=['VR', '單體']
+        → NFO <tag>VR</tag> 恰一個（去重驗端到端不重複）
+        """
+        src = tmp_path / "KAVR-001_mkx200_LR.mp4"
+        src.write_bytes(b"vr content")
+
+        config = self._base_config(tmp_path)
+        metadata = self._base_metadata("KAVR-001", "VR Test", tags=["VR", "單體"])
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        nfo_content = Path(result["nfo_path"]).read_text(encoding="utf-8")
+        assert nfo_content.count("<tag>VR</tag>") == 1, (
+            f"scraper 已有 VR + has_vr=True → 應仍只有一個 <tag>VR</tag>（端到端去重）"
+        )
+        assert nfo_content.count("<genre>VR</genre>") == 1, (
+            f"scraper 已有 VR + has_vr=True → 應仍只有一個 <genre>VR</genre>（端到端去重）"
+        )
+
+    # ---- T4 DoD: 無 VR 檔（SIVR-999.mp4）端到端 ----
+
+    def test_no_vr_file_no_tail_no_canonical_vr_in_nfo(self, tmp_path):
+        """SIVR-999.mp4（無 VR token）+ create_nfo=True →
+        (a) 檔名無 VR tail
+        (b) NFO 無 canonical <tag>VR</tag>（has_vr=False 端到端）
+        """
+        src = tmp_path / "SIVR-999.mp4"
+        src.write_bytes(b"no vr content")
+
+        config = self._base_config(tmp_path)
+        metadata = self._base_metadata("SIVR-999", "Some 2D Title", tags=["單體"])
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        # (a) 檔名無 VR tail
+        new_path = Path(result["new_filename"])
+        stem = new_path.stem
+        assert not stem.endswith(("_LR", "_180", "_mkx200", "_3dh", "_sbs")), (
+            f"無 VR token 檔案不應有 VR tail：{stem!r}"
+        )
+
+        # (b) NFO 無 canonical <tag>VR</tag>（has_vr=False 路徑端到端）
+        nfo_path = result.get("nfo_path")
+        assert nfo_path is not None, "nfo_path 不應為 None"
+        nfo_content = Path(nfo_path).read_text(encoding="utf-8")
+        assert "<tag>VR</tag>" not in nfo_content, (
+            f"SIVR-999（無 VR token）NFO 不應含 canonical <tag>VR</tag>"
+        )
+        assert "<genre>VR</genre>" not in nfo_content, (
+            f"SIVR-999（無 VR token）NFO 不應含 canonical <genre>VR</genre>"
+        )
+
+
+# ============ spec §4 DoD 補洞：Row 3/8 檔名端到端 ============
+
+class TestVrCrossCheck:
+    """spec §4 DoD 表 cross-check 補洞（T4）
+
+    Row 3（WAVR-456_4096x2048_180_sbs.mp4）和 Row 8（KAVR-001_MKX200_lr.mp4）
+    只有 T1 偵測層覆蓋，T2/T3/T4 無 organize_file 檔名層驗證。
+    本 class 補上 organize_file 層的斷言，使 spec §4 全表每列在組裝層都有覆蓋。
+    """
+
+    def _base_config(self, max_filename_length=80):
+        return {
+            "create_folder": False,
+            "filename_format": "[{num}] {title}{suffix}",
+            "download_cover": False,
+            "create_nfo": False,
+            "max_title_length": 50,
+            "max_filename_length": max_filename_length,
+            "suffix_keywords": [],
+        }
+
+    def _base_metadata(self, number, title, tags=None):
+        return {
+            "number": number,
+            "title": title,
+            "actors": [],
+            "tags": tags or [],
+            "maker": "Studio",
+            "date": "2024-01-15",
+            "cover": "",
+            "url": "",
+        }
+
+    def test_row3_wavr_180_sbs_filename_tail(self, tmp_path):
+        """spec §4 Row 3: WAVR-456_4096x2048_180_sbs.mp4 → 檔名 stem 結尾 _180_sbs
+
+        T1 只驗偵測，T2 沒有此 case 的 organize_file 層，T4 補上。
+        """
+        src = tmp_path / "WAVR-456_4096x2048_180_sbs.mp4"
+        src.write_bytes(b"wavr content")
+
+        config = self._base_config()
+        metadata = self._base_metadata("WAVR-456", "VR Title")
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        stem = Path(result["new_filename"]).stem
+        assert stem.endswith("_180_sbs"), (
+            f"spec §4 Row 3: WAVR-456 VR tail 應為 _180_sbs，實際 stem：{stem!r}"
+        )
+
+    def test_row8_mixed_case_filename_tail_preserve_raw(self, tmp_path):
+        """spec §4 Row 8: KAVR-001_MKX200_lr.mp4 → 檔名 stem 結尾 _MKX200_lr（原樣大小寫）
+
+        T1 只驗偵測，T2 沒有此 case 的 organize_file 層，T4 補上。
+        重點：原始大小寫不正規化（MKX200 大寫保留，lr 小寫保留）。
+        """
+        src = tmp_path / "KAVR-001_MKX200_lr.mp4"
+        src.write_bytes(b"mixed case vr content")
+
+        config = self._base_config()
+        metadata = self._base_metadata("KAVR-001", "Mixed Case VR")
+
+        result = organize_file(str(src), metadata, config)
+        assert result["success"] is True, f"organize 失敗: {result.get('error')}"
+
+        stem = Path(result["new_filename"]).stem
+        assert stem.endswith("_MKX200_lr"), (
+            f"spec §4 Row 8: VR tail 大小寫應原樣（_MKX200_lr），實際 stem：{stem!r}"
+        )

--- a/web/app.py
+++ b/web/app.py
@@ -8,7 +8,7 @@ import re
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, HTMLResponse
-from fastapi.staticfiles import StaticFiles
+from web.static_cache import NoCacheStaticFiles
 from fastapi.templating import Jinja2Templates
 
 # 版本號（從 core/version.py 統一管理）
@@ -72,7 +72,7 @@ app = FastAPI(
 )
 
 # 靜態檔案
-app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+app.mount("/static", NoCacheStaticFiles(directory=STATIC_DIR), name="static")
 
 # 模板引擎
 templates = Jinja2Templates(directory=TEMPLATES_DIR)

--- a/web/static_cache.py
+++ b/web/static_cache.py
@@ -1,0 +1,38 @@
+"""
+NoCacheStaticFiles — StaticFiles subclass that injects Cache-Control: no-cache.
+
+目的：根治 heuristic caching。Starlette 原生 StaticFiles 只送 ETag + Last-Modified；
+瀏覽器對「有 Last-Modified 但無 Cache-Control」套用 heuristic freshness（約 (now − Last-Modified) × 10%），
+在 freshness 窗口內不重驗 → 重新部署後同檔名仍吃舊 JS/CSS，直到窗口過期或使用者 hard-reload。
+
+`no-cache` 不是「不快取」；意為「可存快取，但每次必須帶 If-None-Match / If-Modified-Since 重驗」。
+Starlette 已產 ETag + Last-Modified → 未變回 304（空 body），有變才回 200 新版，免 hard-reload。
+
+機制說明（post-construction mutation）：
+  super().file_response(...) 回傳 200 FileResponse 或 304 NotModifiedResponse。
+  對 200 路徑：直接是 FileResponse 物件，headers dict 可寫。
+  對 304 路徑：是 NotModifiedResponse 物件，其 __init__ 在「建構時」已完成白名單過濾，
+  建構後的 headers dict 仍可直接寫入（Python MutableHeaders 不設防）。
+  我們在 super().file_response() 回傳後才 mutate，__init__ 早已執行完畢，
+  白名單不再介入——header 直接寫入即生效。
+  因此 200（FileResponse）與 304（NotModifiedResponse）兩條路均會帶 Cache-Control: no-cache。
+"""
+from fastapi.staticfiles import StaticFiles
+
+
+class NoCacheStaticFiles(StaticFiles):
+    """對 /static 的所有回應加 Cache-Control: no-cache。
+
+    override file_response（同步方法，200 和 304 都經此）。
+    在 super().file_response() 回傳後做 post-construction headers mutation，
+    兩條回應路徑（200 FileResponse / 304 NotModifiedResponse）均有效。
+    """
+
+    def file_response(self, *args, **kwargs):
+        # super 回傳 200 FileResponse 或 304 NotModifiedResponse；
+        # 兩者在 __init__ 執行後 headers dict 仍可直接寫入（post-construction mutation）。
+        # 注意：NotModifiedResponse.__init__ 的白名單過濾在「建構時」已完成；
+        # 我們在建構後才 mutate，故白名單不介入——header 直接寫入即生效。
+        response = super().file_response(*args, **kwargs)
+        response.headers["Cache-Control"] = "no-cache"
+        return response


### PR DESCRIPTION
## 主軸 / Summary

改名時偵測原檔名的 **VR 投影 token**（`_180_LR` / `_3dh` / `mkx200`…）並**原樣保留**到輸出檔名尾端，同時在 NFO 加 `<tag>VR</tag>` + `<genre>VR</genre>`。**無 toggle、無需用戶輸入；檔名無 VR token 時輸出 byte 級零變化。**

*Detects the original filename's VR projection token and preserves it verbatim at the end of the renamed file, plus adds a `VR` tag/genre to the NFO. No toggle, no user input; byte-identical output when there's no VR token.*

**根因**：VR 頭顯播放器（DeoVR / HereSphere / Skybox / Pigasus）100% 靠**檔名 token** 判斷投影/立體格式，不讀 NFO；OpenAver 改名用模板從頭重組檔名 → 原 VR token 被丟掉 → 改名後 VR 檔在頭顯變平面 2D 播放。本 PR 修這個。

純後端、**單檔 `core/organizer.py`**、零新依賴、零 ZIP 影響、零 i18n、零 UI。

## 改了什麼

| Task | 內容 |
|------|------|
| **T1** | `_detect_vr_cluster` 偵測模組 + `_VR_UNIQUE`/`_VR_AMBIGUOUS`：切詞 + 連續 run 共現（高精準，孤立真番號 `MIRD-180`/`REBD-360` → None 守零變化） |
| **T2** | 檔名組裝接 VR tail + S1 獨立截斷 budget（VR cluster 不被 `max_filename_length` 切掉；VR 永遠最後接） |
| **T3** | `generate_nfo` 加 `has_vr` + S2 對 tag/genre 各做 case-insensitive 去重（scraper 已有 VR 不重複） |
| **T4** | 端到端 wiring + spec §4 DoD 全表回歸 |

同梱原 `[Unreleased]` 兩處小修正：`/static` no-cache（根治 stale cache）+「Jellyfin / Emby 圖片模式」正名。

## 偵測契約（高精準）

- **唯一字串 token**（`mkx200`/`180x180`/`3dh`…，無真番號長這樣）單獨成立。
- **高誤判 token**（裸 `180`/`360`/`lr`/`sbs`…）須**同一連續 run 內共現**才算數；散落跨文字不共現。
- 裸 `vr`/`3d`/`200`/`220` 絕不當訊號（SIVR/WAVR/KAVR… 番號含 VR）。
- token 保 raw、不正規化、保大小寫。

## Codex review（兩輪，已 pass）

- **一輪**（P2×2）：whole-stem span → 連續 run 偵測（修散落 token 跨文字誤共現）；消 VR token 在 title 與 tail 雙寫（剝除 extracted_title 尾端 cluster）。
- **二輪**（P2+P3）：bracket/paren 包裝的 cluster 也剝（regex）；多 confirmed run 只取第一個（不 span 把中間 non-VR 文字包進來）。

## 測試

- `tests/unit/test_organizer.py` 新增 VR 測試（5 class、46+ case）：偵測全 DoD 表（命中/None/混大小寫/bracket-paren/誤判防護 `1080`/`color`/`SIVR-999`）+ 檔名組裝（suffix×VR 順序/超長截斷/零變化）+ NFO 去重 + 端到端 + Codex 兩輪回歸。
- 全套 pytest **3588 passed, 2 skipped**（排除 smoke/e2e）+ `npm run lint`（eslint + stylelint）綠。
- 敏感掃描無洩漏、打包清單無變更、capabilities 無變更（純後端零端點）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)