### PR TITLE
fix(i18n): 優化關閉行為文案

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -24,10 +24,10 @@
   "desktop": {
     "tray": {
       "open_app": "Open OpenAver",
-      "close_behavior": "Close button behavior",
+      "close_behavior": "When closing the window",
       "ask_on_close": "Ask every time",
-      "minimize_to_tray": "Minimize to notification area",
-      "exit_program": "Exit application",
+      "minimize_to_tray": "Minimize to tray",
+      "exit_program": "Exit OpenAver",
       "quit_app": "Exit OpenAver",
       "unavailable": "The notification area icon could not be started. OpenAver will remain open; exit from the main window instead."
     },
@@ -399,7 +399,11 @@
       "player_placeholder": "Leave blank for system default",
       "player_hint_prefix": "E.g.:",
       "reset_label": "Reset All Settings",
-      "reset_hint": "Delete all custom settings and restore defaults"
+      "reset_hint": "Delete all custom settings and restore defaults",
+      "close_action_label": "When closing the window",
+      "close_action_ask": "Ask every time",
+      "close_action_tray": "Minimize to tray",
+      "close_action_exit": "Exit OpenAver"
     },
     "action": {
       "test": "Test",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -24,10 +24,10 @@
   "desktop": {
     "tray": {
       "open_app": "OpenAver を開く",
-      "close_behavior": "閉じるボタンの動作",
-      "ask_on_close": "閉じるたびに確認",
+      "close_behavior": "ウィンドウを閉じるとき",
+      "ask_on_close": "毎回確認",
       "minimize_to_tray": "通知領域に最小化",
-      "exit_program": "アプリを終了",
+      "exit_program": "OpenAver を終了",
       "quit_app": "OpenAver を終了",
       "unavailable": "通知領域アイコンを開始できません。OpenAver は開いたままになります。ウィンドウから終了してください。"
     },
@@ -399,7 +399,11 @@
       "player_placeholder": "空欄 = システムデフォルトを使用",
       "player_hint_prefix": "例：",
       "reset_label": "すべての設定をリセット",
-      "reset_hint": "すべてのカスタム設定を削除してデフォルトに戻す"
+      "reset_hint": "すべてのカスタム設定を削除してデフォルトに戻す",
+      "close_action_label": "ウィンドウを閉じるとき",
+      "close_action_ask": "毎回確認",
+      "close_action_tray": "通知領域に最小化",
+      "close_action_exit": "OpenAver を終了"
     },
     "action": {
       "test": "テスト",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -24,10 +24,10 @@
   "desktop": {
     "tray": {
       "open_app": "打开 OpenAver",
-      "close_behavior": "关闭按钮行为",
-      "ask_on_close": "每次关闭时询问",
+      "close_behavior": "关闭窗口时",
+      "ask_on_close": "每次询问",
       "minimize_to_tray": "最小化到系统托盘",
-      "exit_program": "退出程序",
+      "exit_program": "退出 OpenAver",
       "quit_app": "退出 OpenAver",
       "unavailable": "系统托盘图标无法启动，OpenAver 将保持打开。请从窗口选择退出程序。"
     },
@@ -399,7 +399,11 @@
       "player_placeholder": "留空使用系统默认",
       "player_hint_prefix": "例如:",
       "reset_label": "重置所有设置",
-      "reset_hint": "删除所有自定义设置，恢复默认值"
+      "reset_hint": "删除所有自定义设置，恢复默认值",
+      "close_action_label": "关闭窗口时",
+      "close_action_ask": "每次询问",
+      "close_action_tray": "最小化到系统托盘",
+      "close_action_exit": "退出 OpenAver"
     },
     "action": {
       "test": "测试",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -24,10 +24,10 @@
   "desktop": {
     "tray": {
       "open_app": "開啟 OpenAver",
-      "close_behavior": "關閉按鈕行為",
-      "ask_on_close": "每次關閉時詢問",
+      "close_behavior": "關閉視窗時",
+      "ask_on_close": "每次詢問",
       "minimize_to_tray": "最小化到系統匣",
-      "exit_program": "結束程式",
+      "exit_program": "結束 OpenAver",
       "quit_app": "結束 OpenAver",
       "unavailable": "系統匣圖示無法啟動，OpenAver 將保持開啟。請從視窗選擇結束程式。"
     },


### PR DESCRIPTION
## 變更類型

- [x] 🐛 Bug 修復 (non-breaking change)
- [ ] ✨ 新功能 (non-breaking change)
- [ ] 💥 Breaking change (會影響現有功能)
- [ ] 📝 文檔更新
- [ ] ♻️ 重構
- [ ] 🧪 測試

## 變更描述

修正 Windows 關閉行為相關文案與 i18n 缺漏：

- 補齊 `settings.system.close_action_*` 在 `zh_CN`、`en`、`ja` 的翻譯，避免設定頁在非繁中語系下回退顯示繁中文字串。
- 將系統匣選單的「關閉按鈕行為」調整為更通用的「關閉視窗時」。
- 協調設定頁與系統匣選單的關閉行為文案，使各語系下語意一致、避免混用繁中 fallback。
- 保留既有 `zh_TW` 設定頁選項「直接結束」，以符合目前測試守衛與既有 UI 文案。

此變更不修改 `general.close_action = ask | tray | exit` 的既有設定格式，也不影響關閉行為邏輯。

## 相關 Issue

無

## 測試方式

1. `python -m pytest tests\unit\test_windows_tray.py tests\unit\test_core_config.py -q`
2. `python -m pytest tests\unit\test_frontend_lint.py::TestSettingsCloseActionSelect::test_zh_tw_has_close_action_option_keys tests\unit\test_windows_tray.py -q`
3. `python -m ruff check tests\unit\test_windows_tray.py windows\tray.py`
4. 手動確認四個 locale JSON 均包含 `settings.system.close_action_*` 與 `desktop.tray.close_behavior` 文案。

## 檢查清單

- [x] 我已閱讀 [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] 我的代碼遵循專案的代碼風格
- [ ] 我已更新相關文檔
- [ ] 我已新增必要的測試
- [x] 所有測試通過 (`pytest`)

## 截圖（如適用）

| Before | After |
|--------|-------|
| 非繁中語系下設定頁可能顯示繁中關閉行為文案 | zh_CN / en / ja 補齊設定頁關閉行為文案；系統匣選單標題改為更通用的「關閉視窗時」 |