### PR TITLE
v0.10.2 - Mobile display polish & search detail density rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-06-19
+
+本版主軸：**前端呈現優化合輯——行動裝置相容 + 搜尋詳情資訊密度重排**（feature/75）。純前端（CSS / Jinja template / 少量 JS 門檻），**零後端 / DB / serializer / API 改動**。緣起：owner 籌備開放同 LAN 手機連上同一台 server，把三組「以後再說」的呈現痛點推進「本版必修」——搜尋詳情右欄稀疏、翻譯標題沉底；JAV 橫式完整封包封面被裁得帶脊帶封背；以及 hover-only 操作 / scroll trap / JS↔CSS 斷點不一致 / tablet toolbar 裂版等讓真實手機無法操作的缺口。本版分兩階段（plan-75a：封面裁切共用規則 + 行動基礎相容 + 手機相似模式；plan-75b：搜尋詳情重排 + showcase 影片卡 poster 格），並追加燈箱封面去 letterbox 死白、grid→燈箱動畫落地接縫修復，最後把整套行動修正移植到結構近乎雙胞胎的搜尋頁。
+
+### Added
+#### 🔍 搜尋詳情資訊密度重排（US1）/ Search detail density rework
+- 中文翻譯標題區塊從右欄最底**上移到番號下方、metadata 上方**（不再需捲過 8 個稀疏 row 才看到翻譯）；右欄加寬 320→390px；取消 `.av-card-full-body` 撐高（top-pack，消除大視窗下片名與 metadata 間的拉伸留白）。
+- metadata 改**雙欄緊湊排版**：發行日期｜片長、片商｜廠牌各兩兩並排（`.info-grid-pair`），演員 / 系列 / 導演 / Tags 各佔獨行；全欄改 inline label-value（取消舊「label 在上、值在下」block 排法）。≤1024px 折疊單欄時雙欄自動回單欄。
+
+#### 🖼️ 封面正面裁切共用規則（US2）/ Poster-crop shared rule
+- 新增 `--poster-crop-ratio`（≈0.71，直式）CSS 變數作單一真理；JAV 完整橫式封包封面只露「封面正面」（`object-position: right center`，取消舊 `100% 20%` 帶脊帶封背的裁法）。星空 slot / 相似主片 / motion-lab clip 三處裁切點統一引用同一規則。
+
+#### 📱 行動裝置基礎相容 + 手機相似模式（US3 / US4）/ Mobile compatibility + similar mode
+- **US3 四小修**：搜尋詳情手機可垂直捲動（解 scroll trap）；星空白屏修復（JS bail-to-mobile 門檻與 CSS 隱藏門檻對齊 768→960）；`pointer: coarse` 觸控裝置下 showcase 影片卡 overlay / footer 標題 / 女優卡 overlay 常駐可達（不需 hover）；tablet（769–1023px）toolbar 補規則不裂版。
+- **US4 手機相似模式重整**：手機點星空進「主片 + 4 相似推薦」乾淨視圖——修好「只渲染 2 片 / 點不到 / 主片文字被蓋」，相似區移到 metadata 前、主片精簡呈現、4 片全可見可點。
+
+#### 🎴 行動裝置 showcase + 搜尋影片卡 poster 格（US5 / T9）/ Mobile poster grid
+- **≤480px** showcase 影片卡改**直式 3 欄 poster 格**（比照女優格），番號單行 ellipsis、女優名次行隱藏；桌面 / tablet 維持橫式 3:2 不變。
+- **搜尋頁 grid+lightbox 同款行動修正**（T9）：搜尋頁是 showcase 的近雙胞胎（共用 showcase.css / ghost-fly / 燈箱 DOM、卡片 class 相同），把 3 欄 poster 格 / caption / 觸控 footer 還原 / 燈箱封面去 letterbox / grid→燈箱動畫旗標全部 port 到搜尋頁；全進 search.css，showcase 端零改動。
+
+### Changed
+- **燈箱封面貼合原圖比例消死白**（T8）：≤480px 影片燈箱封面從 `object-fit:contain` 在 60vh 高框 letterbox（上下大片死白）改為貼合原圖比例（容器 + img 皆 gate `.has-cover`）；副作用順帶根治 grid→燈箱動畫落地的 cover→contain 接縫（盒比例=圖比例後兩者等價）。女優燈箱、無封面 / 404 影片燈箱皆以 `.has-cover` 三條件排除、不受影響。
+
+### Fixed
+- **grid→燈箱 ghost-fly 落地變形**（T7）：≤480px poster 格縮圖（cover 右半）飛進燈箱（完整封面）落地瞬間 cover→contain 硬切變形；改為 ghost 對齊縮圖右裁 + 落地 0.12s crossfade 溶接（女優模式比例對稱、無此問題）。
+- **觸控 poster 格番號 caption 被標題層蓋住**（Codex P1）：US3c 的 `@media(pointer:coarse)` 無條件把 `.footer-default` 藏起、改顯 `.footer-hover` 標題層，導致 US5 的番號截斷作用在不可見層；補 `≤480px ∩ pointer:coarse` 交集規則還原番號層。
+- **無封面 / 404 影片燈箱塌盒**（Codex P2）：`.has-cover` gate 加上 `!actressLightboxMode() && !!cover && !_heroLightboxImageError` 三條件，避免封面缺失時 `min-height:0` 把 cover 區（含絕對定位的 placeholder / 動作鈕）塌成 0 高。
+
+### Internal
+- poster-crop / has-cover / posterCrop 旗標等裁切邏輯一律封裝在 `ghost-fly.js` / token，呼叫端（state-lightbox.js / grid-mode.js）只傳中性旗標，守住 `test_ghost_fly_cropmode` 邊界。搜尋頁 port 採 Parallel（獨立 `.search-grid` / `.search-container` 規則）而非 widen showcase 選擇器，避免動到已驗證的 showcase 規則與守衛；判別子用 `.search-container`（頁面根）隔離兩頁。
+- 新增 stylelint rule 禁 `object-position: 100% 20%`（CSS 層），inline HTML 與 selector-scoped 檢查走 pytest（依 CLAUDE.md lint 守衛路由）。
+
+### Non-Goals（明確不做）
+- **不做完整 RWD 星空**（手機正確 fallback 到靜態相似列表，星空動畫保持桌面專屬）、**不為無碼封面特判裁切**（一律套同一右裁規則）、**不改後端搜尋路由 / DB / serializer / API 欄位**（pure frontend）、**不改桌面/tablet showcase 影片卡橫式 3:2**、**不在搜尋詳情新增 plot/description 欄位**（只重排現有欄位）、**不改 showcase 燈箱桌面版 metadata 排版**。
+
+### 測試
+- 全套 pytest **4308 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較 0.10.1 的 4249 +59）+ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（pre-merge live 健康檢查）。
+- 新增測試：US1 搜尋詳情重排守衛（標題置頂 / grid-pair / id 保留 / 右欄 CSS）、US2 poster-crop token + 三裁切點、US3 門檻對齊 + similar safety、US4 手機相似 DOM 順序 + JS 門檻、US5 showcase 3 欄 + poster-crop scope + caption、T7 ghost-fly crossfade 契約、T8 cover-fit、T9 搜尋頁 port（`TestUS9SearchGridMobileFix`）等前端守衛；既有 `TestSwitchSourceBtnRemoved` regex 隨 US1 DOM 重排更新。
+- **transient-guard**（下個 milestone 評估刪除）：本版多條「單向遷移後不回退」負向守衛——US1 footer wrapper rename、poster-crop 值/門檻遷移（`100% 20%` / `width:120px` / `4/5` / threshold 768 / 單欄 `1fr`）等標記 `[transient-guard]`；`TestSimilarSlotGsapGuard` 的整檔 JS 字面 ban 屬「應為 eslint 但 CI 未跑 eslint」的 CI backstop，保留至 `npm run lint` 進 CI。
+
 ## [0.10.1] - 2026-06-18
 
 本版主軸：**進階搜尋發現性重設計（來源膠囊常駐化）+ 畢業退 toggle + 全面零長壓**（feature/74）。「自訂來源搜尋／挑來源重刮」這個 power 功能過去只能靠**隱形長壓**觸發——畫面零提示、桌面用戶幾乎不長壓，等於對沒讀文件的人隱形；而 🔄 鈕又一顆扛兩意圖（tap=重整、長壓=挑來源）。本版把「來源範圍」從隱藏模式改成**處處可見的來源膠囊**：搜尋列打字後浮出「自動」膠囊（點開挑單一來源）、結果面板把 🔄 換成常駐「目前來源膠囊」（顯示這筆是哪個源找到的 + 點擊換源）、換來源預覽改用唯讀膠囊讓截圖一眼辨識來源。同時**全面移除所有長壓手勢**（覆寫舊「降級保留」決定）、把 Showcase 進階重刮收斂到燈箱齒輪 ⚙，並讓進階搜尋正式**畢業為永久常駐核心**（移除 Settings 開關 + config 欄位 + 一次性 migration）。**後端搜尋路由零改動**（Active Row 仍是唯一真理，本版只改入口可見性）。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 VERSION = __version__
 
 # 版本資訊

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -15,6 +15,7 @@ module.exports = {
       '/^(-webkit-)?(backdrop-)?filter$/': ['/blur\\(\\s*\\d+px/'],
       'box-shadow': ['/\\brgba\\(\\s*\\d/'],
       'border-radius': ['/^\\d+px/'],
+      'object-position': ['/100%\\s+20%/'],
     },
     'selector-disallowed-list': ['/:is\\([^)]*manual-input/'],
     // Standard config rules relaxed for OpenAver's existing CSS conventions

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4691,9 +4691,9 @@ class TestSearchCssHardcoded:
 
     HARDCODED_RGBA_ALLOWLIST = {
         # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：788→840；90 在插入點上方不變。
-        # T9-port 在 L718 後插入 ~61 行（3-col + poster-crop + coarse + cover-fit blocks）：840→902。
+        # T9-port 在 L718 後插入 blocks：840→902；T9 Codex-P2 fix 補註解 +4 行：902→906。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        902: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        906: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
@@ -11968,6 +11968,21 @@ class TestUS9SearchGridMobileFix:
         m4 = re.search(r'\.footer-default \.av-num \{([^}]*)\}', block)
         assert m4, "找不到 .footer-default .av-num 規則"
         assert "text-overflow: ellipsis" in m4.group(1), ".av-num（番號）應單行 ellipsis"
+
+    def test_search_grid_scope_is_compound_not_descendant(self):
+        """Codex P2 回歸守衛：search grid 的 scope class 在 .search-grid 元素本身
+        （`<div class="search-grid ds-gallery-composition">`），故 :is(…) 必須**複合**接 .search-grid（無空格）。
+        後代形式 `:is(…) .search-grid`（有空格）要求 scope 在「祖先」→ search 無此祖先 → 永不命中（silent no-op）。
+        靜態守衛抓不到「runtime 是否命中」，但能鎖死「複合 vs 後代」這個唯一致命差別。
+        三問：把任一 :is(…).search-grid 改回 :is(…) .search-grid（加一個空格）→ 紅。
+        """
+        css = self._strip_comments(self._search_css())
+        assert ":is(#ds-gallery-components, .ds-gallery-composition).search-grid" in css, (
+            "search.css 的 .search-grid scope 規則必須用複合 :is(…).search-grid（scope class 在 grid 本身，非祖先）"
+        )
+        assert ":is(#ds-gallery-components, .ds-gallery-composition) .search-grid" not in css, (
+            "search.css 不得用後代 :is(…) .search-grid（有空格）——scope 在 grid 本身、後代選擇器永不命中（Codex P2 silent no-op）"
+        )
 
     def test_search_touch_narrow_reshows_footer_default(self):
         """T5：≤480px ∩ pointer:coarse .search-grid 還原 .footer-default（番號層）+ 壓 .footer-hover。

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11736,3 +11736,63 @@ class TestUS5PosterCropScoped:
         assert "opacity: 0" in mh.group(1), (
             "≤480px ∩ coarse poster 格應把 .footer-hover opacity:0（標題層在 107px 窄格不可讀）"
         )
+
+
+# ============================================================================
+# TASK-75b-T7（CD-75b-12）：≤480px poster 格 → lightbox ghost-fly 溶接守衛
+# 跨檔契約：state-lightbox.js 計算並傳 posterCrop → ghost-fly.js 消費（對齊右裁 + 落地 crossfade）
+# ============================================================================
+
+GHOST_FLY_JS = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "shared" / "ghost-fly.js"
+STATE_LIGHTBOX_JS = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "showcase" / "state-lightbox.js"
+
+
+class TestUS5PosterCropGhostCrossfade:
+    """TASK-75b-T7：poster 格開燈箱的 cover→contain 溶接（Codex 視覺 bug2）。
+
+    契約：state-lightbox.js 依「≤480px ∩ 非女優模式 ∩ 非 hero」算 posterCrop 並傳給
+    playGridToLightbox；ghost-fly.js 在 posterCrop 下對齊縮圖右裁（objectPosition right center）
+    並於落地 crossfade（coverEl 淡入 + ghost 淡出 0.12s）取代硬切 cleanupGhost。
+    三問：刪 posterCrop 傳遞 → 紅；刪 objectPosition 對齊 → 紅；把 crossfade 改回硬切 → 紅。
+    """
+
+    def _grid_to_lightbox_body(self) -> str:
+        js = GHOST_FLY_JS.read_text(encoding="utf-8")
+        start = js.find("playGridToLightbox: function")
+        assert start >= 0, "ghost-fly.js 找不到 playGridToLightbox"
+        end = js.find("playLightboxToGrid: function", start)
+        assert end > start, "ghost-fly.js 找不到 playGridToLightbox 結束邊界"
+        return js[start:end]
+
+    def test_state_lightbox_threads_poster_crop(self):
+        js = STATE_LIGHTBOX_JS.read_text(encoding="utf-8")
+        # 計算條件三要素
+        assert "posterCrop" in js, "state-lightbox.js 應計算 posterCrop"
+        assert "window.innerWidth <= 480" in js, "posterCrop 應 gate ≤480px"
+        assert "showFavoriteActresses" in js, "posterCrop 應排除女優模式"
+        assert "hero-card" in js, "posterCrop 應排除 hero 卡（女優入口）"
+        # 傳入 playGridToLightbox 的 options
+        assert "posterCrop: posterCrop" in js, (
+            "state-lightbox.js 應把 posterCrop 傳入 playGridToLightbox options"
+        )
+
+    def test_ghost_fly_consumes_and_aligns_crop(self):
+        body = self._grid_to_lightbox_body()
+        assert "options.posterCrop" in body, "playGridToLightbox 應消費 options.posterCrop"
+        # (A) 對齊縮圖右裁
+        assert "objectPosition = 'right center'" in body, (
+            "posterCrop 下 ghost 應對齊縮圖 objectPosition right center（消起飛 pan）"
+        )
+
+    def test_ghost_fly_landing_crossfade(self):
+        body = self._grid_to_lightbox_body()
+        # (D) 落地 crossfade：coverEl 淡入 + ghost 淡出，且綁在 posterCrop 分支
+        assert "posterCrop && coverEl" in body, (
+            "落地 crossfade 應 gate 在 posterCrop（非 poster 路徑維持硬切 cleanupGhost）"
+        )
+        assert "opacity: 1, duration: 0.12" in body, "coverEl 應 0.12s 淡入（contain 真圖浮現）"
+        assert "opacity: 0, duration: 0.12" in body, "ghost 應 0.12s 淡出（溶接 cover→contain）"
+        # 非 poster 仍走硬切 cleanupGhost
+        assert "cleanupGhost(ghost, coverEl)" in body, (
+            "非 posterCrop 路徑應保留硬切 cleanupGhost（桌面零回歸）"
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4690,16 +4690,16 @@ class TestSearchCssHardcoded:
     SEARCH_CSS = PROJECT_ROOT / "web/static/css/pages/search.css"
 
     HARDCODED_RGBA_ALLOWLIST = {
-        # T2.1 commit 41f2a5b 後狀態：
+        # T2.1 commit 41f2a5b 後狀態（75a-T2 search.css US3a 插入 +8 行後行號順移）：
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        780: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        788: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
-        # T2.2 commit 89d52b6 後狀態：
+        # T2.2 commit 89d52b6 後狀態（75a-T2 search.css US3a 插入 +8 行後 516/571 順移為 524/579；235 在插入點上方不變）：
         235: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
-        516: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
-        571: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
+        524: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
+        579: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
     }
 
     def _scan(self, regex: str, allowlist=None):
@@ -11064,3 +11064,381 @@ class TestRescrapePreviewEffectiveSource:
         assert "sourceCensored" in body and "is_censored" in body and "?? true" in body, (
             f"rescrapePreview 必須含 sourceCensored: ...is_censored ?? true；body: {body!r}"
         )
+
+
+# ── 75a-T4 path constants ──────────────────────────────────────────────────
+CONSTELLATION_ANIMATIONS_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "shared" / "constellation" / "animations.js"
+)
+T4_STATE_SIMILAR_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "pages" / "showcase" / "state-similar.js"
+)
+T4_SHOWCASE_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "showcase.css"
+T4_THEME_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "theme.css"
+T4_MOTION_LAB_HTML = Path(__file__).parent.parent.parent / "web" / "templates" / "motion_lab.html"
+T4_SHOWCASE_HTML = Path(__file__).parent.parent.parent / "web" / "templates" / "showcase.html"
+
+
+class TestPosterCropCSSGuard:
+    """75a-T4: poster-crop token 守衛 — theme.css 變數 + showcase.css selector-bound 斷言。
+
+    涵蓋：
+    - theme.css 含 --poster-crop-ratio: 0.71
+    - .poster-crop rule block 含 var(--poster-crop-ratio) + right center，不含 71/100
+    - showcase.css .similar-slot-img block 含 right center，不含 100% 20%
+    - showcase.css .similar-main-static block 含 width: 178px，不含 width: 200px
+    """
+
+    def _theme(self):
+        return T4_THEME_CSS.read_text(encoding="utf-8")
+
+    def _css(self):
+        return T4_SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def test_poster_crop_ratio_token_value(self):
+        """theme.css 含 --poster-crop-ratio: 0.71"""
+        css = self._theme()
+        assert "--poster-crop-ratio: 0.71" in css, \
+            "theme.css missing: --poster-crop-ratio: 0.71"
+
+    def test_poster_crop_class_uses_token(self):
+        """.poster-crop rule block 含 var(--poster-crop-ratio)"""
+        css = self._theme()
+        match = re.search(r'\.poster-crop\s*\{([^}]+)\}', css)
+        assert match, "theme.css: .poster-crop selector not found"
+        block = match.group(1)
+        assert "var(--poster-crop-ratio)" in block, \
+            ".poster-crop block must contain var(--poster-crop-ratio)"
+
+    def test_poster_crop_class_has_right_center(self):
+        """.poster-crop rule block 含 right center"""
+        css = self._theme()
+        match = re.search(r'\.poster-crop\s*\{([^}]+)\}', css)
+        assert match, "theme.css: .poster-crop selector not found"
+        block = match.group(1)
+        assert "right center" in block, \
+            ".poster-crop block must contain object-position: right center"
+
+    def test_poster_crop_class_no_hardcoded_ratio(self):
+        """.poster-crop rule block 不含 71/100 硬編碼比例"""
+        css = self._theme()
+        match = re.search(r'\.poster-crop\s*\{([^}]+)\}', css)
+        assert match, "theme.css: .poster-crop selector not found"
+        block = match.group(1)
+        assert "71/100" not in block, \
+            ".poster-crop block must not contain hardcoded 71/100 (use var(--poster-crop-ratio))"
+
+    def test_similar_slot_img_no_100_20(self):
+        """showcase.css .similar-slot-img block 不含 100% 20%"""
+        css = self._css()
+        match = re.search(r'\.similar-slot-img\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-slot-img selector not found"
+        block = match.group(1)
+        assert "100% 20%" not in block, \
+            ".similar-slot-img block must not contain object-position: 100% 20%"
+
+    def test_similar_slot_img_has_right_center(self):
+        """showcase.css .similar-slot-img block 含 right center"""
+        css = self._css()
+        match = re.search(r'\.similar-slot-img\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-slot-img selector not found"
+        block = match.group(1)
+        assert "right center" in block, \
+            ".similar-slot-img block must contain object-position: right center"
+
+    def test_similar_main_static_width_178(self):
+        """showcase.css .similar-main-static block 含 width: 178px"""
+        css = self._css()
+        match = re.search(r'\.similar-main-static\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-main-static selector not found"
+        block = match.group(1)
+        assert "width: 178px" in block, \
+            ".similar-main-static block must contain width: 178px"
+
+    def test_similar_main_static_no_200(self):
+        """showcase.css .similar-main-static block 不含 width: 200px"""
+        css = self._css()
+        match = re.search(r'\.similar-main-static\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-main-static selector not found"
+        block = match.group(1)
+        assert "width: 200px" not in block, \
+            ".similar-main-static block must not contain width: 200px (use 178px)"
+
+
+class TestMotionLabObjectPositionGuard:
+    """75a-T4: motion_lab.html inline <style> 守衛 — clip-lab-* object-position。
+
+    NOTE: stylelint glob (web/static/css/**/*.css) 不覆蓋 motion_lab.html inline <style>；
+    且 picker-candidate-img 有合法 100% 20%，不可全域 ban。
+    故用 pytest selector-scoped HTML style-block read（plan-sanctioned pytest fallback）。
+    """
+
+    def _html(self):
+        return T4_MOTION_LAB_HTML.read_text(encoding="utf-8")
+
+    def _style_blocks(self, html):
+        blocks = re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL)
+        assert blocks, "motion_lab.html has no <style> blocks"
+        return "\n".join(blocks)
+
+    def test_clip_lab_img_object_position_right_center(self):
+        """.clip-lab-slot-img, .clip-lab-main-img rule block 含 right center，不含 100% 20%"""
+        html = self._html()
+        css = self._style_blocks(html)
+        match = re.search(
+            r'\.clip-lab-slot-img\s*,\s*\.clip-lab-main-img\s*\{([^}]+)\}',
+            css,
+        )
+        assert match, "motion_lab.html <style>: .clip-lab-slot-img, .clip-lab-main-img rule not found"
+        block = match.group(1)
+        assert "right center" in block, \
+            ".clip-lab-slot-img,.clip-lab-main-img block must contain object-position: right center"
+        assert "100% 20%" not in block, \
+            ".clip-lab-slot-img,.clip-lab-main-img block must not contain 100% 20%"
+
+    def test_clip_lab_slot_no_120(self):
+        """.clip-lab-slot rule block 不含 width: 120px（應為 107px）"""
+        html = self._html()
+        css = self._style_blocks(html)
+        match = re.search(r'\.clip-lab-slot\s*\{([^}]+)\}', css)
+        assert match, "motion_lab.html <style>: .clip-lab-slot rule not found"
+        block = match.group(1)
+        assert "width: 120px" not in block, \
+            ".clip-lab-slot block must not contain width: 120px (should be 107px)"
+
+
+class TestSimilarSlotGsapGuard:
+    """75a-T4: GSAP width literal 守衛 — constellation/animations.js + state-similar.js。
+
+    animations.js: T1 後所有 width 已改為 SLOT_W/MAIN_W 具名常量（無 120/200 literal）；
+    用全文 ban 安全（確認無其他合法 120/200 出現）。
+    assert 'width: 120' not in js + assert 'width: 200' not in js；
+    正向斷言 POSTER_CROP_RATIO 常數存在。
+
+    state-similar.js: 全文只有一處 width: 107（gsap.set slot reset），無 120 出現；
+    用全文 ban 安全。
+    """
+
+    def _animations(self):
+        return CONSTELLATION_ANIMATIONS_JS.read_text(encoding="utf-8")
+
+    def _similar(self):
+        return T4_STATE_SIMILAR_JS.read_text(encoding="utf-8")
+
+    def test_animations_no_width_120_literal(self):
+        """animations.js 全文不含 width: 120（T1 後已改 SLOT_W 常量）"""
+        js = self._animations()
+        assert "width: 120" not in js, \
+            "animations.js must not contain literal 'width: 120' (use SLOT_W constant)"
+
+    def test_animations_no_width_200_literal(self):
+        """animations.js 全文不含 width: 200（T1 後已改 MAIN_W 常量）"""
+        js = self._animations()
+        assert "width: 200" not in js, \
+            "animations.js must not contain literal 'width: 200' (use MAIN_W constant)"
+
+    def test_animations_has_poster_crop_ratio_const(self):
+        """animations.js 含 POSTER_CROP_RATIO 具名常量（單一真理 NC#7）"""
+        js = self._animations()
+        assert "POSTER_CROP_RATIO" in js, \
+            "animations.js must define POSTER_CROP_RATIO constant (single source of truth NC#7)"
+
+    def test_animations_has_slot_w_const(self):
+        """animations.js 含 SLOT_W 具名常量"""
+        js = self._animations()
+        assert "SLOT_W" in js, \
+            "animations.js must define SLOT_W constant derived from POSTER_CROP_RATIO"
+
+    def test_animations_has_main_w_const(self):
+        """animations.js 含 MAIN_W 具名常量"""
+        js = self._animations()
+        assert "MAIN_W" in js, \
+            "animations.js must define MAIN_W constant derived from POSTER_CROP_RATIO"
+
+    def test_state_similar_no_width_120(self):
+        """state-similar.js 全文不含 width: 120（slot reset 應為 107）"""
+        js = self._similar()
+        assert "width: 120" not in js, \
+            "state-similar.js must not contain 'width: 120' (slot width should be 107)"
+
+    def test_state_similar_has_width_107(self):
+        """state-similar.js 含 width: 107（slot reset 正確值）"""
+        js = self._similar()
+        assert "width: 107" in js, \
+            "state-similar.js must contain 'width: 107' (slot reset value)"
+
+
+class TestSimilarMobileDOMOrderGuard:
+    """75a-T4: showcase.html DOM 順序 — lightbox-similar-mobile 在 lightbox-metadata 之前。
+
+    使用 re.search 取 class attr 出現位置，避免誤中 HTML comment。
+    """
+
+    def _html(self):
+        return T4_SHOWCASE_HTML.read_text(encoding="utf-8")
+
+    def test_similar_mobile_before_metadata(self):
+        """lightbox-similar-mobile div 在主 lightbox-metadata div 之前。
+
+        showcase.html 有兩個 lightbox-metadata：actress-lightbox-meta（上方）和主 metadata（下方）。
+        守衛目標是主 lightbox-metadata（不含 actress 子 class），故用 exact class= match。
+        """
+        html = self._html()
+        m_mobile = re.search(r'class="lightbox-similar-mobile"', html)
+        # Match the standalone lightbox-metadata (not actress-lightbox-meta)
+        m_meta = re.search(r'class="lightbox-metadata"(?!\s)', html)
+        assert m_mobile, "showcase.html: lightbox-similar-mobile class attr not found"
+        assert m_meta, "showcase.html: class=\"lightbox-metadata\" (main, non-actress) not found"
+        assert m_mobile.start() < m_meta.start(), (
+            "showcase.html: lightbox-similar-mobile must appear before main lightbox-metadata in DOM"
+        )
+
+
+class TestSimilarJSThresholdGuard:
+    """75a-T4: state-similar.js openSimilarMode 手機門檻 960px 守衛。
+
+    提取 openSimilarMode 函式體後斷言 < 960（不是 < 768）。
+    三問：改回 768 → 紅；刪 960 → 紅；加 768 → 紅。
+    """
+
+    def _js(self):
+        return T4_STATE_SIMILAR_JS.read_text(encoding="utf-8")
+
+    def _extract_method_body(self, js, method_name):
+        """提取 Alpine/module method 函式體（大括號平衡法）"""
+        pattern = re.compile(
+            r'(?:^|\n)\s*async ' + re.escape(method_name) + r'\s*\([^)]*\)\s*\{',
+            re.DOTALL,
+        )
+        m = pattern.search(js)
+        if m is None:
+            # try non-async form
+            pattern2 = re.compile(
+                r'(?:^|\n)\s*' + re.escape(method_name) + r'\s*\([^)]*\)\s*\{',
+                re.DOTALL,
+            )
+            m = pattern2.search(js)
+        assert m is not None, f"state-similar.js: cannot find method {method_name}"
+        start = m.end()
+        depth = 1
+        i = start
+        while i < len(js) and depth > 0:
+            c = js[i]
+            if c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+            i += 1
+        return js[start:i - 1]
+
+    def test_open_similar_mode_threshold_960(self):
+        """openSimilarMode 函式體含 innerWidth < 960"""
+        js = self._js()
+        body = self._extract_method_body(js, 'openSimilarMode')
+        assert "innerWidth < 960" in body, \
+            "state-similar.js openSimilarMode must use 'innerWidth < 960' threshold (not 768)"
+
+    def test_open_similar_mode_no_threshold_768(self):
+        """openSimilarMode 函式體不含 innerWidth < 768（舊錯誤門檻）"""
+        js = self._js()
+        body = self._extract_method_body(js, 'openSimilarMode')
+        assert "innerWidth < 768" not in body, \
+            "state-similar.js openSimilarMode must not use 'innerWidth < 768' (should be 960)"
+
+
+class TestSimilarCssSafetyAndGridGuard:
+    """75a-T4: showcase.css 安全規則 + 手機網格守衛。
+
+    涵蓋：
+    - @media (min-width: 960px) 包含 .lightbox-similar-mobile（安全網，不用 768px）
+    - .similar-mobile-card img block 含 var(--poster-crop-ratio)，不含 4/5
+    - .similar-slot block 含 width: 107px，不含 width: 120px
+    - .similar-mobile-grid block 含 repeat(4
+    - @media (max-width: 960px) 含 .lightbox-content.similar-open .lightbox-cover 縮高規則
+    """
+
+    def _css(self):
+        return T4_SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def test_safety_rule_min_960_hides_mobile(self):
+        """@media (min-width: 960px) 安全網存在且包含 .lightbox-similar-mobile"""
+        css = self._css()
+        match = re.search(r'@media\s*\(\s*min-width\s*:\s*960px\s*\)', css)
+        assert match, "showcase.css: @media (min-width: 960px) not found"
+        # Verify lightbox-similar-mobile is within or near this media block
+        after = css[match.start():]
+        assert "lightbox-similar-mobile" in after[:500], \
+            "@media (min-width: 960px) block must contain .lightbox-similar-mobile rule"
+
+    def test_safety_rule_not_768(self):
+        """安全網媒體查詢用 960px 而非 768px"""
+        css = self._css()
+        # The safety rule specifically for lightbox-similar-mobile hides it at 960px
+        # Confirm there's a min-width: 960px block (not just 768px) for the mobile section
+        idx_960 = css.find("min-width: 960px")
+        assert idx_960 != -1, "showcase.css: min-width: 960px not found (safety rule)"
+        # Confirm lightbox-similar-mobile appears after min-width: 960px
+        idx_mobile = css.find("lightbox-similar-mobile", idx_960)
+        assert idx_mobile != -1, \
+            "showcase.css: lightbox-similar-mobile not found after min-width: 960px"
+
+    def test_similar_mobile_card_img_has_poster_crop_ratio(self):
+        """.similar-mobile-card img block 含 var(--poster-crop-ratio)"""
+        css = self._css()
+        match = re.search(r'\.similar-mobile-card\s+img\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-mobile-card img rule not found"
+        block = match.group(1)
+        assert "var(--poster-crop-ratio)" in block, \
+            ".similar-mobile-card img must contain var(--poster-crop-ratio)"
+
+    def test_similar_mobile_card_img_no_hardcoded_4_5(self):
+        """.similar-mobile-card img block 不含 4/5 硬編碼比例"""
+        css = self._css()
+        match = re.search(r'\.similar-mobile-card\s+img\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-mobile-card img rule not found"
+        block = match.group(1)
+        assert "4/5" not in block, \
+            ".similar-mobile-card img must not contain hardcoded 4/5 (use var(--poster-crop-ratio))"
+
+    def test_similar_slot_width_107(self):
+        """.similar-slot rule block 含 width: 107px"""
+        css = self._css()
+        match = re.search(r'\.similar-slot\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-slot selector not found"
+        block = match.group(1)
+        assert "width: 107px" in block, \
+            ".similar-slot block must contain width: 107px"
+
+    def test_similar_slot_no_width_120(self):
+        """.similar-slot rule block 不含 width: 120px"""
+        css = self._css()
+        match = re.search(r'\.similar-slot\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-slot selector not found"
+        block = match.group(1)
+        assert "width: 120px" not in block, \
+            ".similar-slot block must not contain width: 120px (should be 107px)"
+
+    def test_similar_mobile_grid_repeat_4(self):
+        """.similar-mobile-grid block 含 repeat(4"""
+        css = self._css()
+        match = re.search(r'\.similar-mobile-grid\s*\{([^}]+)\}', css)
+        assert match, "showcase.css: .similar-mobile-grid selector not found"
+        block = match.group(1)
+        assert "repeat(4" in block, \
+            ".similar-mobile-grid must contain repeat(4, 1fr) grid-template-columns"
+
+    def test_similar_open_cover_height_override(self):
+        """@media (max-width: 960px) 含 similar-open 封面縮高規則（min(38vh + height: 40vh）"""
+        css = self._css()
+        # Find the max-width: 960px media block containing similar-open
+        match = re.search(r'@media\s*\(\s*max-width\s*:\s*960px\s*\)', css)
+        assert match, "showcase.css: @media (max-width: 960px) not found"
+        after = css[match.start():]
+        assert "similar-open" in after[:500], \
+            "@media (max-width: 960px) must contain .similar-open cover rule"
+        assert "min(38vh" in after[:500], \
+            "@media (max-width: 960px) similar-open must contain min(38vh cover override"
+        assert "height: 40vh" in after[:500], \
+            "@media (max-width: 960px) similar-open must contain height: 40vh override"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4691,8 +4691,9 @@ class TestSearchCssHardcoded:
 
     HARDCODED_RGBA_ALLOWLIST = {
         # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：788→840；90 在插入點上方不變。
+        # T9-port 在 L718 後插入 ~61 行（3-col + poster-crop + coarse + cover-fit blocks）：840→902。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        840: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        902: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
@@ -11877,4 +11878,204 @@ class TestUS5VideoCoverFitMobile:
         html = SHOWCASE_HTML.read_text(encoding="utf-8")
         assert "'has-cover': !!currentLightboxVideo?.cover_url" in html, (
             "影片燈箱 .lightbox-cover 應綁 :class=\"{'has-cover': !!currentLightboxVideo?.cover_url}\""
+        )
+
+
+# ============================================================================
+# TASK-75b-T9：search 頁 ≤480px 影片格 + 燈箱修正守衛
+# Port of showcase T4/T5/T7/T8 — all search-specific rules live in search.css (決策 ②)
+# ============================================================================
+
+_SHOWCASE_CSS_T9 = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "showcase.css"
+
+
+class TestUS9SearchGridMobileFix:
+    """TASK-75b-T9：search grid ≤480px 三欄 poster + 燈箱 letterbox 消除守衛。
+
+    涵蓋 T4（3-col）、T5（poster-crop/caption/coarse footer）、T7（posterCrop 傳遞）、T8（cover-fit）。
+    全部 search-specific 規則在 search.css（決策 ②）；showcase.css 零改動（回歸護欄）。
+    """
+
+    @staticmethod
+    def _strip_comments(text: str) -> str:
+        """移除 /* ... */ 註解——避免守衛被註解內提及的 selector 字串騙過。"""
+        return re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+
+    def _search_css(self):
+        return SEARCH_CSS.read_text(encoding="utf-8")
+
+    # --- T4 ---
+
+    def test_search_grid_3col_at_480(self):
+        """T4：search.css ≤480px .search-grid 為 repeat(3, 1fr)（非單欄 1fr）。
+        三問：改回 1fr → 紅；刪 3-col 規則 → 紅。
+        """
+        css = self._search_css()
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        assert blocks, "search.css 找不到 @media (max-width: 480px) block"
+        target = [b for b in blocks if re.search(r'\.search-grid \{', b)]
+        assert target, "找不到含 .search-grid 的 ≤480px block"
+        block = target[0]
+        m = re.search(r'\.search-grid \{([^}]*)\}', block)
+        assert m, "≤480px block 內找不到 .search-grid 規則"
+        rule = m.group(1)
+        assert "repeat(3, 1fr)" in rule, (
+            "≤480px .search-grid 應為 repeat(3, 1fr)（T9-T4 port）；目前: " + rule.strip()
+        )
+        assert "grid-template-columns: 1fr;" not in rule, (
+            "≤480px .search-grid 不應殘留單欄 grid-template-columns: 1fr;"
+        )
+
+    # --- T5 ---
+
+    def test_search_poster_crop_scoped(self):
+        """T5：search.css ≤480px poster-crop + caption 帶正確 :is() scope + :not(.hero-card)。
+        STRIP CSS COMMENTS first（防被 selector 說明文字騙過，mirror TestUS5PosterCropScoped）。
+        三問：拔 :is() 前綴 → 紅；用錯 class .av-maker → 紅；拔 :not(.hero-card) → 紅。
+        """
+        css = self._strip_comments(self._search_css())
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".av-card-preview-img" in b and ".search-grid" in b]
+        assert target, "找不到含 .av-card-preview-img + .search-grid 的 ≤480px block（T9-T5 poster-crop 缺失）"
+        block = target[0]
+
+        # rule-bound：aspect-ratio 規則自身 selector 必帶 :is() + :not(.hero-card)
+        m = re.search(r'([^{}]*)\{[^{}]*aspect-ratio: var\(--poster-crop-ratio[^{}]*\}', block, re.DOTALL)
+        assert m, "找不到 aspect-ratio: var(--poster-crop-ratio) 規則"
+        sel = m.group(1)
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in sel, (
+            "aspect-ratio 規則 selector 必帶 :is(#ds-gallery-components,…) scope；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+        assert ":not(.hero-card)" in sel, (
+            "aspect-ratio 規則 selector 必帶 :not(.hero-card)（排除女優 hero 卡）"
+        )
+
+        # object-position 同款 rule-bound 檢查
+        m2 = re.search(r'([^{}]*)\{[^{}]*object-position: right center[^{}]*\}', block, re.DOTALL)
+        assert m2, "找不到 object-position: right center 規則"
+        sel2 = m2.group(1)
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in sel2 and ":not(.hero-card)" in sel2, (
+            "object-position 規則 selector 必帶 :is(…) scope + :not(.hero-card)"
+        )
+
+        # caption：.av-actress display:none
+        m3 = re.search(r'\.footer-default \.av-actress \{([^}]*)\}', block)
+        assert m3, "找不到 .footer-default .av-actress 規則"
+        assert "display: none" in m3.group(1), ".av-actress（女優名次行）應 display: none"
+
+        # .av-num ellipsis
+        m4 = re.search(r'\.footer-default \.av-num \{([^}]*)\}', block)
+        assert m4, "找不到 .footer-default .av-num 規則"
+        assert "text-overflow: ellipsis" in m4.group(1), ".av-num（番號）應單行 ellipsis"
+
+    def test_search_touch_narrow_reshows_footer_default(self):
+        """T5：≤480px ∩ pointer:coarse .search-grid 還原 .footer-default（番號層）+ 壓 .footer-hover。
+        三問：刪此 block → 紅；把 footer-default opacity 改回 0 → 紅。
+        """
+        css = self._strip_comments(self._search_css())
+        m = re.search(
+            r'@media \(max-width: 480px\) and \(pointer: coarse\) \{(.*?)\n\}',
+            css, re.DOTALL,
+        )
+        assert m, "search.css 找不到 @media (max-width: 480px) and (pointer: coarse) block（T9-T5 coarse 還原缺失）"
+        block = m.group(1)
+
+        assert ".search-grid" in block, "coarse 交集 block 應 scope 到 .search-grid"
+
+        # footer-default 還原：selector 帶 :is() + :not(.hero-card) + opacity:1
+        md = re.search(r'([^{}]*\.footer-default)\s*\{([^}]*)\}', block)
+        assert md, "coarse 交集 block 內找不到 .footer-default 規則"
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in md.group(1) and ":not(.hero-card)" in md.group(1), (
+            ".footer-default 還原規則 selector 必帶 :is(…) scope + :not(.hero-card)"
+        )
+        assert "opacity: 1" in md.group(2), (
+            "≤480px ∩ coarse 應把 search 影片格 .footer-default opacity: 1（還原番號 caption 層）"
+        )
+
+        # footer-hover 壓回 opacity:0
+        mh = re.search(r'\.footer-hover\s*\{([^}]*)\}', block)
+        assert mh, "coarse 交集 block 內找不到 .footer-hover 規則"
+        assert "opacity: 0" in mh.group(1), (
+            "≤480px ∩ coarse search 影片格應把 .footer-hover opacity: 0"
+        )
+
+    # --- T8 ---
+
+    def test_search_lightbox_cover_fit(self):
+        """T8：search.css ≤480px .search-container .lightbox-cover.has-cover 消 letterbox。
+        決策 ①：容器 + img 皆 gate .has-cover（排除女優燈箱）。
+        護欄：block 內不得出現未 gate .has-cover 的裸 .search-container .lightbox-cover img（波及女優）。
+        三問：拿掉容器 min-height:0 → 紅；拿掉 img has-cover gate → 紅（bare 出現）。
+        """
+        css = self._search_css()
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".search-container .lightbox-cover" in b]
+        assert target, "search.css 找不到含 .search-container .lightbox-cover 的 ≤480px block（T9-T8 cover-fit 缺失）"
+        block = target[0]
+
+        # 容器：.search-container .lightbox-cover.has-cover { min-height: 0; min-width: 0 }
+        mc = re.search(r'\.search-container \.lightbox-cover\.has-cover \{([^}]*)\}', block)
+        assert mc, "T9-T8 容器規則須為 .search-container .lightbox-cover.has-cover"
+        cbody = mc.group(1)
+        assert "min-height: 0" in cbody, "容器須 min-height: 0（make-or-break）"
+        assert "min-width: 0" in cbody, "容器須 min-width: 0"
+
+        # img：.search-container .lightbox-cover.has-cover img { height: auto; width: 100% }
+        mi = re.search(r'\.search-container \.lightbox-cover\.has-cover img \{([^}]*)\}', block)
+        assert mi, "T9-T8 img 規則須為 .search-container .lightbox-cover.has-cover img（決策 ①：img 同 gate has-cover）"
+        ibody = mi.group(1)
+        assert "height: auto" in ibody, "img 須 height: auto（覆寫 60vh letterbox 源）"
+        assert "width: 100%" in ibody, "img 須 width: 100%"
+
+        # 護欄：不得含裸 .search-container .lightbox-cover img（無 .has-cover）
+        # 正確寫法一定有 .has-cover（如 .lightbox-cover.has-cover img），裸寫不含 .has-cover
+        bare = re.search(r'\.search-container \.lightbox-cover(?!\.has-cover) img \{', block)
+        assert not bare, (
+            "T9-T8 block 不得含裸 .search-container .lightbox-cover img（無 .has-cover gate）"
+            "——會波及女優燈箱封面（決策 ①）"
+        )
+
+    # --- T8 template ---
+
+    def test_search_lightbox_has_cover_class(self):
+        """T8：search.html .lightbox-cover 帶完整三條件 has-cover 旗標（決策 ②）。
+        三條件缺一即紅：非女優模式 + 有 cover 欄位 + 封面未 404。
+        注意：search 欄位是 .cover（非 .cover_url，R3 guard）。
+        """
+        html = SEARCH_HTML.read_text(encoding="utf-8")
+        assert (
+            "'has-cover': !actressLightboxMode() && !!currentLightboxVideo()?.cover && !_heroLightboxImageError"
+            in html
+        ), (
+            "search.html .lightbox-cover 應綁完整三條件 has-cover（決策 ②）；"
+            "缺少非女優判斷、或用 .cover_url（應為 .cover）、或漏 error-state 均為紅"
+        )
+
+    # --- T7 ---
+
+    def test_search_grid_mode_threads_poster_crop(self):
+        """T7：grid-mode.js openLightbox 計算 posterCrop 並傳入 playGridToLightbox。
+        三問：刪 posterCrop 計算 → 紅；刪傳遞 → 紅；拔 hero-card 判斷 → 紅。
+        """
+        js = GRID_MODE_JS.read_text(encoding="utf-8")
+        assert "posterCrop" in js, "grid-mode.js 應計算 posterCrop"
+        assert "window.innerWidth <= 480" in js, "posterCrop 應 gate ≤480px"
+        assert "hero-card" in js, "posterCrop 應排除 hero 卡（防禦性 guard）"
+        assert "posterCrop: posterCrop" in js, (
+            "grid-mode.js 應把 posterCrop 傳入 playGridToLightbox options"
+        )
+
+    # --- showcase 回歸護欄 ---
+
+    def test_showcase_t8_untouched(self):
+        """回歸護欄：T9 不動 showcase.css——showcase T8 block 仍在。
+        三問：T9 誤刪 showcase T8 container 規則 → 紅。
+        """
+        css = _SHOWCASE_CSS_T9.read_text(encoding="utf-8")
+        assert ".lightbox-cover.has-cover:has(.lb-full)" in css, (
+            "showcase.css T8 container 規則 .lightbox-cover.has-cover:has(.lb-full) 應保留（T9 不動 showcase.css）"
+        )
+        assert "min-height: 0" in css, (
+            "showcase.css T8 min-height: 0 應保留（T9 回歸護欄）"
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11796,3 +11796,85 @@ class TestUS5PosterCropGhostCrossfade:
         assert "cleanupGhost(ghost, coverEl)" in body, (
             "非 posterCrop 路徑應保留硬切 cleanupGhost（桌面零回歸）"
         )
+
+
+# ============================================================================
+# TASK-75b-T8：≤480px 影片燈箱封面貼合原圖比例（消 letterbox 死白 + 根治 T7 seam）
+# CSS element-bound 讀取守衛（require-presence of a rule，比照 US5 其他 guard）
+# ============================================================================
+
+
+class TestUS5VideoCoverFitMobile:
+    """TASK-75b-T8：≤480px 影片燈箱封面以原圖比例呈現、消上下 letterbox 死白。
+
+    make-or-break（live 實證）：須同改 (a) img/.lb-full 尺寸法 + (b) 容器 min-*，
+    只改 img 空白會留在容器。scope :has(.lb-full) 只中影片、不波及女優 cover。
+    三問：刪容器 min-height:0 → 紅（make-or-break）；刪 img height:auto → 紅；
+    把 :has(.lb-full) 改裸 .lightbox-cover（會波及女優）→ scope 守衛紅。
+    """
+
+    def _css(self):
+        return SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def _t8_block(self) -> str:
+        """抓含 .lightbox-cover:has(.lb-full) 的那個 @media (max-width: 480px) block。"""
+        css = self._css()
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".lightbox-cover:has(.lb-full)" in b]
+        assert target, "showcase.css 找不到含 .lightbox-cover:has(.lb-full) 的 ≤480px block（T8 缺失）"
+        return target[0]
+
+    def test_video_cover_fit_media_block_exists(self):
+        block = self._t8_block()
+        assert ".lightbox-cover:has(.lb-full)" in block, "T8 block 應 scope 到 :has(.lb-full)"
+
+    def test_container_min_zeroed_gated_on_has_cover(self):
+        """make-or-break：容器 min-height/min-width 必須歸零（否則空白只是重新分配）。
+        Codex P2：容器 min-height:0 必須 gate 在 .has-cover——無封面影片若塌成 0 高、補封面入口會壞，
+        故 selector 必為 .lightbox-cover.has-cover:has(.lb-full)（非裸 :has(.lb-full)）。
+        三問：拿掉 .has-cover gate → 紅（無封面會塌）；拿掉 min-height:0 → 紅（留白未消）。
+        """
+        block = self._t8_block()
+        m = re.search(r'\.lightbox-cover\.has-cover:has\(\.lb-full\) \{([^}]*)\}', block)
+        assert m, "T8 容器規則須為 .lightbox-cover.has-cover:has(.lb-full)（Codex P2：min-height:0 須 gate has-cover）"
+        body = m.group(1)
+        assert "min-height: 0" in body, (
+            "容器須 min-height: 0（否則 min(58vh,460px) 主導、img 置中留白未消）—— make-or-break"
+        )
+        assert "min-width: 0" in body, "容器須 min-width: 0"
+
+    def test_img_height_auto_width_full(self):
+        """img + .lb-full 須 height:auto + width:100%（覆寫 60vh），且規則涵蓋 .lb-full。"""
+        block = self._t8_block()
+        m = re.search(
+            r'\.lightbox-cover:has\(\.lb-full\) img,\s*\.lightbox-cover:has\(\.lb-full\) \.lb-full \{([^}]*)\}',
+            block,
+        )
+        assert m, "T8 block 內找不到涵蓋 img + .lb-full 的尺寸規則"
+        body = m.group(1)
+        assert "height: auto" in body, "img/.lb-full 須 height: auto（覆寫 60vh）"
+        assert "width: 100%" in body, "img/.lb-full 須 width: 100%"
+
+    def test_scoped_to_has_lb_full_not_actress(self):
+        """scope 護欄：T8 block 不得出現裸 .lightbox-cover img 的 height:auto（會波及女優 cover）。"""
+        block = self._t8_block()
+        # 裸 .lightbox-cover img {（無 :has）出現在 block 內即危險
+        bare = re.search(r'(?<!\)) \.lightbox-cover img \{', block)
+        assert not bare, (
+            "T8 block 不得含裸 .lightbox-cover img 規則（無 :has(.lb-full)）—— 會波及女優燈箱封面"
+        )
+
+    def test_similar_open_40vh_untouched(self):
+        """回歸護欄：手機相似模式 similar-open 40vh / 38vh 規則仍在（未被 T8 波及）。"""
+        css = self._css()
+        assert "min(38vh, 290px)" in css, "similar-open 容器 min-height 規則應保留"
+        assert "height: 40vh" in css, "similar-open img/lb-full 40vh 規則應保留"
+
+    def test_video_lightbox_cover_has_cover_class(self):
+        """Codex P2：影片燈箱 .lightbox-cover 須帶 has-cover 旗標（綁 cover_url），
+        供 T8 容器 min-height:0 只在有封面時生效。三問：拿掉旗標 → 紅（CSS gate 失效）。
+        """
+        html = SHOWCASE_HTML.read_text(encoding="utf-8")
+        assert "'has-cover': !!currentLightboxVideo?.cover_url" in html, (
+            "影片燈箱 .lightbox-cover 應綁 :class=\"{'has-cover': !!currentLightboxVideo?.cover_url}\""
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11706,3 +11706,33 @@ class TestUS5PosterCropScoped:
         m2 = re.search(r'\.footer-default \.av-num \{([^}]*)\}', block)
         assert m2, "找不到 .footer-default .av-num 規則"
         assert "text-overflow: ellipsis" in m2.group(1), ".av-num（番號）應單行 ellipsis"
+
+    def test_touch_narrow_reshows_footer_default(self):
+        """Codex P1：≤480px ∩ pointer:coarse 必須還原 .footer-default（番號層）、壓 .footer-hover（標題層）。
+
+        否則 75a-US3c 的 @media(pointer:coarse) 把 .footer-default opacity:0、改顯 footer-hover 標題 →
+        T5 番號 ellipsis 作用在 invisible 層、真機看到的是不可讀標題（spec §US5 caption 失效）。
+        三問：刪此交集 block → 紅（找不到 480+coarse block）；把 footer-default opacity 改回 0 → 紅。
+        """
+        css = self._strip_comments(self._css())
+        m = re.search(
+            r'@media \(max-width: 480px\) and \(pointer: coarse\) \{(.*?)\n\}',
+            css, re.DOTALL,
+        )
+        assert m, "找不到 @media (max-width: 480px) and (pointer: coarse) 交集 block（Codex P1 fix 缺失）"
+        block = m.group(1)
+        # footer-default 規則自身帶 scope + 還原 opacity:1
+        md = re.search(r'([^{}]*\.footer-default)\s*\{([^}]*)\}', block)
+        assert md, "交集 block 內找不到 .footer-default 規則"
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in md.group(1) and ":not(.hero-card)" in md.group(1), (
+            ".footer-default 還原規則 selector 必帶 :is(…) scope + :not(.hero-card)"
+        )
+        assert "opacity: 1" in md.group(2), (
+            "≤480px ∩ coarse 應把 poster 卡 .footer-default opacity:1（還原番號 caption 層）"
+        )
+        # footer-hover 壓回 opacity:0
+        mh = re.search(r'\.footer-hover\s*\{([^}]*)\}', block)
+        assert mh, "交集 block 內找不到 .footer-hover 規則"
+        assert "opacity: 0" in mh.group(1), (
+            "≤480px ∩ coarse poster 格應把 .footer-hover opacity:0（標題層在 107px 窄格不可讀）"
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11471,6 +11471,40 @@ class TestSimilarCssSafetyAndGridGuard:
         assert "height: 40vh" in after[:500], \
             "@media (max-width: 960px) similar-open must contain height: 40vh override"
 
+    def test_similar_open_lb_full_outranks_t8(self):
+        """similar-open .lb-full selector 須用 compound 中間形式 .lightbox-cover .lb-full，
+        使 specificity 達 (0,4,0)，勝 T8 ≤480 的 .lightbox-cover:has(.lb-full) .lb-full (0,3,0)。
+        否則 source order 讓 T8 的 height:auto 在 ≤480px ∩ similar-open 覆寫 overlay → overlay 與
+        base 40vh 脫鉤/溢出。
+
+        mutation test：將 .lightbox-cover 中間節點移除（還原為裸 .lightbox-content.similar-open .lb-full）
+        → 此測試應轉紅（RED）。
+        """
+        css = self._css()
+        # Strip CSS comments so comment-only occurrences don't fool the assertions
+        css_no_comments = re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
+
+        # MUST: compound form with .lightbox-cover intermediate present
+        assert '.lightbox-content.similar-open .lightbox-cover .lb-full' in css_no_comments, (
+            "showcase.css: similar-open .lb-full selector must use compound form "
+            "'.lightbox-content.similar-open .lightbox-cover .lb-full' (specificity (0,4,0)) "
+            "to outrank T8's .lightbox-cover:has(.lb-full) .lb-full (0,3,0). "
+            "Without the .lightbox-cover intermediate, source order lets T8 height:auto win in "
+            "≤480px ∩ similar-open → overlay desyncs from base 40vh."
+        )
+
+        # MUST NOT: bare form without .lightbox-cover intermediate (would tie T8 at (0,3,0) and lose by source order)
+        # Match patterns like: ".lightbox-content.similar-open .lb-full {" or ",\n    .lightbox-content.similar-open .lb-full {"
+        bare_pattern = re.search(
+            r'\.lightbox-content\.similar-open\s+\.lb-full\s*[{,]',
+            css_no_comments
+        )
+        assert bare_pattern is None, (
+            "showcase.css: bare '.lightbox-content.similar-open .lb-full' selector found — "
+            "this ties T8 at (0,3,0) and loses by source order in ≤480px ∩ similar-open. "
+            "Use '.lightbox-content.similar-open .lightbox-cover .lb-full' (0,4,0) instead."
+        )
+
 
 # ============================================================================
 # TASK-75b-T6：US1 搜尋詳情重排 + US5 影片卡 poster 格 守衛

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11075,6 +11075,10 @@ T4_STATE_SIMILAR_JS = (
     Path(__file__).parent.parent.parent
     / "web" / "static" / "js" / "pages" / "showcase" / "state-similar.js"
 )
+T4_CONSTELLATION_HOST_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "pages" / "motion-lab" / "constellation-host.js"
+)
 T4_SHOWCASE_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "showcase.css"
 T4_THEME_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "theme.css"
 T4_MOTION_LAB_HTML = Path(__file__).parent.parent.parent / "web" / "templates" / "motion_lab.html"
@@ -11268,6 +11272,22 @@ class TestSimilarSlotGsapGuard:
         js = self._similar()
         assert "width: 107" in js, \
             "state-similar.js must contain 'width: 107' (slot reset value)"
+
+    def _host(self):
+        return T4_CONSTELLATION_HOST_JS.read_text(encoding="utf-8")
+
+    def test_constellation_host_no_width_120(self):
+        """constellation-host.js 全文不含 width: 120（reduced-motion click + reset baseline path
+        繞過 animations.js gsap.set，應為 107；Codex P3 補洞——plan 6 處 inventory 漏此 host 檔）"""
+        js = self._host()
+        assert "width: 120" not in js, \
+            "constellation-host.js must not contain 'width: 120' (slot box should be 107, NC#7 mirror)"
+
+    def test_constellation_host_has_width_107(self):
+        """constellation-host.js 含 width: 107（reduced-motion / reset slot 正確值）"""
+        js = self._host()
+        assert "width: 107" in js, \
+            "constellation-host.js must contain 'width: 107' (reduced-motion + reset slot value)"
 
 
 class TestSimilarMobileDOMOrderGuard:

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4690,16 +4690,16 @@ class TestSearchCssHardcoded:
     SEARCH_CSS = PROJECT_ROOT / "web/static/css/pages/search.css"
 
     HARDCODED_RGBA_ALLOWLIST = {
-        # T2.1 commit 41f2a5b 後狀態（75a-T2 search.css US3a 插入 +8 行後行號順移）：
+        # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：788→840；90 在插入點上方不變。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        788: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        840: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
-        # T2.2 commit 89d52b6 後狀態（75a-T2 search.css US3a 插入 +8 行後 516/571 順移為 524/579；235 在插入點上方不變）：
-        235: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
-        524: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
-        579: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
+        # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：235→282、524→576、579→631（皆在插入點下方）。
+        282: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
+        576: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
+        631: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
     }
 
     def _scan(self, regex: str, allowlist=None):
@@ -10824,10 +10824,16 @@ class TestSwitchSourceBtnRemoved:
         )
 
     def test_switch_source_btn_arrow_repeat_icon_gone(self):
-        """強化：原 🔄 icon bi-arrow-repeat 隨按鈕一併消失於 .av-card-full-header 區段。"""
+        """強化：原 🔄 icon bi-arrow-repeat 隨按鈕一併消失於 .av-card-full-header 區段。
+
+        TASK-75b-T6（Codex F3）：US1 把 .av-card-full-title 插在 header 與 body 之間，
+        原終止錨點 `<div class="av-card-full-body">` 不再緊接 header → lazy (.*?) 會吞掉
+        整個 title block（測試不紅但 silent 失準）。終止錨點改 adjacency-independent 的
+        `(?:title|body)`，讓 group(1) 仍只取 header 自身（停在 header 的 </div> → title）。
+        """
         html = SEARCH_HTML.read_text(encoding="utf-8")
         m = re.search(
-            r'<div class="av-card-full-header">(.*?)</div>\s*<div class="av-card-full-body">',
+            r'<div class="av-card-full-header">(.*?)</div>\s*<div class="av-card-full-(?:title|body)">',
             html, re.DOTALL,
         )
         assert m, "search.html 找不到 .av-card-full-header 區段"
@@ -11462,3 +11468,241 @@ class TestSimilarCssSafetyAndGridGuard:
             "@media (max-width: 960px) similar-open must contain min(38vh cover override"
         assert "height: 40vh" in after[:500], \
             "@media (max-width: 960px) similar-open must contain height: 40vh override"
+
+
+# ============================================================================
+# TASK-75b-T6：US1 搜尋詳情重排 + US5 影片卡 poster 格 守衛
+# search.html DOM 結構 / search.css + showcase.css element-bound CSS read
+# ============================================================================
+
+SEARCH_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "search.css"
+
+
+class TestUS1TitleAboveMetadata:
+    """TASK-75b-T1：翻譯標題區塊（.av-card-full-title）置於 .av-card-full-body 之上。
+
+    DOM 順序 contract（非單純 presence）：用字串位置比較。
+    三問：把 title 搬回 body 下方 → 紅（index 反轉）；刪 title → 紅（找不到）；註解化 → 紅（class 字串不在）。
+    """
+
+    def test_title_block_precedes_body(self):
+        html = SEARCH_HTML.read_text(encoding="utf-8")
+        idx_title = html.find('class="av-card-full-title"')
+        idx_body = html.find('class="av-card-full-body"')
+        assert idx_title >= 0, "search.html 缺 .av-card-full-title（翻譯標題區塊未置頂）"
+        assert idx_body >= 0, "search.html 缺 .av-card-full-body"
+        assert idx_title < idx_body, (
+            "av-card-full-title 必須在 av-card-full-body 之前（標題置頂，US1）；"
+            f"目前 title@{idx_title} body@{idx_body}"
+        )
+
+
+class TestUS1InfoGridPairPresent:
+    """TASK-75b-T1：metadata 雙欄配對——≥2 個 .info-grid-pair，且日期+片長在同一對。
+
+    三問：刪一個 grid-pair → 紅（count<2）；把 duration 移出該對 → 紅（不在第一對 slice）；註解化 → 紅。
+    """
+
+    def test_two_grid_pairs_and_date_duration_paired(self):
+        html = SEARCH_HTML.read_text(encoding="utf-8")
+        assert html.count('class="info-grid-pair"') >= 2, (
+            "search.html 應有 ≥2 個 .info-grid-pair（日期｜片長、片商｜廠牌）"
+        )
+        # 第一對 = 第一個 info-grid-pair 到第二個 info-grid-pair 之間
+        first = html.find('class="info-grid-pair"')
+        second = html.find('class="info-grid-pair"', first + 1)
+        assert second > first, "找不到第二個 info-grid-pair"
+        first_pair = html[first:second]
+        assert "search.label.date" in first_pair and "search.label.duration" in first_pair, (
+            "日期(search.label.date)與片長(search.label.duration)必須在同一個 info-grid-pair"
+        )
+        assert "search.label.maker" not in first_pair, (
+            "片商(search.label.maker)不應在日期｜片長那一對（應在第二對）— 配對串位"
+        )
+
+
+class TestUS1FooterClassRemoved:
+    """TASK-75b-T1/T3：search.html 不再含 wrapper class="av-card-full-footer"（已改名 av-card-full-title）。
+
+    僅讀 SEARCH_HTML（不全 repo 掃——motion_lab/design-system/theme.css/tailwind.css 合法保留，Codex F6）。
+    精確比對 wrapper（帶結尾引號），不誤殺子 class -content / -actions（search.html title block 內部仍用）。
+    三問：把 wrapper 改回 av-card-full-footer → 紅。
+    """
+
+    def test_footer_wrapper_class_gone_in_search_html_only(self):
+        html = SEARCH_HTML.read_text(encoding="utf-8")
+        assert 'class="av-card-full-footer"' not in html, (
+            "search.html wrapper 應改名 av-card-full-title，不得殘留 class=\"av-card-full-footer\""
+        )
+        # 子 class 仍應存在（title block 內部結構未改名）
+        assert 'class="av-card-full-footer-content"' in html, (
+            "title block 內部 .av-card-full-footer-content 應保留（只 wrapper 改名）"
+        )
+
+
+class TestUS1InfoCellInBody:
+    """TASK-75b-T1：.av-card-full-body 範圍內含 .info-cell（雙欄 cell 結構存在）。
+
+    三問：把 info-cell 移到 body 之外（title/header）→ 紅（body slice 不含）；刪 info-cell → 紅。
+    """
+
+    def test_info_cell_inside_body(self):
+        html = SEARCH_HTML.read_text(encoding="utf-8")
+        idx_body = html.find('class="av-card-full-body"')
+        assert idx_body >= 0, "search.html 缺 .av-card-full-body"
+        body_onward = html[idx_body:]
+        assert 'class="info-cell"' in body_onward, (
+            ".av-card-full-body 內應含 .info-cell（雙欄 cell）"
+        )
+        assert body_onward.count('class="info-cell"') == 4, (
+            f"body 內應有 4 個 info-cell（2 對×2），實得 {body_onward.count('class=\"info-cell\"')}"
+        )
+
+
+class TestUS1IdPreserved:
+    """TASK-75b-T1：重排後 DOM id 全保留（JS / 其他守衛可能依賴）。
+
+    三問：重排時漏刪任一 id → 紅。
+    """
+
+    def test_result_ids_preserved(self):
+        html = SEARCH_HTML.read_text(encoding="utf-8")
+        for _id in ['id="resultActors"', 'id="resultDate"', 'id="resultMaker"', 'id="resultTags"']:
+            assert _id in html, f"search.html 缺 {_id}（重排時誤刪）"
+
+
+class TestUS1SearchCssLayout:
+    """TASK-75b-T2：search.css 右欄重排 element-bound CSS read。
+
+    斷言 override 存在性（require-presence，stylelint 無法 require → 走 pytest）：
+    右欄 flex: 0 0 390px、body top-pack flex:none、雙欄 grid 1fr 1fr、≤1024px collapse 回單欄。
+    不斷言 theme.css 無 flex:1（全域刻意保留，CD-75b-4，測它消失會誤紅）。
+    """
+
+    def _css(self):
+        return SEARCH_CSS.read_text(encoding="utf-8")
+
+    def test_info_column_widened_to_390(self):
+        css = self._css()
+        m = re.search(r'\.search-container \.av-card-full-info \{([^}]*)\}', css)
+        assert m, "search.css 找不到 .search-container .av-card-full-info 規則"
+        assert "flex: 0 0 390px" in m.group(1), (
+            "右欄應加寬為 flex: 0 0 390px（CD-75b-1）；目前: " + m.group(1).strip()
+        )
+
+    def test_body_flex_none_scope_override(self):
+        css = self._css()
+        # bare .search-container .av-card-full-body { ... }（body 後直接 {，非 descendant selector）
+        m = re.search(r'\.search-container \.av-card-full-body \{([^}]*)\}', css)
+        assert m, "search.css 找不到 .search-container .av-card-full-body top-pack override"
+        assert "flex: none" in m.group(1), (
+            "search.css 應有 .search-container .av-card-full-body { flex: none }（top-pack，CD-75b-4）"
+        )
+
+    def test_info_grid_pair_two_columns_desktop(self):
+        css = self._css()
+        m = re.search(r'\.search-container \.av-card-full-body \.info-grid-pair \{([^}]*)\}', css)
+        assert m, "search.css 找不到 .info-grid-pair 桌面規則"
+        assert "grid-template-columns: 1fr 1fr" in m.group(1), (
+            "桌面 .info-grid-pair 應為 grid-template-columns: 1fr 1fr（CD-75b-2）"
+        )
+
+    def test_grid_pair_collapses_single_column_under_1024(self):
+        css = self._css()
+        # 抓 @media (max-width: 1024px) block（close 為行首 }）
+        m = re.search(r'@media \(max-width: 1024px\) \{(.*?)\n\}', css, re.DOTALL)
+        assert m, "search.css 找不到 @media (max-width: 1024px) block"
+        block = m.group(1)
+        m2 = re.search(r'\.info-grid-pair \{([^}]*)\}', block)
+        assert m2, "≤1024px block 內找不到 .info-grid-pair collapse 規則（spec §US1 強制）"
+        # 帶分號：防 `1fr 1fr` 子字串誤過（`1fr;` 不是 `1fr 1fr;` 的子串）
+        assert "grid-template-columns: 1fr;" in m2.group(1), (
+            "≤1024px .info-grid-pair 應 collapse 回單欄 grid-template-columns: 1fr;（spec §US1 L97/L113）"
+        )
+
+
+class TestUS5ShowcaseGridIs3Col:
+    """TASK-75b-T4：showcase.css ≤480px 的 .showcase-grid 為 repeat(3, 1fr)（非 1fr）。
+
+    鎖定含 .showcase-grid 的那個 @media (max-width: 480px) block（另有 actress-grid 的同寬 block）。
+    三問：改回 1fr → 紅；刪 3-col 規則 → 紅。
+    """
+
+    def _css(self):
+        return SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def test_showcase_grid_3col_at_480(self):
+        css = self._css()
+        # 所有 @media (max-width: 480px) block（close = 行首 }）
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        assert blocks, "showcase.css 找不到 @media (max-width: 480px) block"
+        target = [b for b in blocks if re.search(r'\.showcase-grid \{', b)]
+        assert target, "找不到含 .showcase-grid 的 ≤480px block"
+        block = target[0]
+        m = re.search(r'\.showcase-grid \{([^}]*)\}', block)
+        assert m, "≤480px block 內找不到 .showcase-grid 規則"
+        rule = m.group(1)
+        assert "repeat(3, 1fr)" in rule, (
+            "≤480px .showcase-grid 應為 repeat(3, 1fr)（CD-75b-7）；目前: " + rule.strip()
+        )
+        assert "grid-template-columns: 1fr;" not in rule, (
+            "≤480px .showcase-grid 不應殘留單欄 grid-template-columns: 1fr;"
+        )
+
+
+class TestUS5PosterCropScoped:
+    """TASK-75b-T4/T5：影片卡 poster-crop + caption 截斷帶正確 specificity scope。
+
+    斷言 ≤480px 影片卡規則帶 :is(#ds-gallery-components, .ds-gallery-composition) + :not(.hero-card)，
+    引用 var(--poster-crop-ratio)，子 img object-position: right center，caption .av-actress display:none。
+    三問：拔 :is() 前綴 → 紅（silent no-op 不會被擋，靠此守衛擋）；用錯 class .av-maker → 紅。
+    """
+
+    def _css(self):
+        return SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _strip_comments(text: str) -> str:
+        """移除 /* ... */ 註解——避免守衛被註解內提及的 selector 字串騙過（comment 內含 :is(...) 說明）。"""
+        return re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+
+    def test_poster_crop_rules_scoped_and_token_referenced(self):
+        css = self._strip_comments(self._css())
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".av-card-preview-img" in b]
+        assert target, "找不到含 .av-card-preview-img poster-crop 的 ≤480px block"
+        block = target[0]
+        # rule-bound：鎖定「含 aspect-ratio: var(--poster-crop-ratio) 的那條規則自身的 selector」，
+        # 確認該規則本身帶 scope（避免「caption 規則有 :is() 就過關、但關鍵 aspect-ratio 規則漏 :is() → silent no-op」）。
+        m = re.search(r'([^{}]*)\{[^{}]*aspect-ratio: var\(--poster-crop-ratio[^{}]*\}', block, re.DOTALL)
+        assert m, "找不到 aspect-ratio: var(--poster-crop-ratio) 規則"
+        sel = m.group(1)
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in sel, (
+            "aspect-ratio 規則 selector 必帶 :is(#ds-gallery-components,…) scope（否則 (0,4,0) 輸基準 (1,0,1) → silent no-op）；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+        assert ":not(.hero-card)" in sel, (
+            "aspect-ratio 規則 selector 必帶 :not(.hero-card)（排除女優 hero 卡）"
+        )
+        # object-position 規則同樣 rule-bound 檢查 scope
+        m2 = re.search(r'([^{}]*)\{[^{}]*object-position: right center[^{}]*\}', block, re.DOTALL)
+        assert m2, "找不到 object-position: right center 規則"
+        sel2 = m2.group(1)
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in sel2 and ":not(.hero-card)" in sel2, (
+            "object-position 規則 selector 必帶 :is(…) scope + :not(.hero-card)"
+        )
+
+    def test_caption_truncation_uses_av_actress(self):
+        css = self._css()
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".footer-default" in b and ".av-actress" in b]
+        assert target, "找不到含 caption 截斷（.footer-default .av-actress）的 ≤480px block"
+        block = target[0]
+        # .av-actress 隱藏
+        m = re.search(r'\.footer-default \.av-actress \{([^}]*)\}', block)
+        assert m, "找不到 .footer-default .av-actress 規則"
+        assert "display: none" in m.group(1), ".av-actress（女優名次行）應 display:none"
+        # .av-num ellipsis
+        m2 = re.search(r'\.footer-default \.av-num \{([^}]*)\}', block)
+        assert m2, "找不到 .footer-default .av-num 規則"
+        assert "text-overflow: ellipsis" in m2.group(1), ".av-num（番號）應單行 ellipsis"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -4692,8 +4692,9 @@ class TestSearchCssHardcoded:
     HARDCODED_RGBA_ALLOWLIST = {
         # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：788→840；90 在插入點上方不變。
         # T9-port 在 L718 後插入 blocks：840→902；T9 Codex-P2 fix 補註解 +4 行：902→906。
+        # T11：在 L753 後插入 hero 規則（~14 行）：906→920。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        906: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        920: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
@@ -12093,4 +12094,142 @@ class TestUS9SearchGridMobileFix:
         )
         assert "min-height: 0" in css, (
             "showcase.css T8 min-height: 0 應保留（T9 回歸護欄）"
+        )
+
+
+# ============================================================================
+# TASK-75b-T11：≤480px hero 卡（女優精準匹配入口）直式比例修正守衛
+# showcase + search 兩頁 video-mode grid ≤480px hero 卡改 0.71 直式 + img cover
+# ============================================================================
+
+class TestUS11HeroCardMobileFix:
+    """TASK-75b-T11：showcase + search 兩頁 ≤480px hero 卡改直式 poster 比例守衛。
+
+    根因：T4/T5/T9 的 :not(.hero-card) 排除 hero → hero 落回 theme.css 基準 3/2（寬短）→
+    圖高 62px vs 鄰卡 131px → row 死白 110px + 女優照 letterbox。
+    修正：≤480px hero .av-card-preview-img → aspect-ratio: var(--poster-crop-ratio, 0.71)；
+          hero img → object-fit: cover（覆蓋 hero 既有 contain）。
+    selector 規則：showcase 後代 :is(…) .showcase-grid；search 複合 :is(…).search-grid（Codex P2）。
+    三問：
+      - showcase：拔 aspect-ratio → 紅；img object-fit: cover 移除 → 紅
+      - search：同上；compound→descendant（加空格）→ 紅；後代形式存在 → 紅
+    """
+
+    @staticmethod
+    def _strip_comments(text: str) -> str:
+        """移除 /* ... */ 註解——避免守衛被註解內提及的 selector 字串騙過。"""
+        return re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+
+    def _showcase_css(self):
+        return SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def _search_css(self):
+        return SEARCH_CSS.read_text(encoding="utf-8")
+
+    # --- showcase hero guard ---
+
+    def test_showcase_hero_has_portrait_aspect_ratio(self):
+        """showcase.css ≤480px block 含 hero-card .av-card-preview-img aspect-ratio: var(--poster-crop-ratio。
+        rule-bound：驗 aspect-ratio 規則自身 selector 帶 :is(…) scope + .showcase-grid + .hero-card。
+        三問：拔 aspect-ratio → 紅；移除 :is() scope → 紅；移出 ≤480px block → 紅。
+        """
+        css = self._strip_comments(self._showcase_css())
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".av-card-preview.hero-card .av-card-preview-img" in b]
+        assert target, (
+            "showcase.css 找不到含 .av-card-preview.hero-card .av-card-preview-img 的 ≤480px block"
+            "（T11 showcase hero 規則缺失）"
+        )
+        block = target[0]
+        # rule-bound：aspect-ratio 規則 selector 帶正確 scope + hero class
+        m = re.search(r'([^{}]*)\{[^{}]*aspect-ratio: var\(--poster-crop-ratio[^{}]*\}', block, re.DOTALL)
+        assert m, "showcase.css ≤480px hero block 找不到 aspect-ratio: var(--poster-crop-ratio) 規則"
+        sel = m.group(1)
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in sel, (
+            "showcase hero aspect-ratio 規則 selector 必帶 :is(#ds-gallery-components, .ds-gallery-composition) scope；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+        assert ".showcase-grid" in sel, (
+            "showcase hero aspect-ratio 規則 selector 必帶 .showcase-grid；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+        assert ".hero-card" in sel, (
+            "showcase hero aspect-ratio 規則 selector 必帶 .hero-card；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+
+    def test_showcase_hero_img_has_object_fit_cover(self):
+        """showcase.css ≤480px hero img 規則含 object-fit: cover（覆蓋 hero 桌面 contain）。
+        三問：移除 object-fit: cover → 紅；移出 ≤480px block → 紅。
+        """
+        css = self._strip_comments(self._showcase_css())
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".av-card-preview.hero-card .av-card-preview-img" in b]
+        assert target, "showcase.css 找不到含 hero-card .av-card-preview-img 的 ≤480px block"
+        block = target[0]
+        m = re.search(r'([^{}]*)\{[^{}]*object-fit: cover[^{}]*\}', block, re.DOTALL)
+        assert m, "showcase.css ≤480px hero block 找不到 object-fit: cover 規則"
+        sel = m.group(1)
+        assert ".hero-card" in sel, (
+            "object-fit: cover 規則 selector 必帶 .hero-card（確認是 hero img 規則，非鄰卡）"
+        )
+
+    # --- search hero guard ---
+
+    def test_search_hero_has_portrait_aspect_ratio(self):
+        """search.css ≤480px block 含 hero-card .av-card-preview-img aspect-ratio: var(--poster-crop-ratio。
+        rule-bound：驗 selector 帶 :is(…).search-grid（複合）+ .hero-card。
+        三問：拔 aspect-ratio → 紅；移除 :is() scope → 紅；移出 ≤480px block → 紅。
+        """
+        css = self._strip_comments(self._search_css())
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".av-card-preview.hero-card .av-card-preview-img" in b]
+        assert target, (
+            "search.css 找不到含 .av-card-preview.hero-card .av-card-preview-img 的 ≤480px block"
+            "（T11 search hero 規則缺失）"
+        )
+        block = target[0]
+        m = re.search(r'([^{}]*)\{[^{}]*aspect-ratio: var\(--poster-crop-ratio[^{}]*\}', block, re.DOTALL)
+        assert m, "search.css ≤480px hero block 找不到 aspect-ratio: var(--poster-crop-ratio) 規則"
+        sel = m.group(1)
+        assert ":is(#ds-gallery-components, .ds-gallery-composition)" in sel, (
+            "search hero aspect-ratio 規則 selector 必帶 :is(#ds-gallery-components, .ds-gallery-composition) scope；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+        assert ".hero-card" in sel, (
+            "search hero aspect-ratio 規則 selector 必帶 .hero-card；"
+            f"目前 selector: {sel.strip()!r}"
+        )
+
+    def test_search_hero_scope_is_compound_not_descendant(self):
+        """Codex P2 回歸守衛：search hero 規則 selector 必須是複合 :is(…).search-grid（無空格）。
+        後代形式 :is(…) .search-grid .av-card-preview.hero-card（有空格）在 search 永不命中（silent no-op）。
+        三問：hero 規則 compound→descendant（加空格）→ 紅；後代形式 hero 存在 → 紅。
+        """
+        css = self._strip_comments(self._search_css())
+        # 正向：複合形式 .hero-card 規則存在
+        assert ":is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview.hero-card" in css, (
+            "search.css hero 規則 selector 必須用複合 :is(…).search-grid（scope class 在 grid 本身，非祖先；"
+            "後代 :is(…) .search-grid 在 search 永不命中 → silent no-op）"
+        )
+        # 負向：後代形式 hero 規則不得存在（P2 回歸護欄）
+        assert ":is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview.hero-card" not in css, (
+            "search.css 不得有後代 :is(…) .search-grid .av-card-preview.hero-card（有空格）——"
+            "scope class 在 grid 本身，後代選擇器永不命中（Codex P2 P11 hero 回歸）"
+        )
+
+    def test_search_hero_img_has_object_fit_cover(self):
+        """search.css ≤480px hero img 規則含 object-fit: cover（覆蓋 hero 桌面 contain）。
+        三問：移除 object-fit: cover → 紅；移出 ≤480px block → 紅。
+        """
+        css = self._strip_comments(self._search_css())
+        blocks = re.findall(r'@media \(max-width: 480px\) \{(.*?)\n\}', css, re.DOTALL)
+        target = [b for b in blocks if ".av-card-preview.hero-card .av-card-preview-img" in b]
+        assert target, "search.css 找不到含 hero-card .av-card-preview-img 的 ≤480px block"
+        block = target[0]
+        m = re.search(r'([^{}]*)\{[^{}]*object-fit: cover[^{}]*\}', block, re.DOTALL)
+        assert m, "search.css ≤480px hero block 找不到 object-fit: cover 規則"
+        sel = m.group(1)
+        assert ".hero-card" in sel, (
+            "object-fit: cover 規則 selector 必帶 .hero-card（確認是 hero img 規則，非鄰卡）"
         )

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -717,8 +717,70 @@
 
 @media (max-width: 480px) {
     .search-grid {
-        grid-template-columns: 1fr;
-        padding: 1rem;
+        grid-template-columns: repeat(3, 1fr);  /* T9-port：search 影片格對齊 showcase 3-col */
+        gap: 0.5rem;
+        padding: 0.75rem;
+    }
+}
+
+/* T9-port：≤480px search 影片格 poster-crop + caption（對齊 showcase T4/T5，Option P 平行）。
+   selector scope 同 showcase：:is(#ds-gallery-components, .ds-gallery-composition) 帶 (1,0,0) 贏
+   search.css 同類基準；:not(.hero-card) 排除女優入口 hero 卡（其 contain 圖不可 poster-crop）。
+   search-grid 和 showcase-grid 外觀一致：≤480px 三欄直幅格，番號 ellipsis，女優名隱藏。 */
+@media (max-width: 480px) {
+    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-img {
+        aspect-ratio: var(--poster-crop-ratio, 0.71);
+        height: auto;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-img img {
+        object-position: right center;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-num {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.7rem;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-actress {
+        display: none;
+    }
+}
+
+/* T9-port：≤480px ∩ touch 裝置 — search 影片格還原 .footer-default（番號可讀層）。
+   showcase.css 的 @media(pointer:coarse) US3c 把全局 .av-card-preview .footer-default opacity:0，
+   而 showcase 的 ≤480∩coarse 修正只 scope 在 .showcase-grid（L894–902），不涵蓋 .search-grid。
+   故補平行規則：≤480px ∩ coarse ∩ .search-grid 非 hero → 還原 footer-default 番號層。
+   specificity :is(…) ID 帶 (1,0,0) 使 (1,4,0) 勝 US3c .av-card-preview .footer-* (0,2,0)。 */
+@media (max-width: 480px) and (pointer: coarse) {
+    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .footer-default {
+        opacity: 1;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .footer-hover {
+        opacity: 0;
+    }
+}
+
+/* T9-port：≤480px search 影片燈箱封面貼合原圖比例（消 letterbox 死白）。
+   判別子 .search-container 精準限 search 頁——showcase 頁根為 .showcase-container，零波及。
+   容器 + img 皆 gate .has-cover（決策 ①）：search 無 similar-open、無「保低 specificity」顧慮；
+     gate has-cover 後女優模式（has-cover=false）/無封面/404 皆不命中 → 乾淨排除女優燈箱、不塌。
+   specificity（皆自勝、不靠源序）：容器 .search-container .lightbox-cover.has-cover (0,3,0) 勝基準 (0,1,0)；
+     img .search-container .lightbox-cover.has-cover img (0,3,1) 勝基準 .lightbox-cover img (0,1,1)。 */
+@media (max-width: 480px) {
+    /* (b) 容器：有封面才塌到圖盒 */
+    .search-container .lightbox-cover.has-cover {
+        min-height: 0;
+        min-width: 0;
+    }
+    /* (a) img：寬填滿、高隨原圖比例（覆寫 60vh letterbox 源）；同 gate has-cover 排除女優燈箱 */
+    .search-container .lightbox-cover.has-cover img {
+        width: 100%;
+        height: auto;
+        object-fit: contain;
     }
 }
 

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -724,27 +724,30 @@
 }
 
 /* T9-port：≤480px search 影片格 poster-crop + caption（對齊 showcase T4/T5，Option P 平行）。
-   selector scope 同 showcase：:is(#ds-gallery-components, .ds-gallery-composition) 帶 (1,0,0) 贏
-   search.css 同類基準；:not(.hero-card) 排除女優入口 hero 卡（其 contain 圖不可 poster-crop）。
-   search-grid 和 showcase-grid 外觀一致：≤480px 三欄直幅格，番號 ellipsis，女優名隱藏。 */
+   ★ Codex P2 修正：search grid 是 `<div class="search-grid ds-gallery-composition">`——scope class 在
+   grid 元素「本身」，非祖先（showcase 是 `.showcase-container.ds-gallery-composition` 祖先，故用後代）。
+   故此處用**複合選擇器** `:is(…).search-grid`（無空格，同元素），而非後代 `:is(…) .search-grid`——
+   後者要求 scope 在 .search-grid 的祖先 → search 無此祖先 → 永不命中（poster-crop/caption silent no-op）。
+   :is(#id,…) 仍必要：帶 (1,0,0) 使複合 (1,4,0) 勝基準 :is(…) .av-card-preview-img (1,1,0)；
+   去掉 #id 的純 class 複合僅 (0,4,0) 會輸基準。:not(.hero-card) 排除女優入口 hero 卡。 */
 @media (max-width: 480px) {
-    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-img {
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .av-card-preview-img {
         aspect-ratio: var(--poster-crop-ratio, 0.71);
         height: auto;
     }
 
-    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-img img {
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .av-card-preview-img img {
         object-position: right center;
     }
 
-    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-num {
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-num {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
         font-size: 0.7rem;
     }
 
-    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-actress {
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-actress {
         display: none;
     }
 }
@@ -753,13 +756,14 @@
    showcase.css 的 @media(pointer:coarse) US3c 把全局 .av-card-preview .footer-default opacity:0，
    而 showcase 的 ≤480∩coarse 修正只 scope 在 .showcase-grid（L894–902），不涵蓋 .search-grid。
    故補平行規則：≤480px ∩ coarse ∩ .search-grid 非 hero → 還原 footer-default 番號層。
-   specificity :is(…) ID 帶 (1,0,0) 使 (1,4,0) 勝 US3c .av-card-preview .footer-* (0,2,0)。 */
+   specificity :is(…) ID 帶 (1,0,0) 使 (1,4,0) 勝 US3c .av-card-preview .footer-* (0,2,0)。
+   selector 同用複合 `:is(…).search-grid`（scope 在 grid 本身，見上 Codex P2 註）。 */
 @media (max-width: 480px) and (pointer: coarse) {
-    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .footer-default {
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .footer-default {
         opacity: 1;
     }
 
-    :is(#ds-gallery-components, .ds-gallery-composition) .search-grid .av-card-preview:not(.hero-card) .footer-hover {
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .footer-hover {
         opacity: 0;
     }
 }

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -484,6 +484,14 @@
         width: 100%;
         min-width: auto;
     }
+
+    /* 75a-US3a: mobile scroll trap 解鎖 —
+     * 桌面 .av-card-full-info 已有 overflow-y:auto，不動。
+     * column-stacked layout 下四層 overflow:hidden + height 鎖定形成 scroll trap。 */
+    .result-area        { overflow: visible; }
+    #resultCard         { overflow: visible; max-height: none; }
+    #resultCard > .av-card-full { overflow: visible; }
+    .search-container   { height: auto; overflow-y: auto; }
 }
 
 /* Mobile 額外調整 */

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -102,8 +102,55 @@
 }
 
 .search-container .av-card-full-info {
-    flex: 0 0 320px;
+    flex: 0 0 390px;    /* US1-75b：320px → 390px（spec NC#2，CD-75b-1） */
     overflow-y: auto;
+}
+
+/* US1-75b：取消 search 右欄 body 撐高（top-pack）。不刪全域 theme.css flex:1
+   （design-system 也用 + 被 tailwind.css:4430 編譯副本架空，刪 theme.css 那條不生效）；
+   search.css 載入在 tailwind.css 之後、(0,2,0) > 全域 (0,1,0)，scope override 確實生效（CD-75b-4）。 */
+.search-container .av-card-full-body {
+    flex: none;
+}
+
+/* US1-75b：搜尋詳情右欄 inline label-value（覆寫 theme.css 全域 .info-label{display:block}，
+   只在 search 右欄 scope 覆寫，不動全域，避免影響 showcase 燈箱 .lightbox-metadata；CD-75b-3） */
+.search-container .av-card-full-body .info-row,
+.search-container .av-card-full-body .info-cell {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.search-container .av-card-full-body .info-label {
+    flex-shrink: 0;      /* label 不被壓縮 */
+    white-space: nowrap;
+}
+
+.search-container .av-card-full-body .info-value {
+    flex: 1;
+    min-width: 0;        /* 必要：flex min-width:auto 不觸發 text-overflow（CD-75b-10） */
+}
+
+/* US1-75b：雙欄 metadata grid（CD-75b-2） */
+.search-container .av-card-full-body .info-grid-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem 1rem;    /* 縱 0.5rem（8px）、橫 1rem（16px，Fluent 8pt × 2） */
+    margin-bottom: 0.5rem;
+}
+
+/* CD-75b-10：grid cell 內 label/value 截斷 */
+.search-container .av-card-full-body .info-grid-pair .info-label {
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.search-container .av-card-full-body .info-grid-pair .info-value {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* 導航按鈕（絕對定位在封面上） */
@@ -492,6 +539,11 @@
     #resultCard         { overflow: visible; max-height: none; }
     #resultCard > .av-card-full { overflow: visible; }
     .search-container   { height: auto; overflow-y: auto; }
+
+    /* US1-75b：≤1024px 全寬單欄時，雙欄 metadata 回單欄（spec §US1 L97/L113 驗收強制，CD-75b-2） */
+    .search-container .av-card-full-body .info-grid-pair {
+        grid-template-columns: 1fr;
+    }
 }
 
 /* Mobile 額外調整 */

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -750,6 +750,20 @@
     :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-actress {
         display: none;
     }
+
+    /* T11：search 頁平行修正（同 showcase）。
+       ★ Codex P2：search grid 的 ds-gallery-composition 在 .search-grid 本身（非祖先）→ 用複合
+       :is(…).search-grid（無空格、同元素）。後代 :is(…) .search-grid 在 search 永不命中（silent no-op）。
+       :is(#id,…) 帶 (1,0,0) 使複合 (1,4,0) 勝 theme.css 基準 :is(…) .av-card-preview-img (1,0,1)。 */
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview.hero-card .av-card-preview-img {
+        aspect-ratio: var(--poster-crop-ratio, 0.71);
+        height: auto;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition).search-grid .av-card-preview.hero-card .av-card-preview-img img {
+        object-fit: cover;
+        transform-origin: center center;
+    }
 }
 
 /* T9-port：≤480px ∩ touch 裝置 — search 影片格還原 .footer-default（番號可讀層）。

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -911,7 +911,7 @@
 
 .similar-mobile-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: 0.5rem;                  /* --space-2 不存在，用 raw 0.5rem */
 }
 
@@ -934,7 +934,7 @@
 
 .similar-mobile-card img {
     width: 100%;
-    aspect-ratio: 4/5;
+    aspect-ratio: var(--poster-crop-ratio);
     object-fit: cover;
     object-position: right center;  /* CSS layer crop，右半邊視覺 — 非 ghost-fly cropMode（不違反 lint rule）*/
     /* 圖片載入中骨架：lazy img 在 loaded 前顯示淺灰漸層 */
@@ -957,6 +957,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: none;  /* 75a-US4: 77px 卡片寬度無法顯示標題，僅保留番號 */
 }
 
 /* 確保 mobile collapse 只在小螢幕渲染（桌面應永遠 similarModeMobileOpen = false） */
@@ -1184,6 +1185,17 @@
         width: 40px;
         height: 40px;
         font-size: 1rem;
+    }
+}
+
+/* 75a-US4: 手機相似模式主片封面縮高（僅 similar-open，一般燈箱不縮） */
+@media (max-width: 960px) {
+    .lightbox-content.similar-open .lightbox-cover {
+        min-height: min(38vh, 290px);   /* 覆寫容器 min-height: min(58vh, 460px) */
+    }
+    .lightbox-content.similar-open .lightbox-cover img,
+    .lightbox-content.similar-open .lb-full {
+        height: 40vh;   /* 覆寫 img/lb-full 的 60vh */
     }
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -828,6 +828,28 @@
     }
 }
 
+/* 75a-US3c: touch 裝置 hover-only 三處直達（比照 .lightbox-cover .cover-actions 先例，showcase.css:825-829）*/
+@media (pointer: coarse) {
+    /* (1) showcase grid 影片卡 overlay — 常駐顯示 */
+    :is(#ds-gallery-components, .ds-gallery-composition) .av-card-preview-overlay {
+        opacity: 1;
+        pointer-events: auto;
+    }
+    /* (2) 影片卡 footer-hover（標題層）— 常駐顯示，解除 translateY(100%) 入場 transform */
+    .av-card-preview .footer-hover {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    .av-card-preview .footer-default {
+        opacity: 0;    /* touch 裝置：標題層常駐、番號/女優層隱藏 */
+    }
+    /* (3) actress card overlay — 常駐顯示 */
+    .actress-card-overlay {
+        opacity: 1;
+        pointer-events: auto;
+    }
+}
+
 /* ─── 56c-T3 / T3fix: Similar Mode 入口按鈕 + Sparkle Burst 預覽 ────────────
  * .lightbox-similar-btn — 玻璃材質圓鈕，與 .lightbox-close 鏡射對稱（左上 1rem/1rem）
  *   尺寸 44×44，與 .lightbox-close 鏡射對稱（同尺寸 + 同距邊 1rem）
@@ -938,7 +960,7 @@
 }
 
 /* 確保 mobile collapse 只在小螢幕渲染（桌面應永遠 similarModeMobileOpen = false） */
-@media (min-width: 768px) {
+@media (min-width: 960px) {
     .lightbox-similar-mobile {
         display: none !important;   /* 桌面安全網：即使 state 殘留也不顯示 */
     }
@@ -1188,6 +1210,21 @@
     .toolbar-controls .control-group {
         flex-wrap: wrap;
         justify-content: flex-end;
+    }
+}
+
+/* 75a-US3d: tablet toolbar 769–1023px 銜接規則（舊缺失，補齊斷層）*/
+@media (min-width: 769px) and (max-width: 1023px) {
+    .showcase-toolbar {
+        grid-template-columns: auto 1fr auto;   /* 搜尋框置中，控制區靠右 */
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+    }
+    .toolbar-search {
+        grid-column: 2;
+    }
+    .toolbar-controls {
+        grid-column: 3;
     }
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1250,6 +1250,34 @@
     }
 }
 
+/* US5-75b-T8: ≤480px 影片燈箱封面貼合原圖比例（消 object-fit:contain 在 60vh 高框的 letterbox 死白）。
+ * :has(.lb-full) 只命中影片 cover（女優 cover 無 .lb-full，showcase.html:569 vs 669）→ 女優燈箱零波及。
+ * make-or-break（live 實證）：須同改 (a) img/.lb-full 尺寸法 + (b) 容器 min-*，只改 img 會把空白留在容器。
+ * 副作用：盒比例=圖比例後 object-fit:cover≈contain，T7 grid→lightbox flight 落地 cover→contain seam 自然消失。
+ * specificity（Codex P3 修正）：:has(.lb-full) 計入其引數一個 class →
+ *   img 規則 .lightbox-cover:has(.lb-full) img = (0,2,1) 勝基準 §667 .lightbox-cover img (0,1,1)，
+ *   容器 .lightbox-cover.has-cover:has(.lb-full) = (0,3,0) 勝基準 .lightbox-cover (0,1,0)；皆靠 specificity（非源序）。無 !important。
+ * Codex P2：容器 min-height:0 只在 .has-cover（有封面）才套——無封面影片若塌到 0 高，補封面入口會壞，
+ *   故無封面保留基準 min-height。img 規則不 gate has-cover（無封面時 img 空 src→height:auto=0 無害），
+ *   且刻意保持 (0,2,1) 不升到 (0,3,1) 以免在 ≤480∩similar-open 與 similar-open img (0,3,1) 撞同權。
+ * similar-open 交互：.lightbox-content.similar-open .lightbox-cover img (0,3,1) 勝本 img 規則 (0,2,1)
+ *   → ≤480px ∩ similar-open 時手機相似主片維持 40vh（本 task 不接管相似模式，刻意）。 */
+@media (max-width: 480px) {
+    /* (b) 容器塌到圖的盒（Codex P2：僅 .has-cover；無封面保留基準 min-height 防塌成 0 高） */
+    .lightbox-cover.has-cover:has(.lb-full) {
+        min-height: 0;
+        min-width: 0;
+    }
+    /* (a) base img + .lb-full overlay 同步：寬填滿、高隨原圖比例（覆寫 60vh）。
+       不 gate has-cover：無封面 img 空 src→height:auto=0 無害，且保 (0,2,1) 不撞 similar-open。 */
+    .lightbox-cover:has(.lb-full) img,
+    .lightbox-cover:has(.lb-full) .lb-full {
+        width: 100%;
+        height: auto;
+        object-fit: contain;   /* 盒=圖比例時與 cover 等價，保留 contain 不裁切語意 */
+    }
+}
+
 /* ==================== Responsive: Toolbar ==================== */
 /* 小螢幕：Toolbar 單欄堆疊 (44c-T8) */
 @media (max-width: 768px) {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -318,6 +318,20 @@
     :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .av-card-preview-img img {
         object-position: right center; /* (1,4,1) 贏 theme.css 基準 img (1,0,2)；基準本無 object-position（此為加值）；只露封面正面 */
     }
+
+    /* US5-75b：3 欄 poster 格 caption（CD-75b-9）——番號單行 ellipsis、女優名次行隱藏。
+       次行 class = .av-actress（非 .av-maker；grid 卡無 .av-maker，誤用會 silent no-op）。
+       同帶 :is(…) scope + :not(.hero-card) 防誤殺 hero footer（其 footer 也有 .av-num/.av-actress，Codex F5）。 */
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-num {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.7rem; /* 略縮字型容納番號（3 欄每欄 ≈107px） */
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-actress {
+        display: none; /* narrow 下次要資訊，空間不足 */
+    }
 }
 
 /* ==================== Actress Grid — Collection Wall (44c-T6) ==================== */

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -883,6 +883,24 @@
     }
 }
 
+/* US5-75b fix（Codex P1）：真實觸控 ≤480px poster 格——還原 .footer-default（番號可讀層）、
+ * 壓回上方 75a-US3c 的 footer-hover 常駐。
+ * 衝突來源：US3c 在 @media(pointer:coarse) 無條件把 .footer-default opacity:0 + footer-hover opacity:1
+ * （touch 顯示標題層）；但 US5 的 3 欄 poster 格（≤480px）要顯示「番號 caption」（spec §US5 / CD-75b-9），
+ * 標題在 107px 窄格不可讀。故在 ≤480px ∩ pointer:coarse ∩ poster-grid 非 hero 卡，反轉回 footer-default。
+ * scope :is(#id,…) → a=1 勝 US3c .av-card-preview .footer-* 的 (0,2,0)；:not(.hero-card) 不碰女優入口；
+ * 481px+ touch / pointer:fine 桌面皆不受影響（US3c title-on-touch 行為保留）。
+ * T5 的 .av-num ellipsis / .av-actress display:none 規則此時作用在已可見的 .footer-default 上。 */
+@media (max-width: 480px) and (pointer: coarse) {
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .footer-default {
+        opacity: 1;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .footer-hover {
+        opacity: 0;
+    }
+}
+
 /* ─── 56c-T3 / T3fix: Similar Mode 入口按鈕 + Sparkle Burst 預覽 ────────────
  * .lightbox-similar-btn — 玻璃材質圓鈕，與 .lightbox-close 鏡射對稱（左上 1rem/1rem）
  *   尺寸 44×44，與 .lightbox-close 鏡射對稱（同尺寸 + 同距邊 1rem）

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1225,10 +1225,14 @@
     }
 }
 
-/* 75a-US3d: tablet toolbar 769–1023px 銜接規則（舊缺失，補齊斷層）*/
+/* 75a-US3d: tablet toolbar 769–1023px 銜接規則（舊缺失，補齊斷層）
+ * 佈局策略：搜尋框（col2 1fr）填滿中段、控制區（col3 auto）靠右。
+ * 不強制視覺置中——tablet 寬度下真置中需與 controls 等寬的平衡欄，會擠壓 controls
+ * 致換行/溢出；「搜尋框填滿、controls 靠右」是 tablet 慣例且無溢出風險。col1 auto
+ * 無內容會 collapse 成 0（刻意，非 bug）。Codex P2 採「明確布局策略」解。 */
 @media (min-width: 769px) and (max-width: 1023px) {
     .showcase-toolbar {
-        grid-template-columns: auto 1fr auto;   /* 搜尋框置中，控制區靠右 */
+        grid-template-columns: auto 1fr auto;   /* col1 空佔位(0) | 搜尋框填滿 | 控制區靠右 */
         gap: 0.75rem;
         padding: 0.75rem 1rem;
     }

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -293,11 +293,30 @@
     }
 }
 
-/* ≤480px → 1 column */
+/* ≤480px → 3 column poster 格（US5-75b，比照 .actress-grid 的 ≤480 斷點） */
 @media (max-width: 480px) {
     .showcase-grid {
-        grid-template-columns: 1fr;
-        padding: 1rem;
+        grid-template-columns: repeat(3, 1fr); /* US5-75b：1fr → 3-col（CD-75b-7） */
+        gap: 0.5rem;
+        padding: 0.75rem;
+    }
+
+    /* US5-75b：影片卡切直式 poster 比例。
+       數值來源 = plan-75a US2 poster-crop（--poster-crop-ratio），**不可獨立修改**（單一真理）。
+       Codex P1（specificity）：selector 必帶 :is(#ds-gallery-components, .ds-gallery-composition) scope。
+         :is() 含 #id → a=1（無論其他 arg），:not(.hero-card) 的 .hero-card 計入 b。
+         theme.css 基準 :is(#id,…) .av-card-preview-img = (1,0,1)；本規則 4 個 class（showcase-grid /
+         av-card-preview / .hero-card(:not) / av-card-preview-img）= (1,4,0) 贏。
+         若漏 :is() 前綴 → (0,4,0)，a=0 輸給基準 a=1 → aspect-ratio silent no-op、手機卡仍 3:2。
+       Codex F5：:not(.hero-card) 排除女優精準匹配 hero 卡（其圖 object-fit:contain，不可被裁成 0.71）。
+       .av-card-preview-img 是 <div> → aspect-ratio 寫 div；object-position 只對 replaced element 生效 → 寫子 img。 */
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .av-card-preview-img {
+        aspect-ratio: var(--poster-crop-ratio, 0.71);
+        height: auto;   /* aspect-ratio 與 explicit height 互斥，明確 auto 防其他規則殘留高度 */
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .av-card-preview-img img {
+        object-position: right center; /* (1,4,1) 贏 theme.css 基準 img (1,0,2)；基準本無 object-position（此為加值）；只露封面正面 */
     }
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -2829,7 +2829,7 @@ body.sidebar-collapsed .showcase-footer {
  * CSS transition 會與 GSAP tick 賽跑。box-shadow 走 CSS transition 安全。 */
 .similar-slot {
     position: absolute;
-    width: 120px;
+    width: 107px;
     height: 150px;
     transform: translate(-50%, -50%);
     background: var(--color-base-100);
@@ -2870,7 +2870,7 @@ body.sidebar-collapsed .showcase-footer {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: 100% 20%;
+    object-position: right center;
     display: block;
     border-radius: inherit;
     pointer-events: none;
@@ -2924,7 +2924,7 @@ body.sidebar-collapsed .showcase-footer {
     position: absolute;
     left: 380px;
     top: 185px;
-    width: 200px;
+    width: 178px;
     height: 250px;
     object-fit: cover;
     object-position: right center;  /* 沿用 cropMode: 'right-half' 視覺一致 */

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1256,12 +1256,14 @@
 }
 
 /* 75a-US4: 手機相似模式主片封面縮高（僅 similar-open，一般燈箱不縮） */
+/* 特異性升至 (0,4,0)：勝 T8 ≤480 的 .lightbox-cover:has(.lb-full) .lb-full / .lightbox-cover.has-cover:has(.lb-full)
+   (0,3,0)，否則 source order 讓 T8 的 height:auto/min-height:0 在 similar 模式覆寫 → overlay 與 base 40vh 脫鉤/溢出 */
 @media (max-width: 960px) {
-    .lightbox-content.similar-open .lightbox-cover {
+    .showcase-lightbox .lightbox-content.similar-open .lightbox-cover {
         min-height: min(38vh, 290px);   /* 覆寫容器 min-height: min(58vh, 460px) */
     }
     .lightbox-content.similar-open .lightbox-cover img,
-    .lightbox-content.similar-open .lb-full {
+    .lightbox-content.similar-open .lightbox-cover .lb-full {
         height: 40vh;   /* 覆寫 img/lb-full 的 60vh */
     }
 }

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -332,6 +332,22 @@
     :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview:not(.hero-card) .av-card-preview-footer .footer-default .av-actress {
         display: none; /* narrow 下次要資訊，空間不足 */
     }
+
+    /* T11：≤480px hero 卡（女優精準匹配入口）改直式 poster 比例，對齊同列 0.71 鄰卡 → 消 row 死白/錯位。
+       值引用 --poster-crop-ratio（與鄰卡同源，單一真理）。img 改 object-fit:cover（女優照 0.826 略寬胖，
+       cover 填滿僅輕裁上下、無 letterbox），覆蓋 hero 既有 contain（L2342）。
+       selector 帶 :is(#id,…) scope → (1,4,0) 勝 theme.css 基準 (1,0,1)；showcase 的 ds-gallery-composition
+       在 .showcase-container 祖先 → 用後代 :is(…) .showcase-grid（與 L313 同 pattern）。
+       hero 在女優收藏模式不存在（showFavoriteActresses gate），故只影響 video-mode grid。 */
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview.hero-card .av-card-preview-img {
+        aspect-ratio: var(--poster-crop-ratio, 0.71);
+        height: auto;
+    }
+
+    :is(#ds-gallery-components, .ds-gallery-composition) .showcase-grid .av-card-preview.hero-card .av-card-preview-img img {
+        object-fit: cover;             /* 覆蓋 hero 桌面 contain（L2342）；女優照填滿、無 letterbox */
+        transform-origin: center center;
+    }
 }
 
 /* ==================== Actress Grid — Collection Wall (44c-T6) ==================== */

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -457,6 +457,183 @@
       }
     }
   }
+  .menu {
+    @layer daisyui.l1.l2.l3 {
+      display: flex;
+      width: fit-content;
+      flex-direction: column;
+      flex-wrap: wrap;
+      padding: calc(0.25rem * 2);
+      --menu-active-fg: var(--color-neutral-content);
+      --menu-active-bg: var(--color-neutral);
+      font-size: 0.875rem;
+      :where(li ul) {
+        position: relative;
+        margin-inline-start: calc(0.25rem * 4);
+        padding-inline-start: calc(0.25rem * 2);
+        white-space: nowrap;
+        &:before {
+          position: absolute;
+          inset-inline-start: calc(0.25rem * 0);
+          top: calc(0.25rem * 3);
+          bottom: calc(0.25rem * 3);
+          background-color: var(--color-base-content);
+          opacity: 10%;
+          width: var(--border);
+          content: "";
+        }
+      }
+      :where(li > .menu-dropdown:not(.menu-dropdown-show)) {
+        display: none;
+      }
+      :where(li:not(.menu-title) > *:not(ul, details, .menu-title, .btn)), :where(li:not(.menu-title) > details > summary:not(.menu-title)) {
+        display: grid;
+        grid-auto-flow: column;
+        align-content: flex-start;
+        align-items: center;
+        gap: calc(0.25rem * 2);
+        border-radius: var(--radius-field);
+        padding-inline: calc(0.25rem * 3);
+        padding-block: calc(0.25rem * 1.5);
+        text-align: start;
+        transition-property: color, background-color, box-shadow;
+        transition-duration: 0.2s;
+        transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+        grid-auto-columns: minmax(auto, max-content) auto max-content;
+        text-wrap: balance;
+        user-select: none;
+      }
+      :where(li > details > summary) {
+        --tw-outline-style: none;
+        outline-style: none;
+        @media (forced-colors: active) {
+          outline: 2px solid transparent;
+          outline-offset: 2px;
+        }
+        &::-webkit-details-marker {
+          display: none;
+        }
+      }
+      :where(li > details > summary), :where(li > .menu-dropdown-toggle) {
+        &:after {
+          justify-self: flex-end;
+          display: block;
+          height: 0.375rem;
+          width: 0.375rem;
+          rotate: -135deg;
+          translate: 0 -1px;
+          transition-property: rotate, translate;
+          transition-duration: 0.2s;
+          content: "";
+          transform-origin: 50% 50%;
+          box-shadow: 2px 2px inset;
+          pointer-events: none;
+        }
+      }
+      details {
+        overflow: hidden;
+        interpolate-size: allow-keywords;
+      }
+      details::details-content {
+        block-size: 0;
+        @media (prefers-reduced-motion: no-preference) {
+          transition-behavior: allow-discrete;
+          transition-property: block-size, content-visibility;
+          transition-duration: 0.2s;
+          transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+        }
+      }
+      details[open]::details-content {
+        block-size: auto;
+      }
+      :where(li > details[open] > summary):after, :where(li > .menu-dropdown-toggle.menu-dropdown-show):after {
+        rotate: 45deg;
+        translate: 0 1px;
+      }
+      :where( li:not(.menu-title, .disabled) > *:not(ul, details, .menu-title), li:not(.menu-title, .disabled) > details > summary:not(.menu-title) ):not(.menu-active, :active, .btn) {
+        &.menu-focus, &:focus-visible {
+          cursor: pointer;
+          background-color: var(--color-base-content);
+          @supports (color: color-mix(in lab, red, red)) {
+            background-color: color-mix(in oklab, var(--color-base-content) 10%, transparent);
+          }
+          color: var(--color-base-content);
+          --tw-outline-style: none;
+          outline-style: none;
+          @media (forced-colors: active) {
+            outline: 2px solid transparent;
+            outline-offset: 2px;
+          }
+        }
+      }
+      :where( li:not(.menu-title, .disabled) > *:not(ul, details, .menu-title):not(.menu-active, :active, .btn):hover, li:not(.menu-title, .disabled) > details > summary:not(.menu-title):not(.menu-active, :active, .btn):hover ) {
+        cursor: pointer;
+        background-color: var(--color-base-content);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-base-content) 10%, transparent);
+        }
+        --tw-outline-style: none;
+        outline-style: none;
+        @media (forced-colors: active) {
+          outline: 2px solid transparent;
+          outline-offset: 2px;
+        }
+        box-shadow: 0 1px oklch(0% 0 0 / 0.01) inset, 0 -1px oklch(100% 0 0 / 0.01) inset;
+      }
+      :where(li:empty) {
+        background-color: var(--color-base-content);
+        opacity: 10%;
+        margin: 0.5rem 1rem;
+        height: 1px;
+      }
+      :where(li) {
+        position: relative;
+        display: flex;
+        flex-shrink: 0;
+        flex-direction: column;
+        flex-wrap: wrap;
+        align-items: stretch;
+        .badge {
+          justify-self: flex-end;
+        }
+        & > *:not(ul, .menu-title, details, .btn):active, & > *:not(ul, .menu-title, details, .btn).menu-active, & > details > summary:active {
+          --tw-outline-style: none;
+          outline-style: none;
+          @media (forced-colors: active) {
+            outline: 2px solid transparent;
+            outline-offset: 2px;
+          }
+          color: var(--menu-active-fg);
+          background-color: var(--menu-active-bg);
+          background-size: auto, calc(var(--noise) * 100%);
+          background-image: none, var(--fx-noise);
+          &:not(&:active) {
+            box-shadow: 0 2px calc(var(--depth) * 3px) -2px var(--menu-active-bg);
+          }
+        }
+        &.menu-disabled {
+          pointer-events: none;
+          color: var(--color-base-content);
+          @supports (color: color-mix(in lab, red, red)) {
+            color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
+          }
+        }
+      }
+      .dropdown:focus-within {
+        .menu-dropdown-toggle:after {
+          rotate: 45deg;
+          translate: 0 1px;
+        }
+      }
+      .dropdown-content {
+        margin-top: calc(0.25rem * 2);
+        padding: calc(0.25rem * 2);
+        &:before {
+          display: none;
+        }
+      }
+    }
+  }
   .dropdown {
     @layer daisyui.l1.l2.l3 {
       position: relative;
@@ -1783,6 +1960,23 @@
       input:checked ~ .swap-on, input:indeterminate ~ .swap-indeterminate {
         opacity: 100%;
         backface-visibility: visible;
+      }
+    }
+  }
+  .avatar {
+    @layer daisyui.l1.l2.l3 {
+      position: relative;
+      display: inline-flex;
+      vertical-align: middle;
+      & > div {
+        display: block;
+        aspect-ratio: 1 / 1;
+        overflow: hidden;
+      }
+      img {
+        height: 100%;
+        width: 100%;
+        object-fit: cover;
       }
     }
   }
@@ -3188,6 +3382,9 @@
   .rounded-full {
     border-radius: calc(infinity * 1px);
   }
+  .rounded-lg {
+    border-radius: var(--radius-lg);
+  }
   .rounded-xl {
     border-radius: var(--radius-xl);
   }
@@ -3275,6 +3472,9 @@
   }
   .p-0 {
     padding: calc(var(--spacing) * 0);
+  }
+  .p-3 {
+    padding: calc(var(--spacing) * 3);
   }
   .p-4 {
     padding: calc(var(--spacing) * 4);
@@ -4233,6 +4433,14 @@ body {
 .av-card-full-footer {
   padding-top: 1rem;
   border-top: 1px solid var(--border-light);
+}
+:root {
+  --poster-crop-ratio: 0.71;
+}
+.poster-crop {
+  aspect-ratio: var(--poster-crop-ratio);
+  object-fit: cover;
+  object-position: right center;
 }
 .av-card-full-footer-content {
   display: flex;
@@ -5541,6 +5749,9 @@ body {
   padding: 0.375rem 0.75rem;
   font-size: 0.875rem;
   color: var(--text-secondary);
+}
+.fluent-modal {
+  z-index: 1600;
 }
 .fluent-modal::backdrop {
   background-color: var(--fluent-smoke);

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -541,6 +541,15 @@ body {
     border-top: 1px solid var(--border-light);
 }
 
+/* US1-75b：標題區塊（搬至 header 下方、metadata 上方）。
+   .av-card-full-footer 規則保留不動（motion_lab/design-system 仍用，CD-75b-6）；
+   此為並存的新規則，分隔線在下（border-bottom）符合新的上方位置。 */
+.av-card-full-title {
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-light);
+    margin-bottom: 1rem;
+}
+
 /* ── poster-crop 共用規則（US2，v0.10.2）─────────────────────────────────────
  * 封面正面裁切：JAV 橫式包裝 (≈1.49) 右側 47% 即封面正面，比例 ≈0.71。
  * --poster-crop-ratio 是比例的【單一真理】（NC#7 微調點，改這一行即可）。

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -541,6 +541,22 @@ body {
     border-top: 1px solid var(--border-light);
 }
 
+/* ── poster-crop 共用規則（US2，v0.10.2）─────────────────────────────────────
+ * 封面正面裁切：JAV 橫式包裝 (≈1.49) 右側 47% 即封面正面，比例 ≈0.71。
+ * --poster-crop-ratio 是比例的【單一真理】（NC#7 微調點，改這一行即可）。
+ * .poster-crop class 為 canonical 定義；各 spot 因既有元素 rule specificity，
+ * 一律在自身 rule 直接寫 aspect-ratio: var(--poster-crop-ratio)、不施加 class。
+ * 星座 slot 盒尺寸由 GSAP gsap.set width 控制，CSS 只改 object-position。
+ */
+:root {
+    --poster-crop-ratio: 0.71;
+}
+.poster-crop {
+    aspect-ratio: var(--poster-crop-ratio);
+    object-fit: cover;
+    object-position: right center;
+}
+
 /* AV Card Full Footer - 標題區塊佈局 */
 .av-card-full-footer-content {
     display: flex;

--- a/web/static/js/pages/motion-lab/constellation-host.js
+++ b/web/static/js/pages/motion-lab/constellation-host.js
@@ -480,7 +480,8 @@ document.addEventListener('alpine:init', () => {
           const card = this.cards[id];
           if (anchor && card) {
             card.classList.remove('slot--hidden');
-            gsap.set(card, { left: anchor.x, top: anchor.y, opacity: 1, width: 120, height: 150 });
+            // width 107 = round(150 * poster-crop 0.71)；NC#7 微調須同步 animations.js POSTER_CROP_RATIO + CSS --poster-crop-ratio（reduced-motion click path，繞過 animations.js gsap.set）
+            gsap.set(card, { left: anchor.x, top: anchor.y, opacity: 1, width: 107, height: 150 });
           }
         });
         // Rails: nextVisible 顯示，其餘隱藏（DrawSVG 禁用，使用 classList + opacity）
@@ -973,7 +974,7 @@ document.addEventListener('alpine:init', () => {
           gsap.set(card, {
             left: 480,
             top: 310,
-            width: 120,
+            width: 107,   // = round(150 * poster-crop 0.71)；NC#7 同步 animations.js POSTER_CROP_RATIO + CSS --poster-crop-ratio（reset baseline，繞過 animations.js gsap.set）
             height: 150,
             opacity: 0,
             zIndex: '',

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -91,6 +91,7 @@ export function searchStateGridMode() {
         // ★ C17 step 1: 在 state 變更前捕獲 fromRect（僅 grid → lightbox 首次開啟）
         var fromRect = null;
         var coverSrc = null;
+        var posterCrop = false;   // T9-port: ≤480px search 影片卡 poster-crop 旗標（對齊 showcase state-lightbox.js）
         if (!this.lightboxOpen && this.displayMode === 'grid') {
             var grid = document.querySelector('.search-grid');
             var card = grid ? grid.querySelector('[data-slot="' + index + '"]') : null;
@@ -98,6 +99,9 @@ export function searchStateGridMode() {
             if (img && img.complete && img.getBoundingClientRect().width > 0) {
                 fromRect = img.getBoundingClientRect();
                 coverSrc = img.src;
+                // T9-port：≤480px search 影片卡縮圖走 poster-crop，通知 ghost 對齊裁切 + 落地溶接。
+                // search 無 showFavoriteActresses；openLightbox 路徑的 card 皆為影片卡（hero 走 openActressLightbox）。
+                posterCrop = window.innerWidth <= 480 && !card.classList.contains('hero-card');
             }
         }
 
@@ -120,6 +124,7 @@ export function searchStateGridMode() {
                 self._lightboxAnimating = true;
                 window.GhostFly.playGridToLightbox(fromRect, el, {
                     coverSrc: coverSrc,
+                    posterCrop: posterCrop,   // T9-port
                     onComplete: function () { self._lightboxAnimating = false; }
                 });
                 if (window.SearchAnimations && window.SearchAnimations.playLightboxOpen) {

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -140,6 +140,7 @@ export function stateLightbox() {
             // ★ C17 step 1: ghost fly — 在 state 變更前捕獲 fromRect
             var fromRect = null;
             var coverSrc = null;
+            var posterCrop = false;
             if (!this.lightboxOpen) {
                 var gridEl = this._getActiveGrid();
                 if (gridEl) {
@@ -160,6 +161,12 @@ export function stateLightbox() {
                         if (imgEl && imgEl.complete && imgEl.getBoundingClientRect().width > 0) {
                             fromRect = imgEl.getBoundingClientRect();
                             coverSrc = imgEl.src;
+                            // US5-T7 (CD-75b-12)：≤480px 影片卡縮圖走 poster-crop（封面右半正面）。
+                            // 非女優模式、非 hero 卡時通知 ghost 對齊裁切 + 落地溶接，
+                            // 避免 cover→contain 內容框法切換的硬切 glitch。裁切細節封裝在 ghost-fly.js。
+                            posterCrop = !this.showFavoriteActresses
+                                && window.innerWidth <= 480
+                                && !cardEl.classList.contains('hero-card');
                         }
                     }
                 }
@@ -182,6 +189,7 @@ export function stateLightbox() {
                     self._lightboxAnimating = true;
                     window.GhostFly.playGridToLightbox(fromRect, lightboxEl, {
                         coverSrc: coverSrc,
+                        posterCrop: posterCrop,
                         onComplete: function () { self._lightboxAnimating = false; }
                     });
                     if (window.ShowcaseAnimations && window.ShowcaseAnimations.playLightboxOpen) {

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -226,8 +226,8 @@ export function stateSimilar() {
       if (this.showFavoriteActresses) return;     // CD-56C-13 fail-safe
       if (!this.currentLightboxVideo) return;     // 無 lightbox video metadata 時 no-op
 
-      // 56c-T7：手機降級 — viewport < 768px 不進 constellation
-      if (window.innerWidth < 768) {
+      // 56c-T7：手機降級 — viewport < 960px 不進 constellation
+      if (window.innerWidth < 960) {
         if (this.similarModeAnimating) return;
         if (this.similarModeMobileOpen) {
           this.similarModeMobileOpen = false;   // toggle：再點收合

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -538,7 +538,8 @@ export function stateSimilar() {
           const card = this.similarCards[id];
           if (anchor && card) {
             card.classList.remove('slot--hidden');
-            gsap.set(card, { left: anchor.x, top: anchor.y, opacity: 1, width: 120, height: 150 });
+            // width 107 = round(150 * poster-crop 0.71)；NC#7 微調須同步 animations.js POSTER_CROP_RATIO + CSS --poster-crop-ratio
+            gsap.set(card, { left: anchor.x, top: anchor.y, opacity: 1, width: 107, height: 150 });
           }
         });
         ANCHORS.forEach(a => {
@@ -1112,7 +1113,7 @@ export function stateSimilar() {
           gsap.set(card, {
             left: 480,
             top: 310,
-            width: 120,
+            width: 107,   // = round(150 * poster-crop 0.71)；NC#7 同步 animations.js POSTER_CROP_RATIO + CSS --poster-crop-ratio
             height: 150,
             opacity: 0,
             zIndex: '',

--- a/web/static/js/shared/constellation/animations.js
+++ b/web/static/js/shared/constellation/animations.js
@@ -28,6 +28,18 @@ if (typeof CustomEase !== 'undefined') {
 }
 
 // ---------------------------------------------------------------------------
+// poster-crop 比例常數（US2，v0.10.2）
+// NC#7 微調點：改此值同步更新 CSS --poster-crop-ratio（theme.css）
+// poster 盒寬由 POSTER_CROP_RATIO 推導（load-bearing，NC#7 改此一處 JS 即同步）：
+//   SLOT_W = round(150 * 0.71) = 107；MAIN_W = round(250 * 0.71) = 178
+// 注意：state-similar.js 的 slot reset（width:107）為跨模組字面值鏡像，
+//   NC#7 微調時須同步該檔 + CSS --poster-crop-ratio（三套渲染機制各自獨立）。
+// ---------------------------------------------------------------------------
+const POSTER_CROP_RATIO = 0.71;
+const SLOT_W = Math.round(150 * POSTER_CROP_RATIO);   // 107
+const MAIN_W = Math.round(250 * POSTER_CROP_RATIO);   // 178
+
+// ---------------------------------------------------------------------------
 // playInitialExpand — 8 張卡從中心滑出至 anchor 位置（CD-56B-7）
 // ---------------------------------------------------------------------------
 /**
@@ -48,7 +60,7 @@ export function playInitialExpand(cards, railLines, initSlots, onComplete) {
     if (!anchor || !card) return;
 
     card.classList.remove('slot--hidden');
-    gsap.set(card, { xPercent: -50, yPercent: -50, left: 480, top: 310, opacity: 0, width: 120, height: 150, x: 0, y: 0, rotation: 0 });
+    gsap.set(card, { xPercent: -50, yPercent: -50, left: 480, top: 310, opacity: 0, width: SLOT_W, height: 150, x: 0, y: 0, rotation: 0 });
 
     const cardT = idx * 0.06;
 
@@ -113,7 +125,7 @@ export function playSlipThrough(clickedId, prevVisible, nextVisible, cards, rail
     tl.to(cards[clickedId], {
       left: 480,
       top: 310,
-      width: 200,
+      width: MAIN_W,
       height: 250,
       opacity: 1,
       duration: 0.46,
@@ -196,7 +208,7 @@ export function playSlipThrough(clickedId, prevVisible, nextVisible, cards, rail
   if (cards[clickedId]) {
     tl.call(() => {
       cards[clickedId].classList.add('slot--hidden');
-      gsap.set(cards[clickedId], { xPercent: -50, yPercent: -50, opacity: 0, width: 120, height: 150, zIndex: 10, x: 0, y: 0, rotation: 0 });
+      gsap.set(cards[clickedId], { xPercent: -50, yPercent: -50, opacity: 0, width: SLOT_W, height: 150, zIndex: 10, x: 0, y: 0, rotation: 0 });
       // T5 codex-fix3: clicked card 已 hidden，可見 slot src 不再受 reactive rebind 影響，
       // 此時 host 才安全 swap similarResults（rebind bug fix）
       options.onPrevVisibleHidden?.();
@@ -218,7 +230,7 @@ export function playSlipThrough(clickedId, prevVisible, nextVisible, cards, rail
       // reactive :src 還綁舊 similarResults 顯示錯誤封面
       options.onBeforeCardEnter?.(id);
       card.classList.remove('slot--hidden');
-      gsap.set(card, { xPercent: -50, yPercent: -50, left: 480, top: 310, opacity: 0, width: 120, height: 150, x: 0, y: 0, rotation: 0 });
+      gsap.set(card, { xPercent: -50, yPercent: -50, left: 480, top: 310, opacity: 0, width: SLOT_W, height: 150, x: 0, y: 0, rotation: 0 });
     }, null, Math.max(0, startT - 0.01));
 
     tl.to(card, {

--- a/web/static/js/shared/ghost-fly.js
+++ b/web/static/js/shared/ghost-fly.js
@@ -404,6 +404,10 @@
             }
 
             var coverSrc = options.coverSrc || lbImg.src;
+            // US5-75b-T7 (CD-75b-12)：≤480px poster 格縮圖是「封面右半正面」cover 裁切，
+            // 而 lightbox 封面是 contain 完整圖。posterCrop 旗標下：(A) ghost 對齊縮圖右裁
+            // （消起飛 pan），(D) 落地以 crossfade 溶接 cover→contain（藏內容框法硬切 glitch）。
+            var posterCrop = !!options.posterCrop;
             // 71b-T3 (CD-71b-5): 隱/還原對象上移到 .lightbox-cover 容器，一次蓋住
             // base img + T6 .lb-full overlay 兩層（容器 opacity 與各 img 自身 gate 正交）
             var coverEl = lbImg.closest('.lightbox-cover') ||
@@ -415,6 +419,10 @@
             if (!ghost) {
                 if (typeof options.onComplete === 'function') options.onComplete();
                 return null;
+            }
+            // (A) ghost 對齊縮圖的右半裁切（objectFit:cover 已由 createCoverGhost 設定）
+            if (posterCrop) {
+                ghost.style.objectPosition = 'right center';
             }
 
             // 隱藏真實 lightbox 封面容器（ghost 飛行期間，蓋 base + .lb-full 兩層）
@@ -433,7 +441,20 @@
                     x: toRect.left, y: toRect.top, width: toRect.width, height: toRect.height,
                     duration: dur, ease: ease,
                     onComplete: function () {
-                        cleanupGhost(ghost, coverEl);
+                        if (posterCrop && coverEl) {
+                            // (D) 溶接：contain 真圖淡入、ghost(cover,right) 淡出，
+                            // 把 cover→contain 框法切換藏進 ~120ms dissolve（非硬切）。
+                            coverEl.removeAttribute('data-ghost-hidden');
+                            gsap.to(coverEl, { opacity: 1, duration: 0.12 });
+                            gsap.to(ghost, {
+                                opacity: 0, duration: 0.12,
+                                onComplete: function () {
+                                    if (ghost && ghost.parentNode) ghost.remove();
+                                }
+                            });
+                        } else {
+                            cleanupGhost(ghost, coverEl);
+                        }
                         if (typeof options.onComplete === 'function') options.onComplete();
                     }
                 }

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -3405,7 +3405,7 @@
     border: 2px solid var(--star-line-bright);
 }
 
-/* T4 visual probe：slot / main 真實封面圖 — 沿用 picker-candidate-img 的 100% 20% 裁切慣例（橫式 sc-N 對 4/5 portrait box） */
+/* T4 visual probe：slot / main 真實封面圖 — poster-crop 右裁慣例（75a-US2：object-position right center，橫式 sc-N 露封面正面對直式 box） */
 .clip-lab-slot-img {
     position: relative;
     z-index: 0;

--- a/web/templates/motion_lab.html
+++ b/web/templates/motion_lab.html
@@ -3286,7 +3286,7 @@
 
 .clip-lab-slot {
     position: absolute;
-    width: 120px;
+    width: 107px;
     height: 150px;
     transform: translate(-50%, -50%);
     background: var(--color-base-100);
@@ -3387,7 +3387,7 @@
     position: absolute;
     left: 480px;
     top: 310px;
-    width: 200px;
+    width: 178px;
     height: 250px;
     transform: translate(-50%, -50%);
     background: var(--color-base-100);
@@ -3415,7 +3415,7 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: 100% 20%;
+    object-position: right center;
     display: block;
     border-radius: inherit;
     pointer-events: none;

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -32,7 +32,7 @@
             </button>
 
             <!-- Cover Image -->
-            <div class="lightbox-cover">
+            <div class="lightbox-cover" :class="{'has-cover': !actressLightboxMode() && !!currentLightboxVideo()?.cover && !_heroLightboxImageError}">
                 <img :src="actressLightboxMode()
                          ? (actressProfile?.img ? (actressProfile.img.startsWith('/api/') ? actressProfile.img : `/api/proxy-image?url=${encodeURIComponent(actressProfile.img)}`) : '')
                          : (currentLightboxVideo()?.cover ? `/api/proxy-image?url=${encodeURIComponent(currentLightboxVideo().cover)}` : '')"

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -471,69 +471,7 @@
                         <i class="bi bi-box-arrow-up-right"></i>
                     </button>
                 </div>
-                <div class="av-card-full-body">
-                    <div class="info-row">
-                        <span class="info-label">{{ t('search.label.actor') }}</span>
-                        <span class="info-value" id="resultActors" x-text="(current().actors || []).join(', ') || '-'">-</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">{{ t('search.label.date') }}</span>
-                        <span class="info-value" id="resultDate" x-text="current().date || '-'">-</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">{{ t('search.label.maker') }}</span>
-                        <span class="info-value" id="resultMaker" x-text="current().maker || '-'">-</span>
-                    </div>
-                    <div class="info-row" x-show="current().director">
-                        <span class="info-label">{{ t('search.label.director') }}</span>
-                        <span class="info-value" x-text="current().director">-</span>
-                    </div>
-                    <div class="info-row" x-show="current().duration">
-                        <span class="info-label">{{ t('search.label.duration') }}</span>
-                        <span class="info-value" x-text="current().duration + ' ' + t('search.unit.minutes')">-</span>
-                    </div>
-                    <div class="info-row" x-show="current().label">
-                        <span class="info-label">{{ t('search.label.label') }}</span>
-                        <span class="info-value" x-text="current().label">-</span>
-                    </div>
-                    <div class="info-row" x-show="current().series">
-                        <span class="info-label">{{ t('search.label.series') }}</span>
-                        <span class="info-value" x-text="current().series">-</span>
-                    </div>
-                    <div class="info-row">
-                        <span class="info-label">{{ t('search.label.tags') }}</span>
-                        <span class="info-value" id="resultTags">
-                            <!-- 字幕標籤 -->
-                            <span x-show="hasSubtitle()" class="badge tag-badge subtitle">{{ t('search.badge.subtitle') }}</span>
-                            <!-- Fix-1: 版本標記 badges -->
-                            <template x-for="sfx in currentSuffixes()" :key="sfx">
-                                <span class="badge tag-badge suffix-badge" x-text="sfx"></span>
-                            </template>
-                            <!-- 系統標籤 -->
-                            <template x-for="tag in (current().tags || [])" :key="tag">
-                                <span class="badge tag-badge" x-text="tag"></span>
-                            </template>
-                            <!-- 用戶標籤 -->
-                            <template x-for="tag in currentUserTags()" :key="'u_' + tag">
-                                <span class="badge tag-badge user-tag">
-                                    <span x-text="tag"></span>
-                                    <span class="tag-remove" @click="removeUserTag(tag)">&times;</span>
-                                </span>
-                            </template>
-                            <!-- 新增標籤按鈕：僅 file 模式且有路徑才顯示 -->
-                            <button x-show="!addingTag && listMode === 'file' && !!fileList[currentFileIndex]?.path" @click="showAddTagInput()" class="btn btn-sm tag-add-btn" title="{{ t('search.action.add_tag') }}">+</button>
-                            <!-- 新增標籤輸入框 -->
-                            <span x-show="addingTag" class="tag-input-wrapper">
-                                <input type="text" x-ref="tagInput" x-model="newTagValue"
-                                       @keydown.enter="confirmAddTag()" @keydown.escape="cancelAddTag()"
-                                       class="tag-input" placeholder="{{ t('search.placeholder.tag') }}" maxlength="20">
-                                <button @click="confirmAddTag()" class="btn btn-sm tag-confirm">✓</button>
-                                <button @click="cancelAddTag()" class="btn btn-sm tag-cancel">✕</button>
-                            </span>
-                        </span>
-                    </div>
-                </div>
-                <div class="av-card-full-footer">
+                <div class="av-card-full-title">
                     <div class="av-card-full-footer-content">
                         <span class="info-label">{{ t('search.label.title') }}</span>
                         <!-- 顯示模式 -->
@@ -598,6 +536,78 @@
                                 </button>
                             </div>
                         </div>
+                    </div>
+                </div>
+                <div class="av-card-full-body">
+                    <!-- 短值雙欄配對 1：日期 | 片長 -->
+                    <div class="info-grid-pair">
+                        <div class="info-cell">
+                            <span class="info-label">{{ t('search.label.date') }}</span>
+                            <span class="info-value" id="resultDate" x-text="current().date || '-'">-</span>
+                        </div>
+                        <div class="info-cell" x-show="current().duration">
+                            <span class="info-label">{{ t('search.label.duration') }}</span>
+                            <span class="info-value" x-text="current().duration + ' ' + t('search.unit.minutes')">-</span>
+                        </div>
+                    </div>
+                    <!-- 短值雙欄配對 2：片商 | 廠牌 -->
+                    <div class="info-grid-pair">
+                        <div class="info-cell">
+                            <span class="info-label">{{ t('search.label.maker') }}</span>
+                            <span class="info-value" id="resultMaker" x-text="current().maker || '-'">-</span>
+                        </div>
+                        <div class="info-cell" x-show="current().label">
+                            <span class="info-label">{{ t('search.label.label') }}</span>
+                            <span class="info-value" x-text="current().label">-</span>
+                        </div>
+                    </div>
+                    <!-- 長值獨行：演員 -->
+                    <div class="info-row">
+                        <span class="info-label">{{ t('search.label.actor') }}</span>
+                        <span class="info-value" id="resultActors" x-text="(current().actors || []).join(', ') || '-'">-</span>
+                    </div>
+                    <!-- 長值獨行：系列 -->
+                    <div class="info-row" x-show="current().series">
+                        <span class="info-label">{{ t('search.label.series') }}</span>
+                        <span class="info-value" x-text="current().series">-</span>
+                    </div>
+                    <!-- 長值獨行：導演 -->
+                    <div class="info-row" x-show="current().director">
+                        <span class="info-label">{{ t('search.label.director') }}</span>
+                        <span class="info-value" x-text="current().director">-</span>
+                    </div>
+                    <!-- 長值獨行：Tags -->
+                    <div class="info-row">
+                        <span class="info-label">{{ t('search.label.tags') }}</span>
+                        <span class="info-value" id="resultTags">
+                            <!-- 字幕標籤 -->
+                            <span x-show="hasSubtitle()" class="badge tag-badge subtitle">{{ t('search.badge.subtitle') }}</span>
+                            <!-- Fix-1: 版本標記 badges -->
+                            <template x-for="sfx in currentSuffixes()" :key="sfx">
+                                <span class="badge tag-badge suffix-badge" x-text="sfx"></span>
+                            </template>
+                            <!-- 系統標籤 -->
+                            <template x-for="tag in (current().tags || [])" :key="tag">
+                                <span class="badge tag-badge" x-text="tag"></span>
+                            </template>
+                            <!-- 用戶標籤 -->
+                            <template x-for="tag in currentUserTags()" :key="'u_' + tag">
+                                <span class="badge tag-badge user-tag">
+                                    <span x-text="tag"></span>
+                                    <span class="tag-remove" @click="removeUserTag(tag)">&times;</span>
+                                </span>
+                            </template>
+                            <!-- 新增標籤按鈕：僅 file 模式且有路徑才顯示 -->
+                            <button x-show="!addingTag && listMode === 'file' && !!fileList[currentFileIndex]?.path" @click="showAddTagInput()" class="btn btn-sm tag-add-btn" title="{{ t('search.action.add_tag') }}">+</button>
+                            <!-- 新增標籤輸入框 -->
+                            <span x-show="addingTag" class="tag-input-wrapper">
+                                <input type="text" x-ref="tagInput" x-model="newTagValue"
+                                       @keydown.enter="confirmAddTag()" @keydown.escape="cancelAddTag()"
+                                       class="tag-input" placeholder="{{ t('search.placeholder.tag') }}" maxlength="20">
+                                <button @click="confirmAddTag()" class="btn btn-sm tag-confirm">✓</button>
+                                <button @click="cancelAddTag()" class="btn btn-sm tag-cancel">✕</button>
+                            </span>
+                        </span>
                     </div>
                 </div>
             </div>

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -545,7 +545,7 @@
              x-trap.inert="lightboxOpen && !sampleGalleryOpen && !removeActressModalOpen && !rescrapeOpen && !deleteVideoModalOpen"
              @click="handleLightboxBackdropClick($event)">
 
-            <div class="lightbox-content" @click.stop>
+            <div class="lightbox-content" @click.stop :class="{ 'similar-open': similarModeMobileOpen }">
                 <!-- Close Button (shared between actress and video branches) -->
                 <button class="lightbox-close"
                         @click="closeLightbox()"
@@ -724,6 +724,24 @@
                             </div>
                         </div>
 
+                        <!-- 手機 < 960px（75a-US3b）相似模式降級：cosine 前 4 張 collapse（x-collapse 需 @alpinejs/collapse plugin，已在 base.html 行 640 載入）。75a-US4：置於 cover 與 metadata 之間，主片 + 4 相似一眼可見 -->
+                        <div class="lightbox-similar-mobile"
+                             x-show="similarModeMobileOpen"
+                             x-collapse>
+                          <div class="similar-mobile-grid">
+                            <template x-for="item in similarResults.slice(0, 4)" :key="item.video_id">
+                              <div class="similar-mobile-card"
+                                   @click="onSimilarMobileCardClick(item)">
+                                <img :src="item.cover_url" :alt="item.title" loading="lazy">
+                                <div class="similar-mobile-meta">
+                                  <div class="similar-mobile-number" x-text="item.number"></div>
+                                  <div class="similar-mobile-title" x-text="item.title"></div>
+                                </div>
+                              </div>
+                            </template>
+                          </div>
+                        </div>
+
                         <!-- Metadata Panel（緊湊版，匹配原版 gallery） -->
                         <div class="lightbox-metadata">
                             <!-- Row 1: Header (title + sample gallery button) -->
@@ -858,24 +876,6 @@
                                 </span>
                             </div>
 
-                        </div>
-
-                        <!-- 56c-T7：手機 < 768px cosine 前 4 張 collapse（x-collapse 需 @alpinejs/collapse plugin，已在 base.html 行 640 載入） -->
-                        <div class="lightbox-similar-mobile"
-                             x-show="similarModeMobileOpen"
-                             x-collapse>
-                          <div class="similar-mobile-grid">
-                            <template x-for="item in similarResults.slice(0, 4)" :key="item.video_id">
-                              <div class="similar-mobile-card"
-                                   @click="onSimilarMobileCardClick(item)">
-                                <img :src="item.cover_url" :alt="item.title" loading="lazy">
-                                <div class="similar-mobile-meta">
-                                  <div class="similar-mobile-number" x-text="item.number"></div>
-                                  <div class="similar-mobile-title" x-text="item.title"></div>
-                                </div>
-                              </div>
-                            </template>
-                          </div>
                         </div>
                     </div>
                 </template>

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -666,7 +666,9 @@
                 <template x-if="currentLightboxVideo && !currentLightboxActress">
                     <div style="display:contents">
                         <!-- Cover Image -->
-                        <div class="lightbox-cover">
+                        <!-- T8(Codex P2): has-cover 旗標 — 僅有封面時才讓 ≤480px min-height:0 塌到圖盒；
+                             無封面時保留 min-height 避免 cover 區塌成 0 高（補封面入口會壞）。 -->
+                        <div class="lightbox-cover" :class="{'has-cover': !!currentLightboxVideo?.cover_url}">
                             <!-- 56c-T3fix: magic 按鈕已搬至 .lightbox-content（與 .lightbox-close sibling 鏡射對稱）；sparkle-burst overlay 留在 .lightbox-cover 以便 inset:0 精準覆蓋封面區（不擴及 metadata） -->
                             <!-- 71-T6 blur-up: base 層=cover_url（快取開啟=小 webp 秒出、放大略糊；關閉=原圖）。
                                  撐容器尺寸；x-ref + @error 三態留 base（ghost-fly / 破圖偵測沿用 base src）。 -->


### PR DESCRIPTION
## 概要

**前端呈現優化合輯**（feature/75，v0.10.2）。純前端（CSS / Jinja template / 少量 JS 門檻），**零後端 / DB / serializer / API 改動**。緣起：owner 籌備開放同 LAN 手機存取，把三組「以後再說」的呈現痛點推進本版必修。分兩階段（plan-75a / plan-75b）+ 動畫/燈箱接縫修復 + 搜尋頁移植。

*Pure-frontend mobile-compatibility + search-detail density rework. Zero backend/DB/API changes.*

## 變更內容

### Added
- **US1 搜尋詳情密度重排**：翻譯標題置頂、metadata 雙欄（`.info-grid-pair`）、右欄 320→390px + top-pack。
- **US2 封面正面裁切共用規則**：`--poster-crop-ratio`（≈0.71）token，星空/相似/clip 三處統一 `object-position: right center`。
- **US3 行動基礎相容 4 修**：scroll trap 解鎖 / JS↔CSS 門檻對齊（768→960）/ `pointer:coarse` hover 可達 / tablet toolbar。
- **US4 手機相似模式重整**：主片 + 4 相似清晰呈現（修「只 2 片 / 點不到 / 文字被蓋」）。
- **US5 + T9 影片卡 poster 格**：≤480px showcase **與搜尋頁** 影片卡改 3 欄直式 poster 格 + caption 截斷。

### Changed / Fixed
- **T8 燈箱封面去 letterbox 死白**：≤480px 影片燈箱封面貼合原圖比例（容器+img gate `.has-cover`），副作用根治 T7 接縫。
- **T7 grid→燈箱 ghost-fly 落地變形**：ghost 對齊右裁 + 落地 0.12s crossfade。
- **Codex P1** 觸控 poster 格番號 caption 被 hover 標題層蓋住 → `≤480 ∩ pointer:coarse` 還原番號層。
- **Codex P2** 無封面/404 影片燈箱塌盒 → `has-cover` 三條件（`!actressLightboxMode() && cover && !_heroLightboxImageError`）。

## 測試
- 全套 pytest **4308 passed, 2 skipped**（+59 守衛，較 0.10.1 的 4249）。
- `npm run lint`（eslint + stylelint）綠；來源金絲雀 **8/8 PASS**。
- 無敏感資訊；`COPY_ITEMS` 無需更新；capabilities N/A（純前端）。

## transient-guard（下個 milestone 評估刪除）
單向遷移負向守衛：US1 footer wrapper rename、poster-crop 值/門檻遷移（`100% 20%` / `width:120px` / `4/5` / threshold 768 / 單欄 `1fr`）。`TestSimilarSlotGsapGuard` 整檔 JS ban 屬 CI-no-eslint backstop，保留至 `npm run lint` 進 CI。

## 待人工驗收
手機實機（≤480px / CDP 390×800）視覺驗收：showcase + 搜尋頁 3 欄 poster 格、grid→燈箱無變形 seam、燈箱封面無 letterbox 死白、無封面影片燈箱不塌、女優燈箱不變、桌面/tablet 零回歸。

🤖 Generated with [Claude Code](https://claude.com/claude-code)