### PR TITLE
fix(build): Windows 打包 bloat 修復 — ZIP 84MB→34.6MB（allowlist 模型 + 產物守衛）

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build Windows package
         run: python build.py
 
+      - name: Run artifact audit
+        run: python scripts/audit_build_artifact.py "dist/*-Windows-*.zip" --platform win --max-mb 55
+
       - name: Prepare artifact
         run: |
           cd dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,9 @@ jobs:
         run: python build.py
 
       - name: Run artifact audit
-        run: python scripts/audit_build_artifact.py "dist/*-Windows-*.zip" --platform win --max-mb 55
+        # --strict：T2 已移除 uvloop → uvloop/langdetect 由 WARN 翻 hard-fail（擋 release）
+        # --max-mb 48：T2 後 ZIP ~34.6MB（uvloop 16MB 已除）；收緊以擋未來 bloat 回歸
+        run: python scripts/audit_build_artifact.py "dist/*-Windows-*.zip" --platform win --max-mb 48 --strict
 
       - name: Prepare artifact
         run: |

--- a/build.py
+++ b/build.py
@@ -89,6 +89,14 @@ EXCLUDE_PACKAGES = {
     'mypy', 'mypyc', 'mypy-extensions',
     'types-beautifulsoup4', 'types-html5lib',
 
+    # ⚠️ playwright transitive：pytest-playwright（在 requirements-test.txt）的直接依賴是
+    # playwright（36MB wheel，解壓 102MB）和 pyee。_test_only_packages() 只抓直列套件名
+    # 「pytest-playwright」，抓不到其 transitive 的 playwright 本體（wheel 命名 playwright-*
+    # 而非 pytest-playwright-*）→ build.py 解壓 wheel cache 時 playwright 被含入（曾 +32MB）。
+    # greenlet 也是 playwright 的 transitive，但體積極小（<1MB）；本次只止血 playwright 主體
+    # （+pyee），系統性清 transitive 屬 T2 allowlist 範圍，故不在此 denylist 追加（避免 whack-a-mole）。
+    'playwright', 'pyee',
+
     # 開發/打包工具
     'pip', 'setuptools', 'wheel', 'twine', 'build',
 

--- a/build.py
+++ b/build.py
@@ -47,11 +47,14 @@ COPY_ITEMS = [
 
 # uvicorn[standard] 裡的 win-safe extras（uvloop 不含，Windows 用不到）
 # websockets 已是 requirements.txt 頂層，不重複
+# 精確釘版本（==）確保可重現 build：同 git tag = 同 ZIP（與 EXTRA_DEPS_NO_DEPS 同規範）。
+# 版本來源：.build_cache/wheels/ 實際解析的 wheel 檔名（cross-check dist/ ZIP site-packages）。
+# 升版時與 requirements.txt 的 uvicorn[standard]==X.Y.Z 同步評估。
 _UVICORN_WIN_SAFE_EXTRAS = [
-    "httptools",
-    "watchfiles",
-    "python-dotenv",
-    "PyYAML",
+    "httptools==0.8.0",
+    "watchfiles==1.2.0",
+    "python-dotenv==1.2.2",
+    "PyYAML==6.0.3",
 ]
 
 # pure-Python sdist-only 套件（PyPI 從未發 wheel）

--- a/build.py
+++ b/build.py
@@ -25,7 +25,7 @@ PYTHON_VERSION = "3.12.4"
 PYTHON_EMBED_URL = f"https://www.python.org/ftp/python/{PYTHON_VERSION}/python-{PYTHON_VERSION}-embed-amd64.zip"
 
 # 專案結構
-PROJECT_ROOT = Path(__file__).parent
+PROJECT_ROOT = Path(__file__).resolve().parent
 BUILD_DIR = PROJECT_ROOT / "build"
 DIST_DIR = PROJECT_ROOT / "dist"
 CACHE_DIR = PROJECT_ROOT / ".build_cache"  # 緩存目錄（不會被清理）
@@ -39,73 +39,82 @@ COPY_ITEMS = [
     "maker_mapping.json",
 ]
 
-# 主要套件（會自動解析依賴）
-PACKAGES = [
-    "fastapi",
-    "uvicorn[standard]",
-    "jinja2",
-    "python-multipart",
-    "requests",
-    "beautifulsoup4",
-    "lxml",
-    "curl_cffi",
-    "websockets",
-    "pillow",
-    "pywebview",
-    "httpx",  # Required for FastAPI TestClient and async HTTP
+# ============ Allowlist 模型（T2：棄 pip freeze + denylist） ============
+#
+# Windows 打包依賴來源 = requirements.txt 顯式 allowlist（程式碼層調整）
+# + extra_deps（Windows pywebview backend 專用）。
+# 不再 pip freeze dev venv，根除 denylist 漂移與 orphan 污染。
+
+# uvicorn[standard] 裡的 win-safe extras（uvloop 不含，Windows 用不到）
+# websockets 已是 requirements.txt 頂層，不重複
+_UVICORN_WIN_SAFE_EXTRAS = [
+    "httptools",
+    "watchfiles",
+    "python-dotenv",
+    "PyYAML",
 ]
 
-def _test_only_packages() -> set:
-    """從 requirements-test.txt 抽出『純測試/開發』套件名（跳 `-r` / 註解 / 空行）。
+# pure-Python sdist-only 套件（PyPI 從未發 wheel）
+SDIST_OK: set[str] = {"proxy-tools"}
 
-    requirements-test.txt 用 `-r requirements.txt` 繼承 runtime，其餘直列項即「runtime
-    之外額外裝」的測試/開發工具（pytest* / ruff / playwright / PyYAML…）——絕不該進
-    用戶 ZIP。從此檔自動 derive，避免日後新增測試套件忘了同步 EXCLUDE（denylist 漂移）。
+# 無 win_amd64 wheel 但 Windows 合法缺席的套件（skip + warning 而非 hard-fail）
+# 理論上 uvloop 在機制 1 已不應被請求；此集是防禦性後備
+SKIP_IF_NO_WIN_WHEEL: set[str] = {"uvloop"}
+
+# Windows pywebview backend 專用依賴（有 win32 marker，Linux pip 不自動解析）→ Phase 2 逐一 --no-deps
+# 所有項目均釘精確版本（==），確保：
+#   1. stale-cleanup 能偵測版本不匹配並強制重下（防 CI cache 送出舊版）
+#   2. 相同 git tag = 相同 ZIP（可重現 build）
+# pythonnet + clr_loader 釘精確版本：3.0.5 + 0.2.10 是已驗證的相容對；
+# pythonnet 3.1.0 需要 clr_loader>=0.3.1，不可混版。
+# 模組級常數（非函式內 local）：供守衛測試 import 驗證、防新增 extra dep 漏守衛。
+EXTRA_DEPS_NO_DEPS: list[str] = [
+    "pywebview==6.2.1",       # no-deps：pywebview→proxy-tools 無 wheel 會讓 with-deps 失敗
+    "bottle==0.13.4",         # pin：防 CI cache 送舊版（stale-reuse bug fix）
+    "proxy-tools==0.1.0",     # SDIST_OK：PyPI 只有 tar.gz；pin 確保 stale-cleanup 作用
+    "clr_loader==0.2.10",     # pin：與 pythonnet 3.0.5 的相容版本
+    "pythonnet==3.0.5",       # pin：3.1.0 需要 clr_loader>=0.3.1（會破壞現有組合）
+    "win32-setctime==1.2.0",  # pin：防 CI cache 送舊版（stale-reuse bug fix）
+    "colorama==0.4.6",        # pin：防 CI cache 送舊版（stale-reuse bug fix）
+]
+
+
+def _parse_allowlist_lines(lines: list[str]) -> list[str]:
+    """解析 requirements 行 → Windows build 頂層依賴清單。
+
+    extras 處理（fail-closed）：
+    - 只有 `uvicorn[standard]==X.Y.Z` 會被改寫成 `uvicorn==X.Y.Z`（其 win-safe 子套件
+      由 _UVICORN_WIN_SAFE_EXTRAS 明列補回）。
+    - 任何「其他」帶 extra 的依賴（如 `redis[hiredis]`）→ **hard-fail**，不靜默剝除。
+      原因：blanket 剝 extra 會讓該 extra 的子依賴從 Windows ZIP 無聲消失——正是 T2
+      要根除的漂移。新增帶 extra 的依賴時，須先在 build.py 明列其 win-safe 子依賴再放行。
     """
-    names = set()
-    req = PROJECT_ROOT / "requirements-test.txt"
-    if req.exists():
-        for line in req.read_text(encoding="utf-8").splitlines():
-            s = line.split("#", 1)[0].strip()
-            if not s or s.startswith("-"):  # 跳 `-r requirements.txt` / 註解 / 空行
-                continue
-            # 取套件名（去版本/extras）並標準化（pip 視 - 與 _ 等價、大小寫不敏感）
-            name = re.split(r"[=<>!~\[]", s, maxsplit=1)[0].strip().lower().replace("_", "-")
-            if name:
-                names.add(name)
-    return names
+    extra_re = re.compile(r"\[[^\]]*\]")
+    deps: list[str] = []
+    for line in lines:
+        s = line.split("#", 1)[0].strip()
+        if not s or s.startswith("-"):
+            continue
+        m = extra_re.search(s)
+        if m:
+            name = re.split(r"[\[=<>!~]", s, maxsplit=1)[0].strip().lower().replace("_", "-")
+            if name == "uvicorn" and m.group(0) == "[standard]":
+                s = extra_re.sub("", s)  # uvicorn[standard]==X → uvicorn==X
+            else:
+                raise SystemExit(
+                    f"[BUILD ERROR] requirements.txt 有未處理的 extra：{s!r}。\n"
+                    f"build.py 只改寫 uvicorn[standard]（win-safe 子套件已在 "
+                    f"_UVICORN_WIN_SAFE_EXTRAS 明列）。新增帶 extra 的依賴時，請先在 build.py "
+                    f"明列其 win-safe 子依賴再放行——不可讓 extra 被靜默剝除（T2 fail-closed）。"
+                )
+        deps.append(s)
+    return deps
 
 
-# 打包時排除的套件（測試/開發工具，不影響運行）。
-# = requirements-test.txt 的純測試套件（自動 derive）∪ 其 transitive ∪ orphan/開發工具。
-EXCLUDE_PACKAGES = {
-    # 測試工具 transitive（不直接列於 requirements-test.txt，需手動補）
-    'coverage', 'pluggy', 'iniconfig',
-
-    # ⚠️ mypy 殘留：feature/78 從 requirements/mypy.ini 移除「設定」，但套件本體常仍
-    # 物理留在 dev venv（pip freeze 抓得到）→ build.py 若 freeze venv 會把 mypy 含其
-    # 18MB mypyc 編譯 .pyd 打進 ZIP（曾 +11MB）。mypy 不在任一 requirements 檔（orphan），
-    # 故 _test_only_packages() 抓不到，須在此顯式排除（+ 其編譯/相依產物）。
-    'mypy', 'mypyc', 'mypy-extensions',
-    'types-beautifulsoup4', 'types-html5lib',
-
-    # ⚠️ playwright transitive：pytest-playwright（在 requirements-test.txt）的直接依賴是
-    # playwright（36MB wheel，解壓 102MB）和 pyee。_test_only_packages() 只抓直列套件名
-    # 「pytest-playwright」，抓不到其 transitive 的 playwright 本體（wheel 命名 playwright-*
-    # 而非 pytest-playwright-*）→ build.py 解壓 wheel cache 時 playwright 被含入（曾 +32MB）。
-    # greenlet 也是 playwright 的 transitive，但體積極小（<1MB）；本次只止血 playwright 主體
-    # （+pyee），系統性清 transitive 屬 T2 allowlist 範圍，故不在此 denylist 追加（避免 whack-a-mole）。
-    'playwright', 'pyee',
-
-    # 開發/打包工具
-    'pip', 'setuptools', 'wheel', 'twine', 'build',
-
-    # 文檔工具
-    'docutils', 'pygments', 'readme-renderer',
-
-    # 未使用
-    'langdetect',
-} | _test_only_packages()  # pytest* / ruff / pytest-playwright / PyYAML… 自動納入
+def parse_requirements_allowlist() -> list[str]:
+    """從 requirements.txt 解析 Windows build 頂層依賴清單（見 _parse_allowlist_lines）。"""
+    req_path = PROJECT_ROOT / "requirements.txt"
+    return _parse_allowlist_lines(req_path.read_text(encoding="utf-8").splitlines())
 
 
 # ============ 工具函數 ============
@@ -218,32 +227,92 @@ import site
     return python_dir
 
 
-def get_all_dependencies():
-    """從現有 venv 獲取完整依賴列表（排除測試/開發工具）"""
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "freeze"],
-        capture_output=True, text=True
-    )
-    deps = []
-    excluded = []
-    for line in result.stdout.strip().split('\n'):
-        if '==' in line:
-            pkg_name = line.split('==')[0].strip()
-            # 標準化套件名稱（pip 用 - 和 _ 可互換）
-            pkg_normalized = pkg_name.lower().replace('_', '-')
-            if pkg_normalized in EXCLUDE_PACKAGES:
-                excluded.append(pkg_name)
+def _pkg_name_from_filename(filename: str) -> str:
+    """從 wheel/tar.gz 檔名取標準化套件名（首個 '-' 前，標準化為 lowercase + dash）。"""
+    stem = Path(filename).stem
+    # tar.gz: strip second .gz extension already removed by .stem on .tar.gz
+    # For foo-1.0.tar.gz, Path("foo-1.0.tar.gz").stem = "foo-1.0.tar"
+    # So strip trailing .tar if present
+    if stem.endswith(".tar"):
+        stem = stem[:-4]
+    return stem.split("-")[0].lower().replace("_", "-")
+
+
+def _norm_pkg_name(spec: str) -> str:
+    """從 pip spec 字串取標準化套件名（去 extras/版本/標點，lowercase + dash）。"""
+    return re.split(r"[=<>!~\[]", spec, maxsplit=1)[0].strip().lower().replace("_", "-")
+
+
+def _download_one_package(
+    pkg_spec: str,
+    wheels_dir: Path,
+) -> set[Path]:
+    """下載單一套件（spec）為 win_amd64 wheel，或 sdist（限 SDIST_OK 成員）。
+
+    Returns set of new file paths downloaded into wheels_dir.
+    Raises SystemExit on hard-fail (required dep with no win wheel).
+    """
+    pkg_name = re.split(r"[=<>!~\[]", pkg_spec, maxsplit=1)[0].strip().lower().replace("_", "-")
+    before = set(wheels_dir.glob("*.*"))
+
+    if pkg_name in SDIST_OK:
+        # sdist 例外：允許 tar.gz（純 Python，PyPI 無 wheel）
+        pip_cmd = [
+            sys.executable, "-m", "pip", "download",
+            "--dest", str(wheels_dir),
+            "--no-deps",
+            pkg_spec,
+        ]
+        result = subprocess.run(pip_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"\n[BUILD ERROR] sdist 下載失敗（{pkg_spec}）：\n{result.stderr}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # 標準路徑：只允許 win_amd64 binary wheel
+        pip_cmd = [
+            sys.executable, "-m", "pip", "download",
+            "--dest", str(wheels_dir),
+            "--platform", "win_amd64",
+            "--python-version", "3.12",
+            "--only-binary", ":all:",
+            "--no-deps",
+            pkg_spec,
+        ]
+        result = subprocess.run(pip_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            if pkg_name in SKIP_IF_NO_WIN_WHEEL:
+                print(f"  [WARNING] {pkg_name} 無 win_amd64 wheel，已跳過（Windows 合法缺席）")
+                return set()
             else:
-                deps.append(line.strip())
+                # FAIL-CLOSED：必要依賴無 win wheel，硬失敗
+                print(
+                    f"\n[BUILD ERROR] {pkg_spec!r} 無 win_amd64 wheel 且不在 SDIST_OK / SKIP_IF_NO_WIN_WHEEL。\n"
+                    f"請確認此套件是否有 Windows binary wheel，或將其加入 SDIST_OK（純 Python）\n"
+                    f"/ SKIP_IF_NO_WIN_WHEEL（Windows 合法缺席）。\n"
+                    f"pip stderr：\n{result.stderr}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
-    if excluded:
-        print(f"  排除 {len(excluded)} 個測試/開發套件: {', '.join(excluded[:5])}{'...' if len(excluded) > 5 else ''}")
-
-    return deps
+    after = set(wheels_dir.glob("*.*"))
+    return after - before
 
 
 def download_and_install_packages(python_dir: Path):
-    """下載 Windows wheel 並解壓到 site-packages（使用緩存）"""
+    """下載 Windows wheel 並解壓到 site-packages（allowlist + manifest-based extract）
+
+    兩階段下載策略：
+    Phase 1（with-deps）：runtime + win-safe extras（不含 pywebview），讓 pip 解出
+      完整 transitive 依賴樹（pydantic_core / anyio / h11 / markupsafe 等）。
+      pywebview 從此排除：它的 dep proxy-tools 只有 sdist，--only-binary 會失敗。
+
+    Phase 2（--no-deps each）：pywebview + extra_deps 逐一下載，各自套用
+      SDIST_OK（proxy-tools 允許 tar.gz）/ SKIP_IF_NO_WIN_WHEEL / FAIL-CLOSED 規則。
+
+    機制 3（manifest-based extract）：
+      extract_manifest = Phase 1 新下載 + Phase 1 cache-hit + Phase 2 新下載 + Phase 2 cache-hit。
+      解壓只迭代 manifest，不 glob 整個 cache，orphan 永不被帶入。
+    """
     print("\n[3/6] 準備依賴套件...")
 
     site_packages = python_dir / "Lib" / "site-packages"
@@ -253,96 +322,188 @@ def download_and_install_packages(python_dir: Path):
     wheels_dir = CACHE_DIR / "wheels"
     wheels_dir.mkdir(parents=True, exist_ok=True)
 
-    # 從現有 venv 獲取所有已安裝的套件（帶版本號，如 "pydantic==2.11.0"）
-    all_deps = get_all_dependencies()
-    # 加入 pywebview（可能不在 venv 中）
-    dep_names = [d.split('==')[0].lower() for d in all_deps]
-    if "pywebview" not in dep_names:
-        all_deps.append("pywebview")
+    # ── 機制 1：從 requirements.txt 解析 allowlist（取代 pip freeze） ──
+    # uvicorn[standard] → uvicorn（去 extra）+ win-safe extras 明列
+    # pywebview 從 requirements.txt 讀入，但在 Phase 1 排除（proxy-tools 無 wheel）
+    runtime_deps = parse_requirements_allowlist()
+    win_safe_extras = list(_UVICORN_WIN_SAFE_EXTRAS)  # httptools/watchfiles/python-dotenv/PyYAML
 
-    # 額外依賴（手動補充 Windows 專用套件）
-    extra_deps = [
-        "bottle", "proxy-tools", "clr_loader", "pythonnet",
-        "win32-setctime", "colorama",
-    ]
-    all_deps.extend(extra_deps)
+    # Phase 1：runtime（去 pywebview）+ win-safe extras → with-deps，解 transitive
+    phase1_deps = [d for d in runtime_deps + win_safe_extras
+                   if _norm_pkg_name(d) != "pywebview"]
 
-    # 建立需要的套件版本映射（套件名 → 完整 spec）
-    needed = {}
-    for dep in all_deps:
-        name = dep.split('==')[0].lower().replace('_', '-')
-        needed[name] = dep
+    extra_deps_no_deps = EXTRA_DEPS_NO_DEPS
 
-    # ⚠️ 清掉 cache 中版本不匹配的舊 wheel（避免混版）
-    # 這段不是多餘邏輯！PyPI 上游版本更新時，cache 裡的舊 pydantic-core
-    # 會跟新 pydantic 混版，導致 Windows ZIP 執行時 SystemError。
-    # 詳見 CLAUDE.md「Windows 打包 Wheel Cache Gotcha」
+    print(f"  Phase 1 (with-deps): {len(phase1_deps)} 頂層套件")
+    print(f"  Phase 2 (no-deps):   {len(extra_deps_no_deps)} 套件（pywebview + Windows extras）")
+
+    # ⚠️ stale-cleanup Phase 1：版本不匹配的舊 wheel（只清有 == pin 的）
+    # Phase 2 套件有 pin 的也一起清；transitive（無 pin）交給 manifest orphan-cleanup
+    pinned: dict[str, str] = {}
+    for dep in phase1_deps + extra_deps_no_deps:
+        name = _norm_pkg_name(dep)
+        if "==" in dep:
+            pinned[name] = dep.split("==")[1]
     stale_count = 0
     for f in list(wheels_dir.glob("*.*")):
-        cached_name = f.stem.split('-')[0].lower().replace('_', '-')
-        if cached_name in needed and '==' in needed[cached_name]:
-            expected_ver = needed[cached_name].split('==')[1]
-            # wheel 檔名格式: name-version-...
-            parts = f.stem.split('-')
+        cached_name = _pkg_name_from_filename(f.name)
+        if cached_name in pinned:
+            expected_ver = pinned[cached_name]
+            # tar.gz 的 .stem 仍含 ".tar"（foo-1.0.tar.gz → "foo-1.0.tar"）→ 先剝除，
+            # 否則版本被解析成 "1.0.tar"、永遠 != pin 而誤刪（latent，proxy-tools 目前未 pin）
+            stem = f.stem
+            if stem.endswith(".tar"):
+                stem = stem[:-4]
+            parts = stem.split("-")
             if len(parts) >= 2 and parts[1] != expected_ver:
                 f.unlink()
                 stale_count += 1
     if stale_count:
         print(f"  清除 {stale_count} 個版本不匹配的舊 wheel")
 
-    # 檢查已緩存的套件（名稱級，舊版已清除所以不會混版）
-    cached_files = set(f.stem.split('-')[0].lower().replace('_', '-') for f in wheels_dir.glob("*.*"))
-    to_download = [dep for dep in all_deps if dep.split('==')[0].lower().replace('_', '-') not in cached_files]
+    # ── 機制 3：manifest-based extract ──
+    # extract_manifest = Phase 1 + Phase 2 本次下載/cache-hit 的所有檔案集合
+    extract_manifest: set[Path] = set()
 
-    if to_download:
-        print(f"  需下載 {len(to_download)} 個新套件（已緩存 {len(all_deps) - len(to_download)} 個）")
-        for pkg in to_download:
-            # 嘗試下載 Windows wheel
-            pip_cmd = [
-                sys.executable, "-m", "pip", "download",
-                "--dest", str(wheels_dir),
-                "--platform", "win_amd64",
-                "--python-version", "3.12",
-                "--only-binary", ":all:",
-                "--no-deps",
-                pkg,
-            ]
-            result = subprocess.run(pip_cmd, capture_output=True, text=True)
-            if result.returncode != 0:
-                # 嘗試不限平台（純 Python 套件）
-                pip_cmd = [
-                    sys.executable, "-m", "pip", "download",
-                    "--dest", str(wheels_dir),
-                    "--no-deps",
-                    pkg,
-                ]
-                subprocess.run(pip_cmd, capture_output=True, text=True)
+    # Phase 1：以 pip download（with-deps）解完整 transitive 樹
+    # 總是執行（pip 自帶 HTTP metadata cache；--dest 目錄已有的 wheel 瞬間完成）
+    # 這是確保 transitive（pydantic_core/anyio/h11/...）不缺少的唯一可靠方式
+    # 同時解析 pip stdout 的 "Saved PATH" 行，建立本次 Phase 1 精確 manifest
+    print("  Phase 1 執行中（pip 自帶 metadata cache，已緩存項目瞬間完成）...")
+    before_p1 = set(wheels_dir.glob("*.*"))
+    pip_cmd = [
+        sys.executable, "-m", "pip", "download",
+        "--dest", str(wheels_dir),
+        "--platform", "win_amd64",
+        "--python-version", "3.12",
+        "--only-binary", ":all:",
+    ] + phase1_deps
+    result = subprocess.run(pip_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        # Phase 1 失敗：hard-fail（SKIP_IF_NO_WIN_WHEEL 套件不應出現在 Phase 1）
+        print(f"\n[BUILD ERROR] Phase 1 (with-deps) 下載失敗：\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # 解析 pip stdout 取得本次 Phase 1 精確解析集
+    # pip 行為：
+    #   新下載到 --dest → "Saved /abs/path/pkg.whl"
+    #   已在 --dest → "  File was already downloaded /abs/path/pkg.whl"
+    # 兩種行都計入 manifest（精確反映 pip 本次解析的完整依賴集）
+    p1_manifest_files: set[Path] = set()
+    for line in result.stdout.splitlines():
+        line_stripped = line.strip()
+        if line_stripped.startswith("Saved "):
+            p = Path(line_stripped[len("Saved "):].strip()).resolve()
+            if p.exists():
+                p1_manifest_files.add(p)
+        elif line_stripped.startswith("File was already downloaded "):
+            p = Path(line_stripped[len("File was already downloaded "):].strip()).resolve()
+            if p.exists():
+                p1_manifest_files.add(p)
+
+    # N3 防護：Phase 1 有頂層依賴卻解析出空 manifest → pip stdout 格式可能改變
+    # （未來 pip 版本 / --quiet 預設）。若放任，下方 orphan-cleanup 會刪光 Phase 1
+    # wheel、extract 只剩 Phase 2 → 默默產出缺套件的壞 ZIP。fail-closed 擋下。
+    if phase1_deps and not p1_manifest_files:
+        print(
+            "\n[BUILD ERROR] Phase 1 manifest 為空（pip stdout 無 'Saved'/'File was "
+            "already downloaded' 行）。pip 輸出格式可能已變更——中止以免產出缺套件的 ZIP。\n"
+            f"--- pip stdout ---\n{result.stdout}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    after_p1 = set(wheels_dir.glob("*.*"))
+    new_p1 = after_p1 - before_p1
+    if new_p1:
+        print(f"  Phase 1 新增 {len(new_p1)} 個 wheel（含 transitive）；manifest {len(p1_manifest_files)} 個")
     else:
-        print(f"  全部 {len(all_deps)} 個套件已緩存")
+        print(f"  Phase 1 全部已緩存（manifest {len(p1_manifest_files)} 個）")
 
-    # 解壓所有套件到 site-packages
+    # 清除 before_p1 中被 Phase 1 解析選中了不同版本的舊 wheel
+    # 例：cache 有 httptools-0.7.1，Phase 1 解析選 httptools-0.8.0 → 清 0.7.1
+    p1_resolved_names = {_pkg_name_from_filename(f.name) for f in p1_manifest_files}
+    p1_superseded = 0
+    for f in list(before_p1):
+        name = _pkg_name_from_filename(f.name)
+        if name in p1_resolved_names and f not in p1_manifest_files and f.exists():
+            f.unlink()
+            p1_superseded += 1
+    if p1_superseded:
+        print(f"  Phase 1 清除 {p1_superseded} 個被升版取代的舊 wheel")
+
+    extract_manifest.update(p1_manifest_files)
+
+    # Phase 2：逐一下載 pywebview + extra_deps（--no-deps，SDIST_OK / fail-closed）
+    p2_names_in_cache = {_pkg_name_from_filename(f.name) for f in wheels_dir.glob("*.*")}
+    phase2_to_download = [dep for dep in extra_deps_no_deps
+                          if _norm_pkg_name(dep) not in p2_names_in_cache]
+    if phase2_to_download:
+        print(f"  Phase 2 需下載 {len(phase2_to_download)} 個套件")
+        for pkg in phase2_to_download:
+            new_files = _download_one_package(pkg, wheels_dir)
+            extract_manifest.update(new_files)
+    else:
+        print("  Phase 2 全部已緩存")
+
+    # Phase 2 cache-hit 加入 manifest
+    p2_names_set = {_norm_pkg_name(d) for d in extra_deps_no_deps}
+    for f in wheels_dir.glob("*.*"):
+        if _pkg_name_from_filename(f.name) in p2_names_set:
+            extract_manifest.add(f)
+
+    # 延伸 stale-cleanup：移除不在本次 manifest 的 cache 檔（防 cache 無限長大）
+    orphan_removed = 0
+    for f in list(wheels_dir.glob("*.*")):
+        if f not in extract_manifest:
+            f.unlink()
+            orphan_removed += 1
+    if orphan_removed:
+        print(f"  清除 {orphan_removed} 個 cache orphan（不在本次 manifest）")
+
+    # ── 防禦性 dedup：每個套件名最多一個檔案進 extract_manifest ──
+    # 理論上 stale-cleanup + 版本 pin 已排除重複；此 pass 作為不變式驗證，
+    # 防止任何路徑（cache 污染 / 未來程式碼改動）讓兩個不同版本都進入解壓，
+    # 否則先寫的被後寫的覆蓋（last-writer-wins corruption）。
+    deduped: dict[str, Path] = {}  # 標準化套件名 → 保留的檔案
+    for f in sorted(extract_manifest, key=lambda x: x.name):  # 排序讓結果確定
+        pkg = _pkg_name_from_filename(f.name)
+        if pkg not in deduped:
+            deduped[pkg] = f
+        else:
+            # 若有重複，保留版本號較大者（字串比較對 SemVer 大多數情況足夠）
+            existing_stem = deduped[pkg].stem
+            if existing_stem.endswith(".tar"):
+                existing_stem = existing_stem[:-4]
+            new_stem = f.stem
+            if new_stem.endswith(".tar"):
+                new_stem = new_stem[:-4]
+            existing_ver = existing_stem.split("-")[1] if "-" in existing_stem else ""
+            new_ver = new_stem.split("-")[1] if "-" in new_stem else ""
+            kept, dropped = (f, deduped[pkg]) if new_ver > existing_ver else (deduped[pkg], f)
+            deduped[pkg] = kept
+            print(
+                f"  [WARNING] manifest 含同套件兩個版本（{pkg}）："
+                f" 捨棄 {dropped.name}，保留 {kept.name}"
+            )
+    if len(deduped) < len(extract_manifest):
+        extract_manifest = set(deduped.values())
+
+    # ── 解壓：只提取 manifest 內的檔案（不 glob 整個 cache） ──
     print("\n[4/6] 安裝套件到 site-packages...")
-    wheel_files = list(wheels_dir.glob("*.whl"))
-    tar_files = list(wheels_dir.glob("*.tar.gz"))
-    print(f"  找到 {len(wheel_files)} 個 wheel, {len(tar_files)} 個 tar.gz")
+    wheel_files = [f for f in extract_manifest if f.suffix == ".whl"]
+    tar_files = [f for f in extract_manifest if f.name.endswith(".tar.gz")]
+    print(f"  Manifest: {len(wheel_files)} 個 wheel, {len(tar_files)} 個 tar.gz")
 
-    for wheel_file in wheel_files:
-        pkg_name = wheel_file.stem.split('-')[0].lower().replace('_', '-')
-        if pkg_name in EXCLUDE_PACKAGES:
-            print(f"  跳過（排除）: {wheel_file.name}")
-            continue
+    for wheel_file in sorted(wheel_files, key=lambda f: f.name):
         print(f"  安裝: {wheel_file.name}")
         extract_wheel(wheel_file, site_packages)
 
-    for tar_file in tar_files:
-        pkg_name = tar_file.name.split('-')[0].lower().replace('_', '-')
-        if pkg_name in EXCLUDE_PACKAGES:
-            print(f"  跳過（排除）: {tar_file.name}")
-            continue
+    for tar_file in sorted(tar_files, key=lambda f: f.name):
         print(f"  安裝: {tar_file.name}")
         extract_tar_gz(tar_file, site_packages)
 
-    # 保留緩存（不清理 wheels_dir）
+    # 保留緩存（wheels_dir 只含本次 manifest 需要的套件）
 
 
 def copy_project_files():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,4 @@ select = ["E722", "F", "B", "T201", "S110", "S112"]
 "core/gallery_scanner.py" = ["T201"]
 "build.py" = ["T201"]
 "build_macos.py" = ["T201"]
+"scripts/audit_build_artifact.py" = ["T201"]  # CLI build 工具，print 為正常輸出（同 build.py）

--- a/scripts/audit_build_artifact.py
+++ b/scripts/audit_build_artifact.py
@@ -1,0 +1,272 @@
+"""Build artifact auditor — assert Windows/macOS release ZIPs are clean.
+
+Usage:
+    python scripts/audit_build_artifact.py <zip-glob> --platform win|mac [--max-mb N] [--strict]
+
+Exit codes:
+    0  — all checks passed (may still print WARN lines for warn-tier packages)
+    1  — hard-fail (forbidden test/dev tool found, or ZIP too large)
+
+Matching strategy (CRITICAL — avoids false positives):
+    We look for a TOP-LEVEL site-packages/<pkg>/ directory, e.g.:
+        OpenAver/python/Lib/site-packages/playwright/...
+    We do NOT substring-match raw filenames, so the following baseline noise
+    items are intentionally NOT flagged:
+        - pydantic/mypy.py          (legit pydantic file, not mypy package)
+        - pytest_base_url/          (3 KB transitive, acceptable in baseline)
+        - anyio                     (runtime)
+        - *__mypyc.cp312-win_amd64.pyd  (compiled runtime module, not mypy)
+        - greenlet                  (runtime, never flagged)
+
+Size ceiling (--max-mb, default 55):
+    Compressed ZIP size must be <= max_mb.
+    Why 55 (not 90):
+        - Current baseline (containing uvloop) is ~46 MB compressed.
+        - mypy regression was ~58 MB; playwright regression was ~84 MB.
+        - 55 MB sits between baseline (46 MB) and the smallest regression
+          (mypy 58 MB), catching BOTH regressions while never tripping the
+          clean baseline. 90 MB would let playwright (84 MB) slip through.
+    After T2 lands (uvloop removed) the ceiling will be tightened to ~48 MB
+    in the same follow-up commit that flips uvloop to hard-fail.
+
+Ban-list tiers:
+    HARD-FAIL (always non-zero exit, both platforms):
+        playwright, mypy, mypyc, pytest, _pytest, ruff, pyee, coverage, twine
+    WARN tier (default: WARN only, exit 0; --strict: hard-fail):
+        uvloop, langdetect
+    Note: uvloop is a VALID runtime dep on macOS — it is excluded from the
+    mac ban-list entirely (not even WARN).
+
+Sync point with TASK-80-BUILD-T2:
+    T2 adjusts which packages are runtime deps; if it removes uvloop from the
+    Windows release, flip uvloop to HARD_FAIL here (same follow-up commit).
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import sys
+import zipfile
+from pathlib import Path
+
+
+# ── Ban-list definition ──────────────────────────────────────────────────────
+
+# Packages that must NEVER appear in a release ZIP (test/dev tools).
+# Match on site-packages/<pkg>/ top-level directory prefix.
+HARD_FAIL_PKGS: frozenset[str] = frozenset(
+    [
+        "playwright",
+        "mypy",
+        "mypyc",
+        "pytest",
+        "_pytest",
+        "ruff",
+        "pyee",
+        "coverage",
+        "twine",
+    ]
+)
+
+# Packages that should not be in the ZIP but whose presence is not
+# release-blocking until explicitly enabled via --strict.
+# IMPORTANT: uvloop is a valid macOS runtime dep — it is excluded from
+# WARN_PKGS when platform == "mac" (see _get_warn_pkgs()).
+WARN_PKGS_ALL_PLATFORMS: frozenset[str] = frozenset(["uvloop", "langdetect"])
+
+# Packages that are VALID on macOS — do not warn/fail for them.
+MAC_RUNTIME_ALLOWLIST: frozenset[str] = frozenset(["uvloop"])
+
+
+def _get_warn_pkgs(platform: str) -> frozenset[str]:
+    """Return the warn-tier set for the given platform."""
+    if platform == "mac":
+        return WARN_PKGS_ALL_PLATFORMS - MAC_RUNTIME_ALLOWLIST
+    return WARN_PKGS_ALL_PLATFORMS
+
+
+# ── Core audit logic (importable) ────────────────────────────────────────────
+
+
+def _site_packages_top_dirs(zf: zipfile.ZipFile) -> set[str]:
+    """Extract the set of top-level package directory names inside any
+    site-packages/ path within the ZIP.
+
+    A name is included only when it appears as an IMMEDIATE child directory
+    of site-packages/, e.g.:
+        .../site-packages/playwright/   → "playwright"
+        .../site-packages/pydantic/mypy.py → NOT matched (pydantic, not mypy)
+        .../site-packages/pytest_base_url/__init__.py → "pytest_base_url"
+
+    We do NOT do substring matching on raw file paths.
+    """
+    top_dirs: set[str] = set()
+    for entry in zf.infolist():
+        name = entry.filename
+        # Find the site-packages/ segment
+        idx = name.find("site-packages/")
+        if idx == -1:
+            continue
+        after = name[idx + len("site-packages/"):]
+        if not after:
+            continue
+        # Grab the first path component after site-packages/
+        pkg = after.split("/")[0]
+        if pkg:
+            top_dirs.add(pkg)
+    return top_dirs
+
+
+def audit(
+    zip_path: str | Path,
+    platform: str,
+    max_mb: float,
+    strict: bool,
+) -> tuple[int, list[str]]:
+    """Audit a single ZIP file.
+
+    Returns (exit_code, messages).
+    exit_code 0 = pass (may include WARN lines).
+    exit_code 1 = hard-fail.
+
+    Raises FileNotFoundError if zip_path does not exist.
+    """
+    zip_path = Path(zip_path)
+    messages: list[str] = []
+    failed = False
+
+    # ── Size check ────────────────────────────────────────────────────────────
+    compressed_mb = zip_path.stat().st_size / (1024 * 1024)
+    messages.append(
+        f"[SIZE] Compressed ZIP size: {compressed_mb:.1f} MB"
+        f" (ceiling: {max_mb} MB, uses <= semantics)"
+    )
+    if compressed_mb > max_mb:
+        messages.append(
+            f"[FAIL] ZIP exceeds size ceiling:"
+            f" {compressed_mb:.1f} MB > {max_mb} MB"
+        )
+        failed = True
+    else:
+        messages.append(
+            f"[OK  ] Size within ceiling ({compressed_mb:.1f} MB <= {max_mb} MB)"
+        )
+
+    # ── Package scan ──────────────────────────────────────────────────────────
+    warn_pkgs = _get_warn_pkgs(platform)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        top_dirs = _site_packages_top_dirs(zf)
+
+    messages.append(
+        f"[INFO] Scanned {zip_path.name} — platform={platform},"
+        f" strict={strict}, found {len(top_dirs)} top-level site-packages dirs"
+    )
+
+    # Hard-fail tier
+    for pkg in sorted(HARD_FAIL_PKGS):
+        if pkg in top_dirs:
+            messages.append(
+                f"[FAIL] HARD-FAIL: forbidden package '{pkg}' found in"
+                f" site-packages/ — test/dev tool must not be in release ZIP"
+            )
+            failed = True
+
+    # Warn tier
+    for pkg in sorted(warn_pkgs):
+        if pkg in top_dirs:
+            if strict:
+                messages.append(
+                    f"[FAIL] STRICT: warn-tier package '{pkg}' found in"
+                    f" site-packages/ — hard-fail because --strict is active"
+                    f" (T2 will remove this package entirely)"
+                )
+                failed = True
+            else:
+                messages.append(
+                    f"\033[33m[WARN] warn-tier package '{pkg}' found in"
+                    f" site-packages/ — not release-blocking yet"
+                    f" (will hard-fail after T2 lands)\033[0m"
+                )
+
+    # Summary
+    if failed:
+        messages.append(
+            f"[RESULT] FAILED — {zip_path.name} did not pass artifact audit."
+        )
+    else:
+        messages.append(
+            f"[RESULT] PASSED — {zip_path.name} is clean (exit 0)."
+        )
+
+    return (1 if failed else 0, messages)
+
+
+# ── CLI entry point ───────────────────────────────────────────────────────────
+
+
+def _resolve_zip(pattern: str) -> Path:
+    """Resolve a glob pattern to exactly one ZIP path, or raise SystemExit."""
+    matches = glob.glob(pattern)
+    if len(matches) == 0:
+        print(f"[ERROR] No ZIP files matched glob pattern: {pattern!r}", file=sys.stderr)
+        sys.exit(1)
+    if len(matches) > 1:
+        print(
+            f"[ERROR] Glob pattern {pattern!r} matched {len(matches)} files;"
+            f" expected exactly 1:\n  " + "\n  ".join(matches),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return Path(matches[0])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit a release ZIP for forbidden packages and size.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "zip_glob",
+        metavar="<zip-glob>",
+        help="Glob pattern for the ZIP file (must match exactly 1 file).",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["win", "mac"],
+        required=True,
+        help="Target platform: win or mac. Affects uvloop warn/allowlist.",
+    )
+    parser.add_argument(
+        "--max-mb",
+        type=float,
+        default=55.0,
+        metavar="N",
+        help=(
+            "Maximum compressed ZIP size in MB (default: 55). "
+            "Why 55: baseline ~46 MB; mypy regression ~58 MB; playwright ~84 MB. "
+            "55 catches both regressions without tripping the clean baseline."
+        ),
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help=(
+            "Treat warn-tier packages (uvloop, langdetect) as hard-fail. "
+            "Enable this after T2 lands (uvloop removed from Windows build)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    zip_path = _resolve_zip(args.zip_glob)
+    exit_code, messages = audit(zip_path, args.platform, args.max_mb, args.strict)
+    for msg in messages:
+        print(msg)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_build_artifact_audit.py
+++ b/tests/unit/test_build_artifact_audit.py
@@ -1,0 +1,292 @@
+"""Unit tests for scripts/audit_build_artifact.py.
+
+Tests use synthetic in-memory/temp ZIPs to verify:
+  - playwright (hard-fail tier) → exit 1
+  - uvloop (warn tier) → default exit 0, --strict exit 1
+  - ZIP exceeding --max-mb → exit 1
+  - Clean ZIP with baseline noise (pydantic/mypy.py, pytest_base_url/,
+    greenlet/, *__mypyc.cp312-win_amd64.pyd) → exit 0 (no false positives)
+  - glob matching 0 files → SystemExit (non-zero)
+
+The audit() function is imported directly for fast, no-subprocess tests.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+# Ensure the repo root is importable so we can import the script directly.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from audit_build_artifact import audit, _resolve_zip  # noqa: E402  (after path insert)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_zip(tmp_path: Path, entries: dict[str, bytes | None], name: str = "test.zip") -> Path:
+    """Build a ZIP at tmp_path/name with the given {entry_path: content} mapping.
+
+    Pass None as content to use a tiny 4-byte placeholder.
+    """
+    zip_path = tmp_path / name
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for entry_name, content in entries.items():
+            zf.writestr(entry_name, content if content is not None else b"test")
+    return zip_path
+
+
+def _site(pkg: str, filename: str = "__init__.py") -> str:
+    """Return a canonical site-packages path for a package."""
+    return f"OpenAver/python/Lib/site-packages/{pkg}/{filename}"
+
+
+# ── Hard-fail tier ────────────────────────────────────────────────────────────
+
+
+def test_playwright_hard_fails(tmp_path):
+    """playwright in site-packages/ must cause exit 1 (hard-fail tier)."""
+    zp = _make_zip(tmp_path, {_site("playwright", "driver/node.exe"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 1, f"Expected exit 1 for playwright, got {code}\nMessages: {msgs}"
+    combined = "\n".join(msgs)
+    assert "playwright" in combined
+    assert "FAIL" in combined
+
+
+def test_mypy_hard_fails(tmp_path):
+    """mypy in site-packages/ must cause exit 1 (hard-fail tier)."""
+    zp = _make_zip(tmp_path, {_site("mypy", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 1
+    assert any("mypy" in m and "FAIL" in m for m in msgs)
+
+
+def test_pytest_hard_fails(tmp_path):
+    """pytest in site-packages/ must cause exit 1 (hard-fail tier)."""
+    zp = _make_zip(tmp_path, {_site("pytest", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 1
+
+
+def test_ruff_hard_fails(tmp_path):
+    """ruff in site-packages/ must cause exit 1 (hard-fail tier)."""
+    zp = _make_zip(tmp_path, {_site("ruff", "__main__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 1
+
+
+# ── Warn tier (uvloop / langdetect) ──────────────────────────────────────────
+
+
+def test_uvloop_default_warns_exits_0_on_win(tmp_path):
+    """uvloop on win default mode → exit 0 (warn only, not release-blocking)."""
+    zp = _make_zip(tmp_path, {_site("uvloop", "loop.cpython-312-x86_64-linux-gnu.so"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, f"Expected exit 0 for uvloop default, got {code}\nMessages: {msgs}"
+    combined = "\n".join(msgs)
+    assert "WARN" in combined or "warn" in combined.lower()
+
+
+def test_uvloop_strict_exits_1_on_win(tmp_path):
+    """uvloop on win with --strict → exit 1."""
+    zp = _make_zip(tmp_path, {_site("uvloop", "loop.cpython-312-x86_64-linux-gnu.so"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, True)
+    assert code == 1, f"Expected exit 1 for uvloop --strict, got {code}\nMessages: {msgs}"
+
+
+def test_uvloop_allowed_on_mac_default(tmp_path):
+    """uvloop is a valid macOS runtime dep — must NOT be flagged on mac."""
+    zp = _make_zip(tmp_path, {_site("uvloop", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "mac", 55.0, False)
+    assert code == 0, f"uvloop must be allowed on mac (default), got {code}\nMessages: {msgs}"
+    combined = "\n".join(msgs)
+    # Should not even warn about uvloop on mac — no mention at all
+    assert "uvloop" not in combined, f"uvloop must not be flagged on mac, got: {combined}"
+
+
+def test_uvloop_allowed_on_mac_strict(tmp_path):
+    """uvloop is a valid macOS runtime dep — must NOT be flagged even with --strict on mac."""
+    zp = _make_zip(tmp_path, {_site("uvloop", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "mac", 55.0, True)
+    assert code == 0, f"uvloop must be allowed on mac --strict, got {code}\nMessages: {msgs}"
+
+
+def test_langdetect_default_warns_exits_0(tmp_path):
+    """langdetect on win default mode → exit 0 (warn only)."""
+    zp = _make_zip(tmp_path, {_site("langdetect", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0
+
+
+def test_langdetect_strict_exits_1(tmp_path):
+    """langdetect on win --strict → exit 1."""
+    zp = _make_zip(tmp_path, {_site("langdetect", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, True)
+    assert code == 1
+
+
+# ── Size ceiling ──────────────────────────────────────────────────────────────
+
+
+def test_oversized_zip_fails(tmp_path):
+    """ZIP exceeding --max-mb must cause exit 1."""
+    # Create a ZIP that is over 1 MB compressed (we use incompressible data)
+    big_data = bytes(range(256)) * (1024 * 5)  # ~1.28 MB uncompressed
+    zp = _make_zip(
+        tmp_path,
+        {"OpenAver/python/Lib/site-packages/dummy/__init__.py": big_data},
+    )
+    # Set max to 0 MB — guaranteed to fail
+    code, msgs = audit(zp, "win", 0.0, False)
+    assert code == 1, f"Expected exit 1 for oversized ZIP, got {code}"
+    assert any("SIZE" in m or "ceiling" in m.lower() for m in msgs)
+
+
+def test_exactly_at_ceiling_passes(tmp_path):
+    """ZIP at exactly max_mb must pass (we use <= semantics)."""
+    zp = _make_zip(tmp_path, {"OpenAver/file.txt": b"hello"})
+    compressed_mb = zp.stat().st_size / (1024 * 1024)
+    # Set max exactly to the compressed size (rounded up a tiny bit)
+    code, msgs = audit(zp, "win", compressed_mb + 0.001, False)
+    assert code == 0, f"ZIP at/below ceiling must pass: {msgs}"
+
+
+# ── False-positive / baseline noise tests ─────────────────────────────────────
+
+
+def test_clean_zip_with_baseline_noise_passes(tmp_path):
+    """Clean ZIP containing only runtime packages and baseline noise must exit 0.
+
+    Noise items that must NOT trigger false positives:
+      - pydantic/mypy.py          (legit pydantic file, not mypy package)
+      - pytest_base_url/__init__.py  (acceptable 3KB transitive)
+      - greenlet/__init__.py      (runtime, must not be flagged)
+      - somemod__mypyc.cp312-win_amd64.pyd  (compiled runtime, not mypy)
+    """
+    entries = {
+        # Real runtime packages
+        _site("fastapi", "__init__.py"): b"x",
+        _site("uvicorn", "__init__.py"): b"x",
+        _site("pydantic", "__init__.py"): b"x",
+        _site("starlette", "__init__.py"): b"x",
+        _site("httptools", "__init__.py"): b"x",
+        _site("watchfiles", "__init__.py"): b"x",
+        _site("greenlet", "__init__.py"): b"x",
+        _site("anyio", "__init__.py"): b"x",
+        # Baseline noise — must NOT be false-positived
+        "OpenAver/python/Lib/site-packages/pydantic/mypy.py": b"x",  # NOT mypy pkg
+        "OpenAver/python/Lib/site-packages/pytest_base_url/__init__.py": b"x",  # tiny transitive
+        # mypyc compiled runtime module (not the mypy package)
+        "OpenAver/python/Lib/site-packages/somemod__mypyc.cp312-win_amd64.pyd": b"x",
+    }
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, f"Clean baseline ZIP must pass.\nMessages:\n" + "\n".join(msgs)
+
+
+def test_pydantic_mypy_file_not_flagged(tmp_path):
+    """pydantic/mypy.py is a file INSIDE pydantic, not the mypy package.
+    It must NOT trigger the mypy ban."""
+    entries = {
+        "OpenAver/python/Lib/site-packages/pydantic/mypy.py": b"x",
+        "OpenAver/python/Lib/site-packages/pydantic/__init__.py": b"x",
+    }
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, (
+        "pydantic/mypy.py must not trigger mypy ban (it's a pydantic file).\n"
+        + "\n".join(msgs)
+    )
+
+
+def test_greenlet_not_flagged(tmp_path):
+    """greenlet is a runtime dep and must never be flagged."""
+    entries = {_site("greenlet", "__init__.py"): b"x"}
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, True)  # even with --strict
+    assert code == 0, f"greenlet must not be flagged:\n" + "\n".join(msgs)
+
+
+def test_mypyc_pyd_at_root_not_flagged(tmp_path):
+    """A *__mypyc.cp312-win_amd64.pyd file at site-packages ROOT (not in a
+    mypy/ subdirectory) represents a compiled runtime extension, not the mypy
+    package. It must not trigger the ban."""
+    # This file sits directly in site-packages/ with a mypyc-compiled name
+    entries = {
+        "OpenAver/python/Lib/site-packages/pydantic_core__mypyc.cp312-win_amd64.pyd": b"x",
+        _site("pydantic_core", "__init__.py"): b"x",
+    }
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, (
+        "mypyc-compiled .pyd at site-packages root must not trigger mypy ban.\n"
+        + "\n".join(msgs)
+    )
+
+
+def test_pytest_base_url_not_flagged(tmp_path):
+    """pytest_base_url (acceptable pre-existing 3KB transitive) must not trip the audit."""
+    entries = {
+        "OpenAver/python/Lib/site-packages/pytest_base_url/__init__.py": b"x",
+    }
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, (
+        "pytest_base_url must not be flagged (it's not in the hard-fail list).\n"
+        + "\n".join(msgs)
+    )
+
+
+# ── Glob resolution errors ────────────────────────────────────────────────────
+
+
+def test_glob_no_match_exits_nonzero(tmp_path):
+    """Glob pattern matching 0 files must raise SystemExit with non-zero code."""
+    pattern = str(tmp_path / "nonexistent_*.zip")
+    with pytest.raises(SystemExit) as exc_info:
+        _resolve_zip(pattern)
+    assert exc_info.value.code != 0
+
+
+def test_glob_multiple_matches_exits_nonzero(tmp_path):
+    """Glob pattern matching >1 file must raise SystemExit with non-zero code."""
+    _make_zip(tmp_path, {"a.txt": b"x"}, name="foo-Windows-x64.zip")
+    _make_zip(tmp_path, {"b.txt": b"x"}, name="bar-Windows-x64.zip")
+    pattern = str(tmp_path / "*-Windows-*.zip")
+    with pytest.raises(SystemExit) as exc_info:
+        _resolve_zip(pattern)
+    assert exc_info.value.code != 0
+
+
+# ── Test-tool still hard-fails on mac platform ────────────────────────────────
+
+
+def test_playwright_hard_fails_on_mac(tmp_path):
+    """Test tools must hard-fail on mac too (playwright is never OK anywhere)."""
+    zp = _make_zip(tmp_path, {_site("playwright", "driver/node.exe"): b"x"})
+    code, msgs = audit(zp, "mac", 55.0, False)
+    assert code == 1
+
+
+# ── Summary message ───────────────────────────────────────────────────────────
+
+
+def test_summary_line_present_on_pass(tmp_path):
+    """Audit result must always include a RESULT/summary line on pass."""
+    zp = _make_zip(tmp_path, {_site("fastapi", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert any("RESULT" in m or "PASSED" in m for m in msgs)
+
+
+def test_summary_line_present_on_fail(tmp_path):
+    """Audit result must always include a RESULT/summary line on fail."""
+    zp = _make_zip(tmp_path, {_site("playwright", "driver/node.exe"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert any("RESULT" in m or "FAILED" in m for m in msgs)

--- a/tests/unit/test_ci_workflow_guard.py
+++ b/tests/unit/test_ci_workflow_guard.py
@@ -164,6 +164,23 @@ def test_build_excludes_mypy_orphan():
             f"build.py EXCLUDE_PACKAGES 缺 {pkg!r}（mypy orphan 會被 freeze 打包進 ZIP，曾 +11MB）"
 
 
+def test_build_excludes_playwright_transitive():
+    """playwright（pytest-playwright 的 transitive dep）必須在 EXCLUDE——防 +32MB 回歸。
+
+    pytest-playwright 在 requirements-test.txt，_test_only_packages() 只抓直列名
+    「pytest-playwright」，但 wheel cache 裡的 playwright 本體 wheel 命名為 playwright-*
+    （不含 pytest- 前綴），build.py 解壓時無法靠 pytest-playwright 的 EXCLUDE entry 擋住
+    → playwright（36MB wheel / 102MB 解壓）被含入 ZIP（曾使 ZIP 從 56MB 膨脹至 81MB）。
+    必須在 EXCLUDE 顯式列出其 transitive：playwright + pyee。
+    """
+    import build
+    for pkg in ("playwright", "pyee"):
+        assert pkg in build.EXCLUDE_PACKAGES, (
+            f"build.py EXCLUDE_PACKAGES 缺 {pkg!r}（pytest-playwright 的 transitive dep，"
+            f"會被 wheel-cache 掃描帶入 ZIP；playwright 曾 +32MB）"
+        )
+
+
 def test_build_excludes_all_test_only_packages():
     """requirements-test.txt 的純測試套件（pytest*/ruff/playwright/PyYAML…）一律須被排除。
     自動 derive 防 denylist 漂移：日後新增測試套件忘了同步 EXCLUDE 即 RED。"""

--- a/tests/unit/test_ci_workflow_guard.py
+++ b/tests/unit/test_ci_workflow_guard.py
@@ -292,6 +292,21 @@ def test_extra_deps_no_deps_all_pinned():
     )
 
 
+def test_uvicorn_win_safe_extras_all_pinned():
+    """_UVICORN_WIN_SAFE_EXTRAS 每個項目都必須精確 pin（==）。
+
+    httptools / watchfiles / python-dotenv / PyYAML 是 uvicorn[standard] 的 win-safe 子集，
+    經 Phase 1 with-deps 下載。若無 pin，cold cache 或任一套件發佈新版時，pip 抓最新
+    → 不同時間 / 不同機器建出不同版本 → 破壞可重現 build 契約（與 EXTRA_DEPS_NO_DEPS 同規範）。
+    """
+    import build
+    unpinned = [dep for dep in build._UVICORN_WIN_SAFE_EXTRAS if "==" not in dep]
+    assert not unpinned, (
+        f"_UVICORN_WIN_SAFE_EXTRAS 有未 exact-pin（==）的項目：{unpinned}\n"
+        "所有 win-safe extras 必須精確釘版本，確保 reproducible build（同 git tag = 同 ZIP）。"
+    )
+
+
 def test_parse_allowlist_rewrites_only_uvicorn_standard():
     """uvicorn[standard]==X → uvicorn==X（去 extra）；其餘無 extra 的行原樣保留。"""
     import build

--- a/tests/unit/test_ci_workflow_guard.py
+++ b/tests/unit/test_ci_workflow_guard.py
@@ -318,3 +318,86 @@ def test_parse_allowlist_fails_closed_on_unexpected_extra():
     # uvicorn 帶非 standard extra 也須 fail-closed（只認 [standard]）
     with pytest.raises(SystemExit):
         build._parse_allowlist_lines(["uvicorn[foo]==0.46.0"])
+
+
+# ============================================================
+# TASK-80-BUILD-T4b：build.py 模型「三禁」契約（防退回舊模型）
+# 與 T2 的 allowlist 斷言互補：T2 驗「解析結果對」，本段驗「模型沒退回」。
+# 與 T4a（build.yml 真實 ZIP 產物斷言）互補：本段早、快、便宜，在 PR pytest 階段先報紅。
+# 三禁：① 不得回到 pip freeze 取安裝集 ② 不得 glob 整個 cache extract ③ 不得平台不符 fallback。
+# ============================================================
+
+def _build_source_no_comments() -> str:
+    """build.py 原始碼，逐行剝除 `#` 註解（避免註解中提到的字觸發守衛誤判）。"""
+    src = (_REPO_ROOT / "build.py").read_text(encoding="utf-8")
+    return "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+
+
+def test_build_no_pip_freeze():
+    """① build.py 不得用 pip freeze 取安裝集（T2 棄 freeze；舊函式 get_all_dependencies 須消失）。
+
+    freeze 凍結的是「當前 dev venv」→ 任何測試/orphan 套件混入即被打包（denylist 漂移根因）。
+    註解可提及 freeze（歷史說明），但程式碼不得再呼叫。
+    """
+    import build
+    assert not hasattr(build, "get_all_dependencies"), (
+        "build.py 仍有 get_all_dependencies（pip freeze 取安裝集的舊函式）；T2 已改 allowlist，應移除"
+    )
+    code = _build_source_no_comments()
+    assert "freeze" not in code, (
+        "build.py 程式碼（非註解）仍出現 'freeze'；不得退回 pip freeze 取安裝集模型"
+    )
+
+
+def test_build_extract_uses_manifest_not_glob_all():
+    """② extract 必須只解壓 extract_manifest，不得 glob 整個 cache（殘留 orphan 會被帶入）。"""
+    code = _build_source_no_comments()
+    assert "for f in extract_manifest" in code, (
+        "build.py 未見『for f in extract_manifest』；extract 應只迭代本次解析的 manifest"
+    )
+    assert 'glob("*.whl")' not in code, (
+        "build.py 出現 glob(\"*.whl\")（舊 extract-整個-cache 模式）；應改 manifest-based extract"
+    )
+
+
+class _FakePipFail:
+    """模擬 pip download 失敗的 CompletedProcess。"""
+    returncode = 1
+    stdout = ""
+    stderr = "ERROR: No matching distribution found"
+
+
+def test_build_download_fail_closed_no_platform_fallback(monkeypatch, tmp_path):
+    """③ 必要套件無 win wheel → 硬失敗、且只嘗試一次（無平台不符 fallback retry）。
+
+    舊模型：win wheel 失敗 → 再 `pip download`（不限平台）拉 Linux wheel（uvloop .so 混入途徑）。
+    本守衛 mock pip 失敗，斷言 _download_one_package 對非 skip 套件 SystemExit 且只呼叫 pip 一次。
+    """
+    import build
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakePipFail()
+
+    monkeypatch.setattr(build.subprocess, "run", fake_run)
+    with pytest.raises(SystemExit):
+        build._download_one_package("somerequiredpkg==1.0.0", tmp_path)
+    assert len(calls) == 1, (
+        f"非 skip 套件無 win wheel 時應只嘗試一次（無 fallback retry），實際 {len(calls)} 次"
+    )
+
+
+def test_build_download_skip_if_no_win_wheel(monkeypatch, tmp_path):
+    """SKIP_IF_NO_WIN_WHEEL 成員（uvloop）無 win wheel → skip（不 raise）、回空集、只嘗試一次。"""
+    import build
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakePipFail()
+
+    monkeypatch.setattr(build.subprocess, "run", fake_run)
+    result = build._download_one_package("uvloop==0.22.1", tmp_path)
+    assert result == set(), f"uvloop 應 skip 並回空集，實際 {result}"
+    assert len(calls) == 1, f"應只嘗試一次（不 fallback），實際 {len(calls)} 次"

--- a/tests/unit/test_ci_workflow_guard.py
+++ b/tests/unit/test_ci_workflow_guard.py
@@ -137,10 +137,10 @@ def test_requirements_test_has_no_mypy():
 
 
 # ============================================================
-# build.py EXCLUDE_PACKAGES 契約：測試/開發工具不得進用戶 ZIP
-# 緣起：mypy（orphan，殘留在 dev venv 但不在任一 requirements 檔）被 build.py 的
-# pip-freeze 打包 → +11MB（含 18MB mypyc .pyd）。build.py 改為 EXCLUDE 自動 derive
-# requirements-test.txt + 顯式排除 mypy orphan。本守衛防回退。
+# build.py Allowlist 模型契約（T2：棄 pip freeze + denylist）
+# 緣起：T1 前 denylist 反覆漏 transitive（mypy orphan +11MB、playwright +32MB、uvloop +16MB）。
+# T2 改為 allowlist 模型（requirements.txt 解析 + manifest extract），根除漂移根因。
+# 本段守衛驗「allowlist 解析結果不含測試/開發工具、含必備 runtime」合約。
 # ============================================================
 
 def _direct_pkgs(req_path: Path) -> set:
@@ -156,43 +156,165 @@ def _direct_pkgs(req_path: Path) -> set:
     return names
 
 
-def test_build_excludes_mypy_orphan():
-    """mypy 殘留必須在 build.py EXCLUDE（orphan，requirements 檔抓不到）——防 +11MB 回歸。"""
-    import build
-    for pkg in ("mypy", "mypyc", "mypy-extensions"):
-        assert pkg in build.EXCLUDE_PACKAGES, \
-            f"build.py EXCLUDE_PACKAGES 缺 {pkg!r}（mypy orphan 會被 freeze 打包進 ZIP，曾 +11MB）"
+def _get_allowlist_names() -> set[str]:
+    """取得 build.py allowlist 解析結果的套件名集合（標準化）。
 
-
-def test_build_excludes_playwright_transitive():
-    """playwright（pytest-playwright 的 transitive dep）必須在 EXCLUDE——防 +32MB 回歸。
-
-    pytest-playwright 在 requirements-test.txt，_test_only_packages() 只抓直列名
-    「pytest-playwright」，但 wheel cache 裡的 playwright 本體 wheel 命名為 playwright-*
-    （不含 pytest- 前綴），build.py 解壓時無法靠 pytest-playwright 的 EXCLUDE entry 擋住
-    → playwright（36MB wheel / 102MB 解壓）被含入 ZIP（曾使 ZIP 從 56MB 膨脹至 81MB）。
-    必須在 EXCLUDE 顯式列出其 transitive：playwright + pyee。
+    包含 parse_requirements_allowlist() + _UVICORN_WIN_SAFE_EXTRAS + extra_deps。
     """
     import build
-    for pkg in ("playwright", "pyee"):
-        assert pkg in build.EXCLUDE_PACKAGES, (
-            f"build.py EXCLUDE_PACKAGES 缺 {pkg!r}（pytest-playwright 的 transitive dep，"
-            f"會被 wheel-cache 掃描帶入 ZIP；playwright 曾 +32MB）"
+    import re as _re
+
+    def _norm(spec: str) -> str:
+        return _re.split(r"[=<>!~\[]", spec, maxsplit=1)[0].strip().lower().replace("_", "-")
+
+    names: set[str] = set()
+    for dep in build.parse_requirements_allowlist():
+        names.add(_norm(dep))
+    for dep in build._UVICORN_WIN_SAFE_EXTRAS:
+        names.add(_norm(dep))
+    # extra_deps 改讀模組級常數 EXTRA_DEPS_NO_DEPS（N2）：新增 extra dep 即被守衛涵蓋，
+    # 不再用 hardcoded list 代理（避免漏守衛）。proxy-tools 亦在此清單，SDIST_OK 另有專門守衛。
+    for dep in build.EXTRA_DEPS_NO_DEPS:
+        names.add(_norm(dep))
+    return names
+
+
+def test_build_allowlist_excludes_dev_tools():
+    """allowlist 解析結果不得含 uvloop / playwright / mypy / pytest / ruff 等測試/開發工具。
+
+    T2 allowlist 模型：依賴來源 = requirements.txt，無 pip freeze，無 dev venv 污染。
+    uvloop 尤其重要：曾以 Linux .so（16MB）混入每個 release ZIP（P2 bug）。
+    playwright 曾 +32MB；mypy 曾 +11MB——三者在 T1/T2 前長期隨 release 送到用戶。
+    """
+    banned = {"uvloop", "playwright", "mypy", "mypyc", "mypy-extensions",
+              "pytest", "pytest-asyncio", "pytest-mock", "pytest-cov",
+              "pytest-playwright", "ruff", "pyee", "langdetect"}
+    names = _get_allowlist_names()
+    found = sorted(banned & names)
+    assert not found, (
+        f"build.py allowlist 含不應出現的測試/開發工具：{found}\n"
+        f"（T2 allowlist 模型：這些套件不在 requirements.txt，不應被 parse_requirements_allowlist 引入）"
+    )
+
+
+def test_build_allowlist_contains_required_runtime():
+    """allowlist 必須含所有必備 runtime 套件——否則 build 缺套件、用戶端壞掉。"""
+    required = {
+        "fastapi", "uvicorn", "starlette", "jinja2", "python-multipart",
+        "requests", "httpx", "beautifulsoup4", "lxml", "curl-cffi",
+        "pydantic", "websockets", "pillow", "pywebview",
+        "httptools", "watchfiles", "python-dotenv", "pyyaml",
+        "bottle", "clr-loader", "pythonnet", "win32-setctime", "colorama",
+        "proxy-tools",
+    }
+    names = _get_allowlist_names()
+    # 標準化比較（curl_cffi → curl-cffi, clr_loader → clr-loader 等）
+    missing = sorted(required - names)
+    assert not missing, (
+        f"build.py allowlist 缺少必備 runtime 套件（會做出缺套件的 ZIP）：{missing}"
+    )
+
+
+def test_build_allowlist_no_uvicorn_standard_extra():
+    """allowlist 中 uvicorn 不應帶 [standard] extra。
+
+    uvicorn[standard] 在 pip download --platform win_amd64 時會嘗試解 uvloop
+    （marker sys_platform != 'win32' 不被求值）→ 無 win_amd64 wheel → build 失敗。
+    T2 fix：uvicorn 去 [standard]，win-safe extras 改由 _UVICORN_WIN_SAFE_EXTRAS 明列。
+    """
+    import build
+    for dep in build.parse_requirements_allowlist():
+        assert "[standard]" not in dep, (
+            f"parse_requirements_allowlist() 仍含 uvicorn[standard]：{dep!r}\n"
+            f"應改為 uvicorn（去 extra），win-safe extras 由 _UVICORN_WIN_SAFE_EXTRAS 明列"
         )
 
 
-def test_build_excludes_all_test_only_packages():
-    """requirements-test.txt 的純測試套件（pytest*/ruff/playwright/PyYAML…）一律須被排除。
-    自動 derive 防 denylist 漂移：日後新增測試套件忘了同步 EXCLUDE 即 RED。"""
+def test_build_sdist_ok_contains_proxy_tools():
+    """SDIST_OK 必須含 proxy-tools（PyPI 只有 sdist，無 wheel）。"""
     import build
-    test_only = _direct_pkgs(_REQUIREMENTS)
-    missing = sorted(p for p in test_only if p not in build.EXCLUDE_PACKAGES)
-    assert not missing, f"build.py EXCLUDE 未涵蓋測試套件（會被打進用戶 ZIP）：{missing}"
+    assert "proxy-tools" in build.SDIST_OK, (
+        "build.SDIST_OK 缺 'proxy-tools'（PyPI 從未發 wheel，只有 proxy_tools-0.1.0.tar.gz）"
+    )
 
 
-def test_build_does_not_exclude_runtime():
-    """runtime 依賴（requirements.txt）絕不可被排除，否則 build 缺套件、用戶端壞掉。"""
+def test_build_skip_if_no_win_wheel_contains_uvloop():
+    """SKIP_IF_NO_WIN_WHEEL 必須含 uvloop（Windows 合法缺席，無 win_amd64 wheel）。"""
     import build
-    runtime = _direct_pkgs(_REQUIREMENTS_RUNTIME)
-    wrongly = sorted(p for p in runtime if p in build.EXCLUDE_PACKAGES)
-    assert not wrongly, f"build.py EXCLUDE 誤排除 runtime 依賴（會做出缺套件的 ZIP）：{wrongly}"
+    assert "uvloop" in build.SKIP_IF_NO_WIN_WHEEL, (
+        "build.SKIP_IF_NO_WIN_WHEEL 缺 'uvloop'（uvloop 無 win_amd64 wheel，應 skip + warning）"
+    )
+
+
+def test_build_greenlet_not_wrongly_excluded():
+    """greenlet 不應被 allowlist 模型排除（pywebview Windows backend 的合法 transitive）。
+
+    T1 前的 denylist 模型曾被誤列；T2 allowlist 模型無 denylist，greenlet 由 pip 依賴解析
+    自動帶入（若 pywebview 需要）。此守衛確保 greenlet 未被誤加入任何排除機制。
+    """
+    import build
+    # T2 無 EXCLUDE_PACKAGES；確認 SKIP_IF_NO_WIN_WHEEL 和 SDIST_OK 也未誤含 greenlet
+    assert "greenlet" not in build.SKIP_IF_NO_WIN_WHEEL, (
+        "SKIP_IF_NO_WIN_WHEEL 誤含 greenlet（greenlet 有 win_amd64 wheel，不應 skip）"
+    )
+    assert "greenlet" not in build.SDIST_OK, (
+        "SDIST_OK 誤含 greenlet（greenlet 有 win_amd64 wheel，非 sdist-only）"
+    )
+
+
+def test_build_no_exclude_packages_attribute():
+    """T2 後 build.py 不再有 EXCLUDE_PACKAGES（已由 allowlist 模型取代）。
+
+    EXCLUDE_PACKAGES 是 denylist 模型的遺跡，必須移除。
+    若此 test 失敗，代表 denylist 被復活——需重新評估是否違反 T2 設計。
+    """
+    import build
+    assert not hasattr(build, "EXCLUDE_PACKAGES"), (
+        "build.py 仍有 EXCLUDE_PACKAGES（denylist 模型遺跡）；"
+        "T2 改為 allowlist + manifest-based extract，EXCLUDE_PACKAGES 應移除"
+    )
+
+
+def test_extra_deps_no_deps_all_pinned():
+    """EXTRA_DEPS_NO_DEPS 每個項目都必須精確 pin（==）。
+
+    未 pin 的 Phase 2 套件有兩個失效路徑：
+    1. CI cache 有舊版 → 名稱命中跳下載 → 出貨舊版（stale-reuse）。
+    2. cache 同時有多版 → cache-hit loop 全部加入 manifest → 兩版都解壓
+       → last-writer-wins 覆蓋（multi-version corruption）。
+    Pin 後 stale-cleanup 能靠版本號偵測並強制重下，確保 reproducible build。
+    """
+    import build
+    unpinned = [dep for dep in build.EXTRA_DEPS_NO_DEPS if "==" not in dep]
+    assert not unpinned, (
+        f"EXTRA_DEPS_NO_DEPS 有未 exact-pin（==）的項目：{unpinned}\n"
+        "所有 Phase 2 套件必須精確釘版本，防止 CI cache stale-reuse 和多版本解壓污染。"
+    )
+
+
+def test_parse_allowlist_rewrites_only_uvicorn_standard():
+    """uvicorn[standard]==X → uvicorn==X（去 extra）；其餘無 extra 的行原樣保留。"""
+    import build
+    out = build._parse_allowlist_lines([
+        "uvicorn[standard]==0.46.0",
+        "fastapi==0.136.1",
+        "# comment",
+        "-r requirements.txt",
+    ])
+    assert "uvicorn==0.46.0" in out, f"uvicorn[standard] 未正確改寫：{out}"
+    assert all("[standard]" not in d for d in out), f"殘留 [standard]：{out}"
+    assert "fastapi==0.136.1" in out
+
+
+def test_parse_allowlist_fails_closed_on_unexpected_extra():
+    """非 uvicorn[standard] 的任何 extra → hard-fail（不靜默剝除子依賴）。
+
+    Codex P2：blanket 剝 extra 會讓未來 `pkg[extra]==...` 的子依賴從 Windows ZIP
+    無聲消失（正是 T2 要根除的漂移）。必須 fail-closed，逼維護者顯式處理。
+    """
+    import build
+    with pytest.raises(SystemExit):
+        build._parse_allowlist_lines(["redis[hiredis]==5.0.0"])
+    # uvicorn 帶非 standard extra 也須 fail-closed（只認 [standard]）
+    with pytest.raises(SystemExit):
+        build._parse_allowlist_lines(["uvicorn[foo]==0.46.0"])


### PR DESCRIPTION
## 背景 / 問題
Windows 打包 ZIP 體積異常膨脹：v0.10.6 ~56MB（混入 mypy）→ v0.10.7 ~84MB（混入 playwright，含 91MB `node.exe`）。

根因：`build.py` 用 `pip freeze` 凍結 dev venv + denylist 過濾 → 任何測試/開發/orphan 套件（mypy/playwright/uvloop…）只要漏列 denylist 就被打包。且 **release Windows ZIP 就走這條**（`build.yml` 在 ubuntu-latest 跑 `pip install -r requirements.txt` + `python build.py`），故 Linux `uvloop.so`（~16MB）長期隨**每個 release** 出貨給用戶。

## 變更（4 task，逐 commit）
- **T1** `19ab4dce` — 補回 playwright/pyee 排除（f434da9 漏 transitive）→ 84→44.6MB（止血）
- **T4a** `378b0ae9` — `build.yml` artifact audit：對打出的 ZIP 斷言無禁套件 + 體積上限（守真實 release 產物）
- **T2** `9c889267` — `build.py` 改 **allowlist 模型**（棄 pip freeze）：requirements.txt 解析 + manifest-based extract + fail-closed（無 win wheel 只有 uvloop 可 skip）+ sdist 例外（proxy-tools）→ 34.6MB，**local build == CI build**（不再依賴 dev venv 狀態）
- **T4b** `0f55d8ff` — pytest 三禁契約守衛（防退回 freeze / glob-all extract / 平台 fallback，皆 mutation 驗證）

## 結果
- Windows ZIP **84MB → 34.6MB**（甚至低於歷史 ~46MB baseline，因連帶移除長期出貨的 16MB Linux uvloop）
- 測試工具天然不入包（不在 requirements.txt）；同 git tag = 同 ZIP（reproducible）
- 三層守衛：T2 allowlist 斷言 ＋ T4b 源碼/行為契約（PR pytest 早報）＋ T4a 真實產物審計（release 擋版）

## 不做 / 備註
- **不 bump 版號**：純 build 工具修復，無 app 行為變更、無 user-facing 改動
- `build_macos.py` 無此問題（isolated install，已乾淨），不動
- 已驗證：本機真實重打包 exit 0 ＋ 內容/體積/strict-audit 通過；owner Windows 啟動測試 pass
- Codex 開發中已審 T2 兩輪（P1 Phase2 cache stale/multi-version、P2 extra blanket-strip，皆修）
- **follow-up（已 stash，本 PR merge 後單獨上）**：`build.yml` audit 加 `--strict`（uvloop/langdetect 翻 hard-fail）+ ceiling 收緊 55→48MB

> 註：`build.yml` 僅在 tag/`workflow_dispatch` 觸發，故本 PR merge 到 main **不會**自動打包；下次 release tag（或手動 dispatch）才會跑 build + audit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)