### PR TITLE
feat(0.10.3): MPA 跨頁無縫轉場 (Cross-Document View Transitions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2026-06-20
+
+本版主軸：**MPA 跨頁無縫轉場（Cross-Document View Transitions）**（feature/76）。純前端、零後端/DB/依賴。每次點 sidebar 切頁的白屏閃爍消失，改為主內容區約 250ms 平滑淡入淡出（crossfade），sidebar／logo／通知鈴鐺等持久殼元素視覺靜止不重繪——用瀏覽器原生的跨文件 View Transition 達成，不需 SPA 化、不引入前端路由。漸進增強：不支援的舊版 WebView2／瀏覽器、開啟「減少動態效果」的用戶自動退回現狀硬切，功能零損失、UI 零差異。Showcase 因常駐動畫（燈箱環境光／相似探索星空）與大頁快照成本退出轉場、維持硬切。另含兩個一併修掉的問題：主題切換圓形展開被新命名群組破壞、以及 showcase／search 狀態框在前端初始化前的閃爍（FOUC）。
+
+### Added
+#### ✨ 跨頁無縫轉場
+- 點 sidebar 切頁（搜尋／掃描／設定／說明之間）從「白屏＋整頁重建」變成「主內容區平滑淡換」；左側 sidebar 與頂部鈴鐺視覺靜止、像焊在原地。
+- 純 CSS 啟用（`@view-transition`）＋命名持久區，零 JS 攔截導航——保留瀏覽器原生語義（Ctrl/⌘+點擊開新分頁、右鍵選單等照常）。
+- 漸進增強：不支援的環境與「減少動態效果」偏好自動硬切退化，無報錯、無功能損失。
+- 小螢幕漢堡選單（offcanvas）導航同樣有轉場。
+
+### Changed
+- **Showcase 退出轉場（維持硬切）**：showcase 是全站最重頁且有常駐動畫，進出一律即時硬切（`<head>` 內 parser-blocking script 於 `pageswap`／`pagereveal` 依目的地 URL 呼叫 `skipTransition()`），避免動畫被拍成凍結幀、並省去大頁快照成本。
+
+### Fixed
+- **主題切換圓形展開被跨頁命名群組破壞**：跨頁轉場用的 `view-transition-name` 對同頁的主題切換動畫同樣生效，導致 sidebar／主內容脫離整頁快照、圓形展開失效。修法：主題切換期間暫時取消兩區命名、塌回整頁單一快照（specificity 提升、不論順序皆勝）。
+- **Showcase／搜尋頁狀態框初始化閃爍（FOUC）**：載入中／空狀態／錯誤三個狀態框缺 `x-cloak`，前端框架啟動前會裸露疊閃一幀；補齊 `x-cloak`（showcase 5 處、搜尋頁 1 處）。
+
+### Internal
+- 設定頁既有的主題切換 root 轉場規則作用域化（`html.theme-transition-active` 前綴），不再汙染導航到設定／設計系統頁的整頁淡換。
+- stylelint 禁止手動 `view-transition-name: root`；新增跨檔 DOM／CSS 契約守衛（命名／作用域／showcase head script 位置與 parser-blocking／state-page x-cloak，後者以 BeautifulSoup 抓取不受屬性順序影響）。
+
+### Non-Goals（明確不做）
+- 不 SPA 化、不引入前端路由、不用 HTMX 整頁 swap、不做共享元素（封面跨頁飛行）轉場、不加 loading bar／骨架屏／prefetch、不在設定加轉場開關、不改後端任何路由／API。
+- 守衛路徑（設定未存檔／掃描串流中放棄離開）的程式導航維持硬切（owner 簽核；程式導航本就不觸發跨文件轉場、現狀即硬切、零回歸）。
+- showcase 狀態框硬編碼字串的多語系化留 milestone。
+
+### 測試
+- 全套 pytest **4334 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較 0.10.2 的 4308 +26）+ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（pre-merge live 健康檢查）。
+- 新增測試：`TestPageTransitionDomGuard`（命名 / showcase opt-out / head script 在 head 且 parser-blocking）、`TestPageTransitionSettingsScopeGuard`（settings root 作用域化 exhaustive negative + theme-transition.js class lifecycle）、`TestStatePageCloakGuard`（bs4，showcase 5 / search 2 state-page x-cloak）。
+- 跨瀏覽器實機（CDP Chromium 146）：showcase↔他頁雙向硬切（skip）、非 showcase crossfade、主題切換期間命名塌回 root、各頁 console 0 error。
+
 ## [0.10.2] - 2026-06-19
 
 本版主軸：**前端呈現優化合輯——行動裝置相容 + 搜尋詳情資訊密度重排**（feature/75）。純前端（CSS / Jinja template / 少量 JS 門檻），**零後端 / DB / serializer / API 改動**。緣起：owner 籌備開放同 LAN 手機連上同一台 server，把三組「以後再說」的呈現痛點推進「本版必修」——搜尋詳情右欄稀疏、翻譯標題沉底；JAV 橫式完整封包封面被裁得帶脊帶封背；以及 hover-only 操作 / scroll trap / JS↔CSS 斷點不一致 / tablet toolbar 裂版等讓真實手機無法操作的缺口。本版分兩階段（plan-75a：封面裁切共用規則 + 行動基礎相容 + 手機相似模式；plan-75b：搜尋詳情重排 + showcase 影片卡 poster 格），並追加燈箱封面去 letterbox 死白、grid→燈箱動畫落地接縫修復，最後把整套行動修正移植到結構近乎雙胞胎的搜尋頁。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 VERSION = __version__
 
 # 版本資訊

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -35,7 +35,7 @@ module.exports = {
     'value-keyword-case': null,
     'property-no-vendor-prefix': null,
     'value-no-vendor-prefix': null,
-    'at-rule-no-unknown': [true, { ignoreAtRules: ['tailwind', 'apply', 'layer', 'screen', 'variants', 'responsive', 'theme', 'plugin', 'config', 'source', 'utility', 'custom-variant', 'reference'] }],
+    'at-rule-no-unknown': [true, { ignoreAtRules: ['tailwind', 'apply', 'layer', 'screen', 'variants', 'responsive', 'theme', 'plugin', 'config', 'source', 'utility', 'custom-variant', 'reference', 'view-transition'] }],
     'no-empty-source': null,
     'no-invalid-position-at-import-rule': null,
     'rule-empty-line-before': null,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -16,6 +16,9 @@ module.exports = {
       'box-shadow': ['/\\brgba\\(\\s*\\d/'],
       'border-radius': ['/^\\d+px/'],
       'object-position': ['/100%\\s+20%/'],
+      // feature/76：禁手動把 view-transition-name 設為 root（root 是隱式預設，手動覆寫會
+      // 與主題切換的 ::view-transition-*(root) 機制混亂）。命名一律走 sidebar/main-content/none。
+      'view-transition-name': ['root'],
     },
     'selector-disallowed-list': ['/:is\\([^)]*manual-input/'],
     // Standard config rules relaxed for OpenAver's existing CSS conventions

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -12363,3 +12363,127 @@ class TestCoverCacheBustGuard:
             "lightbox overlay（.lb-full `:src='cover_full_url'`）不加 cache-bust 會吃 max-age=86400 舊快取。\n"
             f"當前函式體（去注釋後）：\n{body[:500]}"
         )
+
+
+SHOWCASE_SIMILAR_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "pages" / "showcase" / "state-similar.js"
+)
+
+
+class TestMobileSimilarDrillFallbackGuard:
+    """BUGfix-mobile-similar-stale-cover: 守衛 mobile similar drill 三層 fallback 合約
+
+    (a) state-lightbox.js 的 _setLightboxIndex 函式體必須清除 similarExitVideo（= null），
+        確保 in-grid 切換後不殘留 standalone 旗標（Codex P2b 根治）。
+    (b) state-similar.js 的 onSimilarMobileCardClick 函式體必須含：
+        - `_videos` 查找（tier 2 fallback）
+        - 設置 `similarExitVideo`（standalone 旗標）
+        - 呼叫 `_refreshLbFullBlurUp`（blur-up reset）
+    """
+
+    def _lightbox_js(self):
+        return SHOWCASE_LIGHTBOX_JS.read_text(encoding="utf-8")
+
+    def _similar_js(self):
+        return SHOWCASE_SIMILAR_JS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _extract_function_body(js, func_pattern):
+        """用計數括弧深度方式擷取函式體，從 func_pattern regex 匹配處起算。"""
+        m = re.search(func_pattern, js)
+        if not m:
+            return None
+        start = m.start()
+        body_start = js.index('{', start)
+        depth = 0
+        for i, ch in enumerate(js[body_start:], body_start):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return js[body_start:i + 1]
+        return None
+
+    def test_set_lightbox_index_clears_similar_exit_video(self):
+        """_setLightboxIndex 函式體必須含 similarExitVideo = null（清除 standalone 旗標）。
+        根治：in-grid 切換（tier 1）後不殘留 standalone，prev/next + fly-back 恢復正常。
+        """
+        js = self._lightbox_js()
+        body = self._extract_function_body(js, r'_setLightboxIndex\s*\(')
+        assert body is not None, \
+            "state-lightbox.js 找不到 _setLightboxIndex 函式宣告"
+        # 允許有無空格兩種寫法
+        assert re.search(r'similarExitVideo\s*=\s*null', body), (
+            "_setLightboxIndex 函式體未含 'similarExitVideo = null'。\n"
+            "in-grid 切換（tier 1）後 similarExitVideo 不清除，\n"
+            "連點 tier2/3 再 tier1 時 standalone 旗標殘留，prev/next 被錯誤禁用。\n"
+            f"當前函式體：\n{body[:400]}"
+        )
+
+    def test_on_similar_mobile_card_click_has_videos_lookup(self):
+        """onSimilarMobileCardClick 函式體必須含 _videos 查找（tier 2 fallback）。
+        tier 2：被 filter 排除但仍在庫內的片用 _videos.findIndex 撈回完整 metadata。
+        """
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'onSimilarMobileCardClick\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 onSimilarMobileCardClick 函式宣告"
+        # 收緊：鎖 `_videos.findIndex` code-form，避免被註解中的 '_videos' vacuously 滿足
+        assert re.search(r'_videos\s*\.\s*findIndex', body), (
+            "onSimilarMobileCardClick 函式體未含 '_videos.findIndex' 查找。\n"
+            "tier 2 fallback（filter-subset 片）缺失，完整 metadata 撈不回，\n"
+            "被 filter 排除的片點擊後只能降級到 tier 3 snapshot 而非完整物件。\n"
+            f"當前函式體：\n{body[:400]}"
+        )
+
+    def test_on_similar_mobile_card_click_sets_similar_exit_video(self):
+        """onSimilarMobileCardClick 函式體必須含 similarExitVideo 指派（standalone 旗標）。
+        tier 2/3 fallback 路徑必須設置 similarExitVideo，確保 prev/next 禁用、close 不 fly-back。
+        """
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'onSimilarMobileCardClick\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 onSimilarMobileCardClick 函式宣告"
+        # 收緊：鎖 `similarExitVideo =` 賦值形，避免被註解中的字串 vacuously 滿足
+        assert re.search(r'similarExitVideo\s*=', body), (
+            "onSimilarMobileCardClick 函式體未含 'similarExitVideo =' 指派。\n"
+            "tier 2/3 standalone 旗標缺失：close 會飛回舊卡、prev/next 從舊 index 起跳（Codex P2a）。\n"
+            f"當前函式體：\n{body[:400]}"
+        )
+
+    def test_on_similar_mobile_card_click_calls_refresh_lb_full_blur_up(self):
+        """onSimilarMobileCardClick 函式體必須含 _refreshLbFullBlurUp 呼叫。
+        tier 2/3 路徑繞過 _setLightboxIndex，需手動觸發 blur-up reset + same-URL complete-check，
+        否則 overlay opacity:0 可能卡死。
+        """
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'onSimilarMobileCardClick\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 onSimilarMobileCardClick 函式宣告"
+        assert '_refreshLbFullBlurUp' in body, (
+            "onSimilarMobileCardClick 函式體未含 '_refreshLbFullBlurUp' 呼叫。\n"
+            "tier 2/3 slip-through 路徑缺 blur-up reset，.lb-full overlay opacity:0 可能卡死。\n"
+            f"當前函式體：\n{body[:400]}"
+        )
+
+    def test_close_similar_mode_fallback_has_videos_tier(self):
+        """closeSimilarMode 退場 fallback 必須與 onSimilarMobileCardClick 同採三層策略：
+        _filteredVideos miss 後先查 _videos.findIndex（命中保完整 metadata + path），
+        且仍保留 _similarLastDrilledItem snapshot 當孤兒列 fallback（Codex P2）。
+        否則 mobile tier2 的完整 metadata 會在關閉 similar mode 時被重新降級。
+        """
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'async\s+closeSimilarMode\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 closeSimilarMode 函式宣告"
+        assert re.search(r'_videos\s*\.\s*findIndex', body), (
+            "closeSimilarMode fallback 未含 '_videos.findIndex'（tier 2）。\n"
+            "退場時 _filteredVideos miss 直接降級成 5 欄 snapshot，\n"
+            "mobile tier2 點擊時的完整 metadata + path 會在關閉 similar mode 時被重新降級。"
+        )
+        assert '_similarLastDrilledItem' in body, (
+            "closeSimilarMode fallback 未保留 '_similarLastDrilledItem' snapshot（孤兒列 fallback）。\n"
+            "_videos 也 miss（孤兒列 / demo）時需 snapshot 兜底，不可移除。"
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -150,6 +150,30 @@ class TestPageTransitionDomGuard:
         assert re.search(r"\.page-showcase\s+#main-content\s*\{\s*view-transition-name:\s*none", css), \
             "theme.css 缺少 .page-showcase #main-content { view-transition-name: none }（feature/76 CD-11 輔助）"
 
+    def test_base_html_showcase_skip_script_in_head(self):
+        """showcase 硬切 head script（pagereveal/pageswap + skipTransition）存在且在 </head> 之前（CD-11/F8）。
+
+        pagereveal 在 first rendering opportunity 前觸發 → listener 必須在 <head> 的
+        parser-blocking classic script，掛在 body 底（如 page-lifecycle.js）會漏接。
+        斷言三 token 皆落在 </head> 之前，鎖定位置。
+        """
+        html = self._base()
+        head_end = html.find("</head>")
+        assert head_end != -1, "base.html 找不到 </head>"
+        head = html[:head_end]
+        for token in ("pagereveal", "pageswap", "skipTransition"):
+            assert token in head, \
+                f"base.html <head> 缺少 {token!r}（feature/76 CD-11 showcase 硬切 head script 必須在 head、非 body 底）"
+        # 鎖定 parser-blocking classic：包住 skipTransition 的 <script> open tag 不得有
+        # type=module / defer / async（任一都會把 pagereveal 延後過 first render → 漏接、靜默壞掉）。
+        skip_idx = head.find("skipTransition")
+        open_start = head.rfind("<script", 0, skip_idx)
+        open_tag = head[open_start:head.find(">", open_start) + 1]
+        for banned in ('type="module"', "type='module'", "defer", "async"):
+            assert banned not in open_tag, \
+                (f"base.html showcase 硬切 script 的 <script> tag 含 {banned!r}（feature/76 CD-11）："
+                 "pagereveal listener 必須是 parser-blocking classic script，defer/async/module 會漏接事件")
+
 
 SETTINGS_CSS_T76 = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "settings.css"
 THEME_TRANSITION_JS_T76 = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "settings" / "theme-transition.js"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -150,6 +150,20 @@ class TestPageTransitionDomGuard:
         assert re.search(r"\.page-showcase\s+#main-content\s*\{\s*view-transition-name:\s*none", css), \
             "theme.css 缺少 .page-showcase #main-content { view-transition-name: none }（feature/76 CD-11 輔助）"
 
+    def test_theme_css_theme_toggle_denames_named_groups(self):
+        """主題切換（same-doc startViewTransition）期間 de-name sidebar/main-content（Codex P1）。
+
+        view-transition-name 對 same-document VT 同樣生效 → 不 de-name 則命名群組脫離 root、
+        破壞 theme-transition.js 的圓形 reveal（main-content 還會跑 250ms fade 撞 500ms 圓形）。
+        守 html.theme-transition-active 期間兩區 view-transition-name: none。
+        """
+        css = self._theme()
+        assert re.search(
+            r"html\.theme-transition-active\s+#sidebar\s*,\s*"
+            r"html\.theme-transition-active\s+#main-content\s*\{\s*view-transition-name:\s*none",
+            css,
+        ), "theme.css 缺少 theme-transition-active 期間 de-name sidebar/main-content（feature/76 Codex P1 主題切換共存）"
+
     def test_base_html_showcase_skip_script_in_head(self):
         """showcase 硬切 head script（pagereveal/pageswap + skipTransition）存在且在 </head> 之前（CD-11/F8）。
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -151,6 +151,59 @@ class TestPageTransitionDomGuard:
             "theme.css 缺少 .page-showcase #main-content { view-transition-name: none }（feature/76 CD-11 輔助）"
 
 
+SETTINGS_CSS_T76 = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "settings.css"
+THEME_TRANSITION_JS_T76 = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "settings" / "theme-transition.js"
+
+
+class TestPageTransitionSettingsScopeGuard:
+    """feature/76 T1a（CD-7/F7）：settings.css root 規則作用域化 + theme-transition.js class lifecycle。
+
+    防 settings.css 裸 ::view-transition-*(root) 規則汙染導航到 /settings、/design-system 的
+    跨頁 root crossfade。negative 守衛（無裸 root 規則）是關鍵——只查 positive substring 會
+    假陽性（漏抓新增的裸規則）。
+    """
+
+    # CSS 註解內可能出現字面 pseudo，先 strip 避免假陽性
+    _COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+    _ROOT_PSEUDO_RE = re.compile(r"::view-transition-(?:old|new|group|image-pair)\(root\)")
+    _REQUIRED_PREFIX = "html.theme-transition-active"
+
+    def _settings_css(self):
+        return SETTINGS_CSS_T76.read_text(encoding="utf-8")
+
+    def _theme_js(self):
+        return THEME_TRANSITION_JS_T76.read_text(encoding="utf-8")
+
+    def test_settings_root_rules_scoped(self):
+        """settings.css root 規則已加 html.theme-transition-active 前綴（positive）"""
+        assert f"{self._REQUIRED_PREFIX}::view-transition-old(root)" in self._settings_css(), \
+            "settings.css root 規則未作用域化（缺 html.theme-transition-active 前綴，feature/76 CD-7）"
+
+    def test_settings_all_root_rules_scoped(self):
+        """settings.css 中『每一條』root VT 規則都恰以 html.theme-transition-active 作用域化（negative，exhaustive）。
+
+        SF-2：不只查「無裸 root 規則」，而是窮舉每個 ::view-transition-*(root) 出現點、斷言其緊鄰
+        前綴恰為 html.theme-transition-active。封住「錯誤前綴」盲區——裸規則、`:root::`、`.foo::`
+        等任何非 theme-transition-active 前綴皆會被抓（lookbehind 排除法漏抓後兩者）。
+        """
+        css_nc = self._COMMENT_RE.sub("", self._settings_css())
+        for m in self._ROOT_PSEUDO_RE.finditer(css_nc):
+            prefix = css_nc[:m.start()]
+            assert prefix.endswith(self._REQUIRED_PREFIX), \
+                ("settings.css 有未以 html.theme-transition-active 作用域化的 root VT 規則"
+                 f"（feature/76 CD-7/F7）: ...{css_nc[max(0, m.start() - 40):m.end()]!r}")
+
+    def test_theme_transition_js_class_lifecycle(self):
+        """theme-transition.js 在 startViewTransition 前 add、finished 後 remove theme-transition-active（F7）"""
+        js = self._theme_js()
+        assert "classList.add('theme-transition-active')" in js, \
+            "theme-transition.js 缺少 classList.add('theme-transition-active')（feature/76 F7）"
+        assert "transition.finished" in js, \
+            "theme-transition.js 缺少 transition.finished（class remove 掛點，feature/76 F7）"
+        assert "classList.remove('theme-transition-active')" in js, \
+            "theme-transition.js 缺少 classList.remove('theme-transition-active')（feature/76 F7）"
+
+
 class TestHelpPopoverGuard:
     """38e: help-popover CSS class usage guard (method folded)"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -12267,3 +12267,99 @@ class TestUS11HeroCardMobileFix:
         assert ".hero-card" in sel, (
             "object-fit: cover 規則 selector 必帶 .hero-card（確認是 hero img 規則，非鄰卡）"
         )
+
+
+class TestCoverCacheBustGuard:
+    """BUGfix-lightbox-cover-stale: refreshVideoData 必須對 cover_url 與 cover_full_url 都追加 cache-bust。
+    守衛契約：擋「只 bust 一邊」回歸——任何人把任一欄位的 &t= 移除，對應守衛即紅。
+    三問：
+      1. 移除 cover_url &t= → test_cover_url_has_cache_bust 紅；cover_full_url bust 仍在 → 其守衛獨立 GREEN ✓
+      2. 移除 cover_full_url &t= → test_cover_full_url_has_cache_bust 紅；cover_url bust 仍在 → 其守衛獨立 GREEN ✓
+      3. 把 bust 搬出 refreshVideoData 函式體 → 兩條都紅 ✓
+      4. 只在 comment 留 '&t=' 字串但移除實作 → 紅（守衛先過濾純注釋行，不被 comment 騙過）✓
+    每條 regex 只匹配「同一條賦值語句內」：[^;\\n]* 不跨 ; 與換行，鎖在單一 statement，
+    防止 re.DOTALL 跨行把兩個欄位的 &t= 混用。
+    """
+
+    _LIGHTBOX_JS = (
+        Path(__file__).parent.parent.parent
+        / "web" / "static" / "js" / "pages" / "showcase" / "state-lightbox.js"
+    )
+
+    def _js(self):
+        return self._LIGHTBOX_JS.read_text(encoding="utf-8")
+
+    def _extract_refreshVideoData_body(self, js):
+        """定位 refreshVideoData 函式體（從函式宣告到第一個同層 closing brace）。
+        用計數括弧深度的方式抓完整函式體，確保邊界正確。
+        """
+        # 找 refreshVideoData 宣告起點
+        m = re.search(r'async\s+refreshVideoData\s*\(', js)
+        assert m, "state-lightbox.js 找不到 async refreshVideoData 函式宣告"
+        start = m.start()
+        # 從宣告後面找第一個 '{' 並計數到同層 '}'
+        body_start = js.index('{', start)
+        depth = 0
+        for i, ch in enumerate(js[body_start:], body_start):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return js[body_start:i + 1]
+        raise AssertionError("state-lightbox.js: refreshVideoData 函式體找不到對應的結束括弧")
+
+    @staticmethod
+    def _strip_line_comments(body: str) -> str:
+        """移除函式體內的 // 注釋——整行注釋與「行內尾注釋」都砍。
+        去注釋後 regex 才不會被注釋裡的 `+ '&t='` 騙過：例如
+        `data.video.cover_url = data.video.cover_url // + '&t='`（bust 移進行內注釋）
+        若不砍行內注釋，[^;\\n]* 仍會配到注釋內的 + '&t=' 造成 false-pass。
+        以 (?<!:)// 切除，保護 URL 的 `://`（https:// 等不被誤砍；/api 單斜線不觸發）。
+        state-lightbox.js refreshVideoData 函式體內字串無 `//`、未用區塊注釋（/* */），
+        此 heuristic 對本守衛充分。
+        """
+        return "\n".join(
+            re.sub(r"(?<!:)//.*$", "", line)
+            for line in body.splitlines()
+        )
+
+    def test_cover_url_has_cache_bust(self):
+        """refreshVideoData 函式體內必須對 cover_url 賦值並串接 '&t=' cache-bust。
+        要求：必須匹配「data.video.cover_url = ... + '&t='」賦值結構，
+        且 regex 只匹配同一條賦值語句內（[^;\\n]* 不跨 ; 與換行），
+        不被跨語句的 DOTALL 匹配混淆——保證 cover_url 守衛與 cover_full_url 守衛彼此獨立。
+        先過濾純注釋行，確保配對只落在實際程式碼。
+        """
+        js = self._js()
+        body = self._strip_line_comments(self._extract_refreshVideoData_body(js))
+        m = re.search(
+            r"data\.video\.cover_url\s*=\s*[^;\n]*\+\s*['\"]&t=",
+            body
+        )
+        assert m, (
+            "refreshVideoData 函式體找不到 'data.video.cover_url = ... + &t=' 賦值語句。\n"
+            "cover_url 分支的 cache-bust 遺失，grid 封面更新後瀏覽器可能吃舊快取。\n"
+            f"當前函式體（去注釋後）：\n{body[:500]}"
+        )
+
+    def test_cover_full_url_has_cache_bust(self):
+        """refreshVideoData 函式體內必須對 cover_full_url 賦值並串接 '&t=' cache-bust。
+        這是本 bug 的核心守衛：lightbox overlay（.lb-full）用 cover_full_url，
+        URL 不變會吃瀏覽器 max-age=86400 舊快取。
+        要求：必須匹配「data.video.cover_full_url = ... + '&t='」賦值結構，
+        且 regex 只匹配同一條賦值語句內（[^;\\n]* 不跨 ; 與換行），
+        不被跨語句的 DOTALL 匹配混淆——保證 cover_full_url 守衛與 cover_url 守衛彼此獨立。
+        先過濾注釋行，確保不被注釋裡的 cover_full_url 字樣或別欄位的 &t= 騙過。
+        """
+        js = self._js()
+        body = self._strip_line_comments(self._extract_refreshVideoData_body(js))
+        m = re.search(
+            r"data\.video\.cover_full_url\s*=\s*[^;\n]*\+\s*['\"]&t=",
+            body
+        )
+        assert m, (
+            "refreshVideoData 函式體找不到 'data.video.cover_full_url = ... + &t=' 賦值語句。\n"
+            "lightbox overlay（.lb-full `:src='cover_full_url'`）不加 cache-bust 會吃 max-age=86400 舊快取。\n"
+            f"當前函式體（去注釋後）：\n{body[:500]}"
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -36,6 +36,33 @@ class TestShowcaseMetadataGuard:
             "showcase.html missing: series searchFromMetadata call"
 
 
+class TestStatePageCloakGuard:
+    """showcase / search 的 state-page 框必須有 x-cloak（防 Alpine hydration 前 FOUC 裸露）。
+
+    無 x-cloak 時，Alpine 啟動前瀏覽器把 x-show 尚未生效的框同時裸露一幀、疊閃。
+    用 BeautifulSoup `select` 抓全部 div.state-page（attribute 順序無關，避免 regex 只認
+    class 為首屬性的假陽性，Codex P3）；逐節點斷言 has_attr('x-cloak')，並鎖定確切數量。
+    """
+
+    def _assert_all_state_pages_cloaked(self, path, expected_count):
+        from bs4 import BeautifulSoup
+        html = path.read_text(encoding="utf-8")
+        divs = BeautifulSoup(html, "html.parser").select("div.state-page")
+        assert len(divs) == expected_count, \
+            f"{path.name}: div.state-page 數 {len(divs)} != 預期 {expected_count}（新增/移除狀態框需同步更新守衛）"
+        for d in divs:
+            assert d.has_attr("x-cloak"), \
+                f"{path.name} state-page div 缺 x-cloak（Alpine hydration 前 FOUC）: x-show={d.get('x-show', '')!r}"
+
+    def test_showcase_state_pages_cloaked(self):
+        """showcase.html 5 個 state-page（3 頂層 + 2 actress）皆 x-cloak"""
+        self._assert_all_state_pages_cloaked(SHOWCASE_HTML, 5)
+
+    def test_search_state_pages_cloaked(self):
+        """search.html 2 個 state-page（emptyState 初始可見 / errorState）皆 x-cloak"""
+        self._assert_all_state_pages_cloaked(SEARCH_HTML, 2)
+
+
 SEARCH_HTML = Path(__file__).parent.parent.parent / "web" / "templates" / "search.html"
 
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -102,6 +102,54 @@ DESIGN_SYSTEM_HTML = Path(__file__).parent.parent.parent / "web" / "templates" /
 THEME_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "theme.css"
 TAILWIND_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "tailwind.css"
 
+BASE_HTML_T76 = Path(__file__).parent.parent.parent / "web" / "templates" / "base.html"
+
+
+class TestPageTransitionDomGuard:
+    """feature/76 T1: Cross-Document View Transitions DOM + CSS 契約守衛。
+
+    全 substring/regex 正向存在性（非行號 allowlist）。守衛 base.html 命名錨點 +
+    theme.css opt-in / 命名 / showcase opt-out。settings.css root 作用域化屬 T1a，
+    head skipTransition script 屬 T-showcase，皆不在此守衛。
+    """
+
+    def _base(self):
+        return BASE_HTML_T76.read_text(encoding="utf-8")
+
+    def _theme(self):
+        return THEME_CSS.read_text(encoding="utf-8")
+
+    def test_base_html_main_content_id(self):
+        """base.html <main> 含 id="main-content"（CD-4，T1 新增的命名錨點）"""
+        assert 'id="main-content"' in self._base(), \
+            "base.html <main> 缺少 id=\"main-content\"（feature/76 CD-4）"
+
+    def test_base_html_sidebar_id(self):
+        """base.html <nav> 含 id="sidebar"（現狀錨點，防回歸——VT 持久化依賴此 id）"""
+        assert 'id="sidebar"' in self._base(), \
+            "base.html <nav> 缺少 id=\"sidebar\"（feature/76 CD-3 sidebar 持久化依賴）"
+
+    def test_theme_css_view_transition_opt_in(self):
+        """theme.css 含 @view-transition + navigation: auto（CD-1 全站 opt-in）"""
+        css = self._theme()
+        assert "@view-transition" in css, "theme.css 缺少 @view-transition at-rule（feature/76 CD-1）"
+        assert re.search(r"@view-transition\s*\{\s*navigation:\s*auto", css), \
+            "theme.css @view-transition 缺少 navigation: auto（feature/76 CD-1）"
+
+    def test_theme_css_named_elements(self):
+        """theme.css 含 sidebar / main-content 兩個 view-transition-name（CD-2/CD-3）"""
+        css = self._theme()
+        assert "view-transition-name: sidebar" in css, \
+            "theme.css 缺少 view-transition-name: sidebar（feature/76 CD-3）"
+        assert "view-transition-name: main-content" in css, \
+            "theme.css 缺少 view-transition-name: main-content（feature/76 CD-2）"
+
+    def test_theme_css_showcase_optout(self):
+        """theme.css 含 showcase opt-out 單行（CD-11 輔助：.page-showcase + name:none）"""
+        css = self._theme()
+        assert re.search(r"\.page-showcase\s+#main-content\s*\{\s*view-transition-name:\s*none", css), \
+            "theme.css 缺少 .page-showcase #main-content { view-transition-name: none }（feature/76 CD-11 輔助）"
+
 
 class TestHelpPopoverGuard:
     """38e: help-popover CSS class usage guard (method folded)"""

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -998,16 +998,20 @@
     cursor: wait;
 }
 
-/* ==================== View Transition: theme 圓弧展開 ==================== */
-::view-transition-old(root),
-::view-transition-new(root) {
+/* ==================== View Transition: theme 圓弧展開 ====================
+ * feature/76 T1a（CD-7/F7）：加 html.theme-transition-active 前綴作用域化。
+ * cross-doc VT 偽元素由「目的地新頁」樣式化 → 裸 root 規則會汙染導航「到」
+ * /settings、/design-system 的 root crossfade（砍成 animation:none）。前綴後
+ * 此抑制只在 theme-transition.js 主題切換期間（class 在）生效、不外溢跨頁。 */
+html.theme-transition-active::view-transition-old(root),
+html.theme-transition-active::view-transition-new(root) {
     animation: none;
     mix-blend-mode: normal;
 }
 
 @media (prefers-reduced-motion: reduce) {
-    ::view-transition-old(root),
-    ::view-transition-new(root) {
+    html.theme-transition-active::view-transition-old(root),
+    html.theme-transition-active::view-transition-new(root) {
         animation: none;
     }
 

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -5982,6 +5982,9 @@ body.fluent-canvas:not(.ds-page)::before {
 .page-showcase #main-content {
   view-transition-name: none;
 }
+html.theme-transition-active #sidebar, html.theme-transition-active #main-content {
+  view-transition-name: none;
+}
 :root {
   --fluent-radius-none: 0px;
   --fluent-radius-sm: 2px;

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -4434,6 +4434,11 @@ body {
   padding-top: 1rem;
   border-top: 1px solid var(--border-light);
 }
+.av-card-full-title {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-light);
+  margin-bottom: 1rem;
+}
 :root {
   --poster-crop-ratio: 0.71;
 }
@@ -5934,6 +5939,48 @@ body.fluent-canvas:not(.ds-page)::before {
 }
 .btn-heart-pulse {
   animation: heartPulseFallback 0.3s ease-out forwards;
+}
+@view-transition {
+  navigation: auto;
+}
+@media (prefers-reduced-motion: reduce) {
+  @view-transition {
+    navigation: none;
+  }
+}
+#sidebar {
+  view-transition-name: sidebar;
+}
+::view-transition-group(sidebar) {
+  animation-duration: 250ms;
+}
+#main-content {
+  view-transition-name: main-content;
+}
+::view-transition-old(main-content) {
+  animation: 250ms var(--fluent-ease-accel) both vt-fade-out;
+}
+::view-transition-new(main-content) {
+  animation: 250ms var(--fluent-ease-decel) both vt-fade-in;
+}
+@keyframes vt-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes vt-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.page-showcase #main-content {
+  view-transition-name: none;
 }
 :root {
   --fluent-radius-none: 0px;

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -2440,3 +2440,14 @@ body.fluent-canvas:not(.ds-page)::before {
  * 不達硬切——元素退回 root 快照仍 crossfade。真硬切靠 base.html <head> classic script 的
  * pageswap/pagereveal skipTransition()（URL gate /showcase），見 plan CD-11 / TASK-76-T-showcase。 */
 .page-showcase #main-content { view-transition-name: none; }
+
+/* 主題切換共存（Codex P1）：view-transition-name 對 same-document startViewTransition() 同樣生效
+ * → 主題圓形展開（theme-transition.js 的 ::view-transition-new(root) clipPath）期間，sidebar/
+ * main-content 會脫離 root 快照、自行 crossfade（main-content 還會跑上方 250ms fade），破壞圓形 reveal。
+ * theme-transition.js 切換期間掛 html.theme-transition-active → 此時 de-name 兩區、塌回 root 單一快照、
+ * 圓形 reveal 涵蓋整頁。specificity (1,1,1) > 基礎 #sidebar (1,0,0)，不論順序皆勝；class 移除後命名恢復、
+ * 跨頁轉場照常。 */
+html.theme-transition-active #sidebar,
+html.theme-transition-active #main-content {
+    view-transition-name: none;
+}

--- a/web/static/css/theme.css
+++ b/web/static/css/theme.css
@@ -2410,3 +2410,33 @@ body.fluent-canvas:not(.ds-page)::before {
 .btn-heart-pulse {
     animation: heartPulseFallback 0.3s ease-out forwards;
 }
+
+/* ==================== Cross-Document View Transitions (feature/76) ==================== */
+
+/* 兩端 opt-in：同源導航自動 crossfade（spec D1 / CD-1）。
+ * 此區塊經 input.css @import 編進 tailwind.css → 改後必重編 Tailwind。 */
+@view-transition { navigation: auto; }
+
+/* prefers-reduced-motion：CD-6 首選（巢狀語法）。OS 偏好不動畫時整個跨頁轉場關閉。
+ * 注意：上方 PRM 全域 hammer（*{animation-duration:0.01ms}）不匹配 ::view-transition-* 偽元素樹，故此處顯式處理。 */
+@media (prefers-reduced-motion: reduce) {
+    @view-transition { navigation: none; }
+}
+
+/* sidebar 持久區域（#sidebar id 已存在 base.html）→ 脫離 root crossfade、轉場中視覺靜止（CD-3 / spec D2） */
+#sidebar { view-transition-name: sidebar; }
+/* 顯式對齊 250ms，防 group 預設 duration 與 main-content 漂移 desync */
+::view-transition-group(sidebar) { animation-duration: 250ms; }
+
+/* 主內容區 crossfade（#main-content id 由 base.html <main> 提供）。
+ * 250ms = --fluent-duration-normal；accel=離開 / decel=到達（Fluent 單向語意，禁硬編碼曲線，CD-2 / spec D3） */
+#main-content { view-transition-name: main-content; }
+::view-transition-old(main-content) { animation: 250ms var(--fluent-ease-accel) both vt-fade-out; }
+::view-transition-new(main-content) { animation: 250ms var(--fluent-ease-decel) both vt-fade-in; }
+@keyframes vt-fade-out { from { opacity: 1; } to { opacity: 0; } }
+@keyframes vt-fade-in  { from { opacity: 0; } to { opacity: 1; } }
+
+/* D8（CD-11）：showcase 退出 VT。此單行僅讓 showcase 主內容不成獨立 snapshot group（降快照成本，輔助），
+ * 不達硬切——元素退回 root 快照仍 crossfade。真硬切靠 base.html <head> classic script 的
+ * pageswap/pagereveal skipTransition()（URL gate /showcase），見 plan CD-11 / TASK-76-T-showcase。 */
+.page-showcase #main-content { view-transition-name: none; }

--- a/web/static/js/pages/settings/theme-transition.js
+++ b/web/static/js/pages/settings/theme-transition.js
@@ -14,8 +14,14 @@ function toggleThemeWithTransition(event, applyFn) {
         Math.max(x, innerWidth - x),
         Math.max(y, innerHeight - y)
     );
+    // feature/76 T1a（CD-7/F7）：標記主題切換期間，讓 settings.css 的 root 抑制
+    // 規則（html.theme-transition-active 前綴）只在此期間生效、不汙染跨頁 root crossfade。
+    document.documentElement.classList.add('theme-transition-active');
     const transition = document.startViewTransition(() => {
         applyFn();
+    });
+    transition.finished.finally(() => {
+        document.documentElement.classList.remove('theme-transition-active');
     });
     transition.ready.then(() => {
         document.documentElement.animate(

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -770,13 +770,27 @@ export function stateLightbox() {
                 if (!resp.ok) return;
                 const data = await resp.json();
                 if (data.success && data.video) {
+                    // BUGfix-lightbox-cover-stale: 共用同一個 timestamp，確保 grid 與 lightbox overlay 同步 bust。
+                    const _t = Date.now();
                     if (data.video.cover_url) {
-                        data.video.cover_url = data.video.cover_url + '&t=' + Date.now();
+                        data.video.cover_url = data.video.cover_url + '&t=' + _t;
+                    }
+                    // cover_full_url 恆為 /api/gallery/image（max-age=86400），URL 不變瀏覽器吃舊快取。
+                    // 同步追加 &t= cache-bust，確保 lightbox overlay（.lb-full）顯示新封面。
+                    if (data.video.cover_full_url) {
+                        data.video.cover_full_url = data.video.cover_full_url + '&t=' + _t;
                     }
                     // 67-A2/CD-67-3b: data.video 不帶 _imgLoaded → 舊 true 殘留會讓新封面跳過 skeleton/fade。
                     // Object.assign 前 reset，讓補封面/重抓的新 cover_url（含上面 &t= cache-bust）重走 skeleton→@load→淡入。
                     if (data.video.cover_url) video._imgLoaded = false;
                     Object.assign(video, data.video);
+                    // BUGfix-lightbox-cover-stale: 若燈箱正開在這支影片，重置 blur-up overlay，
+                    // 讓 cover_full_url（已 bust）重新觸發 @load → _lbFullLoaded 淡入。
+                    // 用 === video 守住：燈箱開在別支影片時不誤 reset。
+                    // 必須在 Object.assign 之後呼叫（src 已更新，$nextTick complete-check 才讀到新 URL）。
+                    if (this.currentLightboxVideo === video) {
+                        this._refreshLbFullBlurUp();
+                    }
                 }
             } catch (e) {
                 // refresh 失敗不顯示額外 toast

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -92,6 +92,9 @@ export function stateLightbox() {
             this.currentLightboxActress = null;   // video setter always clear actress
             this.addingLbTag = false;             // 切換影片時重置輸入框
             this._videoChipsExpanded = false;     // 影片切換時 reset chips 展開
+            // BUGfix-mobile-similar-stale-cover P2b: in-grid 切換後清除 standalone 旗標，
+            // 確保連點 tier2/3 再 tier1 時 prev/next + fly-back 恢復正常（不殘留 standalone）
+            this.similarExitVideo = null;
             // 71c-P2: 抽至 _refreshLbFullBlurUp helper（slip-through 路徑共用）
             this._refreshLbFullBlurUp();
         },

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -427,11 +427,19 @@ export function stateSimilar() {
           // 找到 → 沿用既有邏輯（_setLightboxIndex + currentLightboxVideo 同步）
           this._silentSwitchLightboxByNumber(this._similarLastDrilledNumber);
         } else {
-          // 找不到 → standalone 模式：用 _similarLastDrilledItem snapshot（v2 修法；
-          // v1 用 similarResults.find 常找不到 — similarResults 在 onComplete 已替換為 clickedItem 的鄰居，
-          // 不保證包含 clickedItem 本身，導致 fallback no-op 回原始 lightbox。）
-          const drilledItem = this._similarLastDrilledItem;
-          if (drilledItem) {
+          // _filteredVideos 找不到 → BUGfix-mobile-similar-stale-cover P2 三層 fallback（對齊 onSimilarMobileCardClick）：
+          // 先查 _videos（庫內、被 active filter 排除）→ standalone 但保完整 metadata + path，
+          // 避免關閉 similar mode 時把 mobile tier2 的完整 metadata + path 重新降級成 5 欄 snapshot。
+          const drilledVIdx = _videos.findIndex(v => v.number === this._similarLastDrilledNumber);
+          if (drilledVIdx >= 0) {
+            this.similarExitVideo = _videos[drilledVIdx];
+            this.currentLightboxVideo = this.similarExitVideo;
+            this._refreshLbFullBlurUp();
+          } else if (this._similarLastDrilledItem) {
+            // _videos 也 miss（孤兒列 / demo）→ standalone snapshot：用 _similarLastDrilledItem（v2 修法；
+            // v1 用 similarResults.find 常找不到 — similarResults 在 onComplete 已替換為 clickedItem 的鄰居，
+            // 不保證包含 clickedItem 本身，導致 fallback no-op 回原始 lightbox。）
+            const drilledItem = this._similarLastDrilledItem;
             // actresses 在 similarResults 是 array，lightbox template 用 .split(',') 解析；轉字串對齊
             const actressStr = Array.isArray(drilledItem.actresses)
               ? drilledItem.actresses.join(', ')
@@ -451,9 +459,8 @@ export function stateSimilar() {
             // 71c-P2: slip-through 繞過 _setLightboxIndex，需手動重走 blur-up reset + same-URL complete-check
             // （assignment 先、helper 後，讓 $nextTick 在 Alpine patch DOM 後才讀 lightboxCoverFull.complete）
             this._refreshLbFullBlurUp();
-          } else {
-            // similarResults 裡也找不到（理論上不發生）→ 靜默，顯示進場前舊影片（同 no-op 行為）
           }
+          // 三者皆 miss（理論上不發生）→ 靜默，顯示進場前舊影片（同 no-op 行為）
         }
       } else {
         // 無 slip-through（進 similar mode 後直接關）→ 不動，沿用既有行為
@@ -1225,7 +1232,37 @@ export function stateSimilar() {
         this.similarResults = data.results;
         this.similarQueryVideo = data.query_video;
         // Alpine x-for 自動 reactive，畫面 swap
-        this._silentSwitchLightboxByNumber(item.number);
+
+        // BUGfix-mobile-similar-stale-cover: 三層 fallback（tier 1→2→3）
+        // tier 1: 命中 _filteredVideos → _setLightboxIndex（含自動清 similarExitVideo=null）
+        if (!this._silentSwitchLightboxByNumber(item.number)) {
+          // tier 2: 在 _videos（庫內、被 filter 排除）→ standalone，完整 metadata + path
+          const vIdx = _videos.findIndex(v => v.number === item.number);
+          if (vIdx >= 0) {
+            this.similarExitVideo = _videos[vIdx];
+          } else {
+            // tier 3: 孤兒列 / demo — 前端只有 similar API 的 5 欄 snapshot
+            const actressStr = Array.isArray(item.actresses)
+              ? item.actresses.join(', ') : (item.actresses || '');
+            this.similarExitVideo = {
+              number: item.number, title: item.title,
+              cover_url: item.cover_url,
+              cover_full_url: item.cover_full_url || '',  // 必帶 || ''：確保 .lb-full @load fire
+              actresses: actressStr,
+              // path 故意 undefined → play/open-folder/user-tags 靠 ?. guard 靜默不渲染
+            };
+          }
+          // tier 2 + 3 共用收尾：standalone housekeeping + blur-up reset
+          this.currentLightboxVideo = this.similarExitVideo;
+          this.currentLightboxActress = null;
+          this._videoChipsExpanded = false;
+          this.addingLbTag = false;
+          this._refreshLbFullBlurUp();
+        }
+
+        // P3: _similarLastDrilled* 在 fetch 成功後設（非 fetch 前），退場 exit 目標正確
+        this._similarLastDrilledNumber = item.number;
+        this._similarLastDrilledItem = item;
       }).catch(() => {
         // _fetchSimilarResults 已 showToast；x-for 不刷新，留原 4 張
       }).finally(() => {
@@ -1268,9 +1305,10 @@ export function stateSimilar() {
      * CD-56C-12
      */
     _silentSwitchLightboxByNumber(number) {
-      if (!number) return;
+      if (!number) return false;
       const idx = _filteredVideos.findIndex(v => v.number === number);
-      if (idx >= 0) this._setLightboxIndex(idx);
+      if (idx >= 0) { this._setLightboxIndex(idx); return true; }
+      return false;
     },
   };
 }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -33,6 +33,35 @@
       }
     </script>
 
+    <!-- feature/76 T-showcase（CD-11）：showcase 退出跨頁轉場、硬切。
+         pagereveal 在新頁 first rendering opportunity 之前觸發 → 此 listener 必須是
+         <head> 內 parser-blocking classic script（非 module/defer/async），否則漏接。
+         URL gate：導航任一端為 /showcase 即 skipTransition()（即時完成動畫＝硬切）。
+         全站共用點：離 showcase 走 pageswap（舊頁端）、進 showcase 走 pagereveal（新頁端），
+         兩方向各自在其端點 skip——showcase-only module 掛不到「他頁→showcase」的 pageswap。 -->
+    <script>
+      (function () {
+        function pathOf(u) { try { return new URL(u, location.href).pathname; } catch (e) { return ''; } }
+        function involvesShowcase(a, b) { return a === '/showcase' || b === '/showcase'; }
+        // 離開頁（舊文件）：from = 目前頁、to = 目的頁
+        window.addEventListener('pageswap', function (e) {
+          if (!e.viewTransition) return;
+          var act = e.activation;
+          var from = act && act.from ? pathOf(act.from.url) : location.pathname;
+          var to = act && act.entry ? pathOf(act.entry.url) : '';
+          if (involvesShowcase(from, to)) e.viewTransition.skipTransition();
+        });
+        // 到達頁（新文件）：from = 來源頁、to = 目前頁
+        window.addEventListener('pagereveal', function (e) {
+          if (!e.viewTransition) return;
+          var act = (window.navigation && window.navigation.activation) || null;
+          var from = act && act.from ? pathOf(act.from.url) : '';
+          var to = act && act.entry ? pathOf(act.entry.url) : location.pathname;
+          if (involvesShowcase(from, to)) e.viewTransition.skipTransition();
+        });
+      })();
+    </script>
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="icon" type="image/png" href="/static/favicon.png">

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -597,7 +597,7 @@
     </nav>
 
     <!-- 主內容區 -->
-    <main class="main-content">
+    <main id="main-content" class="main-content">
         {% block content %}{% endblock %}
     </main>
 

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -313,7 +313,7 @@
     <!-- 結果區域 -->
     <div class="result-area">
         <!-- 初始狀態 -->
-        <div id="emptyState" class="state-page w-full" x-show="pageState === 'empty'">
+        <div id="emptyState" class="state-page w-full" x-show="pageState === 'empty'" x-cloak>
             <i class="bi bi-film state-page-icon"></i>
             <p class="state-page-text">{{ t('search.empty.hint') }}</p>
             <div class="empty-actions">

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -18,13 +18,13 @@
      @keydown.window="handleKeydown($event)">
 
     <!-- Loading State (初始顯示) -->
-    <div class="state-page" x-show="!showFavoriteActresses && loading && videoCount === 0">
+    <div class="state-page" x-cloak x-show="!showFavoriteActresses && loading && videoCount === 0">
         <i class="bi bi-hourglass-split state-page-icon"></i>
         <p class="state-page-text">載入影片列表中...</p>
     </div>
 
     <!-- Empty State (API 回傳空資料時) -->
-    <div class="state-page" x-show="!showFavoriteActresses && !loading && !error && videoCount === 0">
+    <div class="state-page" x-cloak x-show="!showFavoriteActresses && !loading && !error && videoCount === 0">
         <i class="bi bi-collection-play state-page-icon"></i>
         <p class="state-page-text">尚未產生影片列表</p>
         <div class="empty-actions">
@@ -35,7 +35,7 @@
     </div>
 
     <!-- Error State (API 錯誤時) -->
-    <div class="state-page error" x-show="!loading && error">
+    <div class="state-page error" x-cloak x-show="!loading && error">
         <i class="bi bi-exclamation-triangle state-page-icon"></i>
         <p class="state-page-text" x-text="error"></p>
         <div class="empty-actions">
@@ -486,11 +486,11 @@
         <template x-if="showFavoriteActresses">
           <div>
             <!-- Loading spinner -->
-            <div class="state-page" x-show="actressLoading">
+            <div class="state-page" x-cloak x-show="actressLoading">
                 <i class="bi bi-hourglass-split state-page-icon"></i>
             </div>
             <!-- Empty state -->
-            <div class="state-page" x-show="!actressLoading && actressCount === 0">
+            <div class="state-page" x-cloak x-show="!actressLoading && actressCount === 0">
                 <i class="bi bi-person-heart state-page-icon"></i>
                 <p class="state-page-text" x-text="t('showcase.actress.empty')"></p>
                 <p class="state-page-text" x-text="t('showcase.actress.emptyHint')"></p>


### PR DESCRIPTION
## 概要

v0.10.3 / feature/76。**MPA 跨頁無縫轉場（Cross-Document View Transitions）**——純前端、零後端/DB/依賴。點 sidebar 切頁的白屏閃爍消失，改為主內容區約 250ms crossfade、sidebar/鈴鐺/logo 視覺靜止；用瀏覽器原生跨文件 View Transition 達成，不 SPA 化、不引入路由。漸進增強：不支援的環境與 `prefers-reduced-motion` 自動退回現狀硬切、零差異。

## 變更內容（task → commit）

| Task | 內容 |
|------|------|
| **T1** | `@view-transition` opt-in + `#sidebar`/`#main-content` 命名持久化 + 250ms crossfade（Fluent accel/decel token）+ showcase 輔助 opt-out；`<main id="main-content">`；Tailwind 重編；DOM 守衛 |
| **T1a** | settings.css 既有 root 規則作用域化（`html.theme-transition-active`），不汙染導航到 /settings、/design-system 的 root crossfade；theme-transition.js class lifecycle |
| **T2/T2.5** | 守衛路徑（settings/scanner dirty/串流放棄離開）的 `location.href` 程式導航維持硬切（owner 簽核 (a)；programmatic 本就不觸發跨文件 VT、零回歸）|
| **T-showcase** | showcase 退出轉場：`<head>` parser-blocking classic script 於 `pageswap`/`pagereveal` 依 URL `skipTransition()`（CSS `view-transition-name:none` 只降快照成本、不達硬切）|
| **T6** | stylelint 禁 `view-transition-name: root` + 全套 gate |
| **fix（Codex P1）** | 主題圓形展開被跨頁命名群組破壞：`view-transition-name` 對 same-document 主題切換同樣生效 → 切換期間 de-name 兩區、塌回 root |
| **fix（FOUC）** | showcase/search 狀態框缺 `x-cloak`、Alpine hydration 前裸露疊閃 → 補齊（showcase 5 + search 2，pre-existing、順手修）|

## 驗證

- **全套 pytest 4334 passed, 2 skipped, 0 failed**（較 0.10.2 +26）；`npm run lint`（eslint + stylelint）綠。
- **來源金絲雀 8 源全 PASS**（live advisory）。
- **CDP 實機（Chromium 146）**：showcase↔他頁雙向硬切（差分 probe `SKIPPED`）、非 showcase crossfade（`VT_SEEN`）、主題切換期間命名塌回 root、各頁 console 0 error。
- **Gemini（agy）整支 branch holistic review：LGTM、no material findings**。
- 敏感掃描 / 打包完整性 clean；無 API 變更（capabilities 不動）。

## Non-Goals
不 SPA 化、不引入路由、不用 HTMX swap、不做共享元素（封面飛行）轉場、不加 loading bar/骨架屏、不在 Settings 加開關、不改後端任何路由/API。

## 備註
- **`/motion-lab` 回 500 為 pre-existing**（隔離驗證確認 feature/76 前即 500）、與本 PR 無關、out of scope（建議另開 issue）。
- showcase 狀態框硬編碼字串的 i18n 留 milestone。
- 後續 feature/77（screening-room）依賴本 PR 先合（D8 showcase 退出轉場鎖定快照約束）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)