### PR TITLE
v0.9.8 - Dim theme color-encoding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-06-06
+
+本版單一主軸：**dim（暗色）主題色彩編碼修復**（feature/69），純前端 CSS、零後端、零依賴、零 i18n、零 ZIP 影響。問題：切到 dim 主題時大量「靠顏色區分狀態」的 UI 變得無法分辨——有碼 vs 無碼來源膠囊長一樣、metatube 連沒連看不出、segmented 選中態消失、警告 banner 跟一般容器混同。根因兩 factor 疊加：(A) 狀態用 `color-mix(語義色 ≤15%, transparent/surface)` 當背景 tint，dim surface 近黑（oklch 26–31%）把低% 色調吃光；(B) dim 沒 override `--color-primary` → 有碼膠囊掉回 DaisyUI 萊姆綠（139°），與無碼 success 綠（166°）只差 27° → 都綠。修復後每個色彩編碼狀態在 dim 下都能一眼辨識，且 light 主題完全不回歸。
+
+*This release has one theme: **dim (dark) theme color-encoding fix** (feature/69) — pure frontend CSS, zero backend, zero deps, zero i18n, zero ZIP impact. Switching to dim made many "state-by-color" UIs indistinguishable — censored vs uncensored source pills looked identical, metatube connected/not was unreadable, the segmented selection state vanished, warning banners blended into ordinary containers. Two stacked root causes: (A) states used `color-mix(semantic ≤15%, transparent/surface)` as a background tint, and the near-black dim surface (oklch 26–31%) swallows the low-% hue; (B) dim never overrode `--color-primary`, so the censored pill fell back to DaisyUI lime-green (139°), only 27° from the uncensored success green (166°) → both green. After the fix every color-encoded state is legible in dim, with zero light-theme regression.*
+
+### Fixed
+#### 🎨 dim 主題色彩編碼 / dim color encoding
+- **token patch（根 unlock）**：`theme.css` 的 `[data-theme="dim"]` 區補 `--color-primary`（`oklch(0.66 0.04 250)`，與 light 同 250° 冷色家族、調亮供暗底對比、遠離綠相 → 根除膠囊色相碰撞）+ `--color-warning`（`#ff9f0a` Apple dark-mode amber）。cascade 自動改善所有引用這兩 token 的 dim border/文字通道。
+- **來源膠囊**（跨 Settings 掃描來源 / Search / 進階重刮三入口共用）：dim 下有碼（primary 冷藍）vs 無碼（success 綠）一眼可辨；啟用態 tint + solid 色邊；Parts Bin 不可達 warning 色邊；載入 spinner 對比提升。
+- **Settings**：segmented 選中態（亮面 + 1.5px inset accent 環，純結構信號）、suffix-tag（改 oklch + accent 邊）、metatube 已連線 status banner（綠 tint + 3px 左色條）、來源上限/全停用警告 banner、tier-hint / focus 環。
+- **散點**：進階重刮彈窗 inline-error / 取消鈕 / 數字輸入 focus、showcase 取樣鈕、女優別名 primary 膠囊。
+- **color-mix 色相插值修正**（CDP 終驗發現）：tint/border 的 `color-mix` partner 一律用 `transparent`（同 base 慣例）——dim surface 帶藍色相（264°），oklch 與暖色 mix 會沿色相環插值變調（amber→紫）；`transparent` 無色相 → 精準保留語義色。
+
+### Changed
+- **design-system**：補進階重刮彈窗 + metatube 連線 banner 兩 demo（dim 驗證面）；膠囊 999px 白名單標題「5 類」→「7 類」+ 補類 6（source-pill）/ 類 7（segmented）交叉引用卡；過時 notification center 註解修正。修掉新增 demo 引入的 duplicate `id="settings-components"`（Codex P3）。
+
+### Non-Goals（明確不做）
+- 不改 light 主題行為、不換主題 / 不調 surface 明度、不新增第二套狀態色（一律走命名 token）、不碰 design-system 完整 dedupe（→ feature/70）。
+
+### 測試
+- CDP 雙主題實機終驗（design-system demo + 生產 /settings 掃描來源頁）：dim 各色彩編碼狀態可辨（amber 67° / 膠囊 blue 250° vs green 147°）、light computed 全 base 值零回歸。
+- 全套 pytest 綠（unit + integration，排除 smoke / e2e）+ `npm run lint`（eslint + stylelint）綠；無 pytest 守衛（CLAUDE.md lint-guard：CSS 字串守衛歸 stylelint）。
+
 ## [0.9.7] - 2026-06-06
 
 本版主軸：**VR 投影標籤保留 + 自動 VR tag**（feature/68），純後端、單檔 `core/organizer.py`、零新依賴、零 ZIP 影響、零 i18n、零 UI。問題根因：頭顯 App（DeoVR / HereSphere / Skybox / Pigasus）100% 靠「**檔名 token**」判斷 VR 投影/立體格式（`_180_LR` / `_3dh` / `mkx200`…），不讀 NFO；而 OpenAver 改名是用模板從頭重組檔名，原檔名的 VR token **不會被帶過來** → 改名後 VR 檔在頭顯 App 變成平面 2D 播放。本版讓改名時偵測原檔名的 VR token 並**原樣保留**到輸出檔名尾端，同時在 NFO 加一個 `VR` tag/genre。**無 toggle、無需用戶輸入；檔名無 VR token 時輸出 byte 級零變化**（2D 轉檔 / 一般片完全不受影響）。同梱兩處先前的小修正：`/static` no-cache 根治 stale cache、「Jellyfin / Emby 圖片模式」正名。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 VERSION = __version__
 
 # 版本資訊

--- a/web/static/css/components/rescrape-modal.css
+++ b/web/static/css/components/rescrape-modal.css
@@ -280,3 +280,21 @@
         transition: none !important;
     }
 }
+
+/* ─── Dark theme (dim) calibration — feature/69 T4 ───
+ * 近黑 dim surface 吃光低% tint：語義色 banner/按鈕 tint 提至 ~20% + solid 色邊
+ * （混 surface-0 成不透明）。全彩文字已部分救援，本區補背景/邊結構清晰。
+ * 狀態色全走命名 token（--color-warning / --color-error / --accent），無硬編碼。 */
+[data-theme="dim"] .rescrape-inline-error {
+    background: color-mix(in oklch, var(--color-warning) 20%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--color-warning) 50%, var(--surface-0));
+}
+
+[data-theme="dim"] .rescrape-confirm-btn.cancel {
+    background: color-mix(in oklch, var(--color-error) 20%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--color-error) 55%, var(--surface-0));
+}
+
+[data-theme="dim"] .rescrape-num-input:focus {
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 40%, transparent);
+}

--- a/web/static/css/components/rescrape-modal.css
+++ b/web/static/css/components/rescrape-modal.css
@@ -282,17 +282,18 @@
 }
 
 /* ─── Dark theme (dim) calibration — feature/69 T4 ───
- * 近黑 dim surface 吃光低% tint：語義色 banner/按鈕 tint 提至 ~20% + solid 色邊
- * （混 surface-0 成不透明）。全彩文字已部分救援，本區補背景/邊結構清晰。
- * 狀態色全走命名 token（--color-warning / --color-error / --accent），無硬編碼。 */
+ * 近黑 dim surface 吃光低% tint：語義色 banner/按鈕 tint 提至 ~20% + border ~50-55%。
+ * ⚠️ mix partner 用 transparent（同 base 慣例）：dim surface 帶藍色相，oklch 與 warning(70°)
+ * /error(25°) mix 會沿色相環插值變調；transparent 無色相 → 精準保留語義色。
+ * 全彩文字已部分救援，本區補背景/邊結構清晰。狀態色全走命名 token，無硬編碼。 */
 [data-theme="dim"] .rescrape-inline-error {
-    background: color-mix(in oklch, var(--color-warning) 20%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--color-warning) 50%, var(--surface-0));
+    background: color-mix(in oklch, var(--color-warning) 20%, transparent);
+    border-color: color-mix(in oklch, var(--color-warning) 50%, transparent);
 }
 
 [data-theme="dim"] .rescrape-confirm-btn.cancel {
-    background: color-mix(in oklch, var(--color-error) 20%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--color-error) 55%, var(--surface-0));
+    background: color-mix(in oklch, var(--color-error) 20%, transparent);
+    border-color: color-mix(in oklch, var(--color-error) 55%, transparent);
 }
 
 [data-theme="dim"] .rescrape-num-input:focus {

--- a/web/static/css/components/source-pill.css
+++ b/web/static/css/components/source-pill.css
@@ -271,30 +271,31 @@
 
 /* ─── Dark theme (dim) calibration — feature/69 T2 ───
  * 近黑 dim surface（oklch ~26-31%）吃光低% color-mix tint（research §2 Factor A）。
- * 補：enabled tint 10%→22%、border 由 transparent-mix 改 solid-mix（混 surface-0
- * 成不透明色邊）作結構信號。T1 已校準 --color-primary（冷藍）解 Factor B 色相碰撞，
- * 本區只解背景物理隱形 → dim 下有碼(primary 冷藍) vs 無碼(success 綠) 一眼可辨。
- * 狀態色一律走命名 token（--accent / --pill-accent / --color-warning），無硬編碼。 */
+ * 補：提高 tint% + border%。⚠️ mix partner 一律用 transparent（同 base 規則 L50 慣例），
+ * 不混 surface：dim surface 帶藍色相（264°），oklch 與暖色(warning 70°)/綠(success 156°)
+ * mix 會沿色相環插值變調（amber→紫）；transparent 無色相 → 色相精準保留。
+ * T1 已校準 --color-primary（冷藍 250°）解 Factor B → 有碼(primary 冷藍) vs 無碼(success 綠)
+ * 一眼可辨。狀態色全走命名 token（--accent / --pill-accent / --color-warning），無硬編碼。 */
 
-/* P1/P3: enabled 態（有/無碼）— 提 tint + solid 色邊 */
+/* P1/P3: enabled 態（有/無碼）— 提 tint 22% + border 60%（色邊清楚） */
 [data-theme="dim"] .source-pill[data-enabled="true"] {
-    background: color-mix(in oklch, var(--pill-accent) 22%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--pill-accent) 60%, var(--surface-0));
+    background: color-mix(in oklch, var(--pill-accent) 22%, transparent);
+    border-color: color-mix(in oklch, var(--pill-accent) 60%, transparent);
 }
 
-/* P2/P4: inline badge — 提 tint + solid 色邊（dim 下不退化成普通文字） */
+/* P2/P4: inline badge — 提 tint 28% + border 60%（dim 下不退化成普通文字） */
 [data-theme="dim"] .source-pill-badge {
-    background: color-mix(in oklch, var(--accent) 28%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--accent) 60%, var(--surface-0));
+    background: color-mix(in oklch, var(--accent) 28%, transparent);
+    border-color: color-mix(in oklch, var(--accent) 60%, transparent);
 }
 
-/* P7: Parts Bin 不可達 — warning 色邊提強度（slash-icon 已救，補 border 在暗底可見） */
+/* P7: Parts Bin 不可達 — warning 色邊提至 70%（slash-icon 已救，補 border 在暗底可見） */
 [data-theme="dim"] .source-pill.is-partsbin[data-available="false"] {
-    border-color: color-mix(in oklch, var(--color-warning) 70%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--color-warning) 70%, transparent);
 }
 
-/* P8: 載入 spinner — track 由 35%-transparent 改 50%-solid，暗底上轉動對比清楚 */
+/* P8: 載入 spinner — track 由 35% 提至 55%，暗底上轉動對比清楚 */
 [data-theme="dim"] .source-pill .pill-spin {
-    border-color: color-mix(in oklch, var(--pill-accent) 50%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--pill-accent) 55%, transparent);
     border-top-color: var(--pill-accent);
 }

--- a/web/static/css/components/source-pill.css
+++ b/web/static/css/components/source-pill.css
@@ -268,3 +268,33 @@
         animation: source-pill-spin 0.6s linear infinite;
     }
 }
+
+/* ─── Dark theme (dim) calibration — feature/69 T2 ───
+ * 近黑 dim surface（oklch ~26-31%）吃光低% color-mix tint（research §2 Factor A）。
+ * 補：enabled tint 10%→22%、border 由 transparent-mix 改 solid-mix（混 surface-0
+ * 成不透明色邊）作結構信號。T1 已校準 --color-primary（冷藍）解 Factor B 色相碰撞，
+ * 本區只解背景物理隱形 → dim 下有碼(primary 冷藍) vs 無碼(success 綠) 一眼可辨。
+ * 狀態色一律走命名 token（--accent / --pill-accent / --color-warning），無硬編碼。 */
+
+/* P1/P3: enabled 態（有/無碼）— 提 tint + solid 色邊 */
+[data-theme="dim"] .source-pill[data-enabled="true"] {
+    background: color-mix(in oklch, var(--pill-accent) 22%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--pill-accent) 60%, var(--surface-0));
+}
+
+/* P2/P4: inline badge — 提 tint + solid 色邊（dim 下不退化成普通文字） */
+[data-theme="dim"] .source-pill-badge {
+    background: color-mix(in oklch, var(--accent) 28%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--accent) 60%, var(--surface-0));
+}
+
+/* P7: Parts Bin 不可達 — warning 色邊提強度（slash-icon 已救，補 border 在暗底可見） */
+[data-theme="dim"] .source-pill.is-partsbin[data-available="false"] {
+    border-color: color-mix(in oklch, var(--color-warning) 70%, var(--surface-0));
+}
+
+/* P8: 載入 spinner — track 由 35%-transparent 改 50%-solid，暗底上轉動對比清楚 */
+[data-theme="dim"] .source-pill .pill-spin {
+    border-color: color-mix(in oklch, var(--pill-accent) 50%, var(--surface-0));
+    border-top-color: var(--pill-accent);
+}

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -1015,48 +1015,50 @@
 
 /* ==================== Dark theme (dim) calibration — feature/69 T3 ====================
  * 近黑 dim surface 吃光低% color-mix tint（research §2 Factor A）+ segmented 選中態
- * 純靠 surface 對比（無語義色）。修法：警告/連線 banner 提 tint + solid 色邊 + 左色條
- * 作結構信號；segmented 選中態走亮面 + accent 環（L3 純結構，色彩物理救不了）。
- * specificity：[data-theme="dim"] 多一屬性選擇器，穩定勝同名 base 規則。
- * 狀態色全走命名 token（--color-warning / --color-success / --accent），無硬編碼。 */
+ * 純靠 surface 對比（無語義色）。修法：警告/連線 banner 提 tint% + border% + 3px solid 左
+ * 色條作結構信號；segmented 選中態走亮面 + accent 環（L3 純結構，色彩物理救不了）。
+ * ⚠️ tint/border 的 mix partner 一律用 transparent（同 base 慣例）：dim surface 帶藍
+ * 色相(264°)，oklch 與暖色(warning 70°)mix 會沿色相環插值變調(amber→紫)；transparent
+ * 無色相 → 精準保留語義色。左色條/box-shadow 用 solid token 不受影響。
+ * specificity：[data-theme="dim"] 多一屬性選擇器穩定勝 base。狀態色全走命名 token。 */
 
 /* P15: segmented 選中態（純 surface 對比，dim 兩段皆近黑幾乎無差）—
-   亮面提對比 + 1.5px inset accent 環作明確選中指示（L3 結構信號，對齊 Fluent active tab） */
+   亮面提對比（surface+white，無語義色不受插值影響）+ 1.5px inset accent 環作明確選中指示 */
 [data-theme="dim"] #settings-components .settings-sources-segmented button.is-on {
     background: color-mix(in oklch, var(--surface-2), white 16%);
     box-shadow: var(--fluent-shadow-2), inset 0 0 0 1.5px var(--accent);
 }
 
-/* P16: suffix-tag（base 用 srgb 20% 無對比，dim 最糟）— 改 oklch 提 tint + solid accent 邊 */
+/* P16: suffix-tag（base 用 srgb 20% 無對比，dim 最糟）— 改 oklch 提 tint 28% + accent 邊 55% */
 [data-theme="dim"] .suffix-tag {
-    background: color-mix(in oklch, var(--accent) 28%, var(--surface-0));
-    border: 1px solid color-mix(in oklch, var(--accent) 55%, var(--surface-0));
+    background: color-mix(in oklch, var(--accent) 28%, transparent);
+    border: 1px solid color-mix(in oklch, var(--accent) 55%, transparent);
 }
 
-/* P9/P10: metatube 已連線 status banner — 提 tint + solid 邊 + 左色條（綠態明確可辨） */
+/* P9/P10: metatube 已連線 status banner — 提 tint + border + 3px solid 左色條（綠態明確可辨） */
 [data-theme="dim"] #settings-components .settings-mt-connect-status {
-    background: color-mix(in oklch, var(--color-success) 16%, var(--surface-1));
-    border-color: color-mix(in oklch, var(--color-success) 45%, var(--surface-1));
+    background: color-mix(in oklch, var(--color-success) 16%, transparent);
+    border-color: color-mix(in oklch, var(--color-success) 45%, transparent);
     border-left: 3px solid var(--color-success);
 }
 
-/* P11/P12: 來源上限警告 banner — 提 tint + solid 邊 + 左色條 */
+/* P11/P12: 來源上限警告 banner — 提 tint + border + 3px solid 左色條 */
 [data-theme="dim"] #settings-components .settings-sources-cap-alert {
-    background: color-mix(in oklch, var(--color-warning) 18%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--color-warning) 50%, var(--surface-0));
+    background: color-mix(in oklch, var(--color-warning) 18%, transparent);
+    border-color: color-mix(in oklch, var(--color-warning) 50%, transparent);
     border-left: 3px solid var(--color-warning);
 }
 
-/* P13/P14: 全部停用警告 banner — 提 tint + solid 邊 */
+/* P13/P14: 全部停用警告 banner — 提 tint + border */
 [data-theme="dim"] #settings-components .settings-sources-warn {
-    background: color-mix(in oklch, var(--color-warning) 18%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--color-warning) 50%, var(--surface-0));
+    background: color-mix(in oklch, var(--color-warning) 18%, transparent);
+    border-color: color-mix(in oklch, var(--color-warning) 50%, transparent);
 }
 
-/* P17/P18: tier-hint — 提 tint + solid 邊（資訊性，icon 已救，補結構清晰） */
+/* P17/P18: tier-hint — 提 tint + border（資訊性，icon 已救，補結構清晰） */
 [data-theme="dim"] #settings-components .settings-mt-tier-hint {
-    background: color-mix(in oklch, var(--accent) 16%, var(--surface-1));
-    border-color: color-mix(in oklch, var(--accent) 40%, var(--surface-1));
+    background: color-mix(in oklch, var(--accent) 16%, transparent);
+    border-color: color-mix(in oklch, var(--accent) 40%, transparent);
 }
 
 /* P19: mt-field focus 環 — box-shadow 提至 40%（暗底上 22% 不可見；solid border 已救） */

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -1012,3 +1012,54 @@
     }
 
 }
+
+/* ==================== Dark theme (dim) calibration — feature/69 T3 ====================
+ * 近黑 dim surface 吃光低% color-mix tint（research §2 Factor A）+ segmented 選中態
+ * 純靠 surface 對比（無語義色）。修法：警告/連線 banner 提 tint + solid 色邊 + 左色條
+ * 作結構信號；segmented 選中態走亮面 + accent 環（L3 純結構，色彩物理救不了）。
+ * specificity：[data-theme="dim"] 多一屬性選擇器，穩定勝同名 base 規則。
+ * 狀態色全走命名 token（--color-warning / --color-success / --accent），無硬編碼。 */
+
+/* P15: segmented 選中態（純 surface 對比，dim 兩段皆近黑幾乎無差）—
+   亮面提對比 + 1.5px inset accent 環作明確選中指示（L3 結構信號，對齊 Fluent active tab） */
+[data-theme="dim"] #settings-components .settings-sources-segmented button.is-on {
+    background: color-mix(in oklch, var(--surface-2), white 16%);
+    box-shadow: var(--fluent-shadow-2), inset 0 0 0 1.5px var(--accent);
+}
+
+/* P16: suffix-tag（base 用 srgb 20% 無對比，dim 最糟）— 改 oklch 提 tint + solid accent 邊 */
+[data-theme="dim"] .suffix-tag {
+    background: color-mix(in oklch, var(--accent) 28%, var(--surface-0));
+    border: 1px solid color-mix(in oklch, var(--accent) 55%, var(--surface-0));
+}
+
+/* P9/P10: metatube 已連線 status banner — 提 tint + solid 邊 + 左色條（綠態明確可辨） */
+[data-theme="dim"] #settings-components .settings-mt-connect-status {
+    background: color-mix(in oklch, var(--color-success) 16%, var(--surface-1));
+    border-color: color-mix(in oklch, var(--color-success) 45%, var(--surface-1));
+    border-left: 3px solid var(--color-success);
+}
+
+/* P11/P12: 來源上限警告 banner — 提 tint + solid 邊 + 左色條 */
+[data-theme="dim"] #settings-components .settings-sources-cap-alert {
+    background: color-mix(in oklch, var(--color-warning) 18%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--color-warning) 50%, var(--surface-0));
+    border-left: 3px solid var(--color-warning);
+}
+
+/* P13/P14: 全部停用警告 banner — 提 tint + solid 邊 */
+[data-theme="dim"] #settings-components .settings-sources-warn {
+    background: color-mix(in oklch, var(--color-warning) 18%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--color-warning) 50%, var(--surface-0));
+}
+
+/* P17/P18: tier-hint — 提 tint + solid 邊（資訊性，icon 已救，補結構清晰） */
+[data-theme="dim"] #settings-components .settings-mt-tier-hint {
+    background: color-mix(in oklch, var(--accent) 16%, var(--surface-1));
+    border-color: color-mix(in oklch, var(--accent) 40%, var(--surface-1));
+}
+
+/* P19: mt-field focus 環 — box-shadow 提至 40%（暗底上 22% 不可見；solid border 已救） */
+[data-theme="dim"] #settings-components .settings-mt-field input:focus-visible {
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 40%, transparent);
+}

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1915,16 +1915,17 @@ body.sidebar-collapsed .showcase-footer {
     border-color: var(--accent-secondary);
 }
 
-/* Dark theme (dim) calibration — feature/69 T4: 近黑底吃光低% tint，提 tint + solid 色邊。
-   accent-secondary 無 dim override（Apple Blue 暗底可見），只補背景物理隱形。
+/* Dark theme (dim) calibration — feature/69 T4: 近黑底吃光低% tint，提 tint% + border%。
+   mix partner 用 transparent（同 base 慣例，色相安全）。accent-secondary 無 dim override
+   （Apple Blue 暗底可見），只補背景物理隱形。
    hover override 必要：base hover (3 class) specificity 高於 dim resting，否則 hover 反更淡。 */
 [data-theme="dim"] .fetch-samples-btn {
-    background: color-mix(in oklch, var(--accent-secondary) 25%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--accent-secondary) 55%, var(--surface-0));
+    background: color-mix(in oklch, var(--accent-secondary) 25%, transparent);
+    border-color: color-mix(in oklch, var(--accent-secondary) 55%, transparent);
 }
 
 [data-theme="dim"] .fetch-samples-btn:hover:not(:disabled) {
-    background: color-mix(in oklch, var(--accent-secondary) 40%, var(--surface-0));
+    background: color-mix(in oklch, var(--accent-secondary) 40%, transparent);
 }
 
 .fetch-samples-btn:disabled {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1915,6 +1915,18 @@ body.sidebar-collapsed .showcase-footer {
     border-color: var(--accent-secondary);
 }
 
+/* Dark theme (dim) calibration — feature/69 T4: 近黑底吃光低% tint，提 tint + solid 色邊。
+   accent-secondary 無 dim override（Apple Blue 暗底可見），只補背景物理隱形。
+   hover override 必要：base hover (3 class) specificity 高於 dim resting，否則 hover 反更淡。 */
+[data-theme="dim"] .fetch-samples-btn {
+    background: color-mix(in oklch, var(--accent-secondary) 25%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--accent-secondary) 55%, var(--surface-0));
+}
+
+[data-theme="dim"] .fetch-samples-btn:hover:not(:disabled) {
+    background: color-mix(in oklch, var(--accent-secondary) 40%, var(--surface-0));
+}
+
 .fetch-samples-btn:disabled {
     filter: grayscale(1);
     opacity: 0.45;

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -4999,6 +4999,16 @@ body {
     border: 1px solid color-mix(in oklch, var(--accent-pink) 25%, transparent);
   }
 }
+[data-theme="dim"] :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-primary {
+  background: var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    background: color-mix(in oklch, var(--accent-pink) 24%, var(--surface-0));
+  }
+  border-color: var(--accent-pink);
+  @supports (color: color-mix(in lab, red, red)) {
+    border-color: color-mix(in oklch, var(--accent-pink) 50%, var(--surface-0));
+  }
+}
 :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-alias {
   background: var(--color-base-content);
   @supports (color: color-mix(in lab, red, red)) {

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -3,10 +3,10 @@
 @layer theme, base, components, utilities;
 @layer theme {
   :root, :host {
-    --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-    'Noto Color Emoji';
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-    monospace;
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
     --color-black: #000;
     --spacing: 0.25rem;
     --breakpoint-2xl: 96rem;
@@ -57,7 +57,7 @@
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     tab-size: 4;
-    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji');
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
     font-feature-settings: var(--default-font-feature-settings, normal);
     font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
@@ -84,7 +84,7 @@
     font-weight: bolder;
   }
   code, kbd, samp, pre {
-    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
     font-feature-settings: var(--default-mono-font-feature-settings, normal);
     font-variation-settings: var(--default-mono-font-variation-settings, normal);
     font-size: 1em;
@@ -184,13 +184,13 @@
   :-moz-ui-invalid {
     box-shadow: none;
   }
-  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
+  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
     appearance: button;
   }
   ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
     height: auto;
   }
-  [hidden]:where(:not([hidden='until-found'])) {
+  [hidden]:where(:not([hidden="until-found"])) {
     display: none !important;
   }
 }
@@ -457,183 +457,6 @@
       }
     }
   }
-  .menu {
-    @layer daisyui.l1.l2.l3 {
-      display: flex;
-      width: fit-content;
-      flex-direction: column;
-      flex-wrap: wrap;
-      padding: calc(0.25rem * 2);
-      --menu-active-fg: var(--color-neutral-content);
-      --menu-active-bg: var(--color-neutral);
-      font-size: 0.875rem;
-      :where(li ul) {
-        position: relative;
-        margin-inline-start: calc(0.25rem * 4);
-        padding-inline-start: calc(0.25rem * 2);
-        white-space: nowrap;
-        &:before {
-          position: absolute;
-          inset-inline-start: calc(0.25rem * 0);
-          top: calc(0.25rem * 3);
-          bottom: calc(0.25rem * 3);
-          background-color: var(--color-base-content);
-          opacity: 10%;
-          width: var(--border);
-          content: "";
-        }
-      }
-      :where(li > .menu-dropdown:not(.menu-dropdown-show)) {
-        display: none;
-      }
-      :where(li:not(.menu-title) > *:not(ul, details, .menu-title, .btn)), :where(li:not(.menu-title) > details > summary:not(.menu-title)) {
-        display: grid;
-        grid-auto-flow: column;
-        align-content: flex-start;
-        align-items: center;
-        gap: calc(0.25rem * 2);
-        border-radius: var(--radius-field);
-        padding-inline: calc(0.25rem * 3);
-        padding-block: calc(0.25rem * 1.5);
-        text-align: start;
-        transition-property: color, background-color, box-shadow;
-        transition-duration: 0.2s;
-        transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-        grid-auto-columns: minmax(auto, max-content) auto max-content;
-        text-wrap: balance;
-        user-select: none;
-      }
-      :where(li > details > summary) {
-        --tw-outline-style: none;
-        outline-style: none;
-        @media (forced-colors: active) {
-          outline: 2px solid transparent;
-          outline-offset: 2px;
-        }
-        &::-webkit-details-marker {
-          display: none;
-        }
-      }
-      :where(li > details > summary), :where(li > .menu-dropdown-toggle) {
-        &:after {
-          justify-self: flex-end;
-          display: block;
-          height: 0.375rem;
-          width: 0.375rem;
-          rotate: -135deg;
-          translate: 0 -1px;
-          transition-property: rotate, translate;
-          transition-duration: 0.2s;
-          content: "";
-          transform-origin: 50% 50%;
-          box-shadow: 2px 2px inset;
-          pointer-events: none;
-        }
-      }
-      details {
-        overflow: hidden;
-        interpolate-size: allow-keywords;
-      }
-      details::details-content {
-        block-size: 0;
-        @media (prefers-reduced-motion: no-preference) {
-          transition-behavior: allow-discrete;
-          transition-property: block-size, content-visibility;
-          transition-duration: 0.2s;
-          transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-        }
-      }
-      details[open]::details-content {
-        block-size: auto;
-      }
-      :where(li > details[open] > summary):after, :where(li > .menu-dropdown-toggle.menu-dropdown-show):after {
-        rotate: 45deg;
-        translate: 0 1px;
-      }
-      :where( li:not(.menu-title, .disabled) > *:not(ul, details, .menu-title), li:not(.menu-title, .disabled) > details > summary:not(.menu-title) ):not(.menu-active, :active, .btn) {
-        &.menu-focus, &:focus-visible {
-          cursor: pointer;
-          background-color: var(--color-base-content);
-          @supports (color: color-mix(in lab, red, red)) {
-            background-color: color-mix(in oklab, var(--color-base-content) 10%, transparent);
-          }
-          color: var(--color-base-content);
-          --tw-outline-style: none;
-          outline-style: none;
-          @media (forced-colors: active) {
-            outline: 2px solid transparent;
-            outline-offset: 2px;
-          }
-        }
-      }
-      :where( li:not(.menu-title, .disabled) > *:not(ul, details, .menu-title):not(.menu-active, :active, .btn):hover, li:not(.menu-title, .disabled) > details > summary:not(.menu-title):not(.menu-active, :active, .btn):hover ) {
-        cursor: pointer;
-        background-color: var(--color-base-content);
-        @supports (color: color-mix(in lab, red, red)) {
-          background-color: color-mix(in oklab, var(--color-base-content) 10%, transparent);
-        }
-        --tw-outline-style: none;
-        outline-style: none;
-        @media (forced-colors: active) {
-          outline: 2px solid transparent;
-          outline-offset: 2px;
-        }
-        box-shadow: 0 1px oklch(0% 0 0 / 0.01) inset, 0 -1px oklch(100% 0 0 / 0.01) inset;
-      }
-      :where(li:empty) {
-        background-color: var(--color-base-content);
-        opacity: 10%;
-        margin: 0.5rem 1rem;
-        height: 1px;
-      }
-      :where(li) {
-        position: relative;
-        display: flex;
-        flex-shrink: 0;
-        flex-direction: column;
-        flex-wrap: wrap;
-        align-items: stretch;
-        .badge {
-          justify-self: flex-end;
-        }
-        & > *:not(ul, .menu-title, details, .btn):active, & > *:not(ul, .menu-title, details, .btn).menu-active, & > details > summary:active {
-          --tw-outline-style: none;
-          outline-style: none;
-          @media (forced-colors: active) {
-            outline: 2px solid transparent;
-            outline-offset: 2px;
-          }
-          color: var(--menu-active-fg);
-          background-color: var(--menu-active-bg);
-          background-size: auto, calc(var(--noise) * 100%);
-          background-image: none, var(--fx-noise);
-          &:not(&:active) {
-            box-shadow: 0 2px calc(var(--depth) * 3px) -2px var(--menu-active-bg);
-          }
-        }
-        &.menu-disabled {
-          pointer-events: none;
-          color: var(--color-base-content);
-          @supports (color: color-mix(in lab, red, red)) {
-            color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
-          }
-        }
-      }
-      .dropdown:focus-within {
-        .menu-dropdown-toggle:after {
-          rotate: 45deg;
-          translate: 0 1px;
-        }
-      }
-      .dropdown-content {
-        margin-top: calc(0.25rem * 2);
-        padding: calc(0.25rem * 2);
-        &:before {
-          display: none;
-        }
-      }
-    }
-  }
   .dropdown {
     @layer daisyui.l1.l2.l3 {
       position: relative;
@@ -728,6 +551,9 @@
       @layer daisyui.l1.l2.l3 {
         width: unset;
       }
+    }
+    .prose :where(a&:not(.btn-link)):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+      text-decoration-line: none;
     }
     @layer daisyui.l1.l2.l3 {
       display: inline-flex;
@@ -1222,6 +1048,7 @@
         grid-row-start: 1;
         aspect-ratio: 1 / 1;
         height: 100%;
+        width: 100%;
         border-radius: var(--radius-selector);
         background-color: currentcolor;
         translate: 0;
@@ -2551,6 +2378,9 @@
       }
     }
   }
+  .isolate {
+    isolation: isolate;
+  }
   .stack {
     @layer daisyui.l1.l2.l3 {
       display: inline-grid;
@@ -2888,6 +2718,9 @@
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
   }
+  .ml-1 {
+    margin-left: calc(var(--spacing) * 1);
+  }
   .status {
     @layer daisyui.l1.l2.l3 {
       display: inline-block;
@@ -2957,6 +2790,17 @@
       font-size: 0.875rem;
       height: var(--size);
       min-width: var(--size);
+    }
+  }
+  .tabs {
+    @layer daisyui.l1.l2.l3 {
+      display: flex;
+      flex-wrap: wrap;
+      --tabs-height: auto;
+      --tabs-direction: row;
+      --tab-height: calc(var(--size-field, 0.25rem) * 10);
+      height: var(--tabs-height);
+      flex-direction: var(--tabs-direction);
     }
   }
   .footer {
@@ -3037,6 +2881,20 @@
       flex-shrink: 0;
     }
   }
+  .carousel {
+    @layer daisyui.l1.l2.l3 {
+      display: inline-flex;
+      overflow-x: scroll;
+      scroll-snap-type: x mandatory;
+      scrollbar-width: none;
+      @media (prefers-reduced-motion: no-preference) {
+        scroll-behavior: smooth;
+      }
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+  }
   .alert {
     border-width: var(--border);
     border-color: var(--alert-border-color, var(--color-base-200));
@@ -3093,6 +2951,15 @@
       gap: calc(0.25rem * 2);
       font-size: var(--cardtitle-fs, 1.125rem);
       font-weight: 600;
+    }
+  }
+  .mask {
+    @layer daisyui.l1.l2.l3 {
+      display: inline-block;
+      vertical-align: middle;
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
     }
   }
   .block {
@@ -3268,9 +3135,6 @@
   .cursor-not-allowed {
     cursor: not-allowed;
   }
-  .cursor-pointer {
-    cursor: pointer;
-  }
   .resize {
     resize: both;
   }
@@ -3294,9 +3158,6 @@
   }
   .justify-between {
     justify-content: space-between;
-  }
-  .gap-0\.5 {
-    gap: calc(var(--spacing) * 0.5);
   }
   .gap-1 {
     gap: calc(var(--spacing) * 1);
@@ -3337,6 +3198,14 @@
   .border-b {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
+  }
+  .badge-ghost {
+    @layer daisyui.l1.l2 {
+      border-color: var(--color-base-200);
+      background-color: var(--color-base-200);
+      color: var(--color-base-content);
+      background-image: none;
+    }
   }
   .border-base-200 {
     border-color: var(--color-base-200);
@@ -3614,9 +3483,6 @@
     text-transform: uppercase;
   }
   .btn-link {
-    .prose :where(&):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-      text-decoration-line: none;
-    }
     @layer daisyui.l1 {
       text-decoration-line: underline;
       outline-color: currentcolor;
@@ -3633,11 +3499,11 @@
       }
     }
   }
+  .line-through {
+    text-decoration-line: line-through;
+  }
   .opacity-0 {
     opacity: 0%;
-  }
-  .opacity-30 {
-    opacity: 30%;
   }
   .opacity-40 {
     opacity: 40%;
@@ -3650,6 +3516,9 @@
   }
   .opacity-70 {
     opacity: 70%;
+  }
+  .opacity-80 {
+    opacity: 80%;
   }
   .opacity-100 {
     opacity: 100%;
@@ -4416,6 +4285,8 @@ body {
   --glow-error: rgba(255, 69, 58, 0.25);
   --color-success: #30d158;
   --color-translate: oklch(0.72 0.14 260);
+  --color-primary: oklch(0.66 0.04 250);
+  --color-warning: #ff9f0a;
 }
 [data-theme="dim"] .info-icon-btn:hover {
   background: rgba(255, 255, 255, 0.08);
@@ -5664,6 +5535,11 @@ body {
 .fluent-modal::backdrop {
   background-color: var(--fluent-smoke);
   animation: modal-backdrop-fade-in var(--fluent-duration-normal) var(--fluent-ease-standard);
+}
+.fluent-modal.modal-open {
+  background: var(--overlay-modal);
+  backdrop-filter: blur(var(--fluent-blur-light));
+  -webkit-backdrop-filter: blur(var(--fluent-blur-light));
 }
 .fluent-modal-box {
   box-shadow: var(--fluent-shadow-28);

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -5002,11 +5002,11 @@ body {
 [data-theme="dim"] :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-primary {
   background: var(--accent-pink);
   @supports (color: color-mix(in lab, red, red)) {
-    background: color-mix(in oklch, var(--accent-pink) 24%, var(--surface-0));
+    background: color-mix(in oklch, var(--accent-pink) 24%, transparent);
   }
   border-color: var(--accent-pink);
   @supports (color: color-mix(in lab, red, red)) {
-    border-color: color-mix(in oklch, var(--accent-pink) 50%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--accent-pink) 50%, transparent);
   }
 }
 :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-alias {

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -608,6 +608,13 @@ body {
     /* stylelint-disable-next-line color-no-hex -- Apple HIG dark-mode green palette source-of-truth, 2026-05-03 */
     --color-success: #30d158;         /* Dark mode 使用較亮綠 */
     --color-translate: oklch(0.72 0.14 260);
+
+    /* feature/69: dim 色彩編碼修復 — 補 primary/warning dim 校準（root unlock） */
+    /* primary：與 light oklch(32% 0.02 250) 同 250° 冷色家族、調亮供暗底對比；
+       色相 250°（藍）遠離 success 綠相 166° 與 DaisyUI 萊姆 139° → 解膠囊 Factor B 色相碰撞 */
+    --color-primary: oklch(0.66 0.04 250);
+    /* stylelint-disable-next-line color-no-hex -- Apple HIG dark-mode amber palette source-of-truth, 2026-06-06 */
+    --color-warning: #ff9f0a;         /* dim 校準 amber，近黑底不偏暗 */
 }
 
 [data-theme="dim"] .info-icon-btn:hover {

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -1487,6 +1487,12 @@ body {
     border: 1px solid color-mix(in oklch, var(--accent-pink) 25%, transparent);
 }
 
+/* feature/69 T4: dim 近黑底吃光低% tint，提 tint + solid pink 邊（全彩 pink 文字已部分救） */
+[data-theme="dim"] :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-primary {
+    background: color-mix(in oklch, var(--accent-pink) 24%, var(--surface-0));
+    border-color: color-mix(in oklch, var(--accent-pink) 50%, var(--surface-0));
+}
+
 /* Alias pill */
 :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-alias {
     background: color-mix(in oklch, var(--color-base-content) 6%, transparent);

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -1487,10 +1487,11 @@ body {
     border: 1px solid color-mix(in oklch, var(--accent-pink) 25%, transparent);
 }
 
-/* feature/69 T4: dim 近黑底吃光低% tint，提 tint + solid pink 邊（全彩 pink 文字已部分救） */
+/* feature/69 T4: dim 近黑底吃光低% tint，提 tint 24% + pink 邊 50%（全彩 pink 文字已部分救）。
+   mix partner 用 transparent（同 base 慣例，色相安全；混 dim 藍色相 surface 會使 pink 偏紫）。 */
 [data-theme="dim"] :is(#ds-gallery-components, .ds-gallery-composition) .alias-pill-primary {
-    background: color-mix(in oklch, var(--accent-pink) 24%, var(--surface-0));
-    border-color: color-mix(in oklch, var(--accent-pink) 50%, var(--surface-0));
+    background: color-mix(in oklch, var(--accent-pink) 24%, transparent);
+    border-color: color-mix(in oklch, var(--accent-pink) 50%, transparent);
 }
 
 /* Alias pill */

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -880,12 +880,13 @@
                         </div>
                     </div>
 
-                    <!-- 7. segmented 控件容器（完整狀態見下方 §15；需 id=settings-components 啟用 scoped CSS） -->
+                    <!-- 7. segmented 控件容器（白名單僅示意 pill 外形，自包含 inline mock；完整可互動 + dim 校準 demo 見 §15。刻意不 clone 生產 id="settings-components"） -->
                     <div class="ds-pill-card">
-                        <div class="ds-pill-card-demo" id="settings-components" style="display: flex; justify-content: center;">
-                            <div class="settings-sources-segmented" style="pointer-events: none;" aria-hidden="true">
-                                <button type="button" class="is-on">全開</button>
-                                <button type="button">無碼模式</button>
+                        <div class="ds-pill-card-demo" style="display: flex; justify-content: center;">
+                            <!-- 白名單僅示意 pill 外形；可互動 + dim 校準的完整 segmented demo 見 §15（不 clone 生產 id） -->
+                            <div style="display: inline-flex; gap: 2px; padding: 2px; border-radius: var(--radius-pill); background: color-mix(in oklch, var(--surface-1) 60%, transparent); border: 1px solid var(--stroke-subtle);">
+                                <span style="padding: 0.25rem 0.75rem; border-radius: var(--radius-pill); background: color-mix(in oklch, var(--surface-2) 80%, transparent); color: var(--text-primary); font-size: 0.85rem; font-weight: 500;">全開</span>
+                                <span style="padding: 0.25rem 0.75rem; color: var(--text-secondary); font-size: 0.85rem; font-weight: 500;">無碼模式</span>
                             </div>
                         </div>
                         <div class="ds-pill-card-meta">

--- a/web/templates/design-system.html
+++ b/web/templates/design-system.html
@@ -785,8 +785,8 @@
 
             <!-- §1 Pill 999px 白名單 -->
             <div class="ds-subsection">
-                <h3>§1 Pill 999px 白名單（5 類）</h3>
-                <p class="ds-desc">ui-conventions §1：<code>border-radius: 999px</code>（<code>--radius-pill</code>）限這 5 類使用，其他元件用 <code>var(--fluent-radius-*)</code> token。</p>
+                <h3>§1 Pill 999px 白名單（7 類）</h3>
+                <p class="ds-desc">ui-conventions §1：<code>border-radius: 999px</code>（<code>--radius-pill</code>）限這 7 類使用，其他元件用 <code>var(--fluent-radius-*)</code> token。</p>
                 <div class="ds-pill-whitelist-grid">
 
                     <!-- 1. spotlight-search -->
@@ -859,6 +859,38 @@
                         <div class="ds-pill-card-meta">
                             <span class="ds-pill-card-class">類 5 · <code>.sg-open-btn</code> / <code>.fetch-samples-btn</code> / <code>.mode-toggle</code></span>
                             <p class="ds-pill-card-desc">Lightbox / control action pill</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                    <!-- 6. source pill（跨頁共用；完整狀態見下方 §13） -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo" style="display: flex; gap: 0.4rem; flex-wrap: wrap; justify-content: center;">
+                            <div class="source-pill" data-enabled="true" style="pointer-events: none;">
+                                <span class="pill-name">JavBus</span>
+                            </div>
+                            <div class="source-pill source-pill--uncensored" data-enabled="true" style="pointer-events: none;">
+                                <span class="pill-name">AVSOX</span>
+                            </div>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 6 · <code>.source-pill</code></span>
+                            <p class="ds-pill-card-desc">掃描來源開關膠囊（完整狀態見 §13）</p>
+                            <code class="ds-pill-card-token">--radius-pill: 999px</code>
+                        </div>
+                    </div>
+
+                    <!-- 7. segmented 控件容器（完整狀態見下方 §15；需 id=settings-components 啟用 scoped CSS） -->
+                    <div class="ds-pill-card">
+                        <div class="ds-pill-card-demo" id="settings-components" style="display: flex; justify-content: center;">
+                            <div class="settings-sources-segmented" style="pointer-events: none;" aria-hidden="true">
+                                <button type="button" class="is-on">全開</button>
+                                <button type="button">無碼模式</button>
+                            </div>
+                        </div>
+                        <div class="ds-pill-card-meta">
+                            <span class="ds-pill-card-class">類 7 · <code>.settings-sources-segmented</code></span>
+                            <p class="ds-pill-card-desc">搜尋來源 segmented 容器（完整狀態見 §15）</p>
                             <code class="ds-pill-card-token">--radius-pill: 999px</code>
                         </div>
                     </div>
@@ -3065,7 +3097,7 @@
         <!-- Notification Center (53b-T1 demo) -->
         <section id="ds-notif-center" class="ds-section glass"
                  x-data="{
-                     demoDrawerOpen: true,  /* TODO 53b-T4: 接 toggle，本 demo 永遠展開 */
+                     demoDrawerOpen: true,  /* demo 永遠展開；真實鈴鐺 toggle 已在 base.html */
                      demoItemsFull: [],
                      demoItems: [],
                      fakeDataMode: 'has_items',
@@ -3086,7 +3118,7 @@
                      clearAll() { this.demoItems = []; this.fakeDataMode = 'empty'; }
                  }">
             <h2>Notification Center</h2>
-            <p class="ds-note">53b-T1 靜態 demo — 鈴鐺 4 狀態 + 抽屜 4 嚴重度通知樣本。實際 poll / 已讀邏輯 / anchor 定位 / focus trap 在 T2-T5 接入 base.html。</p>
+            <p class="ds-note">53b-T1 靜態 demo — 鈴鐺 4 狀態 + 抽屜 4 嚴重度通知樣本。實際 poll / 已讀邏輯 / anchor 定位 / focus trap 已於 53b-T2~T5 接入 base.html（本頁為靜態樣本登記）。</p>
 
             <!-- Subsection 1: 鈴鐺 4 狀態並排 -->
             <div class="ds-subsection">

--- a/web/templates/design_system/settings-components.html
+++ b/web/templates/design_system/settings-components.html
@@ -850,6 +850,10 @@ mergeState(..., longPressState());
     @click="longPressClickGuard($event) || tapHandler()"&gt;...&lt;/button&gt;</code></pre>
 </div>
 
+<!-- #settings-components scope wrapper：包 §15 segmented + §16 metatube banner 兩個 demo，
+     使 settings.css 的 #settings-components scoped 規則生效（唯一真 id，避免 duplicate id）。 -->
+<div id="settings-components">
+
 <!-- D.15: Segmented 控件 — 全開 | 無碼模式（TASK-64e-2） -->
 <div class="ds-subsection">
     <h3>15. Segmented 控件（全開 | 無碼模式）</h3>
@@ -861,8 +865,8 @@ mergeState(..., longPressState());
         <code>.is-on</code> 態玻璃高亮（backdrop-filter + shadow-2）。<code>prefers-reduced-motion</code> 停 transition。
     </p>
 
-    <!-- 需 id="settings-components" 使 settings.css scoped 規則生效 -->
-    <div class="ds-card-demo" id="settings-components" style="max-width: 600px; margin: 0 auto; padding: 1.5rem;">
+    <!-- scope 由外層 #settings-components wrapper 提供（見上） -->
+    <div class="ds-card-demo" style="max-width: 600px; margin: 0 auto; padding: 1.5rem;">
         <!-- 態一：全開段亮（全開段 .is-on） -->
         <div style="margin-bottom: 1rem;">
             <small style="color: var(--text-muted); display: block; margin-bottom: 0.5rem;">態一：全開段亮（allBuiltinEnabled &amp;&amp; !uncensoredMode）</small>
@@ -910,8 +914,8 @@ mergeState(..., longPressState());
         綠態明確可辨。切 dim 對照即 <strong>P9/P10</strong> 驗證點。
     </p>
 
-    <!-- 需 id="settings-components" 使 settings.css scoped 規則生效 -->
-    <div class="ds-card-demo" id="settings-components" style="max-width: 700px; margin: 0 auto; padding: 1.5rem;">
+    <!-- scope 由外層 #settings-components wrapper 提供（見 §15 之上） -->
+    <div class="ds-card-demo" style="max-width: 700px; margin: 0 auto; padding: 1.5rem;">
         <div class="settings-mt-connect-status" style="pointer-events: none;" aria-hidden="true">
             <i class="bi bi-check-circle-fill" aria-hidden="true"></i>
             <span class="status-text">
@@ -928,6 +932,8 @@ mergeState(..., longPressState());
         </div>
     </div>
 </div>
+
+</div><!-- /#settings-components scope wrapper（§15 + §16）-->
 
 <!-- D.17: 進階重刮彈窗 source picker（step-1）— feature/69 T5 dim 驗證面（P1/P20）-->
 <div class="ds-subsection">

--- a/web/templates/design_system/settings-components.html
+++ b/web/templates/design_system/settings-components.html
@@ -898,3 +898,69 @@ mergeState(..., longPressState());
   &lt;/button&gt;
 &lt;/div&gt;</code></pre>
 </div>
+
+<!-- D.16: metatube 連線狀態 banner — feature/69 T5 dim 驗證面（P9/P10）-->
+<div class="ds-subsection">
+    <h3>16. metatube 連線狀態 banner（已連線態）</h3>
+    <p class="ds-desc">
+        掃描來源卡 metatube 區「已連線」狀態列（<code>.settings-mt-connect-status</code>，僅 <code>metatubeConnected</code> 分支渲染；
+        未連線是 connect form 非 banner）。綠 ✓ + 伺服器 URL + 編輯／中斷／重測 mini 鈕，下接 tier-hint。
+        CSS scope：<code>#settings-components</code>。
+        <strong>dim 校準（69 T3）</strong>：近黑底吃光 8% success tint → 提 tint 16% + solid 邊 + 3px 左色條，
+        綠態明確可辨。切 dim 對照即 <strong>P9/P10</strong> 驗證點。
+    </p>
+
+    <!-- 需 id="settings-components" 使 settings.css scoped 規則生效 -->
+    <div class="ds-card-demo" id="settings-components" style="max-width: 700px; margin: 0 auto; padding: 1.5rem;">
+        <div class="settings-mt-connect-status" style="pointer-events: none;" aria-hidden="true">
+            <i class="bi bi-check-circle-fill" aria-hidden="true"></i>
+            <span class="status-text">
+                已連線 metatube
+                <code>http://192.168.1.50:8090</code>
+            </span>
+            <button type="button" class="settings-sources-mini-btn"><i class="bi bi-pencil"></i> 編輯</button>
+            <button type="button" class="settings-sources-mini-btn"><i class="bi bi-x-circle"></i> 中斷</button>
+            <button type="button" class="settings-sources-mini-btn"><i class="bi bi-arrow-clockwise"></i> 重測</button>
+        </div>
+        <div class="settings-mt-tier-hint" style="margin-top: 0.6rem;">
+            <i class="bi bi-stars" aria-hidden="true"></i>
+            <span>已連線 metatube，30+ provider 可用於進階重刮與搜尋。</span>
+        </div>
+    </div>
+</div>
+
+<!-- D.17: 進階重刮彈窗 source picker（step-1）— feature/69 T5 dim 驗證面（P1/P20）-->
+<div class="ds-subsection">
+    <h3>17. 進階重刮彈窗 — 來源 picker（step-1）</h3>
+    <p class="ds-desc">
+        🔄 長壓開的進階重刮彈窗 step-1「挑來源」視圖（<code>_rescrape_modal.html</code>）。
+        重用 <code>.source-pill--action</code>（點擊式非拖曳）：auto pill + builtin（有碼／無碼）+ metatube pill（<code>m</code> 角標）；
+        找不到番號就地顯示 <code>.rescrape-inline-error</code>（不換頁）。
+        <strong>dim 校準（69 T2/T4）</strong>：膠囊有碼／無碼一眼可辨（<strong>P1</strong>）、inline-error warning 提 tint + solid 邊（<strong>P20</strong>）。
+        切 dim 對照即 P1/P20 驗證點。
+    </p>
+
+    <div class="ds-card-demo" style="max-width: 700px; margin: 0 auto; padding: 1.5rem;">
+        <label class="rescrape-label" style="display: block; margin-bottom: 0.6rem;">挑選刮削來源</label>
+        <div class="source-pill-row" style="display: flex; flex-wrap: wrap; gap: 8px; pointer-events: none;" aria-hidden="true">
+            <button type="button" class="source-pill source-pill--action" data-enabled="true">
+                <i class="bi bi-stars" aria-hidden="true"></i>
+                <span class="pill-name">自動選擇</span>
+            </button>
+            <button type="button" class="source-pill source-pill--action" data-enabled="true">
+                <span class="pill-name">JavBus</span>
+            </button>
+            <button type="button" class="source-pill source-pill--action source-pill--uncensored" data-enabled="true">
+                <span class="pill-name">AVSOX</span>
+            </button>
+            <button type="button" class="source-pill source-pill--action" data-enabled="true">
+                <span class="pill-name">JAV321</span>
+                <span class="source-pill-mt-badge" aria-hidden="true">m</span>
+            </button>
+        </div>
+        <div class="rescrape-inline-error" style="margin-top: 0.7rem; pointer-events: none;" aria-hidden="true">
+            <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
+            <span>找不到此番號，換個來源或確認番號正確</span>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## 摘要 / Summary

修復 **dim（暗色）主題色彩編碼失效**：切到 dim 時大量「靠顏色區分狀態」的 UI 變得無法分辨。純前端 CSS、零後端/依賴/i18n/ZIP，**light 主題零回歸**。

Fixes the **dim theme color-encoding failure**: switching to dim made many "state-by-color" UIs indistinguishable. Pure frontend CSS, zero backend/deps/i18n/ZIP, **zero light-theme regression**.

## 根因 / Root cause

兩 factor 疊加：
- **A**：狀態用 `color-mix(語義色 ≤15%, transparent/surface)` 當 tint，dim 近黑 surface（oklch 26–31%）吃光低% 色調。
- **B**：dim 漏 override `--color-primary` → 有碼膠囊掉回 DaisyUI 萊姆綠（139°），與無碼 success 綠（166°）只差 27° → 都綠。

## 修法（Hybrid）/ Fix

- **T1 token patch**：`theme.css` dim 區補 `--color-primary`（冷藍 250°，根治色相碰撞）+ `--color-warning`（amber），cascade 自動修引用者。
- **T2–T4**：source-pill / settings / 散點 per-instance dim 提 tint + solid 色邊 + segmented 結構信號。
- **T5**：design-system 補進階重刮 + metatube banner dim 驗證 demo（選項 A）+ 白名單 5→7。
- **T6 終驗發現修正**：`color-mix` partner 一律用 `transparent`（避 oklch 色相環插值把 amber 變紫）。

## 驗證 / Verification

- CDP 雙主題實機終驗（design-system demo + 生產 /settings 掃描來源頁）：dim 各狀態可辨（amber 67° / 膠囊 blue 250° vs green 147°），light computed 全 base 值零回歸。
- 全套 pytest **3589 passed, 2 skipped**；`npm run lint`（eslint + stylelint）綠。
- Codex 兩輪 review 已修（duplicate `id="settings-components"` + card7 token 化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)