### PR TITLE
feat(0.10.10): 封面比例自適應 + 行動相似探索面板（feature/83）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.10] - 2026-06-24
+
+本版主軸：**封面比例自適應 + 行動相似探索面板**（feature/83）——兩條並行：83a 讓燈箱封面不留空白（寬比例作品自動填滿容器、AR 不污染女優模式）；83b 在行動裝置新增相似探索面板（全螢幕疊加 + 六張爆射卡 + 封面飛行進/退場 + 主圖播放按鈕）。
+
+### Added
+#### 🪄 行動相似探索面板（83b）
+- 🎯 **行動版相似探索**：手機/平板燈箱新增星形爆射相似面板——點 🪄 按鈕開啟全螢幕疊加，六張相似卡從中心爆射散開，中央主圖以飛行動畫從燈箱封面轉入。
+- 🎯 **封面飛行進/退場**：主圖以 ghost-fly 動畫從燈箱封面飛入面板（enter），關閉時原路飛回（exit）；進退場期間播放按鈕自動隱藏，不懸空。
+- 🎯 **主圖播放按鈕**：相似面板主圖底部中央有播放圓鈕（對齊桌面星空模式，44×44 Fluent 玻璃材質）；drill 動畫中鎖定、無路徑影片時隱藏。
+- 🎯 **drill 並發硬化**：快速切換相似卡時舊 drill 立即中止、新 drill 接管；runId guard 確保舊的動畫/狀態不干擾新結果。
+
+### Changed
+#### 🖼️ 燈箱封面比例自適應（83a）
+- 🎯 **封面不再留白**：燈箱封面改採 aspect-box/modal-hug 模型，以圖片載入事件讀取實際比例，寬比例（橫版封面）自動填滿容器，不再出現上下空白；破圖/未載入時安全回退不塌陷、不污染女優模式比例。
+- 搜尋燈箱、搜尋詳情頁封面區同步採用同款模型；search detail 封面留白與劇照截斷一併修正。
+
+### Fixed
+- 修正 83a/83b-T1 引入後 `TestCoverLoadingUx67Guard` 四條守衛因 `:class has-cover` 新屬性 + T1 注釋位移雙因導致正則 stale。
+
+### 測試
+- 全套 pytest **4686 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較 0.10.9 的 4650 +36）+ `ruff check .` 綠 + `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**7 PASS、1 SKIP**（fc2 unreachable，已知正常）。
+- Gemini 3.1 Pro 三群審查：83a LGTM、83b-rest Approved、83b-T1 Codex 三審已通過（Gemini payload 邊界 timeout）。
+- Codex PR review P1（行動播放按鈕未接 ghost-hide 流程）已修（CSS sibling selector）。
+
 ## [0.10.9] - 2026-06-22
 
 本版主軸：**Windows 系統匣關閉行為**（feature/82）——在 Windows 點關閉視窗時可選擇「最小化到系統匣繼續背景執行」或「完整退出」並記住選擇，系統匣常駐圖示隨時喚回視窗或切換行為。核心 close-to-tray 由社群貢獻者 @YongCard（PR #77）提供，本版合併後做穩定性硬化並補上設定頁入口。

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.10.9"
+__version__ = "0.10.10"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5413,8 +5413,9 @@ class TestSearchCssHardcoded:
         # T11：在 L753 後插入 hero 規則（~14 行）：906→920。
         # T10（US-10）：poster-crop / coarse block 註解 +4 行（481–899 擴斷點）：920→924。
         # 83a-T3：在 L789 插入 modal-hug block（~21 行）：924→945。
+        # 83a-T3-fix P1：在 L810（T9-port 前）插入 lightbox overflow block（~12 行）：945→957。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        945: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        957: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
@@ -14498,6 +14499,17 @@ class TestLightboxModalHugContract:
             "state-lightbox.js 缺少 setProperty('--lb-cover-ar') 呼叫"
         )
 
+    def test_metadata_flex_distribution(self):
+        """83a-T3-fix P1: .lightbox-metadata 有 flex:1 1 auto + overflow-y:auto（metadata 自行捲，modal 不捲）"""
+        block = self._metadata_block(self._css())
+        assert block is not None, "showcase.css 找不到 .lightbox-metadata 規則"
+        assert re.search(r'flex\s*:\s*1\s+1\s+auto', block), (
+            ".lightbox-metadata 缺少 flex:1 1 auto（P1 fix：metadata 佔剩餘高度）"
+        )
+        assert re.search(r'overflow-y\s*:\s*auto', block), (
+            ".lightbox-metadata 缺少 overflow-y:auto（P1 fix：metadata 內部捲，modal 不捲）"
+        )
+
 
 class TestSearchLightboxModalHugContract:
     """83a-T3: 固化 search 頁 lightbox modal-hug 契約（7 條純加法守衛）
@@ -14621,4 +14633,21 @@ class TestSearchLightboxModalHugContract:
         )
         assert "setProperty('--lb-cover-ar'" in js, (
             "grid-mode.js 缺少 setProperty('--lb-cover-ar') 呼叫"
+        )
+
+    def _search_lightbox_content_block(self, css):
+        m = re.search(
+            r'\.search-container\s+\.lightbox-content\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def test_s8_search_lightbox_content_overflow_hidden(self):
+        """83a-T3-fix P1: .search-container .lightbox-content 有 overflow-y:hidden（modal 不捲）"""
+        block = self._search_lightbox_content_block(self._css())
+        assert block is not None, (
+            "search.css 找不到 .search-container .lightbox-content 規則（P1 fix 缺失）"
+        )
+        assert re.search(r'overflow-y\s*:\s*hidden', block), (
+            ".search-container .lightbox-content 缺少 overflow-y:hidden（P1 fix：modal 整體不捲）"
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -14942,3 +14942,223 @@ class TestMobileSimilarPanelContractGuard:
         assert "nextLightboxVideo" not in guard_block, (
             "handleKeydown similarModeMobileOpen block 含 nextLightboxVideo（箭頭不得切片，D10）"
         )
+
+
+# ============================================================================
+# TASK-83b-T3: Mobile Similar Panel Transition Guards（6 條）
+# 鎖住 T3 建立的封面飛行進 / 退場合約：helper 存在 / 不包裝禁區 / token 化 /
+# async closeMobilePanel / PRM 分支 / 桌面禁區 anchor 不被 mobile helper 引用。
+# ============================================================================
+
+_T3_GHOST_FLY_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "shared" / "ghost-fly.js"
+)
+
+
+class TestMobilePanelT3Guards:
+    """TASK-83b-T3: 行動相似面板封面飛行進退場（6 條靜態守衛）。
+
+    每條 guard 均 mutation-detectable：刪除或改動對應實作即 RED。
+    """
+
+    @staticmethod
+    def _ghost_fly_js():
+        return _T3_GHOST_FLY_JS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _similar_js():
+        return _T2_SIMILAR_JS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _extract_function_body(js, func_pattern):
+        """大括號平衡法擷取函式體（reuse T2 pattern）。"""
+        m = re.search(func_pattern, js)
+        if not m:
+            return None
+        start = m.start()
+        try:
+            body_start = js.index('{', start)
+        except ValueError:
+            return None
+        depth = 0
+        for i, ch in enumerate(js[body_start:], body_start):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return js[body_start:i + 1]
+        return None
+
+    # ── 1. Helper functions exported ────────────────────────────────────────
+
+    def test_mobile_panel_enter_exit_functions_exported(self):
+        """ghost-fly.js 含 playMobilePanelEnter + playMobilePanelExit 函式定義，
+        且兩者均出現在 GhostFly export 物件中。"""
+        js = self._ghost_fly_js()
+        assert "playMobilePanelEnter" in js, \
+            "ghost-fly.js 缺 playMobilePanelEnter 函式（83b-T3 helper 未建立）"
+        assert "playMobilePanelExit" in js, \
+            "ghost-fly.js 缺 playMobilePanelExit 函式（83b-T3 helper 未建立）"
+        # 確認 export 在 GhostFly 物件中（兩者均以 property: function 形式 export）
+        assert re.search(r'playMobilePanelEnter\s*:\s*playMobilePanelEnter', js), \
+            "ghost-fly.js GhostFly export 物件缺 playMobilePanelEnter 屬性"
+        assert re.search(r'playMobilePanelExit\s*:\s*playMobilePanelExit', js), \
+            "ghost-fly.js GhostFly export 物件缺 playMobilePanelExit 屬性"
+
+    # ── 2. Enter uses createCoverGhost, not constellation wrapper ───────────
+
+    def test_mobile_enter_uses_create_cover_ghost_not_constellation(self):
+        """ghost-fly.js playMobilePanelEnter 函式體含 createCoverGhost，
+        且不含 play56cConstellationEnter（不包裝桌面禁區函式）。
+        comment 中的字串不算（去掉 // 和 /* */ comment 後才驗證）。"""
+        js = self._ghost_fly_js()
+        body = self._extract_function_body(js, r'function\s+playMobilePanelEnter\s*\(')
+        assert body is not None, \
+            "ghost-fly.js 找不到 playMobilePanelEnter 函式宣告"
+        assert "createCoverGhost" in body, \
+            "playMobilePanelEnter 函式體缺 createCoverGhost 呼叫（必須直接用 primitive，不可包裝桌面函式）"
+        # 去掉 comment 後再搜尋（comment 中可能有說明性文字提及禁區函式名）
+        body_no_comments = re.sub(r'//[^\n]*', '', body)
+        body_no_comments = re.sub(r'/\*.*?\*/', '', body_no_comments, flags=re.DOTALL)
+        assert "play56cConstellationEnter" not in body_no_comments, \
+            "playMobilePanelEnter 函式體（去注釋後）含 play56cConstellationEnter（禁區：不可包裝桌面函式）"
+
+    # ── 3. Transition tokenized（DURATION.medium + fluent ease strings）──────
+
+    def test_mobile_transition_tokenized(self):
+        """ghost-fly.js playMobilePanelEnter / playMobilePanelExit 均：
+        - 含 DURATION.medium（token 不硬編碼）
+        - 含 0.333（fallback 允許）
+        - enter 含 fluent-decel；exit 含 fluent-accel
+        - 函式體（排除 fallback 表達式後）不含裸 duration 數字 literal（如 duration: 0.333）
+
+        Correction B：0.333 只允許作為 || fallback，不得作為 duration: 的直接值。
+        """
+        js = self._ghost_fly_js()
+
+        enter_body = self._extract_function_body(js, r'function\s+playMobilePanelEnter\s*\(')
+        assert enter_body is not None, "ghost-fly.js 找不到 playMobilePanelEnter"
+        exit_body = self._extract_function_body(js, r'function\s+playMobilePanelExit\s*\(')
+        assert exit_body is not None, "ghost-fly.js 找不到 playMobilePanelExit"
+
+        for name, body in [("playMobilePanelEnter", enter_body), ("playMobilePanelExit", exit_body)]:
+            assert "DURATION.medium" in body, \
+                f"{name} 函式體缺 DURATION.medium（必須用 token，不可硬編碼 duration）"
+            assert "0.333" in body, \
+                f"{name} 函式體缺 0.333 fallback（token guard chain 要求 || 0.333 fallback）"
+
+        assert "fluent-decel" in enter_body, \
+            "playMobilePanelEnter 函式體缺 fluent-decel ease（禁用 power2.* 代換）"
+        assert "fluent-accel" in exit_body, \
+            "playMobilePanelExit 函式體缺 fluent-accel ease（禁用 power2.* 代換）"
+
+        # Correction B：排除 || 0.333 fallback 行後，不得有 duration: <數字> 裸值
+        # 方法：把 "|| 0.333" fallback 表達式置換掉，再搜尋 duration: 後接數字
+        for name, body in [("playMobilePanelEnter", enter_body), ("playMobilePanelExit", exit_body)]:
+            body_stripped = body.replace("|| 0.333", "").replace("|| 0.5", "")
+            # 搜尋 duration: 後緊接數字 literal（含小數）
+            assert not re.search(r'\bduration\s*:\s*\d+(\.\d+)?', body_stripped), \
+                (f"{name} 函式體含裸 duration 數字 literal（排除 fallback 後仍殘留）；"
+                 "必須用 dur 變數（來自 DURATION.medium || 0.333）")
+
+    # ── 4. closeMobilePanel is async ────────────────────────────────────────
+
+    def test_mobile_close_panel_is_async(self):
+        """state-similar.js closeMobilePanel 為 async 函式（exit ghost await 前提）。"""
+        js = self._similar_js()
+        assert re.search(r'async\s+closeMobilePanel\s*\(', js), \
+            "state-similar.js closeMobilePanel 不是 async 函式（83b-T3：exit ghost 需 async + await）"
+
+    # ── 5. PRM fallback branches exist ──────────────────────────────────────
+
+    def test_mobile_transition_prm_fallback(self):
+        """state-similar.js _openMobilePanel 函式體含 shouldSkip（PRM 閘），
+        且 enter ghost 飛行（playMobilePanelEnter）被 shouldSkip 閘控（!...shouldSkip 在呼叫前）；
+        closeMobilePanel 含 shouldSkip + playMobilePanelExit 被閘控。"""
+        js = self._similar_js()
+
+        open_body = self._extract_function_body(js, r'async\s+_openMobilePanel\s*\(')
+        assert open_body is not None, \
+            "state-similar.js 找不到 _openMobilePanel 函式宣告"
+        assert "shouldSkip" in open_body, \
+            "_openMobilePanel 函式體缺 shouldSkip（PRM 降級分支未實作）"
+        assert "mobilePanelCoverImg" in open_body, \
+            "_openMobilePanel 函式體缺 mobilePanelCoverImg（PRM 分支中央主圖 src 設定缺失）"
+        # Nit 強化：enter ghost 飛行必須被 PRM 閘控（!...shouldSkip(...) 出現在 playMobilePanelEnter 呼叫之前）
+        assert "playMobilePanelEnter" in open_body, \
+            "_openMobilePanel 函式體缺 playMobilePanelEnter 呼叫（enter 飛行未接線）"
+        open_no_comments = re.sub(r'//[^\n]*', '', open_body)
+        open_no_comments = re.sub(r'/\*.*?\*/', '', open_no_comments, flags=re.DOTALL)
+        m_neg = re.search(r'!\s*window\.BurstPicker\.shouldSkip', open_no_comments)
+        m_enter = re.search(r'playMobilePanelEnter', open_no_comments)
+        assert m_neg is not None, \
+            "_openMobilePanel 缺 !window.BurstPicker.shouldSkip 否定閘（enter 飛行未受 PRM 閘控）"
+        assert m_neg.start() < m_enter.start(), (
+            "_openMobilePanel 的 !shouldSkip 閘必須在 playMobilePanelEnter 呼叫之前"
+            "（否則 PRM 用戶仍會跑進場飛行）"
+        )
+
+        close_body = self._extract_function_body(js, r'async\s+closeMobilePanel\s*\(')
+        assert close_body is not None, \
+            "state-similar.js 找不到 async closeMobilePanel 函式宣告"
+        assert "shouldSkip" in close_body, \
+            "closeMobilePanel 函式體缺 shouldSkip（PRM 快捷隱藏路徑未實作）"
+        # exit ghost 飛行同樣被 PRM 閘控
+        assert "playMobilePanelExit" in close_body, \
+            "closeMobilePanel 函式體缺 playMobilePanelExit 呼叫（exit 飛行未接線）"
+        close_no_comments = re.sub(r'//[^\n]*', '', close_body)
+        close_no_comments = re.sub(r'/\*.*?\*/', '', close_no_comments, flags=re.DOTALL)
+        m_neg_c = re.search(r'!\s*window\.BurstPicker\.shouldSkip', close_no_comments)
+        m_exit = re.search(r'playMobilePanelExit', close_no_comments)
+        assert m_neg_c is not None and m_neg_c.start() < m_exit.start(), (
+            "closeMobilePanel 的 !shouldSkip 閘必須在 playMobilePanelExit 呼叫之前"
+            "（否則 PRM 用戶仍會跑退場飛行）"
+        )
+
+    # ── 5b. closeMobilePanel kills in-flight enter timeline (P1-T3fix) ───────
+
+    def test_mobile_close_kills_enter_timeline(self):
+        """state-similar.js closeMobilePanel 函式體在 playMobilePanelExit 之前 kill in-flight
+        enter timeline（_mobileEnterTl.kill()）+ 顯式 cleanup enter ghost（_mobileEnterGhost）。
+        P1-T3fix：防中途打斷時 enter onComplete 在 exit 飛行中誤還原 mobileCoverEl opacity → 雙圖。"""
+        js = self._similar_js()
+        close_body = self._extract_function_body(js, r'async\s+closeMobilePanel\s*\(')
+        assert close_body is not None, \
+            "state-similar.js 找不到 async closeMobilePanel 函式宣告"
+        close_no_comments = re.sub(r'//[^\n]*', '', close_body)
+        close_no_comments = re.sub(r'/\*.*?\*/', '', close_no_comments, flags=re.DOTALL)
+        # 必須 kill in-flight enter timeline
+        m_kill = re.search(r'_mobileEnterTl\s*\.\s*kill\s*\(', close_no_comments)
+        assert m_kill is not None, (
+            "closeMobilePanel 缺 _mobileEnterTl.kill()（P1-T3fix：未 kill in-flight 進場 timeline → "
+            "中途打斷雙圖）"
+        )
+        # 必須顯式 cleanup enter ghost（.kill() 不保證 fire onInterrupt，故不可只靠 timeline 自清）
+        assert "_mobileEnterGhost" in close_no_comments, (
+            "closeMobilePanel 缺 _mobileEnterGhost 顯式 cleanup（.kill() 不 fire onInterrupt → "
+            "enter ghost 殘留 + opacity 未還原）"
+        )
+        # kill 必須在 exit 飛行（playMobilePanelExit）之前
+        m_exit = re.search(r'playMobilePanelExit', close_no_comments)
+        assert m_exit is not None, "closeMobilePanel 缺 playMobilePanelExit"
+        assert m_kill.start() < m_exit.start(), (
+            "_mobileEnterTl.kill() 必須在 playMobilePanelExit 之前"
+            "（否則 enter ghost 仍在飛 → 與 exit ghost 雙圖）"
+        )
+
+    # ── 6. Desktop constellation anchor not in mobile enter ─────────────────
+
+    def test_desktop_constellation_byte_identical_anchor(self):
+        """ghost-fly.js 含 .similar-main-anchor（桌面 anchor lookup 未被移除）；
+        且 playMobilePanelEnter 函式體不含 .similar-main-anchor（禁區 anchor 不被 mobile helper 引用）。"""
+        js = self._ghost_fly_js()
+        assert ".similar-main-anchor" in js, \
+            "ghost-fly.js 缺 .similar-main-anchor（桌面 play56cConstellationEnter 被破壞或移除）"
+
+        enter_body = self._extract_function_body(js, r'function\s+playMobilePanelEnter\s*\(')
+        assert enter_body is not None, \
+            "ghost-fly.js 找不到 playMobilePanelEnter 函式宣告"
+        assert ".similar-main-anchor" not in enter_body, \
+            "playMobilePanelEnter 函式體含 .similar-main-anchor（禁區：桌面 DOM 不得出現在 mobile helper）"

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2169,10 +2169,12 @@ class TestShowcaseLightboxSentinel:
         assert 'cancelDeleteVideo()' in block, 'delete modal 缺 cancelDeleteVideo() 取消 handler'
 
     def test_t7_xtrap_releases_on_delete_modal(self):
-        """燈箱 x-trap 行必須含 deleteVideoModalOpen（modal 開時釋放 trap 給 modal）。"""
+        """燈箱 x-trap 行必須含 deleteVideoModalOpen（modal 開時釋放 trap 給 modal）。
+        錨定 lightbox 已知條件字串（非 re.search 第一個 match），防面板 x-trap 混淆。
+        """
         html = self._html()
-        m = re.search(r'x-trap\.inert="([^"]*)"', html)
-        assert m, 'showcase.html 缺 x-trap.inert 行'
+        m = re.search(r'x-trap\.inert="([^"]*deleteVideoModalOpen[^"]*)"', html)
+        assert m, 'showcase.html 缺含 deleteVideoModalOpen 的 x-trap.inert 行'
         expr = m.group(1)
         assert 'deleteVideoModalOpen' in expr, \
             f'x-trap.inert 未含 deleteVideoModalOpen（delete modal 開時 trap 未釋放）: {expr!r}'
@@ -12076,32 +12078,6 @@ class TestSimilarSlotGsapGuard:
             "constellation-host.js must contain 'width: 107' (reduced-motion + reset slot value)"
 
 
-class TestSimilarMobileDOMOrderGuard:
-    """75a-T4: showcase.html DOM 順序 — lightbox-similar-mobile 在 lightbox-metadata 之前。
-
-    使用 re.search 取 class attr 出現位置，避免誤中 HTML comment。
-    """
-
-    def _html(self):
-        return T4_SHOWCASE_HTML.read_text(encoding="utf-8")
-
-    def test_similar_mobile_before_metadata(self):
-        """lightbox-similar-mobile div 在主 lightbox-metadata div 之前。
-
-        showcase.html 有兩個 lightbox-metadata：actress-lightbox-meta（上方）和主 metadata（下方）。
-        守衛目標是主 lightbox-metadata（不含 actress 子 class），故用 exact class= match。
-        """
-        html = self._html()
-        m_mobile = re.search(r'class="lightbox-similar-mobile"', html)
-        # Match the standalone lightbox-metadata (not actress-lightbox-meta)
-        m_meta = re.search(r'class="lightbox-metadata"(?!\s)', html)
-        assert m_mobile, "showcase.html: lightbox-similar-mobile class attr not found"
-        assert m_meta, "showcase.html: class=\"lightbox-metadata\" (main, non-actress) not found"
-        assert m_mobile.start() < m_meta.start(), (
-            "showcase.html: lightbox-similar-mobile must appear before main lightbox-metadata in DOM"
-        )
-
-
 class TestSimilarJSThresholdGuard:
     """75a-T4: state-similar.js openSimilarMode 手機門檻 960px 守衛。
 
@@ -12157,56 +12133,25 @@ class TestSimilarJSThresholdGuard:
 class TestSimilarCssSafetyAndGridGuard:
     """75a-T4: showcase.css 安全規則 + 手機網格守衛。
 
-    涵蓋：
-    - @media (min-width: 960px) 包含 .lightbox-similar-mobile（安全網，不用 768px）
-    - .similar-mobile-card img block 含 var(--poster-crop-ratio)，不含 4/5
-    - .similar-slot block 含 width: 107px，不含 width: 120px
-    - .similar-mobile-grid block 含 repeat(4
-    - @media (max-width: 960px) 含 .lightbox-content.similar-open .lightbox-cover 縮高規則
+    83b-T2：舊 .lightbox-similar-mobile / .similar-mobile-grid / .similar-mobile-card 相關守衛已退役；
+    remaining：@media (min-width: 960px) .similar-mobile-panel safety-net + .similar-slot 守衛。
     """
 
     def _css(self):
         return T4_SHOWCASE_CSS.read_text(encoding="utf-8")
 
     def test_safety_rule_min_960_hides_mobile(self):
-        """@media (min-width: 960px) 安全網存在且包含 .lightbox-similar-mobile"""
+        """@media (min-width: 960px) 安全網存在且包含 .similar-mobile-panel（桌面 display:none）"""
         css = self._css()
-        match = re.search(r'@media\s*\(\s*min-width\s*:\s*960px\s*\)', css)
-        assert match, "showcase.css: @media (min-width: 960px) not found"
-        # Verify lightbox-similar-mobile is within or near this media block
-        after = css[match.start():]
-        assert "lightbox-similar-mobile" in after[:500], \
-            "@media (min-width: 960px) block must contain .lightbox-similar-mobile rule"
-
-    def test_safety_rule_not_768(self):
-        """安全網媒體查詢用 960px 而非 768px"""
-        css = self._css()
-        # The safety rule specifically for lightbox-similar-mobile hides it at 960px
-        # Confirm there's a min-width: 960px block (not just 768px) for the mobile section
-        idx_960 = css.find("min-width: 960px")
-        assert idx_960 != -1, "showcase.css: min-width: 960px not found (safety rule)"
-        # Confirm lightbox-similar-mobile appears after min-width: 960px
-        idx_mobile = css.find("lightbox-similar-mobile", idx_960)
-        assert idx_mobile != -1, \
-            "showcase.css: lightbox-similar-mobile not found after min-width: 960px"
-
-    def test_similar_mobile_card_img_has_poster_crop_ratio(self):
-        """.similar-mobile-card img block 含 var(--poster-crop-ratio)"""
-        css = self._css()
-        match = re.search(r'\.similar-mobile-card\s+img\s*\{([^}]+)\}', css)
-        assert match, "showcase.css: .similar-mobile-card img rule not found"
-        block = match.group(1)
-        assert "var(--poster-crop-ratio)" in block, \
-            ".similar-mobile-card img must contain var(--poster-crop-ratio)"
-
-    def test_similar_mobile_card_img_no_hardcoded_4_5(self):
-        """.similar-mobile-card img block 不含 4/5 硬編碼比例"""
-        css = self._css()
-        match = re.search(r'\.similar-mobile-card\s+img\s*\{([^}]+)\}', css)
-        assert match, "showcase.css: .similar-mobile-card img rule not found"
-        block = match.group(1)
-        assert "4/5" not in block, \
-            ".similar-mobile-card img must not contain hardcoded 4/5 (use var(--poster-crop-ratio))"
+        found = False
+        for m in re.finditer(r'@media\s*\(\s*min-width\s*:\s*960px\s*\)', css):
+            after = css[m.start():]
+            if "similar-mobile-panel" in after[:500]:
+                found = True
+                break
+        assert found, (
+            "showcase.css: @media (min-width: 960px) block must contain .similar-mobile-panel rule"
+        )
 
     def test_similar_slot_width_107(self):
         """.similar-slot rule block 含 width: 107px"""
@@ -12225,63 +12170,6 @@ class TestSimilarCssSafetyAndGridGuard:
         block = match.group(1)
         assert "width: 120px" not in block, \
             ".similar-slot block must not contain width: 120px (should be 107px)"
-
-    def test_similar_mobile_grid_repeat_4(self):
-        """.similar-mobile-grid block 含 repeat(4"""
-        css = self._css()
-        match = re.search(r'\.similar-mobile-grid\s*\{([^}]+)\}', css)
-        assert match, "showcase.css: .similar-mobile-grid selector not found"
-        block = match.group(1)
-        assert "repeat(4" in block, \
-            ".similar-mobile-grid must contain repeat(4, 1fr) grid-template-columns"
-
-    def test_similar_open_cover_height_override(self):
-        """@media (max-width: 960px) 含 similar-open 封面縮高規則（min(38vh + height: 40vh）"""
-        css = self._css()
-        # Find the max-width: 960px media block containing similar-open
-        match = re.search(r'@media\s*\(\s*max-width\s*:\s*960px\s*\)', css)
-        assert match, "showcase.css: @media (max-width: 960px) not found"
-        after = css[match.start():]
-        assert "similar-open" in after[:500], \
-            "@media (max-width: 960px) must contain .similar-open cover rule"
-        assert "min(38vh" in after[:500], \
-            "@media (max-width: 960px) similar-open must contain min(38vh cover override"
-        assert "height: 40vh" in after[:500], \
-            "@media (max-width: 960px) similar-open must contain height: 40vh override"
-
-    def test_similar_open_lb_full_outranks_t8(self):
-        """similar-open .lb-full selector 須用 compound 中間形式 .lightbox-cover .lb-full，
-        使 specificity 達 (0,4,0)，勝 T8 ≤480 的 .lightbox-cover:has(.lb-full) .lb-full (0,3,0)。
-        否則 source order 讓 T8 的 height:auto 在 ≤480px ∩ similar-open 覆寫 overlay → overlay 與
-        base 40vh 脫鉤/溢出。
-
-        mutation test：將 .lightbox-cover 中間節點移除（還原為裸 .lightbox-content.similar-open .lb-full）
-        → 此測試應轉紅（RED）。
-        """
-        css = self._css()
-        # Strip CSS comments so comment-only occurrences don't fool the assertions
-        css_no_comments = re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
-
-        # MUST: compound form with .lightbox-cover intermediate present
-        assert '.lightbox-content.similar-open .lightbox-cover .lb-full' in css_no_comments, (
-            "showcase.css: similar-open .lb-full selector must use compound form "
-            "'.lightbox-content.similar-open .lightbox-cover .lb-full' (specificity (0,4,0)) "
-            "to outrank T8's .lightbox-cover:has(.lb-full) .lb-full (0,3,0). "
-            "Without the .lightbox-cover intermediate, source order lets T8 height:auto win in "
-            "≤480px ∩ similar-open → overlay desyncs from base 40vh."
-        )
-
-        # MUST NOT: bare form without .lightbox-cover intermediate (would tie T8 at (0,3,0) and lose by source order)
-        # Match patterns like: ".lightbox-content.similar-open .lb-full {" or ",\n    .lightbox-content.similar-open .lb-full {"
-        bare_pattern = re.search(
-            r'\.lightbox-content\.similar-open\s+\.lb-full\s*[{,]',
-            css_no_comments
-        )
-        assert bare_pattern is None, (
-            "showcase.css: bare '.lightbox-content.similar-open .lb-full' selector found — "
-            "this ties T8 at (0,3,0) and loses by source order in ≤480px ∩ similar-open. "
-            "Use '.lightbox-content.similar-open .lightbox-cover .lb-full' (0,4,0) instead."
-        )
 
 
 # ============================================================================
@@ -12625,73 +12513,15 @@ class TestUS5PosterCropGhostCrossfade:
 class TestUS5VideoCoverFitMobile:
     """TASK-75b-T8：≤480px 影片燈箱封面以原圖比例呈現、消上下 letterbox 死白。
 
-    make-or-break（live 實證）：須同改 (a) img/.lb-full 尺寸法 + (b) 容器 min-*，
-    只改 img 空白會留在容器。scope :has(.lb-full) 只中影片、不波及女優 cover。
-    三問：刪容器 min-height:0 → 紅（make-or-break）；刪 img height:auto → 紅；
-    把 :has(.lb-full) 改裸 .lightbox-cover（會波及女優）→ scope 守衛紅。
+    83b-T2：T8 block（@media (max-width:899px) .lightbox-cover:has(.lb-full)）已移除；
+    相關守衛（test_video_cover_fit_media_block_exists / test_container_min_zeroed_gated_on_has_cover /
+    test_img_height_auto_width_full / test_scoped_to_has_lb_full_not_actress / test_similar_open_40vh_untouched）
+    全數退役（確認 RED 後刪除）。僅保留 has-cover HTML 旗標守衛。
     """
 
-    def _css(self):
-        return SHOWCASE_CSS.read_text(encoding="utf-8")
-
-    def _t8_block(self) -> str:
-        """抓含 .lightbox-cover:has(.lb-full) 的那個 @media (max-width: 899px) block。
-        T11（US-10）：燈箱封面貼合斷點由 ≤480 擴到 ≤899（對齊 poster-crop 門檻）。"""
-        css = self._css()
-        blocks = re.findall(r'@media \(max-width: 899px\) \{(.*?)\n\}', css, re.DOTALL)
-        target = [b for b in blocks if ".lightbox-cover:has(.lb-full)" in b]
-        assert target, "showcase.css 找不到含 .lightbox-cover:has(.lb-full) 的 ≤899px block（T8/T11 缺失）"
-        return target[0]
-
-    def test_video_cover_fit_media_block_exists(self):
-        block = self._t8_block()
-        assert ".lightbox-cover:has(.lb-full)" in block, "T8 block 應 scope 到 :has(.lb-full)"
-
-    def test_container_min_zeroed_gated_on_has_cover(self):
-        """make-or-break：容器 min-height/min-width 必須歸零（否則空白只是重新分配）。
-        Codex P2：容器 min-height:0 必須 gate 在 .has-cover——無封面影片若塌成 0 高、補封面入口會壞，
-        故 selector 必為 .lightbox-cover.has-cover:has(.lb-full)（非裸 :has(.lb-full)）。
-        三問：拿掉 .has-cover gate → 紅（無封面會塌）；拿掉 min-height:0 → 紅（留白未消）。
-        """
-        block = self._t8_block()
-        m = re.search(r'\.lightbox-cover\.has-cover:has\(\.lb-full\) \{([^}]*)\}', block)
-        assert m, "T8 容器規則須為 .lightbox-cover.has-cover:has(.lb-full)（Codex P2：min-height:0 須 gate has-cover）"
-        body = m.group(1)
-        assert "min-height: 0" in body, (
-            "容器須 min-height: 0（否則 min(58vh,460px) 主導、img 置中留白未消）—— make-or-break"
-        )
-        assert "min-width: 0" in body, "容器須 min-width: 0"
-
-    def test_img_height_auto_width_full(self):
-        """img + .lb-full 須 height:auto + width:100%（覆寫 60vh），且規則涵蓋 .lb-full。"""
-        block = self._t8_block()
-        m = re.search(
-            r'\.lightbox-cover:has\(\.lb-full\) img,\s*\.lightbox-cover:has\(\.lb-full\) \.lb-full \{([^}]*)\}',
-            block,
-        )
-        assert m, "T8 block 內找不到涵蓋 img + .lb-full 的尺寸規則"
-        body = m.group(1)
-        assert "height: auto" in body, "img/.lb-full 須 height: auto（覆寫 60vh）"
-        assert "width: 100%" in body, "img/.lb-full 須 width: 100%"
-
-    def test_scoped_to_has_lb_full_not_actress(self):
-        """scope 護欄：T8 block 不得出現裸 .lightbox-cover img 的 height:auto（會波及女優 cover）。"""
-        block = self._t8_block()
-        # 裸 .lightbox-cover img {（無 :has）出現在 block 內即危險
-        bare = re.search(r'(?<!\)) \.lightbox-cover img \{', block)
-        assert not bare, (
-            "T8 block 不得含裸 .lightbox-cover img 規則（無 :has(.lb-full)）—— 會波及女優燈箱封面"
-        )
-
-    def test_similar_open_40vh_untouched(self):
-        """回歸護欄：手機相似模式 similar-open 40vh / 38vh 規則仍在（未被 T8 波及）。"""
-        css = self._css()
-        assert "min(38vh, 290px)" in css, "similar-open 容器 min-height 規則應保留"
-        assert "height: 40vh" in css, "similar-open img/lb-full 40vh 規則應保留"
-
     def test_video_lightbox_cover_has_cover_class(self):
-        """Codex P2：影片燈箱 .lightbox-cover 須帶 has-cover 旗標（綁 cover_url），
-        供 T8 容器 min-height:0 只在有封面時生效。三問：拿掉旗標 → 紅（CSS gate 失效）。
+        """Codex P2：影片燈箱 .lightbox-cover 須帶 has-cover 旗標（綁 cover_url）。
+        三問：拿掉旗標 → 紅（CSS .lightbox-content .lightbox-cover.has-cover img 規則失效）。
         """
         html = SHOWCASE_HTML.read_text(encoding="utf-8")
         assert "'has-cover': !!currentLightboxVideo?.cover_url" in html, (
@@ -12905,16 +12735,22 @@ class TestUS9SearchGridMobileFix:
 
     # --- showcase 回歸護欄 ---
 
-    def test_showcase_t8_untouched(self):
-        """回歸護欄：T9 不動 showcase.css——showcase T8 block 仍在。
-        三問：T9 誤刪 showcase T8 container 規則 → 紅。
+    def test_showcase_modal_hug_untouched(self):
+        """回歸護欄：T9 不動 showcase.css——83b-T2 後 modal-hug 規則（.lightbox-content .lightbox-cover.has-cover img）仍在。
+        83b-T2：T8 block 已被 83b-T2 移除；modal-hug（gate 已移除）接管 width:100%。
+        三問：T9 誤刪 modal-hug img 規則 → 紅。
         """
         css = _SHOWCASE_CSS_T9.read_text(encoding="utf-8")
-        assert ".lightbox-cover.has-cover:has(.lb-full)" in css, (
-            "showcase.css T8 container 規則 .lightbox-cover.has-cover:has(.lb-full) 應保留（T9 不動 showcase.css）"
+        css_no_comments = re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
+        m = re.search(
+            r'\.lightbox-content\s+\.lightbox-cover\.has-cover\s+img\s*\{([^}]+)\}',
+            css_no_comments,
         )
-        assert "min-height: 0" in css, (
-            "showcase.css T8 min-height: 0 應保留（T9 回歸護欄）"
+        assert m, (
+            "showcase.css modal-hug img 規則應保留（83b-T2 接管 T8 的 width:100%，T9 不動 showcase.css）"
+        )
+        assert "width: 100%" in m.group(1), (
+            "showcase.css .lightbox-content .lightbox-cover.has-cover img block 缺 width: 100%（modal-hug 接管，T9 回歸護欄）"
         )
 
 
@@ -13209,52 +13045,6 @@ class TestMobileSimilarDrillFallbackGuard:
             f"當前函式體：\n{body[:400]}"
         )
 
-    def test_on_similar_mobile_card_click_has_videos_lookup(self):
-        """onSimilarMobileCardClick 函式體必須含 _videos 查找（tier 2 fallback）。
-        tier 2：被 filter 排除但仍在庫內的片用 _videos.findIndex 撈回完整 metadata。
-        """
-        js = self._similar_js()
-        body = self._extract_function_body(js, r'onSimilarMobileCardClick\s*\(')
-        assert body is not None, \
-            "state-similar.js 找不到 onSimilarMobileCardClick 函式宣告"
-        # 收緊：鎖 `_videos.findIndex` code-form，避免被註解中的 '_videos' vacuously 滿足
-        assert re.search(r'_videos\s*\.\s*findIndex', body), (
-            "onSimilarMobileCardClick 函式體未含 '_videos.findIndex' 查找。\n"
-            "tier 2 fallback（filter-subset 片）缺失，完整 metadata 撈不回，\n"
-            "被 filter 排除的片點擊後只能降級到 tier 3 snapshot 而非完整物件。\n"
-            f"當前函式體：\n{body[:400]}"
-        )
-
-    def test_on_similar_mobile_card_click_sets_similar_exit_video(self):
-        """onSimilarMobileCardClick 函式體必須含 similarExitVideo 指派（standalone 旗標）。
-        tier 2/3 fallback 路徑必須設置 similarExitVideo，確保 prev/next 禁用、close 不 fly-back。
-        """
-        js = self._similar_js()
-        body = self._extract_function_body(js, r'onSimilarMobileCardClick\s*\(')
-        assert body is not None, \
-            "state-similar.js 找不到 onSimilarMobileCardClick 函式宣告"
-        # 收緊：鎖 `similarExitVideo =` 賦值形，避免被註解中的字串 vacuously 滿足
-        assert re.search(r'similarExitVideo\s*=', body), (
-            "onSimilarMobileCardClick 函式體未含 'similarExitVideo =' 指派。\n"
-            "tier 2/3 standalone 旗標缺失：close 會飛回舊卡、prev/next 從舊 index 起跳（Codex P2a）。\n"
-            f"當前函式體：\n{body[:400]}"
-        )
-
-    def test_on_similar_mobile_card_click_calls_refresh_lb_full_blur_up(self):
-        """onSimilarMobileCardClick 函式體必須含 _refreshLbFullBlurUp 呼叫。
-        tier 2/3 路徑繞過 _setLightboxIndex，需手動觸發 blur-up reset + same-URL complete-check，
-        否則 overlay opacity:0 可能卡死。
-        """
-        js = self._similar_js()
-        body = self._extract_function_body(js, r'onSimilarMobileCardClick\s*\(')
-        assert body is not None, \
-            "state-similar.js 找不到 onSimilarMobileCardClick 函式宣告"
-        assert '_refreshLbFullBlurUp' in body, (
-            "onSimilarMobileCardClick 函式體未含 '_refreshLbFullBlurUp' 呼叫。\n"
-            "tier 2/3 slip-through 路徑缺 blur-up reset，.lb-full overlay opacity:0 可能卡死。\n"
-            f"當前函式體：\n{body[:400]}"
-        )
-
     def test_close_similar_mode_fallback_has_videos_tier(self):
         """closeSimilarMode 退場 fallback 必須與 onSimilarMobileCardClick 同採三層策略：
         _filteredVideos miss 後先查 _videos.findIndex（命中保完整 metadata + path），
@@ -13273,6 +13063,39 @@ class TestMobileSimilarDrillFallbackGuard:
         assert '_similarLastDrilledItem' in body, (
             "closeSimilarMode fallback 未保留 '_similarLastDrilledItem' snapshot（孤兒列 fallback）。\n"
             "_videos 也 miss（孤兒列 / demo）時需 snapshot 兜底，不可移除。"
+        )
+
+    def test_mobile_silent_switch_three_tier(self):
+        """_mobileSilentSwitch 函式體必須採 3-tier silent-switch（恢復退役的 onSimilarMobileCardClick 守衛之 contract）：
+        tier1 _silentSwitchLightboxByNumber（_filteredVideos 命中 → _setLightboxIndex）、
+        tier2 _videos.findIndex（庫內 standalone，setSimilarExitVideo）、
+        tier3 snapshot（_mobileLastDrilledItem 孤兒列 fallback）、
+        且 tier2/3 收尾呼叫 _refreshLbFullBlurUp（blur-up reset，否則 overlay opacity:0 卡死）。
+        """
+        js = self._similar_js()
+        # 錨定方法宣告（行首縮排 + 名稱，非 this._mobileSilentSwitch( 呼叫處）
+        body = self._extract_function_body(js, r'\n\s*_mobileSilentSwitch\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 _mobileSilentSwitch 函式宣告"
+        # tier 1: _filteredVideos 命中走 _silentSwitchLightboxByNumber
+        assert '_silentSwitchLightboxByNumber' in body, (
+            "_mobileSilentSwitch 缺 tier1 '_silentSwitchLightboxByNumber'（_filteredVideos 命中路徑）。"
+        )
+        # tier 2: _videos.findIndex 撈庫內被 filter 排除片的完整 metadata
+        assert re.search(r'_videos\s*\.\s*findIndex', body), (
+            "_mobileSilentSwitch 缺 tier2 '_videos.findIndex'（庫內 standalone metadata 撈回）。"
+        )
+        # tier 2/3 設 similarExitVideo standalone 旗標
+        assert re.search(r'similarExitVideo\s*=', body), (
+            "_mobileSilentSwitch 缺 'similarExitVideo =' 指派（tier2/3 standalone 旗標，close 不 fly-back / prev-next 禁用）。"
+        )
+        # tier 3: snapshot 兜底（孤兒列 / demo）
+        assert '_mobileLastDrilledItem' in body, (
+            "_mobileSilentSwitch 缺 '_mobileLastDrilledItem' snapshot（tier3 孤兒列 fallback）。"
+        )
+        # tier 2/3 收尾：blur-up reset
+        assert '_refreshLbFullBlurUp' in body, (
+            "_mobileSilentSwitch 缺 '_refreshLbFullBlurUp' 呼叫（tier2/3 blur-up reset，否則 overlay opacity:0 卡死）。"
         )
 
 
@@ -14171,12 +13994,20 @@ class TestPosterCropThresholdAlignment:
 
     # ---- CSS 燈箱封面貼合 ----
     def test_showcase_lightbox_fit_covers_899(self):
-        """showcase.css 燈箱封面貼合（.lightbox-cover:has(.lb-full)）@media == max-width: 899px。"""
+        """showcase.css 燈箱封面貼合：83b-T2 後由 modal-hug 規則（.lightbox-content .lightbox-cover.has-cover img）
+        無條件提供 width:100%（不再依賴 @media max-width:899px T8 block）。
+        守衛改為確認 modal-hug img 規則存在且含 width:100%。
+        """
         css = T11_SHOWCASE_CSS.read_text(encoding="utf-8")
-        mw = self._css_media_max_width_for_selector(
-            css, ".lightbox-cover:has(.lb-full)", "showcase.css 燈箱貼合"
+        # 83b-T2 移除 T8 block，modal-hug 接管（無 @media gate）
+        assert ".lightbox-content .lightbox-cover.has-cover img" in css, (
+            "showcase.css modal-hug img 規則缺失（83b-T2 後應由此規則提供 width:100%）"
         )
-        assert mw == 899, f"showcase.css 燈箱貼合 @media max-width={mw}px，應為 899"
+        # 確認 img 規則內含 width:100%（strip comments 後查）
+        css_no_comments = re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
+        m = re.search(r'\.lightbox-content\s+\.lightbox-cover\.has-cover\s+img\s*\{([^}]+)\}', css_no_comments)
+        assert m, "showcase.css modal-hug img block 找不到"
+        assert "width: 100%" in m.group(1), "modal-hug img block 缺 width: 100%"
 
     def test_search_lightbox_fit_covers_899(self):
         """search.css 燈箱封面貼合（.search-container .lightbox-cover.has-cover）@media == max-width: 899px。"""
@@ -14201,10 +14032,11 @@ class TestPosterCropThresholdAlignment:
 
     # ---- 核心：跨 6 值單一對齊斷言 ----
     def test_all_thresholds_aligned_899(self):
-        """核心對齊守衛：2 JS 門檻 + 2 CSS 燈箱貼合 + 2 CSS poster grid 全部相等且 == 899。
+        """核心對齊守衛：2 JS 門檻 + search CSS 燈箱貼合 + 2 CSS poster grid 全部相等且 == 899。
 
-        鎖「posterCrop 門檻 == 燈箱貼合斷點 == poster grid 斷點 == 899」三位一體；
-        未來改任一值不同步即整段紅。
+        83b-T2：showcase.css T8 block（@media max-width:899px .lightbox-cover:has(.lb-full)）已移除；
+        showcase 燈箱貼合改由 modal-hug 無條件提供。核心對齊守衛去掉 showcase-lightbox-fit 維度，
+        保留其他 5 值（2 JS + 1 search CSS lightbox-fit + 2 poster grid）。
         """
         showcase_css = T11_SHOWCASE_CSS.read_text(encoding="utf-8")
         search_css = T11_SEARCH_CSS.read_text(encoding="utf-8")
@@ -14214,9 +14046,6 @@ class TestPosterCropThresholdAlignment:
             ),
             "js:search": self._js_poster_crop_threshold(
                 T11_GRID_MODE_JS, "grid-mode.js"
-            ),
-            "css:showcase-lightbox-fit": self._css_media_max_width_for_selector(
-                showcase_css, ".lightbox-cover:has(.lb-full)", "showcase.css 燈箱貼合"
             ),
             "css:search-lightbox-fit": self._css_media_max_width_for_selector(
                 search_css, ".search-container .lightbox-cover.has-cover", "search.css 燈箱貼合"
@@ -14375,6 +14204,7 @@ class TestSettingsCloseActionSelect:
 class TestLightboxModalHugContract:
     """83a-T2: 固化 T1/T1fix1 modal-hug 契約（8 條純加法守衛）
 
+    83b-T2：:not(.similar-open) gate 已移除，選擇器改為無條件形式。
     #1 has-cover 含 aspect-ratio:var(--lb-cover-ar)
     #2 has-cover 含 flex-shrink:0（防 T1 letterbox 主因回歸）
     #3 has-cover 含 min-width:0 AND min-height:0
@@ -14394,23 +14224,25 @@ class TestLightboxModalHugContract:
         return SHOWCASE_LIGHTBOX_JS.read_text(encoding="utf-8")
 
     def _has_cover_block(self, css):
-        """擷取 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover { ... } 塊內容"""
+        """擷取 .lightbox-content .lightbox-cover.has-cover { ... } 塊內容
+        （83b-T2 後：:not(.similar-open) gate 移除）
+        """
         m = re.search(
-            r'\.lightbox-content:not\(\.similar-open\)\s+\.lightbox-cover\.has-cover\s*\{([^}]*)\}',
+            r'\.lightbox-content\s+\.lightbox-cover\.has-cover\s*\{([^}]*)\}',
             css, re.DOTALL
         )
         return m.group(1) if m else None
 
     def _has_cover_img_block(self, css):
         m = re.search(
-            r'\.lightbox-content:not\(\.similar-open\)\s+\.lightbox-cover\.has-cover\s+img\s*\{([^}]*)\}',
+            r'\.lightbox-content\s+\.lightbox-cover\.has-cover\s+img\s*\{([^}]*)\}',
             css, re.DOTALL
         )
         return m.group(1) if m else None
 
     def _has_cover_lb_full_block(self, css):
         m = re.search(
-            r'\.lightbox-content:not\(\.similar-open\)\s+\.lightbox-cover\.has-cover\s+\.lb-full\s*\{([^}]*)\}',
+            r'\.lightbox-content\s+\.lightbox-cover\.has-cover\s+\.lb-full\s*\{([^}]*)\}',
             css, re.DOTALL
         )
         return m.group(1) if m else None
@@ -14423,7 +14255,7 @@ class TestLightboxModalHugContract:
         """modal-hug 主規則含 aspect-ratio:var(--lb-cover-ar)（無此行盒不跟圖比例）"""
         block = self._has_cover_block(self._css())
         assert block is not None, (
-            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+            "showcase.css 找不到 .lightbox-content .lightbox-cover.has-cover 規則（83b-T2 後 gate 已移除）"
         )
         assert re.search(r'aspect-ratio\s*:\s*var\(--lb-cover-ar', block), (
             ".lightbox-cover.has-cover 缺少 aspect-ratio: var(--lb-cover-ar)（modal-hug 核心）"
@@ -14433,7 +14265,7 @@ class TestLightboxModalHugContract:
         """.lightbox-cover.has-cover 含 flex-shrink:0（T1 letterbox 主 bug 的修正守衛）"""
         block = self._has_cover_block(self._css())
         assert block is not None, (
-            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+            "showcase.css 找不到 .lightbox-content .lightbox-cover.has-cover 規則（83b-T2 後 gate 已移除）"
         )
         assert re.search(r'flex-shrink\s*:\s*0', block), (
             ".lightbox-cover.has-cover 缺少 flex-shrink:0（此為 T1 letterbox 主 bug 的修正守衛）"
@@ -14443,7 +14275,7 @@ class TestLightboxModalHugContract:
         """.lightbox-cover.has-cover 含 min-width:0 且 min-height:0（floor 歸零讓 AR 完整掌控尺寸）"""
         block = self._has_cover_block(self._css())
         assert block is not None, (
-            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+            "showcase.css 找不到 .lightbox-content .lightbox-cover.has-cover 規則（83b-T2 後 gate 已移除）"
         )
         assert re.search(r'min-width\s*:\s*0', block), ".lightbox-cover.has-cover 缺少 min-width:0"
         assert re.search(r'min-height\s*:\s*0', block), ".lightbox-cover.has-cover 缺少 min-height:0"
@@ -14452,7 +14284,7 @@ class TestLightboxModalHugContract:
         """width formula 含 90dvh 且整塊不含 100dvh/100vh（T1fix1 FHD 捲動修正）"""
         block = self._has_cover_block(self._css())
         assert block is not None, (
-            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+            "showcase.css 找不到 .lightbox-content .lightbox-cover.has-cover 規則（83b-T2 後 gate 已移除）"
         )
         assert '90dvh' in block, (
             ".lightbox-cover.has-cover width formula 缺少 90dvh（T1fix1 FHD 捲動修正）"
@@ -14468,7 +14300,7 @@ class TestLightboxModalHugContract:
         """.has-cover img 填滿盒（position:absolute + width/height:100%）"""
         block = self._has_cover_img_block(self._css())
         assert block is not None, (
-            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover img 規則"
+            "showcase.css 找不到 .lightbox-content .lightbox-cover.has-cover img 規則（83b-T2 後 gate 已移除）"
         )
         assert re.search(r'position\s*:\s*absolute', block), ".has-cover img 缺少 position:absolute"
         assert re.search(r'width\s*:\s*100%', block), ".has-cover img 缺少 width:100%"
@@ -14478,7 +14310,7 @@ class TestLightboxModalHugContract:
         """.has-cover .lb-full 填滿盒（width/height:100% + margin:0）"""
         block = self._has_cover_lb_full_block(self._css())
         assert block is not None, (
-            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover .lb-full 規則"
+            "showcase.css 找不到 .lightbox-content .lightbox-cover.has-cover .lb-full 規則（83b-T2 後 gate 已移除）"
         )
         assert re.search(r'width\s*:\s*100%', block), ".has-cover .lb-full 缺少 width:100%"
         assert re.search(r'height\s*:\s*100%', block), ".has-cover .lb-full 缺少 height:100%"
@@ -14784,4 +14616,329 @@ class TestSearchDetailCoverFixContract:
         assert re.search(r'overflow\s*:\s*visible', block), (
             "≤1024px .search-container .av-card-full-cover 缺少 overflow:visible"
             "（Bug A mobile：max-height:50vh+overflow:hidden 截 sample-strip 會回歸）"
+        )
+
+
+# ============================================================================
+# TASK-83b-T2: Mobile Similar Panel Contract Guards（13 條）
+# 鎖住 T1 建立的行動相似面板合約：CSS default-hidden、safety-net、scrim、burst-card、
+# JS drill-lock、no-desktop-close、picker-params、matchMedia、keydown intercept。
+# ============================================================================
+
+_T2_SHOWCASE_HTML = Path(__file__).parent.parent.parent / "web" / "templates" / "showcase.html"
+_T2_SHOWCASE_CSS = Path(__file__).parent.parent.parent / "web" / "static" / "css" / "pages" / "showcase.css"
+_T2_SIMILAR_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "pages" / "showcase" / "state-similar.js"
+)
+_T2_LIGHTBOX_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "pages" / "showcase" / "state-lightbox.js"
+)
+_T2_BASE_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "pages" / "showcase" / "state-base.js"
+)
+_T2_BURST_PICKER_JS = (
+    Path(__file__).parent.parent.parent
+    / "web" / "static" / "js" / "shared" / "burst-picker.js"
+)
+
+
+class TestMobileSimilarPanelContractGuard:
+    """TASK-83b-T2: 行動相似面板（.similar-mobile-panel）13 條合約守衛。
+
+    鎖住 T1 建立的 CSS / HTML / JS 合約，防回歸。
+    每條 guard 均 mutation-detectable：刪除對應實作即 RED。
+    """
+
+    @staticmethod
+    def _html():
+        return _T2_SHOWCASE_HTML.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _css():
+        return _T2_SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _similar_js():
+        return _T2_SIMILAR_JS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _lightbox_js():
+        return _T2_LIGHTBOX_JS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _base_js():
+        return _T2_BASE_JS.read_text(encoding="utf-8")
+
+    @staticmethod
+    def _extract_function_body(js, func_pattern):
+        """大括號平衡法擷取函式體。"""
+        m = re.search(func_pattern, js)
+        if not m:
+            return None
+        start = m.start()
+        body_start = js.index('{', start)
+        depth = 0
+        for i, ch in enumerate(js[body_start:], body_start):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return js[body_start:i + 1]
+        return None
+
+    # ── 1. CSS default-hidden + .show visible ──────────────────────────────
+
+    def test_mobile_panel_default_hidden(self):
+        """.similar-mobile-panel 存在於 HTML；CSS 含 default-hidden（opacity:0/visibility:hidden/
+        pointer-events:none）+ .show block（opacity:1/visibility:visible/pointer-events:auto）。"""
+        html = self._html()
+        assert 'class="similar-mobile-panel"' in html, \
+            "showcase.html 缺 .similar-mobile-panel div"
+        css = self._css()
+        # default-hidden block（strip CSS comment 後查，commented-out 行也應 RED）
+        m_panel = re.search(r'\.similar-mobile-panel\s*\{([^}]+)\}', css, re.DOTALL)
+        assert m_panel, "showcase.css 缺 .similar-mobile-panel default-hidden block"
+        block = re.sub(r'/\*.*?\*/', '', m_panel.group(1), flags=re.DOTALL)
+        assert "opacity: 0" in block, \
+            ".similar-mobile-panel block 缺 opacity: 0（FOUC 防護）"
+        assert "visibility: hidden" in block, \
+            ".similar-mobile-panel block 缺 visibility: hidden"
+        assert "pointer-events: none" in block, \
+            ".similar-mobile-panel block 缺 pointer-events: none"
+        # .show block
+        m_show = re.search(r'\.similar-mobile-panel\.show\s*\{([^}]+)\}', css, re.DOTALL)
+        assert m_show, "showcase.css 缺 .similar-mobile-panel.show block"
+        show_block = re.sub(r'/\*.*?\*/', '', m_show.group(1), flags=re.DOTALL)
+        assert "opacity: 1" in show_block, \
+            ".similar-mobile-panel.show 缺 opacity: 1"
+        assert "visibility: visible" in show_block, \
+            ".similar-mobile-panel.show 缺 visibility: visible"
+        assert "pointer-events: auto" in show_block, \
+            ".similar-mobile-panel.show 缺 pointer-events: auto"
+
+    # ── 2. Desktop safety net ───────────────────────────────────────────────
+
+    def test_mobile_panel_desktop_safety_net(self):
+        """showcase.css @media (min-width:960px) 內含 similar-mobile-panel + display:none（桌面安全網）。"""
+        css = self._css()
+        # 找含 similar-mobile-panel 的那個 @media (min-width:960px) block（可能有多個同斷點）
+        found = False
+        for m in re.finditer(r'@media\s*\(\s*min-width\s*:\s*960px\s*\)', css):
+            window = css[m.start():m.start() + 500]
+            if "similar-mobile-panel" in window and "display: none" in window:
+                found = True
+                break
+        assert found, (
+            "showcase.css 缺含 similar-mobile-panel + display:none 的 @media (min-width: 960px) block"
+            "（桌面安全網缺失，面板在桌面可能顯示）"
+        )
+
+    # ── 3. HTML x-trap ─────────────────────────────────────────────────────
+
+    def test_mobile_panel_has_x_trap(self):
+        """showcase.html .similar-mobile-panel block 含 x-trap.inert=\"similarModeMobileOpen\"。"""
+        html = self._html()
+        # 找 .similar-mobile-panel div 開始的 block
+        m = re.search(r'class="similar-mobile-panel"[^>]*>(.*?)</div>', html, re.DOTALL)
+        # 寬鬆：直接全文搜尋（similar-mobile-panel 唯一，不會誤中）
+        idx_panel = html.find('class="similar-mobile-panel"')
+        assert idx_panel != -1, "showcase.html 缺 similar-mobile-panel"
+        # x-trap 必須在 panel div 開啟標籤附近（同一 tag attribute）
+        panel_tag_end = html.index('>', idx_panel)
+        panel_opening_tag = html[idx_panel:panel_tag_end + 1]
+        assert 'x-trap.inert="similarModeMobileOpen"' in panel_opening_tag, \
+            "similar-mobile-panel div 開啟標籤缺 x-trap.inert=\"similarModeMobileOpen\""
+
+    # ── 4. Lightbox trap yields to mobile panel ─────────────────────────────
+
+    def test_mobile_panel_lightbox_trap_yields(self):
+        """showcase.html lightbox x-trap.inert 含 similarModeMobileOpen 條件（!similarModeMobileOpen）。
+        面板開時 trap 釋放給面板（防焦點被困在 lightbox）。
+        """
+        html = self._html()
+        # 錨定含 deleteVideoModalOpen 的那條（lightbox x-trap，T2 rewrite 後的錨點）
+        m = re.search(r'x-trap\.inert="([^"]*deleteVideoModalOpen[^"]*)"', html)
+        assert m, "showcase.html 缺含 deleteVideoModalOpen 的 x-trap.inert 行（lightbox trap）"
+        expr = m.group(1)
+        assert "similarModeMobileOpen" in expr, \
+            f"lightbox x-trap.inert 未含 similarModeMobileOpen: {expr!r}"
+        assert "!similarModeMobileOpen" in expr, \
+            f"lightbox x-trap.inert 缺 !similarModeMobileOpen（面板開時 trap 未釋放）: {expr!r}"
+
+    # ── 5. Burst card CSS ───────────────────────────────────────────────────
+
+    def test_mobile_burst_card_class_exists(self):
+        """.similar-mobile-burst-card block 存在；含 opacity:0、position:relative、transition:none。"""
+        css = self._css()
+        m = re.search(r'\.similar-mobile-burst-card\s*\{([^}]+)\}', css, re.DOTALL)
+        assert m, "showcase.css 缺 .similar-mobile-burst-card block（T1 burst card CSS 未被誤刪）"
+        block = re.sub(r'/\*.*?\*/', '', m.group(1), flags=re.DOTALL)
+        assert "opacity: 0" in block, \
+            ".similar-mobile-burst-card 缺 opacity: 0（GSAP-only，防 1-frame paint glitch）"
+        assert "position: relative" in block, \
+            ".similar-mobile-burst-card 缺 position: relative"
+        assert "transition: none" in block, \
+            ".similar-mobile-burst-card 缺 transition: none（GSAP-only）"
+
+    def test_mobile_burst_card_img_poster_crop(self):
+        """.similar-mobile-burst-card img block 含 aspect-ratio:var(--poster-crop-ratio)（單一真理、禁硬編碼）
+        + object-position:right center（右半裁切）。
+        恢復退役的 test_similar_mobile_card_img_has_poster_crop_ratio / _no_hardcoded_4_5 之 contract。
+        """
+        css = self._css()
+        m = re.search(r'\.similar-mobile-burst-card\s+img\s*\{([^}]+)\}', css, re.DOTALL)
+        assert m, "showcase.css 缺 .similar-mobile-burst-card img block"
+        block = re.sub(r'/\*.*?\*/', '', m.group(1), flags=re.DOTALL)
+        assert "aspect-ratio: var(--poster-crop-ratio)" in block, (
+            ".similar-mobile-burst-card img 缺 aspect-ratio: var(--poster-crop-ratio)（單一真理，禁硬編碼比例）"
+        )
+        assert "4/5" not in block, \
+            ".similar-mobile-burst-card img 不得含硬編碼 4/5（應用 var(--poster-crop-ratio)）"
+        assert "object-position: right center" in block, (
+            ".similar-mobile-burst-card img 缺 object-position: right center（右半裁切）"
+        )
+
+    # ── 6. Scrim blur token ─────────────────────────────────────────────────
+
+    def test_mobile_panel_scrim_blur_token(self):
+        """.similar-mobile-scrim 含 var(--fluent-blur)（不硬編碼 px）且含 -webkit-backdrop-filter。"""
+        css = self._css()
+        m = re.search(r'\.similar-mobile-scrim\s*\{([^}]+)\}', css, re.DOTALL)
+        assert m, "showcase.css 缺 .similar-mobile-scrim block"
+        block = m.group(1)
+        assert "var(--fluent-blur)" in block, \
+            ".similar-mobile-scrim backdrop-filter 必須用 var(--fluent-blur)（禁硬編碼 px）"
+        assert "-webkit-backdrop-filter" in block, \
+            ".similar-mobile-scrim 缺 -webkit-backdrop-filter（Safari fallback）"
+
+    # ── 7. Drill lock before await ──────────────────────────────────────────
+
+    def test_mobile_drill_lock_before_await(self):
+        """onMobileDrillClick 函式體在首個 await keyword 之前有 similarModeAnimating = true（lock-before-await）。"""
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'async\s+onMobileDrillClick\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 onMobileDrillClick 函式宣告"
+        # 去掉 // 單行 comment 和 /* */ 多行 comment，避免 "lock-before-await" 誤中
+        body_no_comments = re.sub(r'//[^\n]*', '', body)
+        body_no_comments = re.sub(r'/\*.*?\*/', '', body_no_comments, flags=re.DOTALL)
+        # 找首個 await 作為 JS 關鍵字（空白/符號前置，非 -await 形式）
+        m_await = re.search(r'(?<![A-Za-z0-9_$-])\bawait\b', body_no_comments)
+        assert m_await is not None, "onMobileDrillClick 函式體找不到 await keyword（非 async 路徑？）"
+        pre_await = body_no_comments[:m_await.start()]
+        assert "similarModeAnimating = true" in pre_await, (
+            "onMobileDrillClick 在首個 await keyword 之前缺 similarModeAnimating = true（lock-before-await 缺失，"
+            "連點空窗導致並發進入）"
+        )
+
+    # ── 8. closeMobilePanel does NOT call closeSimilarMode ──────────────────
+
+    def test_mobile_panel_no_call_desktop_closeSimilarMode(self):
+        """state-similar.js closeMobilePanel 函式體不含 closeSimilarMode() 呼叫（CD-4 / R3 防凍結）。
+        注：去掉 comment 後檢查（comment 中提及 closeSimilarMode 做對比說明是合法的）。
+        """
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'closeMobilePanel\s*\(\s*\)\s*\{')
+        assert body is not None, \
+            "state-similar.js 找不到 closeMobilePanel 函式宣告"
+        # 去掉 comment，避免說明性文字（如 mirror closeSimilarMode）誤觸
+        body_no_comments = re.sub(r'//[^\n]*', '', body)
+        body_no_comments = re.sub(r'/\*.*?\*/', '', body_no_comments, flags=re.DOTALL)
+        assert "closeSimilarMode" not in body_no_comments, (
+            "closeMobilePanel 函式體含 closeSimilarMode() 呼叫（非 comment）！"
+            "CD-4/R3：桌面 close 在 similarCards={} 時 await playExit 永不 resolve → 凍結"
+        )
+
+    # ── 9. Burst card count = 6 ─────────────────────────────────────────────
+
+    def test_mobile_burst_card_count_6(self):
+        """state-similar.js _openMobilePanel 函式體含 slice(0, 6)（CD-6 固定 6 張）。"""
+        js = self._similar_js()
+        body = self._extract_function_body(js, r'async\s+_openMobilePanel\s*\(')
+        assert body is not None, \
+            "state-similar.js 找不到 _openMobilePanel 函式宣告"
+        assert "slice(0, 6)" in body, (
+            "_openMobilePanel 函式體缺 slice(0, 6)（CD-6：行動面板固定 6 張，不多不少）"
+        )
+
+    # ── 10. Uses own picker params ───────────────────────────────────────────
+
+    def test_mobile_uses_own_picker_params(self):
+        """state-similar.js 含 _MOBILE_PICKER_PARAMS local const 定義；
+        且程式碼（非 comment）中不含裸 _PICKER_PARAMS 字串（不直接引用 state-lightbox 的 private const）。
+        """
+        js = self._similar_js()
+        assert "_MOBILE_PICKER_PARAMS" in js, \
+            "state-similar.js 缺 _MOBILE_PICKER_PARAMS（行動面板專屬 picker params 未定義）"
+        # const 定義（不只是字串使用）
+        assert re.search(r'const\s+_MOBILE_PICKER_PARAMS', js), \
+            "state-similar.js 缺 const _MOBILE_PICKER_PARAMS 定義"
+        # 去掉 comment，再去掉 _MOBILE_PICKER_PARAMS，剩下若有 _PICKER_PARAMS 即裸引用
+        js_no_comments = re.sub(r'//[^\n]*', '', js)
+        js_no_comments = re.sub(r'/\*.*?\*/', '', js_no_comments, flags=re.DOTALL)
+        js_stripped = js_no_comments.replace("_MOBILE_PICKER_PARAMS", "")
+        assert "_PICKER_PARAMS" not in js_stripped, (
+            "state-similar.js 程式碼（非 comment）含裸 _PICKER_PARAMS 引用（state-lightbox private const，"
+            "直接引用在 stateSimilar 作用域會 ReferenceError）"
+        )
+
+    # ── 11. matchMedia 960 reset ─────────────────────────────────────────────
+
+    def test_mobile_panel_matchmedia_960(self):
+        """state-base.js 含 matchMedia + 960 + similarModeMobileOpen + closeMobilePanel（D12 reset）。"""
+        js = self._base_js()
+        assert "matchMedia" in js, "state-base.js 缺 matchMedia（D12 breakpoint reset 未實作）"
+        assert "960" in js, "state-base.js 缺 960（matchMedia 960px breakpoint）"
+        assert "similarModeMobileOpen" in js, \
+            "state-base.js 缺 similarModeMobileOpen（D12 reset 條件缺失）"
+        assert "closeMobilePanel" in js, \
+            "state-base.js 缺 closeMobilePanel 呼叫（D12 reset 動作缺失）"
+
+    # ── 12. burst-picker back.out exists, no 1.7 pinned ─────────────────────
+
+    def test_burst_picker_back_out_exists_no_1_7_pinned(self):
+        """burst-picker.js 含 back.out；且 guard 自身不 pin 具體 1.7 值（CD-11：doc/code drift）。"""
+        js = _T2_BURST_PICKER_JS.read_text(encoding="utf-8")
+        assert "back.out" in js, \
+            "burst-picker.js 缺 back.out（爆射 overshoot ease 未使用）"
+        # guard 自身不 assert 1.7（CD-11：不把 1.7 寫進守衛，避免文件/code drift）
+        # 只守 back.out 存在；具體值由 arcOvershoot param 決定，不硬鎖
+        # 反向：確保 burst-picker.js 仍用動態 arcOvershoot（非硬編碼 1.7 字串）
+        assert "arcOvershoot" in js, \
+            "burst-picker.js 缺 arcOvershoot param（back.out 值應來自 param，非硬編碼）"
+
+    # ── 13. Keydown intercept ────────────────────────────────────────────────
+
+    def test_mobile_panel_keydown_intercept(self):
+        """state-lightbox.js handleKeydown 函式體含 similarModeMobileOpen 條件分支 + closeMobilePanel。
+        且 similarModeMobileOpen guard block 不含 closeLightbox / prevLightboxVideo / nextLightboxVideo
+        （CD-7/D10：Esc 不關 lightbox，箭頭不切片）。
+        """
+        js = self._lightbox_js()
+        body = self._extract_function_body(js, r'handleKeydown\s*\(')
+        assert body is not None, \
+            "state-lightbox.js 找不到 handleKeydown 函式宣告"
+        assert "similarModeMobileOpen" in body, \
+            "handleKeydown 函式體缺 similarModeMobileOpen 條件（面板開時未攔截鍵盤）"
+        assert "closeMobilePanel" in body, \
+            "handleKeydown 函式體缺 closeMobilePanel 呼叫（Esc 未關行動面板）"
+        # 找 similarModeMobileOpen guard block，確認 block 不含 closeLightbox/prev/next
+        m = re.search(
+            r'if\s*\(\s*this\.similarModeMobileOpen\s*\)\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}',
+            body, re.DOTALL
+        )
+        assert m, "handleKeydown 缺 if (this.similarModeMobileOpen) { ... } block"
+        guard_block = m.group(1)
+        assert "closeLightbox" not in guard_block, (
+            "handleKeydown similarModeMobileOpen block 含 closeLightbox()（Esc 不得關 lightbox，CD-7）"
+        )
+        assert "prevLightboxVideo" not in guard_block, (
+            "handleKeydown similarModeMobileOpen block 含 prevLightboxVideo（箭頭不得切片，D10）"
+        )
+        assert "nextLightboxVideo" not in guard_block, (
+            "handleKeydown similarModeMobileOpen block 含 nextLightboxVideo（箭頭不得切片，D10）"
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -14360,3 +14360,139 @@ class TestSettingsCloseActionSelect:
                 f"settings.system.{key} value mismatch: "
                 f"expected {value!r}, got {system[key]!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# feature/83a T2: Lightbox modal-hug contract guards (8 guards, pure additive)
+# ---------------------------------------------------------------------------
+
+class TestLightboxModalHugContract:
+    """83a-T2: 固化 T1/T1fix1 modal-hug 契約（8 條純加法守衛）
+
+    #1 has-cover 含 aspect-ratio:var(--lb-cover-ar)
+    #2 has-cover 含 flex-shrink:0（防 T1 letterbox 主因回歸）
+    #3 has-cover 含 min-width:0 AND min-height:0
+    #4 width formula 含 90dvh 且整塊不含 100dvh/100vh（T1fix1 FHD 捲動修正）
+    #5 has-cover img 填滿盒（position:absolute + width/height:100%）
+    #6 has-cover .lb-full 填滿盒（width/height:100% + margin:0）
+    #7 .lightbox-metadata 不含 max-width:600px
+    #8 state-lightbox.js _setCoverAspect + closest + setProperty 三元素存在
+    """
+
+    def _css(self):
+        # Reuse module-level constant declared at line 3474
+        return SHOWCASE_CSS.read_text(encoding="utf-8")
+
+    def _js(self):
+        # Reuse module-level constant declared at line 91
+        return SHOWCASE_LIGHTBOX_JS.read_text(encoding="utf-8")
+
+    def _has_cover_block(self, css):
+        """擷取 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover { ... } 塊內容"""
+        m = re.search(
+            r'\.lightbox-content:not\(\.similar-open\)\s+\.lightbox-cover\.has-cover\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def _has_cover_img_block(self, css):
+        m = re.search(
+            r'\.lightbox-content:not\(\.similar-open\)\s+\.lightbox-cover\.has-cover\s+img\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def _has_cover_lb_full_block(self, css):
+        m = re.search(
+            r'\.lightbox-content:not\(\.similar-open\)\s+\.lightbox-cover\.has-cover\s+\.lb-full\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def _metadata_block(self, css):
+        m = re.search(r'\.lightbox-metadata\s*\{([^}]*)\}', css, re.DOTALL)
+        return m.group(1) if m else None
+
+    def test_has_cover_aspect_ratio_set(self):
+        """modal-hug 主規則含 aspect-ratio:var(--lb-cover-ar)（無此行盒不跟圖比例）"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+        )
+        assert re.search(r'aspect-ratio\s*:\s*var\(--lb-cover-ar', block), (
+            ".lightbox-cover.has-cover 缺少 aspect-ratio: var(--lb-cover-ar)（modal-hug 核心）"
+        )
+
+    def test_has_cover_flex_shrink_zero(self):
+        """.lightbox-cover.has-cover 含 flex-shrink:0（T1 letterbox 主 bug 的修正守衛）"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+        )
+        assert re.search(r'flex-shrink\s*:\s*0', block), (
+            ".lightbox-cover.has-cover 缺少 flex-shrink:0（此為 T1 letterbox 主 bug 的修正守衛）"
+        )
+
+    def test_has_cover_floor_zeroed(self):
+        """.lightbox-cover.has-cover 含 min-width:0 且 min-height:0（floor 歸零讓 AR 完整掌控尺寸）"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+        )
+        assert re.search(r'min-width\s*:\s*0', block), ".lightbox-cover.has-cover 缺少 min-width:0"
+        assert re.search(r'min-height\s*:\s*0', block), ".lightbox-cover.has-cover 缺少 min-height:0"
+
+    def test_has_cover_width_formula_uses_90dvh(self):
+        """width formula 含 90dvh 且整塊不含 100dvh/100vh（T1fix1 FHD 捲動修正）"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover 規則"
+        )
+        assert '90dvh' in block, (
+            ".lightbox-cover.has-cover width formula 缺少 90dvh（T1fix1 FHD 捲動修正）"
+        )
+        assert '100dvh' not in block, (
+            ".lightbox-cover.has-cover 含 100dvh，應為 90dvh（T1fix1 FHD 捲動修正）"
+        )
+        assert '100vh' not in block, (
+            ".lightbox-cover.has-cover 含 100vh，應為 90vh/90dvh"
+        )
+
+    def test_has_cover_img_fills_box(self):
+        """.has-cover img 填滿盒（position:absolute + width/height:100%）"""
+        block = self._has_cover_img_block(self._css())
+        assert block is not None, (
+            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover img 規則"
+        )
+        assert re.search(r'position\s*:\s*absolute', block), ".has-cover img 缺少 position:absolute"
+        assert re.search(r'width\s*:\s*100%', block), ".has-cover img 缺少 width:100%"
+        assert re.search(r'height\s*:\s*100%', block), ".has-cover img 缺少 height:100%"
+
+    def test_has_cover_lb_full_fills_box(self):
+        """.has-cover .lb-full 填滿盒（width/height:100% + margin:0）"""
+        block = self._has_cover_lb_full_block(self._css())
+        assert block is not None, (
+            "showcase.css 找不到 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover .lb-full 規則"
+        )
+        assert re.search(r'width\s*:\s*100%', block), ".has-cover .lb-full 缺少 width:100%"
+        assert re.search(r'height\s*:\s*100%', block), ".has-cover .lb-full 缺少 height:100%"
+        assert re.search(r'margin\s*:\s*0', block), ".has-cover .lb-full 缺少 margin:0"
+
+    def test_metadata_no_max_width_600(self):
+        """.lightbox-metadata 不含 max-width:600px（T1 M4 已移除，勿復原）"""
+        block = self._metadata_block(self._css())
+        assert block is not None, "showcase.css 找不到 .lightbox-metadata 規則"
+        assert not re.search(r'max-width\s*:\s*600px', block), (
+            ".lightbox-metadata 含 max-width:600px（T1 M4 已移除，勿復原）"
+        )
+
+    def test_set_cover_aspect_js_contract(self):
+        """state-lightbox.js 含 _setCoverAspect + closest('.lightbox-cover') + setProperty('--lb-cover-ar') 三元素"""
+        js = self._js()
+        assert '_setCoverAspect' in js, "state-lightbox.js 缺少 _setCoverAspect 函數"
+        assert "closest('.lightbox-cover')" in js, (
+            "state-lightbox.js 缺少 closest('.lightbox-cover') 呼叫"
+        )
+        assert "setProperty('--lb-cover-ar'" in js, (
+            "state-lightbox.js 缺少 setProperty('--lb-cover-ar') 呼叫"
+        )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5412,8 +5412,9 @@ class TestSearchCssHardcoded:
         # T9-port 在 L718 後插入 blocks：840→902；T9 Codex-P2 fix 補註解 +4 行：902→906。
         # T11：在 L753 後插入 hero 規則（~14 行）：906→920。
         # T10（US-10）：poster-crop / coarse block 註解 +4 行（481–899 擴斷點）：920→924。
+        # 83a-T3：在 L789 插入 modal-hug block（~21 行）：924→945。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        924: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        945: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
@@ -14495,4 +14496,129 @@ class TestLightboxModalHugContract:
         )
         assert "setProperty('--lb-cover-ar'" in js, (
             "state-lightbox.js 缺少 setProperty('--lb-cover-ar') 呼叫"
+        )
+
+
+class TestSearchLightboxModalHugContract:
+    """83a-T3: 固化 search 頁 lightbox modal-hug 契約（7 條純加法守衛）
+
+    #S1 search.css .search-container .lightbox-cover.has-cover 含 aspect-ratio:var(--lb-cover-ar)
+    #S2 search.css .search-container .lightbox-cover.has-cover 含 flex-shrink:0
+    #S3 search.css .search-container .lightbox-cover.has-cover 含 min-width:0 AND min-height:0
+    #S4 search.css .search-container .lightbox-cover.has-cover 含 90dvh（且不含 100dvh/100vh）
+    #S5 search.css .search-container .lightbox-cover.has-cover img 含 position:absolute + width/height:100%
+    #S6 search.html lightbox img 含 @load="_setCoverAspect($event)"
+    #S7 grid-mode.js 含 _setCoverAspect + closest('.lightbox-cover') + setProperty('--lb-cover-ar')
+    """
+
+    GRID_MODE_JS = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "pages" / "search" / "state" / "grid-mode.js"
+    SEARCH_HTML = Path(__file__).parent.parent.parent / "web" / "templates" / "search.html"
+
+    def _css(self):
+        return SEARCH_CSS.read_text(encoding="utf-8")
+
+    def _js(self):
+        return self.GRID_MODE_JS.read_text(encoding="utf-8")
+
+    def _html(self):
+        return self.SEARCH_HTML.read_text(encoding="utf-8")
+
+    def _has_cover_block(self, css):
+        """擷取 .search-container .lightbox-cover.has-cover { ... } 塊內容"""
+        m = re.search(
+            r'\.search-container\s+\.lightbox-cover\.has-cover\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def _has_cover_img_block(self, css):
+        m = re.search(
+            r'\.search-container\s+\.lightbox-cover\.has-cover\s+img\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def test_s1_has_cover_aspect_ratio(self):
+        """#S1 .search-container .lightbox-cover.has-cover 含 aspect-ratio:var(--lb-cover-ar)"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "search.css 找不到 .search-container .lightbox-cover.has-cover 規則"
+        )
+        assert re.search(r'aspect-ratio\s*:\s*var\(--lb-cover-ar', block), (
+            ".search-container .lightbox-cover.has-cover 缺少 aspect-ratio: var(--lb-cover-ar)（modal-hug 核心）"
+        )
+
+    def test_s2_has_cover_flex_shrink_zero(self):
+        """#S2 .search-container .lightbox-cover.has-cover 含 flex-shrink:0"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "search.css 找不到 .search-container .lightbox-cover.has-cover 規則"
+        )
+        assert re.search(r'flex-shrink\s*:\s*0', block), (
+            ".search-container .lightbox-cover.has-cover 缺少 flex-shrink:0"
+        )
+
+    def test_s3_has_cover_floor_zeroed(self):
+        """#S3 .search-container .lightbox-cover.has-cover 含 min-width:0 AND min-height:0"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "search.css 找不到 .search-container .lightbox-cover.has-cover 規則"
+        )
+        assert re.search(r'min-width\s*:\s*0', block), (
+            ".search-container .lightbox-cover.has-cover 缺少 min-width:0"
+        )
+        assert re.search(r'min-height\s*:\s*0', block), (
+            ".search-container .lightbox-cover.has-cover 缺少 min-height:0"
+        )
+
+    def test_s4_has_cover_width_formula_uses_90dvh(self):
+        """#S4 width formula 含 90dvh 且不含 100dvh/100vh"""
+        block = self._has_cover_block(self._css())
+        assert block is not None, (
+            "search.css 找不到 .search-container .lightbox-cover.has-cover 規則"
+        )
+        assert '90dvh' in block, (
+            ".search-container .lightbox-cover.has-cover width formula 缺少 90dvh"
+        )
+        assert '100dvh' not in block, (
+            ".search-container .lightbox-cover.has-cover 含 100dvh，應為 90dvh"
+        )
+        assert '100vh' not in block, (
+            ".search-container .lightbox-cover.has-cover 含 100vh，應為 90vh/90dvh"
+        )
+
+    def test_s5_has_cover_img_fills_box(self):
+        """#S5 .search-container .lightbox-cover.has-cover img 含 position:absolute + width/height:100%"""
+        block = self._has_cover_img_block(self._css())
+        assert block is not None, (
+            "search.css 找不到 .search-container .lightbox-cover.has-cover img 規則"
+        )
+        assert re.search(r'position\s*:\s*absolute', block), (
+            ".search-container .lightbox-cover.has-cover img 缺少 position:absolute"
+        )
+        assert re.search(r'width\s*:\s*100%', block), (
+            ".search-container .lightbox-cover.has-cover img 缺少 width:100%"
+        )
+        assert re.search(r'height\s*:\s*100%', block), (
+            ".search-container .lightbox-cover.has-cover img 缺少 height:100%"
+        )
+
+    def test_s6_search_html_load_handler(self):
+        """#S6 search.html lightbox img 含 @load="_setCoverAspect($event)" """
+        html = self._html()
+        assert '@load="_setCoverAspect($event)"' in html, (
+            "search.html lightbox img 缺少 @load=\"_setCoverAspect($event)\"（83a-T3 移植守衛）"
+        )
+
+    def test_s7_grid_mode_js_set_cover_aspect(self):
+        """#S7 grid-mode.js 含 _setCoverAspect + closest('.lightbox-cover') + setProperty('--lb-cover-ar')"""
+        js = self._js()
+        assert '_setCoverAspect' in js, (
+            "grid-mode.js 缺少 _setCoverAspect 函式（83a-T3 移植守衛）"
+        )
+        assert "closest('.lightbox-cover')" in js, (
+            "grid-mode.js 缺少 closest('.lightbox-cover') 呼叫"
+        )
+        assert "setProperty('--lb-cover-ar'" in js, (
+            "grid-mode.js 缺少 setProperty('--lb-cover-ar') 呼叫"
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5414,15 +5414,19 @@ class TestSearchCssHardcoded:
         # T10（US-10）：poster-crop / coarse block 註解 +4 行（481–899 擴斷點）：920→924。
         # 83a-T3：在 L789 插入 modal-hug block（~21 行）：924→945。
         # 83a-T3-fix P1：在 L810（T9-port 前）插入 lightbox overflow block（~12 行）：945→957。
+        # 83a2-T4：在 L102（detail cover scope 區）插入 ~22 行 + mobile block 插入 ~5 行（皆在 957 上方）：957→984。
+        # 83a2-T4 Codex P2 fix：loading-placeholder fallback 併入（comment+第二 selector）+4 行：984→988。
         90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        957: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        988: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
         # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：235→282、524→576、579→631（皆在插入點下方）。
-        282: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
-        576: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
-        631: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
+        # 83a2-T4：detail cover scope +22 行（L102 上方）+ mobile block +5 行（L519 上方）後順移：282→304、576→603、631→658。
+        # 83a2-T4 Codex P2 fix：loading-placeholder fallback +4 行後順移：304→308、603→607、658→662。
+        308: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
+        607: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
+        662: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
     }
 
     def _scan(self, regex: str, allowlist=None):
@@ -14650,4 +14654,134 @@ class TestSearchLightboxModalHugContract:
         )
         assert re.search(r'overflow-y\s*:\s*hidden', block), (
             ".search-container .lightbox-content 缺少 overflow-y:hidden（P1 fix：modal 整體不捲）"
+        )
+
+
+# feature/83a2 T4: Search detail cover fix contract guards (pure additive)
+# 鎖 search detail 封面欄留白 + 劇照截斷修正（Bug A/B）的跨檔 CSS 覆寫契約。
+class TestSearchDetailCoverFixContract:
+    """83a2-T4: 固化 search detail 封面欄修正契約（純加法守衛）
+
+    #D1 .search-container .av-card-full-cover 含 min-height:0（清 theme.css 200px 地板）
+    #D2 .search-container .av-card-full-cover-wrapper 含 min-height:0（清 search.css 400px 地板）
+    #D3 .search-container .av-card-full-cover-img 含 height:auto（不依賴父容器死高）
+    #D4 :has(.cover-error-placeholder...) min-height fallback 存在（無圖時 placeholder 不塌）
+    #D5 @media ≤1024px .search-container .av-card-full-cover 含 overflow:visible（mobile 不截 sample-strip）
+    """
+
+    def _css(self):
+        # 去 /* ... */ 註解：本 task 的說明註解刻意提到 override 值（min-height:0 等），
+        # 不剝除會讓守衛比對到註解文字而非真宣告（false-positive，mutation 抓不到）。
+        raw = SEARCH_CSS.read_text(encoding="utf-8")
+        return re.sub(r'/\*.*?\*/', '', raw, flags=re.DOTALL)
+
+    def _block(self, css, selector_regex):
+        """擷取首個 `selector { ... }` 塊內容（非貪婪到第一個 }）"""
+        m = re.search(selector_regex + r'\s*\{([^}]*)\}', css, re.DOTALL)
+        return m.group(1) if m else None
+
+    def test_d1_cover_min_height_zero(self):
+        """#D1 .search-container .av-card-full-cover 含 min-height:0（覆寫 theme.css min-height:200px）"""
+        block = self._block(
+            self._css(),
+            r'\.search-container\s+\.av-card-full-cover(?![-\w])'
+        )
+        assert block is not None, (
+            "search.css 找不到 .search-container .av-card-full-cover 規則"
+        )
+        assert re.search(r'min-height\s*:\s*0', block), (
+            ".search-container .av-card-full-cover 缺少 min-height:0（Bug B 留白會回歸）"
+        )
+
+    def test_d2_wrapper_min_height_zero(self):
+        """#D2 .search-container .av-card-full-cover-wrapper 含 min-height:0（覆寫 400px 主地板）"""
+        block = self._block(
+            self._css(),
+            r'\.search-container\s+\.av-card-full-cover-wrapper(?![-\w])'
+        )
+        assert block is not None, (
+            "search.css 找不到 .search-container .av-card-full-cover-wrapper 規則"
+        )
+        assert re.search(r'min-height\s*:\s*0', block), (
+            ".search-container .av-card-full-cover-wrapper 缺少 min-height:0（Bug B 主地板未清）"
+        )
+
+    def test_d3_cover_img_height_auto(self):
+        """#D3 .search-container .av-card-full-cover-img 含 height:auto（圖高由 AR 自然推導）"""
+        block = self._block(
+            self._css(),
+            r'\.search-container\s+\.av-card-full-cover-img(?![-\w])'
+        )
+        assert block is not None, (
+            "search.css 找不到 .search-container .av-card-full-cover-img 規則"
+        )
+        assert re.search(r'height\s*:\s*auto', block), (
+            ".search-container .av-card-full-cover-img 缺少 height:auto（仍靠父容器死高 → 留白）"
+        )
+
+    def test_d4_error_placeholder_min_height_fallback(self):
+        """#D4 :has(.cover-error-placeholder:not([style*=display:none])) min-height fallback 存在"""
+        css = self._css()
+        # 找 :has(.cover-error-placeholder...) 規則塊
+        # 用 [^{]* 而非 [^)]*：selector 含 :not(...) 巢狀括號，不能在第一個 ) 停
+        m = re.search(
+            r'\.search-container\s+\.av-card-full-cover-wrapper:has\([^{]*cover-error-placeholder[^{]*\)\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        assert m is not None, (
+            "search.css 找不到 wrapper:has(.cover-error-placeholder) fallback 規則"
+            "（min-height:0 後無圖時 placeholder 會塌掉不可見）"
+        )
+        block = m.group(1)
+        # 必須非零（min-height:0 等於沒 fallback，placeholder 仍塌）
+        assert re.search(r'min-height\s*:\s*[1-9]\d*', block), (
+            "error-placeholder fallback 規則缺少非零 min-height（placeholder 仍會塌）"
+        )
+
+    def test_d4b_loading_placeholder_min_height_fallback(self):
+        """#D4b :has(.cover-loading-placeholder:not([style*=display:none])) min-height fallback 存在
+
+        83a2-T4 Codex P2：封面載入中（_coverLoaded=false，慢速/未快取）走 .cover-loading-placeholder
+        shimmer 路徑，img height:auto 尚無 intrinsic size + shimmer position:absolute → wrapper 塌 0，
+        shimmer 與 nav-indicator 一起閃失。D4（error-placeholder）抓不到此單邊回歸，須獨立守衛。
+        """
+        css = self._css()
+        m = re.search(
+            r'\.search-container\s+\.av-card-full-cover-wrapper:has\([^{]*cover-loading-placeholder[^{]*\)\s*\{([^}]*)\}',
+            css, re.DOTALL
+        )
+        assert m is not None, (
+            "search.css 找不到 wrapper:has(.cover-loading-placeholder) fallback 規則"
+            "（83a2-T4 Codex P2：載入期 shimmer 塌 0 高、nav-indicator 閃失）"
+        )
+        block = m.group(1)
+        assert re.search(r'min-height\s*:\s*[1-9]\d*', block), (
+            "loading-placeholder fallback 規則缺少非零 min-height（shimmer 仍會塌）"
+        )
+
+    def test_d5_mobile_cover_overflow_visible(self):
+        """#D5 @media ≤1024px .search-container .av-card-full-cover 含 overflow:visible"""
+        css = self._css()
+        # 擷取 @media (max-width:1024px) { ... } 整段（巢狀 brace，用平衡掃描）
+        start = re.search(r'@media\s*\(\s*max-width\s*:\s*1024px\s*\)\s*\{', css)
+        assert start is not None, "search.css 找不到 @media (max-width:1024px) 區塊"
+        i = start.end()
+        depth = 1
+        while i < len(css) and depth > 0:
+            if css[i] == '{':
+                depth += 1
+            elif css[i] == '}':
+                depth -= 1
+            i += 1
+        media_body = css[start.end():i - 1]
+        block = self._block(
+            media_body,
+            r'\.search-container\s+\.av-card-full-cover(?![-\w])'
+        )
+        assert block is not None, (
+            "≤1024px media 內找不到 .search-container .av-card-full-cover 規則"
+        )
+        assert re.search(r'overflow\s*:\s*visible', block), (
+            "≤1024px .search-container .av-card-full-cover 缺少 overflow:visible"
+            "（Bug A mobile：max-height:50vh+overflow:hidden 截 sample-strip 會回歸）"
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -10729,10 +10729,12 @@ class TestCoverLoadingUx67Guard:
     # ---- 71-T6: 燈箱封面 blur-up（thumb 底層秒出 → 原圖淡入）----
 
     def _lightbox_cover_block(self):
-        """抽出燈箱封面 <div class=\"lightbox-cover\">…</div> 區塊（element-bound，避免整檔裸 grep）"""
+        """抽出影片燈箱封面 <div class="lightbox-cover" :class="{'has-cover':…}">…</div> 區塊"""
         html = self._html()
-        m = re.search(r'<div class="lightbox-cover">.*?</div>\s*<!-- Metadata Panel', html, re.S)
-        assert m, "showcase.html: <div class=\"lightbox-cover\"> 區塊不存在"
+        # 83a modal-hug 給影片 div 加了 :class has-cover（與女優 div 區分）；
+        # 83b-T1 在 </div> 後插入說明注釋，故用 has-cover 錨點 + .*?<!-- Metadata Panel 取代 \s*
+        m = re.search(r'<div class="lightbox-cover"[^>]*has-cover[^>]*>.*?</div>.*?<!-- Metadata Panel', html, re.S)
+        assert m, "showcase.html: 影片燈箱 .lightbox-cover（has-cover :class）區塊不存在"
         return m.group(0)
 
     def _lb_overlay_img(self):

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -15164,3 +15164,84 @@ class TestMobilePanelT3Guards:
             "ghost-fly.js 找不到 playMobilePanelEnter 函式宣告"
         assert ".similar-main-anchor" not in enter_body, \
             "playMobilePanelEnter 函式體含 .similar-main-anchor（禁區：桌面 DOM 不得出現在 mobile helper）"
+
+
+class TestSimilarMobilePanelT4Guard:
+    """83b-T4: 行動相似面板主圖播放按鈕合約守衛"""
+
+    def _html(self):
+        return Path("web/templates/showcase.html").read_text(encoding="utf-8")
+
+    def _css(self):
+        return Path("web/static/css/pages/showcase.css").read_text(encoding="utf-8")
+
+    def test_mobile_play_btn_exists_in_stage(self):
+        """T4: .similar-mobile-stage 內含 .similar-mobile-play-btn button（.similar-mobile-cover 子元素，overflow:hidden 已移至 img）"""
+        html = self._html()
+        # 先找 .similar-mobile-stage block
+        m = re.search(
+            r'<div class="similar-mobile-stage">(.*?)</div>\s*<!-- 右上',
+            html, re.S
+        )
+        assert m, "showcase.html: .similar-mobile-stage block 不存在"
+        stage = m.group(1)
+        assert 'class="similar-mobile-play-btn"' in stage, \
+            ".similar-mobile-stage 內缺 <button class=\"similar-mobile-play-btn\">（T4 播放按鈕）"
+
+    def test_mobile_play_btn_handlers(self):
+        """T4: 播放按鈕有 @click.stop + x-show path guard + :disabled drill-lock + aria-label"""
+        html = self._html()
+        m = re.search(r'<button class="similar-mobile-play-btn"[^>]*>', html, re.S)
+        assert m, "showcase.html: 找不到 <button class=\"similar-mobile-play-btn\">"
+        btn = m.group(0)
+        assert '@click.stop="playVideo(currentLightboxVideo?.path)"' in btn, \
+            "播放按鈕須有 @click.stop=\"playVideo(currentLightboxVideo?.path)\"（stop 防冒泡觸發 closeMobilePanel）"
+        assert 'x-show="!!currentLightboxVideo?.path"' in btn, \
+            "播放按鈕須有 x-show=\"!!currentLightboxVideo?.path\"（tier-3 孤兒 path=undefined 時隱藏）"
+        assert ':disabled="similarModeAnimating"' in btn, \
+            "播放按鈕須有 :disabled=\"similarModeAnimating\"（drill 動畫中 lock）"
+        assert ":aria-label=\"t('showcase.action.play')\"" in btn, \
+            "播放按鈕須有 :aria-label=\"t('showcase.action.play')\"（i18n）"
+
+    def test_mobile_play_btn_css_tokens(self):
+        """T4: .similar-mobile-play-btn CSS 在 max-width:959px 內，使用 Fluent token，含雙寫 -webkit-backdrop-filter"""
+        css = self._css()
+        # 確認 class 存在
+        assert ".similar-mobile-play-btn" in css, \
+            "showcase.css 缺 .similar-mobile-play-btn 規則"
+        # 找規則區塊
+        m = re.search(r'\.similar-mobile-play-btn\s*\{([^}]*)\}', css, re.S)
+        assert m, "showcase.css: .similar-mobile-play-btn {} block 不存在"
+        body = m.group(1)
+        assert "var(--overlay-control)" in body, \
+            ".similar-mobile-play-btn background 須用 var(--overlay-control)（不硬編碼 rgba）"
+        assert "var(--fluent-blur-light)" in body, \
+            ".similar-mobile-play-btn backdrop-filter 須用 var(--fluent-blur-light)（不硬編碼 px）"
+        assert "-webkit-backdrop-filter" in body, \
+            ".similar-mobile-play-btn 須含 -webkit-backdrop-filter 雙寫（iOS Safari）"
+        assert "border-radius: 50%" in body, \
+            ".similar-mobile-play-btn 須是圓形（border-radius: 50%）"
+        # 確認在 max-width:959px media query 內
+        # 找包含此 class 的 @media block
+        media_block = re.search(
+            r'@media\s*\(max-width:\s*959px\)[^{]*\{(.*?)(?=@media|\Z)',
+            css, re.S
+        )
+        assert media_block and ".similar-mobile-play-btn" in media_block.group(1), \
+            ".similar-mobile-play-btn 須在 @media (max-width:959px) 內（行動限定）"
+
+    def test_mobile_play_btn_ghost_hide(self):
+        """T4-fix: ghost-fly 飛行期間按鈕隱藏規則（img[data-ghost-hidden] ~ .similar-mobile-play-btn）"""
+        css = self._css()
+        assert "img[data-ghost-hidden] ~ .similar-mobile-play-btn" in css, \
+            "showcase.css 缺 ghost-hide 規則：img[data-ghost-hidden] ~ .similar-mobile-play-btn"
+        m = re.search(
+            r'img\[data-ghost-hidden\]\s*~\s*\.similar-mobile-play-btn\s*\{([^}]*)\}',
+            css, re.S
+        )
+        assert m, "showcase.css: ghost-hide rule block 不存在"
+        body = m.group(1)
+        assert "opacity: 0" in body, \
+            "ghost-hide 規則須含 opacity: 0"
+        assert "pointer-events: none" in body, \
+            "ghost-hide 規則須含 pointer-events: none（飛行期間防誤點）"

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -807,6 +807,18 @@
     object-fit: contain;
 }
 
+/* 83a-T3-fix P1: search 燈箱 metadata 可變高 → modal 捲動修正。
+   search 無 similar-open → 直接加 overflow-y:hidden，不需 :not(.similar-open) scope。
+   .lightbox-metadata flex 分配：吃剩餘高度並自行捲動（同 showcase）。 */
+.search-container .lightbox-content {
+    overflow-y: hidden;
+}
+.search-container .lightbox-metadata {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}
+
 /* T9-port：≤480px search 影片燈箱封面貼合原圖比例（消 letterbox 死白）。
    判別子 .search-container 精準限 search 頁——showcase 頁根為 .showcase-container，零波及。
    容器 + img 皆 gate .has-cover（決策 ①）：search 無 similar-open、無「保低 specificity」顧慮；

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -786,6 +786,27 @@
     }
 }
 
+/* 83a-T3: search 頁燈箱封面 modal-hug（aspect-box 模型，對齊 showcase T1/T1fix1）。
+   search 無 similar-open → selector 不需 :not(.similar-open)；
+   scope 靠 .search-container（不波及 showcase 頁）。 */
+.search-container .lightbox-cover.has-cover {
+    flex-shrink: 0;
+    min-width: 0;
+    min-height: 0;
+    aspect-ratio: var(--lb-cover-ar, 1.5);
+    width: min(90vw, calc((90vh - 15rem) * var(--lb-cover-ar, 1.5)));
+    width: min(90vw, calc((90dvh - 15rem) * var(--lb-cover-ar, 1.5)));
+    height: auto;
+}
+
+.search-container .lightbox-cover.has-cover img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
 /* T9-port：≤480px search 影片燈箱封面貼合原圖比例（消 letterbox 死白）。
    判別子 .search-container 精準限 search 頁——showcase 頁根為 .showcase-container，零波及。
    容器 + img 皆 gate .has-cover（決策 ①）：search 無 similar-open、無「保低 specificity」顧慮；

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -99,6 +99,32 @@
 .search-container .av-card-full-cover {
     flex: 1;
     min-width: 0;
+    /* 83a2-T4 (Bug B)：清 theme.css L495 的 min-height:200px 地板。
+       與 wrapper min-height:0 + img height:auto 合力消除封面下方 letterbox 留白，
+       並讓 block flow 自然包含 sample-strip（Bug A 桌面連帶修，overflow:hidden 不再截）。 */
+    min-height: 0;
+}
+
+/* 83a2-T4 (Bug B)：清 search.css L50 wrapper 的 min-height:400px 主地板（scope 覆寫，不動全域 L50）。 */
+.search-container .av-card-full-cover-wrapper {
+    min-height: 0;
+}
+
+/* 83a2-T4 (Bug B)：封面圖高由 width:100% + AR 自然推導，不依賴父容器死高（原 L84 height:100% 靠 wrapper 400px）。
+   max-height:calc(100vh-200px) 由 L84-91 既有規則保留。specificity (0,2,0) > 原 (0,1,0)。 */
+.search-container .av-card-full-cover-img {
+    height: auto;
+}
+
+/* 83a2-T4 邊界：min-height:0 後，下列兩條無圖內容路徑會讓 wrapper 高=0
+   （子元素皆 position:absolute;inset:0，不佔 flow；img height:auto 在無 intrinsic size 時也是 0）：
+     1. 無圖 / 封面 404 → .cover-error-placeholder（含無封面 fallback）
+     2. 封面載入中（_coverLoaded=false，慢速/未快取）→ .cover-loading-placeholder（shimmer）
+   塌 0 會讓 placeholder/shimmer + nav-indicator 一起消失/閃動。只在對應元素顯示時（Alpine x-show
+   未寫 display:none）才撐高；圖片載入完成後兩條 :has 皆不命中 → min-height 回 0，無 Bug B letterbox 復發。 */
+.search-container .av-card-full-cover-wrapper:has(.cover-error-placeholder:not([style*="display: none"])),
+.search-container .av-card-full-cover-wrapper:has(.cover-loading-placeholder:not([style*="display: none"])) {
+    min-height: 120px;
 }
 
 .search-container .av-card-full-info {
@@ -520,6 +546,11 @@
         flex: none;
         width: 100%;
         max-height: 50vh;
+        /* 83a2-T4 (Bug A mobile)：max-height:50vh + overflow:hidden 確定截 sample-strip
+           （img 留 60px 但 strip ≈ clamp(48,0.18×50vh,120)≈81px > 60px）。獨立必要 override，
+           非桌面備援。外層 #resultCard>.av-card-full 已 overflow:visible、本 media 內 .av-card-full
+           已 overflow-y:auto 負責捲動，cover 改 visible 不破壞捲動模型。 */
+        overflow: visible;
     }
 
     .av-card-full-cover-img {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -671,6 +671,13 @@
     min-height: min(58vh, 460px);
 }
 
+/* 83a-T3-fix P1: metadata 可變高 → modal 整體捲動修正。
+   :not(.similar-open) scope — similar-open 禁區保留 overflow-y:auto（需捲動）。
+   metadata 靠 flex:1 1 auto + min-height:0 + overflow-y:auto 自行消化剩餘高度。 */
+.lightbox-content:not(.similar-open) {
+    overflow-y: hidden;
+}
+
 /* 83a-T1fix1 M1+M2+M3: has-cover 時 aspect-box modal-hug 模型（全斷點適用）。
    修正 T1 的 flex-shrink letterbox bug（CDP 實測：cover box 1139×610 AR=1.869≠圖 AR 1.481
    → img object-fit:contain 只佔 903px → 左右各 118px 暗死白）。
@@ -757,11 +764,16 @@
 }
 
 /* Metadata Panel — 緊湊版（匹配原版 gallery） */
-/* 83a-T1 M4: 移除 max-width:600px，改 width:100% 對齊封面寬（modal shrink-to-fit 後即封面寬）。 */
+/* 83a-T1 M4: 移除 max-width:600px，改 width:100% 對齊封面寬（modal shrink-to-fit 後即封面寬）。
+   83a-T3-fix P1: flex:1 1 auto + min-height:0 讓 metadata 吃剩餘空間並自行捲動，
+   配合上方 .lightbox-content:not(.similar-open){overflow-y:hidden} 防 modal 整體捲動。 */
 .lightbox-metadata {
     padding: 0.5rem 0 0 0;
     width: 100%;
     border-top: 1px solid var(--stroke-subtle);
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 /* Header row: title + sample gallery button */

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -672,9 +672,9 @@
 }
 
 /* 83a-T3-fix P1: metadata 可變高 → modal 整體捲動修正。
-   :not(.similar-open) scope — similar-open 禁區保留 overflow-y:auto（需捲動）。
+   83b-T2：:not(.similar-open) gate 已移除（similar-open class 不再使用）；規則無條件命中。
    metadata 靠 flex:1 1 auto + min-height:0 + overflow-y:auto 自行消化剩餘高度。 */
-.lightbox-content:not(.similar-open) {
+.lightbox-content {
     overflow-y: hidden;
 }
 
@@ -687,8 +687,8 @@
      cover 高 + 15rem ≤ 90dvh = content max-height → 不捲動。
      T1 錯用 100dvh：cover 高 = dvh−15rem，content max-height=90vh < dvh → 溢出捲動。
    T1fix1 就是把 100dvh/100vh 改 90dvh/90vh 這一行，其餘不變。
-   guard：:not(.similar-open) — similar-open 禁區（83b）完全不動。 */
-.lightbox-content:not(.similar-open) .lightbox-cover.has-cover {
+   83b-T2：:not(.similar-open) gate 已移除（similar-open class 不再使用）；規則無條件命中。 */
+.lightbox-content .lightbox-cover.has-cover {
     flex-shrink: 0;
     min-width: 0;
     min-height: 0;
@@ -699,10 +699,10 @@
 }
 
 /* 83a-T1 M1: base img 與 .lb-full 皆填滿 aspect-ratio 正確的盒（兩層疊在 has-cover 盒內）。
-   guard：same :not(.similar-open) — similar-open 禁區的 img 保持 40vh 規則不干擾。
+   83b-T2：:not(.similar-open) gate 已移除；此規則無條件命中，接管 T8 block 移除後的 width:100% 供應。
    盒 AR == 圖 AR → 不 letterbox；border-radius 保留視覺細節。
    無封面的普通 img（破圖/placeholder）維持舊規則（非 has-cover，不命中此選擇器）。 */
-.lightbox-content:not(.similar-open) .lightbox-cover.has-cover img {
+.lightbox-content .lightbox-cover.has-cover img {
     position: absolute;
     inset: 0;
     width: 100%;
@@ -727,7 +727,7 @@
    83a-T1 M1: has-cover 時 .lb-full 填滿 has-cover 盒（盒 AR == 圖 AR，不 letterbox）；
    opacity 溶接不變；pointer-events:none 確保不擋 cover-actions / sparkle 點擊。
    transition 用 fluent token；duration-slow=300ms、ease-decel 為進場/淡入角色。
-   guard：:not(.similar-open) — similar-open 禁區維持 40vh + margin:auto 垂直置中。 */
+   83b-T2：similar-open 禁區已移除；has-cover 時 .lb-full 由 .lightbox-content .lightbox-cover.has-cover .lb-full 填滿盒。 */
 .lb-full {
     position: absolute;
     inset: 0;
@@ -742,9 +742,9 @@
     transition: opacity var(--fluent-duration-slow) var(--fluent-ease-decel);
 }
 
-/* 83a-T1 M1: has-cover + not similar-open → lb-full 填滿盒（覆寫舊 60vh 規則）。
-   specificity (0,3,0) 勝 .lb-full (0,1,0)；similar-open ≤960px (0,3,1) 仍勝此規則（禁區維持）。 */
-.lightbox-content:not(.similar-open) .lightbox-cover.has-cover .lb-full {
+/* 83a-T1 M1: has-cover → lb-full 填滿盒（覆寫舊 60vh 規則）。
+   83b-T2：:not(.similar-open) gate 已移除；specificity (0,3,0) 勝 .lb-full (0,1,0)。 */
+.lightbox-content .lightbox-cover.has-cover .lb-full {
     inset: 0;
     width: 100%;
     height: 100%;
@@ -766,7 +766,7 @@
 /* Metadata Panel — 緊湊版（匹配原版 gallery） */
 /* 83a-T1 M4: 移除 max-width:600px，改 width:100% 對齊封面寬（modal shrink-to-fit 後即封面寬）。
    83a-T3-fix P1: flex:1 1 auto + min-height:0 讓 metadata 吃剩餘空間並自行捲動，
-   配合上方 .lightbox-content:not(.similar-open){overflow-y:hidden} 防 modal 整體捲動。 */
+   配合上方 .lightbox-content{overflow-y:hidden} 防 modal 整體捲動（83b-T2 gate 已移除）。 */
 .lightbox-metadata {
     padding: 0.5rem 0 0 0;
     width: 100%;
@@ -1020,71 +1020,8 @@
     line-height: 1;
 }
 
-/* 56c-T7：手機降級 mobile similar grid =========================================*/
-.lightbox-similar-mobile {
-    margin-top: 0.75rem;         /* --space-3 不存在，用 raw 0.75rem */
-    padding: 0.75rem;
-    background: rgba(255,255,255,0.06);  /* 低於 .lb-action-btn 0.15，輕量區分 */
-    border-radius: var(--fluent-radius-lg);  /* 8px，對齊卡片 radius */
-}
-
-.similar-mobile-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 0.5rem;                  /* --space-2 不存在，用 raw 0.5rem */
-}
-
-.similar-mobile-card {
-    cursor: pointer;
-    border-radius: var(--fluent-radius-md);  /* 4px */
-    overflow: hidden;
-    transition: transform var(--fluent-duration-fast) var(--fluent-ease-standard);
-}
-
-.similar-mobile-card:hover {
-    transform: scale(1.02);
-}
-
-/* 手機觸控回饋：active 態往下縮，給拇指觸感確認 */
-.similar-mobile-card:active {
-    transform: scale(0.97);
-    opacity: 0.85;
-}
-
-.similar-mobile-card img {
-    width: 100%;
-    aspect-ratio: var(--poster-crop-ratio);
-    object-fit: cover;
-    object-position: right center;  /* CSS layer crop，右半邊視覺 — 非 ghost-fly cropMode（不違反 lint rule）*/
-    /* 圖片載入中骨架：lazy img 在 loaded 前顯示淺灰漸層 */
-    background: linear-gradient(135deg, rgba(255,255,255,0.06) 25%, rgba(255,255,255,0.12) 50%, rgba(255,255,255,0.06) 75%);
-    background-size: 200% 100%;
-}
-
-.similar-mobile-meta {
-    padding: 0.5rem;
-    font-size: 0.8125rem;         /* --text-sm 不存在，對齊 .lb-otitle 同值 */
-}
-
-.similar-mobile-number {
-    color: var(--text-muted);
-    font-size: 0.75rem;
-}
-
-.similar-mobile-title {
-    color: var(--text-primary);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: none;  /* 75a-US4: 77px 卡片寬度無法顯示標題，僅保留番號 */
-}
-
-/* 確保 mobile collapse 只在小螢幕渲染（桌面應永遠 similarModeMobileOpen = false） */
-@media (min-width: 960px) {
-    .lightbox-similar-mobile {
-        display: none !important;   /* 桌面安全網：即使 state 殘留也不顯示 */
-    }
-}
+/* 56c-T7 舊手機 grid（.lightbox-similar-mobile / .similar-mobile-grid / .similar-mobile-card 等）
+   已於 83b-T2 移除：T1 改為獨立全螢幕 .similar-mobile-panel；HTML block 已移除，CSS 同步清理。 */
 
 /* ===================================================================
  * 83b-T1: 行動相似探索面板（Mobile Photo Picker 爆射）
@@ -1462,52 +1399,11 @@ body.similar-mobile-active [data-picker-ghost] {
     }
 }
 
-/* 75a-US4: 手機相似模式主片封面縮高（僅 similar-open，一般燈箱不縮） */
-/* 特異性升至 (0,4,0)：勝 T8 ≤480 的 .lightbox-cover:has(.lb-full) .lb-full / .lightbox-cover.has-cover:has(.lb-full)
-   (0,3,0)，否則 source order 讓 T8 的 height:auto/min-height:0 在 similar 模式覆寫 → overlay 與 base 40vh 脫鉤/溢出 */
-@media (max-width: 960px) {
-    .showcase-lightbox .lightbox-content.similar-open .lightbox-cover {
-        min-height: min(38vh, 290px);   /* 覆寫容器 min-height: min(58vh, 460px) */
-    }
-    .lightbox-content.similar-open .lightbox-cover img,
-    .lightbox-content.similar-open .lightbox-cover .lb-full {
-        height: 40vh;   /* 覆寫 img/lb-full 的 60vh */
-    }
-}
+/* 75a-US4 similar-open 40vh override 已於 83b-T2 移除：similar-open class 不再由 lightbox 使用，
+   行動相似模式已改為獨立全螢幕 .similar-mobile-panel（T1）。 */
 
-/* US5-75b-T8: ≤480px 影片燈箱封面貼合原圖比例（消 object-fit:contain 在 60vh 高框的 letterbox 死白）。
- * :has(.lb-full) 只命中影片 cover（女優 cover 無 .lb-full，showcase.html:569 vs 669）→ 女優燈箱零波及。
- * make-or-break（live 實證）：須同改 (a) img/.lb-full 尺寸法 + (b) 容器 min-*，只改 img 會把空白留在容器。
- * 副作用：盒比例=圖比例後 object-fit:cover≈contain，T7 grid→lightbox flight 落地 cover→contain seam 自然消失。
- * specificity（Codex P3 修正）：:has(.lb-full) 計入其引數一個 class →
- *   img 規則 .lightbox-cover:has(.lb-full) img = (0,2,1) 勝基準 §667 .lightbox-cover img (0,1,1)，
- *   容器 .lightbox-cover.has-cover:has(.lb-full) = (0,3,0) 勝基準 .lightbox-cover (0,1,0)；皆靠 specificity（非源序）。無 !important。
- * Codex P2：容器 min-height:0 只在 .has-cover（有封面）才套——無封面影片若塌到 0 高，補封面入口會壞，
- *   故無封面保留基準 min-height。img 規則不 gate has-cover（無封面時 img 空 src→height:auto=0 無害），
- *   且刻意保持 (0,2,1) 不升到 (0,3,1) 以免在 ≤480∩similar-open 與 similar-open img (0,3,1) 撞同權。
- * similar-open 交互：.lightbox-content.similar-open .lightbox-cover img (0,3,1) 勝本 img 規則 (0,2,1)
- *   → ≤480px ∩ similar-open 時手機相似主片維持 40vh（本 task 不接管相似模式，刻意）。
- *
- * ⚠️ 83a-T2 勿刪本 block：83a modal-hug（(0,3,1)）帶 :not(.similar-open) gate，similar-open 時不命中；
- *   而 similar-open 規則只設 height:40vh、沒設 width → mobile similar-open 封面的 width:100% **唯一來源是本 block**。
- *   刪本 block 會讓 similar-open 封面寬默默掉成 auto（base (0,1,1)）。一般（非 similar-open）lightbox 下本 block
- *   已被 modal-hug 完全覆蓋、是 inert 的，看似冗餘但 similar-open 仍依賴。正確清理＝83b 重寫 similar-open 時
- *   先把 width:100% 收進 similar-open 規則再刪本 block（同段 CSS、同 changeset）。詳見 spec-83b.md §5 D1。 */
-@media (max-width: 899px) {
-    /* (b) 容器塌到圖的盒（Codex P2：僅 .has-cover；無封面保留基準 min-height 防塌成 0 高） */
-    .lightbox-cover.has-cover:has(.lb-full) {
-        min-height: 0;
-        min-width: 0;
-    }
-    /* (a) base img + .lb-full overlay 同步：寬填滿、高隨原圖比例（覆寫 60vh）。
-       不 gate has-cover：無封面 img 空 src→height:auto=0 無害，且保 (0,2,1) 不撞 similar-open。 */
-    .lightbox-cover:has(.lb-full) img,
-    .lightbox-cover:has(.lb-full) .lb-full {
-        width: 100%;
-        height: auto;
-        object-fit: contain;   /* 盒=圖比例時與 cover 等價，保留 contain 不裁切語意 */
-    }
-}
+/* US5-75b-T8 block 已於 83b-T2 移除：modal-hug（:not(.similar-open) gate 同步去除）接管 width:100%。
+   .lightbox-content .lightbox-cover.has-cover img { width:100%; } 為 regular mobile lightbox 供應 cover fit。 */
 
 /* ==================== Responsive: Toolbar ==================== */
 /* 小螢幕：Toolbar 單欄堆疊 (44c-T8) */

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1086,6 +1086,123 @@
     }
 }
 
+/* ===================================================================
+ * 83b-T1: 行動相似探索面板（Mobile Photo Picker 爆射）
+ * 全螢幕獨立面板（.showcase-lightbox 外側 sibling），<960px only。
+ * Core 無轉場：default-hidden（opacity/visibility/pointer-events）+ .show 直顯/直隱。
+ * cover + cards layout-isolated（position:absolute）→ BurstPicker 內部 getBCR()
+ * 在爆射並行期間讀到穩定 rect（R1 緩解，模組無 rect 注入口 CD-12）。
+ * =================================================================== */
+@media (max-width: 959px) {
+    .similar-mobile-panel {
+        position: fixed;
+        inset: 0;
+        z-index: 1502;  /* > .similar-stage 1501 > .showcase-lightbox 1000 */
+        /* default-hidden（非 bare x-show）：Alpine boot 前 overlay 不閃現（FOUC，D10/AC-8） */
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+    }
+
+    .similar-mobile-panel.show {
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+    }
+
+    /* scrim：overlay 30px 模糊完全遮住 lightbox（CD-10；雙寫 -webkit-，禁硬編碼 px） */
+    .similar-mobile-scrim {
+        position: absolute;
+        inset: 0;
+        background-color: var(--overlay-modal);
+        backdrop-filter: blur(var(--fluent-blur));
+        -webkit-backdrop-filter: blur(var(--fluent-blur));
+    }
+
+    /* stage：爆射 origin frame（cover 在中央，cards 從中央爆射） */
+    .similar-mobile-stage {
+        position: absolute;
+        inset: 0;
+    }
+
+    /* 中央主圖：layout-isolated（爆射卡 out of flow 不 reflow 它，R1 根本緩解） */
+    .similar-mobile-cover {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 44vw;
+        max-width: 320px;
+        overflow: hidden;
+        border-radius: var(--fluent-radius-lg);
+        cursor: pointer;
+    }
+
+    .similar-mobile-cover img {
+        display: block;
+        width: 100%;
+        aspect-ratio: var(--poster-crop-ratio);   /* 單一真理，禁硬編碼 4/5 */
+        object-fit: cover;
+        object-position: right center;             /* 右半裁切 */
+    }
+
+    /* cards 容器：absolute 覆蓋 stage，爆射卡定位其內 */
+    .similar-mobile-cards {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;   /* 容器不擋；卡片各自 pointer-events:auto */
+    }
+
+    /* 爆射卡：GSAP-only（opacity:0 + transition:none 防 1-frame paint glitch，mirror .picker-candidate-card） */
+    .similar-mobile-burst-card {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 26vw;
+        max-width: 150px;
+        overflow: hidden;
+        border-radius: var(--fluent-radius-lg);
+        cursor: pointer;
+        pointer-events: auto;
+        opacity: 0;
+        transition: none;
+    }
+
+    .similar-mobile-burst-card img {
+        display: block;
+        width: 100%;
+        aspect-ratio: var(--poster-crop-ratio);
+        object-fit: cover;
+        object-position: right center;
+    }
+
+    /* 右上 ✕ 關閉鈕（x-trap Tab 目標） */
+    .similar-mobile-panel-close {
+        position: absolute;
+        top: max(1rem, env(safe-area-inset-top));
+        right: max(1rem, env(safe-area-inset-right));
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.75rem;
+        height: 2.75rem;
+        border: none;
+        border-radius: var(--radius-pill);
+        background: rgba(0, 0, 0, 0.35);
+        color: var(--text-primary);
+        font-size: 1.25rem;
+        cursor: pointer;
+    }
+}
+
+/* 桌面安全網：即使 flag 殘留（matchMedia reset 未及）也不顯示（mirror 既有 .lightbox-similar-mobile） */
+@media (min-width: 960px) {
+    .similar-mobile-panel {
+        display: none !important;
+    }
+}
+
 /* 56c-T3fix: Sparkle burst overlay — 10 顆四角星 ring 分佈，GSAP 操作 opacity/scale/rotation
  * 容器 .sparkle-burst 與 .lightbox-cover 內 <img> 同層 absolute overlay；
  * inset:0 自動覆蓋封面區（不擴及 metadata），無需 hardcoded size。

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1319,7 +1319,13 @@
  *   故無封面保留基準 min-height。img 規則不 gate has-cover（無封面時 img 空 src→height:auto=0 無害），
  *   且刻意保持 (0,2,1) 不升到 (0,3,1) 以免在 ≤480∩similar-open 與 similar-open img (0,3,1) 撞同權。
  * similar-open 交互：.lightbox-content.similar-open .lightbox-cover img (0,3,1) 勝本 img 規則 (0,2,1)
- *   → ≤480px ∩ similar-open 時手機相似主片維持 40vh（本 task 不接管相似模式，刻意）。 */
+ *   → ≤480px ∩ similar-open 時手機相似主片維持 40vh（本 task 不接管相似模式，刻意）。
+ *
+ * ⚠️ 83a-T2 勿刪本 block：83a modal-hug（(0,3,1)）帶 :not(.similar-open) gate，similar-open 時不命中；
+ *   而 similar-open 規則只設 height:40vh、沒設 width → mobile similar-open 封面的 width:100% **唯一來源是本 block**。
+ *   刪本 block 會讓 similar-open 封面寬默默掉成 auto（base (0,1,1)）。一般（非 similar-open）lightbox 下本 block
+ *   已被 modal-hug 完全覆蓋、是 inert 的，看似冗餘但 similar-open 仍依賴。正確清理＝83b 重寫 similar-open 時
+ *   先把 width:100% 收進 similar-open 規則再刪本 block（同段 CSS、同 changeset）。詳見 spec-83b.md §5 D1。 */
 @media (max-width: 899px) {
     /* (b) 容器塌到圖的盒（Codex P2：僅 .has-cover；無封面保留基準 min-height 防塌成 0 高） */
     .lightbox-cover.has-cover:has(.lb-full) {

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -666,17 +666,48 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    /* 給容器最小尺寸 — 無封面時 placeholder SVG 不會讓 lightbox 塌陷成迷你卡片，
-       cover-actions absolute 仍能撐開到 lightbox 應有的氣勢 */
+    /* 無封面時保留 floor — placeholder SVG 不塌陷、cover-actions absolute 仍能撐盒 */
     min-width: min(60vw, 600px);
     min-height: min(58vh, 460px);
 }
 
+/* 83a-T1fix1 M1+M2+M3: has-cover 時 aspect-box modal-hug 模型（全斷點適用）。
+   修正 T1 的 flex-shrink letterbox bug（CDP 實測：cover box 1139×610 AR=1.869≠圖 AR 1.481
+   → img object-fit:contain 只佔 903px → 左右各 118px 暗死白）。
+   修法 A — flex-shrink:0（禁止 cover 被壓縮）：配合 width-formula 確保 cover 高不超 content。
+   修法 B — width-formula 用正確 vreserve（15rem≈240px = metadata≈175px + padding 48px + gap 16px）：
+     width = min(90vw, (90dvh − 15rem) × AR) → cover 高 = width/AR；
+     cover 高 + 15rem = min(90vw/AR, 90dvh) ≤ 90dvh → 不捲動、不依賴 max-height 壓縮。
+   T1 用 flex-grow:1（height-driven）無效因為 content 無 explicit height → cover 塌 0×0。
+   guard：:not(.similar-open) — similar-open 禁區（83b）完全不動。 */
+.lightbox-content:not(.similar-open) .lightbox-cover.has-cover {
+    flex-shrink: 0;
+    min-width: 0;
+    min-height: 0;
+    aspect-ratio: var(--lb-cover-ar, 1.5);
+    width: min(90vw, calc((100vh - 15rem) * var(--lb-cover-ar, 1.5)));
+    width: min(90vw, calc((100dvh - 15rem) * var(--lb-cover-ar, 1.5)));
+    height: auto;
+}
+
+/* 83a-T1 M1: base img 與 .lb-full 皆填滿 aspect-ratio 正確的盒（兩層疊在 has-cover 盒內）。
+   guard：same :not(.similar-open) — similar-open 禁區的 img 保持 40vh 規則不干擾。
+   盒 AR == 圖 AR → 不 letterbox；border-radius 保留視覺細節。
+   無封面的普通 img（破圖/placeholder）維持舊規則（非 has-cover，不命中此選擇器）。 */
+.lightbox-content:not(.similar-open) .lightbox-cover.has-cover img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    border-radius: var(--radius-sm);
+}
+
+/* 83a-T1 M1: 無封面 / 女優分支 base img — 維持舊規則（cover-first，不干擾 has-cover 內 absolute 層疊）。
+   specificity (0,1,1) 低於上方 .has-cover img (0,3,1)，has-cover 時上方規則勝出。 */
 .lightbox-cover img {
-    /* 71c：height 明確（非僅 max-height），讓 400px thumb 放大撐滿 60vh；
-       width:auto + max-width:100% 保持比例且不超容器寬；object-fit:contain 絕不裁切。
-       T4 前原圖靠自然尺寸填滿，T4 後 thumb 自然 400px < 60vh → 用 max-* 無法放大，
-       需 height 明確才能撐高（瀏覽器按 height 限制縮放比例，object-fit:contain 補完）。 */
+    /* 舊規則保留給無封面路徑（placeholder/破圖）與女優照（.lightbox-cover 無 has-cover class）。
+       height:60vh 讓無封面 lightbox 維持既有視覺氣勢；object-fit:contain 不裁切。 */
     height: 60vh;
     width: auto;
     max-width: 100%;
@@ -685,10 +716,10 @@
 }
 
 /* 71-T6 blur-up overlay：原圖（cover_full_url）疊在 base（cover_url 小圖）之上。
-   sizing 鏡像 .lightbox-cover img 使兩層精準對齊；預設 opacity:0、@load 後翻 .lb-full-shown 淡入。
-   pointer-events:none → overlay 永不攔截 cover-actions / sparkle 的點擊。
-   transition 用 fluent token（不寫裸 .3s）；duration-slow=300ms（= plan .3s）、ease-decel 為進場/淡入角色。
-   71c：height/width/object-fit 完全鏡像 base img，確保原圖淡入時尺寸不偏移（兩層像素對齊）。 */
+   83a-T1 M1: has-cover 時 .lb-full 填滿 has-cover 盒（盒 AR == 圖 AR，不 letterbox）；
+   opacity 溶接不變；pointer-events:none 確保不擋 cover-actions / sparkle 點擊。
+   transition 用 fluent token；duration-slow=300ms、ease-decel 為進場/淡入角色。
+   guard：:not(.similar-open) — similar-open 禁區維持 40vh + margin:auto 垂直置中。 */
 .lb-full {
     position: absolute;
     inset: 0;
@@ -703,6 +734,16 @@
     transition: opacity var(--fluent-duration-slow) var(--fluent-ease-decel);
 }
 
+/* 83a-T1 M1: has-cover + not similar-open → lb-full 填滿盒（覆寫舊 60vh 規則）。
+   specificity (0,3,0) 勝 .lb-full (0,1,0)；similar-open ≤960px (0,3,1) 仍勝此規則（禁區維持）。 */
+.lightbox-content:not(.similar-open) .lightbox-cover.has-cover .lb-full {
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    max-width: none;
+}
+
 .lb-full-shown {
     opacity: 1;
 }
@@ -715,9 +756,9 @@
 }
 
 /* Metadata Panel — 緊湊版（匹配原版 gallery） */
+/* 83a-T1 M4: 移除 max-width:600px，改 width:100% 對齊封面寬（modal shrink-to-fit 後即封面寬）。 */
 .lightbox-metadata {
     padding: 0.5rem 0 0 0;
-    max-width: 600px;
     width: 100%;
     border-top: 1px solid var(--stroke-subtle);
 }

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -675,18 +675,19 @@
    修正 T1 的 flex-shrink letterbox bug（CDP 實測：cover box 1139×610 AR=1.869≠圖 AR 1.481
    → img object-fit:contain 只佔 903px → 左右各 118px 暗死白）。
    修法 A — flex-shrink:0（禁止 cover 被壓縮）：配合 width-formula 確保 cover 高不超 content。
-   修法 B — width-formula 用正確 vreserve（15rem≈240px = metadata≈175px + padding 48px + gap 16px）：
+   修法 B — width-formula 對齊 content max-height:90vh（vreserve=15rem≈240px）：
      width = min(90vw, (90dvh − 15rem) × AR) → cover 高 = width/AR；
-     cover 高 + 15rem = min(90vw/AR, 90dvh) ≤ 90dvh → 不捲動、不依賴 max-height 壓縮。
-   T1 用 flex-grow:1（height-driven）無效因為 content 無 explicit height → cover 塌 0×0。
+     cover 高 + 15rem ≤ 90dvh = content max-height → 不捲動。
+     T1 錯用 100dvh：cover 高 = dvh−15rem，content max-height=90vh < dvh → 溢出捲動。
+   T1fix1 就是把 100dvh/100vh 改 90dvh/90vh 這一行，其餘不變。
    guard：:not(.similar-open) — similar-open 禁區（83b）完全不動。 */
 .lightbox-content:not(.similar-open) .lightbox-cover.has-cover {
     flex-shrink: 0;
     min-width: 0;
     min-height: 0;
     aspect-ratio: var(--lb-cover-ar, 1.5);
-    width: min(90vw, calc((100vh - 15rem) * var(--lb-cover-ar, 1.5)));
-    width: min(90vw, calc((100dvh - 15rem) * var(--lb-cover-ar, 1.5)));
+    width: min(90vw, calc((90vh - 15rem) * var(--lb-cover-ar, 1.5)));
+    width: min(90vw, calc((90dvh - 15rem) * var(--lb-cover-ar, 1.5)));
     height: auto;
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1073,7 +1073,8 @@
         left: 50%;
         transform: translate(-50%, -50%);
         width: min(88vw, 56vh * var(--poster-crop-ratio));
-        overflow: hidden;
+        /* T4: overflow:hidden 移到 img（border-radius 掛 img 可裁角），
+           讓 .similar-mobile-play-btn 子元素不被裁切而能在封面內顯示 */
         border-radius: var(--fluent-radius-lg);
         cursor: pointer;
     }
@@ -1084,6 +1085,7 @@
         aspect-ratio: var(--poster-crop-ratio);   /* 單一真理，禁硬編碼 4/5 */
         object-fit: cover;
         object-position: right center;             /* 右半裁切 */
+        border-radius: var(--fluent-radius-lg);    /* T4: 接管 overflow:hidden 的裁角職責 */
     }
 
     /* cards 容器：absolute（layout-isolated，不 reflow cover）但改放螢幕下方區域，
@@ -1142,6 +1144,58 @@
         color: var(--text-primary);
         font-size: 1.25rem;
         cursor: pointer;
+    }
+
+    /* T4: 行動相似面板播放按鈕（mirror .similar-play-button，桌面 L3255） */
+    .similar-mobile-play-btn {
+        position: absolute;
+        left: 50%;
+        /* 相對 .similar-mobile-cover（position:absolute，子元素 containing block）定位；
+           bottom:12px 置於封面底部中央，對齊桌面 .similar-play-button 位置邏輯 */
+        bottom: 12px;
+        transform: translateX(-50%);
+        width: 44px;
+        height: 44px;
+        border: 1px solid rgba(255, 255, 255, 0.4);
+        border-radius: 50%;
+        background: var(--overlay-control);
+        backdrop-filter: blur(var(--fluent-blur-light));
+        -webkit-backdrop-filter: blur(var(--fluent-blur-light));
+        color: white;
+        font-size: 1.25rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        box-shadow: var(--fluent-shadow-8);
+        z-index: 12;
+        transition: background var(--fluent-duration-fast) var(--fluent-ease-standard),
+                    border-color var(--fluent-duration-fast) var(--fluent-ease-standard),
+                    box-shadow var(--fluent-duration-fast) var(--fluent-ease-standard);
+    }
+
+    .similar-mobile-play-btn:hover,
+    .similar-mobile-play-btn:active {
+        background: rgba(0, 0, 0, 0.5);
+        border-color: rgba(255, 255, 255, 0.6);
+        box-shadow: var(--fluent-shadow-16);
+    }
+
+    .similar-mobile-play-btn:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .similar-mobile-play-btn:focus-visible {
+        outline: 2px solid var(--star-glow);
+        outline-offset: 2px;
+    }
+
+    /* T4-fix: ghost-fly 飛行期間（img data-ghost-hidden 存在）隱藏播放按鈕，
+       避免 enter 封面尚未落地 / exit 封面已飛走 時按鈕懸空或可點 */
+    .similar-mobile-cover img[data-ghost-hidden] ~ .similar-mobile-play-btn {
+        opacity: 0;
+        pointer-events: none;
     }
 }
 

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1125,14 +1125,17 @@
         inset: 0;
     }
 
-    /* 中央主圖：layout-isolated（爆射卡 out of flow 不 reflow 它，R1 根本緩解） */
+    /* 中央主圖：layout-isolated（爆射卡 out of flow 不 reflow 它，R1 根本緩解）。
+     * 83b-T1fix1: 大封面、置中偏上。維持 position:absolute（R1 不破）。
+     * 寬度雙約束 min(vw界, vh界*ratio)：--poster-crop-ratio=0.71（portrait），故 vh*ratio
+     * 上界鎖住封面「高度」≤56vh，下方預留 ~40vh 給 3+3 grid（9:16 矮 / 9:21 高 / 平板直式皆不溢出）。
+     * 垂直置中偏上：cover 中心落在 ~30vh（視口中線之上），上緣貼近 close 鈕下方。 */
     .similar-mobile-cover {
         position: absolute;
-        top: 50%;
+        top: 30vh;
         left: 50%;
         transform: translate(-50%, -50%);
-        width: 44vw;
-        max-width: 320px;
+        width: min(88vw, 56vh * var(--poster-crop-ratio));
         overflow: hidden;
         border-radius: var(--fluent-radius-lg);
         cursor: pointer;
@@ -1146,20 +1149,29 @@
         object-position: right center;             /* 右半裁切 */
     }
 
-    /* cards 容器：absolute 覆蓋 stage，爆射卡定位其內 */
+    /* cards 容器：absolute（layout-isolated，不 reflow cover）但改放螢幕下方區域，
+     * 內部 3 欄 grid（mirror 女優 picker mobile L2877–2887）→ 6 卡自然版位 = 下方 3+3 各格。
+     * 83b-T1fix1: 從 inset:0（全覆蓋、卡疊中心）改為下方 grid。 */
     .similar-mobile-cards {
         position: absolute;
-        inset: 0;
+        left: 0;
+        right: 0;
+        top: auto;
+        bottom: calc(4vh + env(safe-area-inset-bottom));
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        justify-items: center;
+        gap: 10px;
+        padding: 0 16px;
         pointer-events: none;   /* 容器不擋；卡片各自 pointer-events:auto */
     }
 
-    /* 爆射卡：GSAP-only（opacity:0 + transition:none 防 1-frame paint glitch，mirror .picker-candidate-card） */
+    /* 爆射卡：GSAP-only（opacity:0 + transition:none 防 1-frame paint glitch，mirror .picker-candidate-card）。
+     * 83b-T1fix1: position:relative（grid item，有獨立版位 → burst 落各格不再疊），尺寸用 grid 欄寬。 */
     .similar-mobile-burst-card {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        width: 26vw;
-        max-width: 150px;
+        position: relative;
+        width: 100%;
+        max-width: 120px;
         overflow: hidden;
         border-radius: var(--fluent-radius-lg);
         cursor: pointer;
@@ -1201,6 +1213,26 @@
     .similar-mobile-panel {
         display: none !important;
     }
+}
+
+/* 83b-T1fix2 (3): iPad / 寬平板 grid 收緊置中（base minmax(0,1fr) 不動，僅 ≥600 覆蓋）。
+ * base 1fr 在寬平板每欄 ~256px 但卡 max-width:120px → 三卡橫向被拉開大留白（owner 真機回饋）。
+ * 固定欄寬 + justify-content:center 讓卡緊靠置中（mirror 女優 picker tablet-fixed 雙軌）。
+ * <600 手機保留 proven 1fr（極窄機零溢出）。 */
+@media (min-width: 600px) and (max-width: 959px) {
+    .similar-mobile-cards {
+        grid-template-columns: repeat(3, 120px);
+        justify-content: center;
+    }
+}
+
+/* 83b-T1fix2 (1a): 行動相似面板開啟期間，把飛行 FlipReplace ghost 抬到 scrim 前方（銳利）。
+ * ghost（burst-picker.js）以 inline style 設 z-index:1000、掛在 document.body → 在面板
+ * scrim（z-index:1502 + backdrop-filter blur）後方 → 飛行全程被模糊。!important 為必須
+ * （覆蓋 inline z-index）。scope 到 body.similar-mobile-active → 女優 picker 共用 ghost
+ * （面板未開、無此 class）完全不受影響。scrim blur 保留（D8 lightbox 遮蔽）。 */
+body.similar-mobile-active [data-picker-ghost] {
+    z-index: 1600 !important;
 }
 
 /* 56c-T3fix: Sparkle burst overlay — 10 顆四角星 ring 分佈，GSAP 操作 opacity/scale/rotation

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -1233,6 +1233,12 @@
  * （面板未開、無此 class）完全不受影響。scrim blur 保留（D8 lightbox 遮蔽）。 */
 body.similar-mobile-active [data-picker-ghost] {
     z-index: 1600 !important;
+    /* 83b-T1fix4: ghost（burst-picker.js）inline 只設 object-fit:cover、無 object-position
+     * → 飛行全程 center-crop；但 cards/封面用 object-position:right center（右半裁切）→ 落地瞬間
+     * center→right snap。補上 right center 讓右半裁切飛行全程一致（如桌面星座）。無 inline
+     * object-position 可覆蓋故不需 !important。scope 到 body.similar-mobile-active → 女優 picker
+     * 共用 ghost（面板未開、無此 class）維持 center-crop 不受影響。 */
+    object-position: right center;
 }
 
 /* 56c-T3fix: Sparkle burst overlay — 10 顆四角星 ring 分佈，GSAP 操作 opacity/scale/rotation

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -75,6 +75,10 @@ export function searchStateGridMode() {
             this.lightboxIndex = index;
             this.currentIndex = index;
 
+            // 83a-T3-fix P2 reset C: 清除殘留 AR（女優→影片切換時 CSS 在封面 @load 前用 fallback 1.5）
+            var coverElSwitch = document.querySelector('.lightbox-cover');
+            if (coverElSwitch) coverElSwitch.style.removeProperty('--lb-cover-ar');
+
             // B19: 動畫（state 已更新，$nextTick 後 Alpine 已 patch DOM）
             var lbGen = ++this._lightboxGeneration;
             this.$nextTick(() => {
@@ -111,6 +115,11 @@ export function searchStateGridMode() {
 
         this._heroLightboxImageError = false;  // A6-1: 重置圖片錯誤狀態
         this.lightboxIndex = index;
+
+        // 83a-T3-fix P2 reset C: 清除殘留 AR（女優→影片切換時 CSS 在封面 @load 前用 fallback 1.5）
+        var coverElOpen = document.querySelector('.lightbox-cover');
+        if (coverElOpen) coverElOpen.style.removeProperty('--lb-cover-ar');
+
         var lightboxEl = document.querySelector('.showcase-lightbox');
         if (lightboxEl) lightboxEl.classList.add('gsap-animating');
         this.lightboxOpen = true;
@@ -203,6 +212,8 @@ export function searchStateGridMode() {
 
     // 83a-T3: lightbox 封面比例 hook — img @load 讀 naturalW/H 寫 --lb-cover-ar
     _setCoverAspect(e) {
+        // 83a-T3-fix P2 guard A: 女優模式時不寫入 --lb-cover-ar，防女優照片 AR 污染影片封面
+        if (this.actressLightboxMode && this.actressLightboxMode()) return;
         var img = e && e.target;
         if (!img) return;
         var nw = img.naturalWidth;
@@ -224,6 +235,9 @@ export function searchStateGridMode() {
         this._heroLightboxImageError = false;  // A6-1: 重置圖片錯誤狀態
         this._actressChipsExpanded = { aliases: false, info: false };  // Phase 43 T6: 重置 chips 展開狀態
         this.lightboxIndex = -1;
+        // 83a-T3-fix P2 注：不清除 --lb-cover-ar。女優模式下 .lightbox-cover 無 has-cover class
+        // （search.html :class gate），CSS 選擇器 .has-cover 不命中，--lb-cover-ar 即使殘留也完全 inert。
+        // 開影片 lightbox（openLightbox）才 removeProperty，確保影片封面用 fallback 1.5 撐盒直到 @load。
         var lightboxEl = document.querySelector('.showcase-lightbox');
         if (lightboxEl) lightboxEl.classList.add('gsap-animating');
         this.lightboxOpen = true;
@@ -384,6 +398,9 @@ export function searchStateGridMode() {
         this._heroLightboxImageError = false;
         this.lightboxIndex = newIdx;
         this.currentIndex = newIdx;
+        // 83a-T3-fix P2: 清除殘值，特別是 actress(-1)→video 切換時 --lb-cover-ar 有女優照片舊 AR
+        var coverElNext = document.querySelector('.lightbox-cover');
+        if (coverElNext) coverElNext.style.removeProperty('--lb-cover-ar');
 
         // B19: 動畫（state 已更新，$nextTick 後 Alpine 已 patch DOM）
         var lbGen = ++this._lightboxGeneration;

--- a/web/static/js/pages/search/state/grid-mode.js
+++ b/web/static/js/pages/search/state/grid-mode.js
@@ -201,6 +201,20 @@ export function searchStateGridMode() {
         }, 250);
     },
 
+    // 83a-T3: lightbox 封面比例 hook — img @load 讀 naturalW/H 寫 --lb-cover-ar
+    _setCoverAspect(e) {
+        var img = e && e.target;
+        if (!img) return;
+        var nw = img.naturalWidth;
+        var nh = img.naturalHeight;
+        if (!nw || !nh) return;
+        var ar = (nw / nh).toFixed(4);
+        var containerEl = img.closest('.lightbox-cover');
+        if (containerEl) {
+            containerEl.style.setProperty('--lb-cover-ar', ar);
+        }
+    },
+
     /**
      * 開啟 Actress Lightbox（Hero Card 專用）
      */

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -242,6 +242,20 @@ export function stateBase() {
                     window.ShowcaseAnimations?.playSettle?.(grid);
                 }); });
             }
+
+            // 83b-T1 (D12 / R7): 跨 960 breakpoint reset 行動相似面板。
+            // CSS @media (min-width:960px) display:none 藏面板，但 flag 殘留會卡住
+            // lightbox trap 的 `&& !similarModeMobileOpen`（iPad 旋轉）→ 強制 closeMobilePanel。
+            // 註冊在合併 init（單一 lifecycle，不另開競爭 hook）；closeMobilePanel 屬 state-similar
+            // 同一 Alpine 元件可達（main.js mergeState）。
+            if (typeof window.matchMedia === 'function') {
+                const mq = window.matchMedia('(min-width: 960px)');
+                mq.addEventListener('change', (e) => {
+                    if (e.matches && this.similarModeMobileOpen) {
+                        this.closeMobilePanel();
+                    }
+                });
+            }
         },
 
         // --- 狀態恢復 (M2c) ---

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -1200,6 +1200,20 @@ export function stateLightbox() {
                 return;
             }
 
+            // 83b-T1：行動相似面板開啟時鍵盤獨佔（高於 lightbox keydown 路由）。
+            // x-trap.inert 只陷焦點，全域 window keydown 仍觸發 → 必須在此攔截，
+            // 否則 Esc 穿透到 lightbox 分支關 lightbox、左右箭頭切底層影片（違反 AC-5/AC-8）。
+            // closeMobilePanel 屬 state-similar，main.js mergeState 同 this 可達。
+            if (this.similarModeMobileOpen) {
+                const mobileKey = (e.key || '').toUpperCase();
+                if (mobileKey === 'ESCAPE') {
+                    e.preventDefault();
+                    this.closeMobilePanel();
+                }
+                // ArrowLeft/Right 及其他鍵：面板無 prev/next → 吞掉，防底層 lightbox 切片
+                return;
+            }
+
             // T3.3: Remove Actress modal 開啟時，Esc 優先關閉 modal
             if (e.key === 'Escape' && this.removeActressModalOpen) {
                 this.cancelRemoveActressModal();

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -72,6 +72,24 @@ export function stateLightbox() {
 
         // --- helper in return {} ---
 
+        // 83a-T1 M1：比例 hook — 縮圖 base img @load 讀 naturalWidth/naturalHeight，
+        // 在最近 .lightbox-cover 容器設 --lb-cover-ar custom property。
+        // 不寫 inline aspect-ratio；不 removeProperty（換片 / close / similar-open enter/exit 皆不清）。
+        // 破圖/空 src（naturalWidth === 0）→ skip，保留前值撐盒（禁止任何清除路徑）。
+        // 目標掛點：.lightbox-content（縮圖載入即定，原圖未到也不塌、不閃）。
+        _setCoverAspect(e) {
+            var img = e && e.target;
+            if (!img) return;
+            var nw = img.naturalWidth;
+            var nh = img.naturalHeight;
+            if (!nw || !nh) return;  // 破圖/空 src → skip，保留前值
+            var ar = (nw / nh).toFixed(4);
+            var containerEl = img.closest('.lightbox-cover');
+            if (containerEl) {
+                containerEl.style.setProperty('--lb-cover-ar', ar);
+            }
+        },
+
         // 71c-P2: helper — blur-up state reset + same-URL complete-check（DRY；供 _setLightboxIndex 與
         // slip-through 路徑（state-similar.js closeSimilarMode）共用，避免兩處邏輯漂移）。
         // 呼叫時機：currentLightboxVideo 已更新、Alpine reactive patch 尚未跑完（$nextTick 前）。

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -339,6 +339,10 @@ export function stateLightbox() {
             if (typeof this.similarModeMobileOpen !== 'undefined') {
                 this.similarModeMobileOpen = false;
             }
+            // 83b-T1fix2 (1a)：維持「body.similar-mobile-active class 存在 ⟺ 面板開」不變量。
+            // closeLightbox 直接 reset flag（非經 closeMobilePanel）時也清 class，防殘留卡住
+            // 後續 [data-picker-ghost] z-index（女優 picker ghost）。class 不存在時 remove 為 no-op。
+            document.body.classList.remove('similar-mobile-active');
 
             // 56c-fix: standalone similar-exit mode — lightbox 關閉時清 similarExitVideo，
             // 回到原 alice 搜尋結果不動（currentLightboxVideo 在 250ms timer 內由 _setLightboxIndex(-1) 清除）

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -1275,18 +1275,28 @@ export function stateSimilar() {
       const cards = [...document.querySelectorAll('.similar-mobile-burst-card')];
       const runId = this._mobilePanelRunId;
       if (window.BurstPicker && !window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS)) {
-        await window.BurstPicker.playPickerBurst(cards, coverEl, _MOBILE_PICKER_PARAMS, {
+        // P1-1: instant-mode playPickerBurst resolves on LAUNCH（tween 啟動即 resolve），
+        // 非卡片落定。鎖若在此立即釋放，arc 弧（arcDuration≈0.75s）仍飛行中，
+        // 第二次 drill 可在卡片移動中啟動。故 await 爆射 launch 後再等 arcDuration 才解鎖。
+        // 不等無限 float yoyo，只等 arc settle。
+        const burst = window.BurstPicker.playPickerBurst(cards, coverEl, _MOBILE_PICKER_PARAMS, {
           streamMode: 'instant',
           floatTimerSink: this._mobileFloatTweens,
           runId,
           getRunId: () => this._mobilePanelRunId,
         });
+        await Promise.resolve(burst).then(() =>
+          new Promise(res => gsap.delayedCall(_MOBILE_PICKER_PARAMS.arcDuration, res)));
       } else if (window.BurstPicker) {
-        // PRM：shouldSkip 內建瞬顯，仍呼叫以確保卡片 opacity:1 終態
+        // PRM：shouldSkip 內建瞬顯（無飛行），仍呼叫以確保卡片 opacity:1 終態；不加 arc 等待。
         await window.BurstPicker.playPickerBurst(cards, coverEl, _MOBILE_PICKER_PARAMS, { streamMode: 'instant' });
       }
 
-      this.similarModeAnimating = false;
+      // P1-2 對稱：只在自己仍是當前世代時才釋放鎖。若 arc 等待窗內 close→reopen 起了新 session
+      // （runId 已遞增、新 _openMobilePanel 持鎖），不可把新 session 的鎖釋放掉。
+      if (this._mobilePanelRunId === runId) {
+        this.similarModeAnimating = false;
+      }
     },
 
     /**
@@ -1300,6 +1310,10 @@ export function stateSimilar() {
       if (this.similarModeAnimating) return;   // lock-before-await 防連點空窗
       if (!item) return;
       this.similarModeAnimating = true;
+      // P1-2（Codex 二審）：fetch window 早期 session token。在 await 前捕獲世代；await 期間若
+      // close（closeMobilePanel bump runId）甚至 close→reopen 起新 session，sessionRunId 即落後。
+      // fetch/preload 後立即比對 → 防舊 drill 在重開的新 session 上 kill float / clone / swap / 啟動動畫。
+      const sessionRunId = this._mobilePanelRunId;
 
       const pickedCard = $event.currentTarget;
       const coverEl = this.$refs.mobilePanelCoverImg;
@@ -1312,15 +1326,18 @@ export function stateSimilar() {
       try {
         data = await this._fetchSimilarResults(item.number);
       } catch (_err) {
-        this.similarModeAnimating = false;   // _fetchSimilarResults 已 showToast；面板維持當前狀態
+        // _fetchSimilarResults 已 showToast。只在仍是當前世代才還原鎖（close 期間鎖屬新 session）。
+        if (this._mobilePanelRunId === sessionRunId) this.similarModeAnimating = false;
         return;
       }
       const items = data.results.slice(0, 6);   // CD-6
       await this._preloadImages(items.map(r => r.cover_url));
 
-      // stale-check：await 期間關面板 → 中止、不 commit
-      if (!this.similarModeMobileOpen) {
-        this.similarModeAnimating = false;
+      // stale-check（runId 世代，Codex 二審）：await(fetch/preload) 期間若 close（bump runId）或
+      // close→reopen（新 session 持鎖、similarModeMobileOpen 又變 true），sessionRunId 落後 → 中止，
+      // **不**碰新 session 的狀態（不 kill float / clone / swap），**不**還原 similarModeAnimating
+      // （close-only 時 closeMobilePanel 已設 false；reopen 時新 session 持有）。
+      if (this._mobilePanelRunId !== sessionRunId) {
         return;
       }
 
@@ -1434,7 +1451,7 @@ export function stateSimilar() {
       const newCards = [...document.querySelectorAll(
         '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
         .filter(el => !oldCards.includes(el));
-      const burst = window.BurstPicker
+      const burstLaunch = window.BurstPicker
         ? window.BurstPicker.playPickerBurst(newCards, coverEl, _MOBILE_PICKER_PARAMS, {
             streamMode: 'instant',
             floatTimerSink: skip ? undefined : this._mobileFloatTweens,
@@ -1442,8 +1459,24 @@ export function stateSimilar() {
             getRunId: () => this._mobilePanelRunId,
           })
         : Promise.resolve();
+      // P1-1: instant-mode burst resolves on LAUNCH，非卡片落定。flip/exit 約 0.55/0.4s 先完成，
+      // 但新 6 卡 arc（arcDuration≈0.75s）仍飛行 → 鎖若此時釋放，第二次 drill 可在移動中卡片上啟動。
+      // 故把 burst 包成「launch 後再等 arcDuration」才算 settle。skip（PRM）路徑無飛行 → 不加等待。
+      const burstSettled = skip
+        ? Promise.resolve(burstLaunch)
+        : Promise.resolve(burstLaunch).then(() =>
+            new Promise(res => gsap.delayedCall(_MOBILE_PICKER_PARAMS.arcDuration, res)));
 
-      await Promise.all([flip, exit, burst]);
+      await Promise.all([flip, exit, burstSettled]);
+
+      // P1-2: 第二道 stale-check 用 runId 世代（非僅 open flag）。closeMobilePanel 會 bump
+      // _mobilePanelRunId；若 Promise.all 動畫窗內發生 close（甚至 close→reopen 起新 session），
+      // 本 drill 捕獲的 runId 即落後 → 必須中止 commit（否則會用舊 item 覆寫 closeMobilePanel 的還原，
+      // 或汙染重開後的新 session）。runId 不符時**不還原 similarModeAnimating**——鎖屬新 session
+      // （close-only 時 closeMobilePanel 已設 false；reopen 時新 _openMobilePanel 持有）。
+      if (this._mobilePanelRunId !== runId) {
+        return;
+      }
 
       // commit（onComplete 後）：3-tier silent-switch 還原底層 lightbox（裁決 2）
       this._mobileSilentSwitch(item);
@@ -1460,6 +1493,12 @@ export function stateSimilar() {
       // kill float tweens（R5）
       this._mobileFloatTweens.forEach(t => t && t.kill && t.kill());
       this._mobileFloatTweens = [];
+
+      // P1-2: bump runId 使任何 in-flight burst 失效。burst per-card onComplete（burst-picker.js）
+      // 以 getRunId() !== runId 為閘——關面板後 in-flight burst 的 onComplete 會讀到新 runId → 早退，
+      // 不在已清空/已關的面板上啟動 float tween（避免 leak）。亦與第二道 drill stale-check 協同：
+      // 重開面板取得全新 runId，不被舊 in-flight burst 汙染。
+      this._mobilePanelRunId++;
 
       // 83b-T1fix1: 清掉仍在墜落的 detached fixed 舊卡（ExitAll Promise 尚未 resolve 時關面板），避免殘留 overlay
       document.querySelectorAll('.similar-mobile-card-detached').forEach(el => el.remove());

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -119,6 +119,9 @@ export function stateSimilar() {
     _mobileFloatTweens: [],           // 爆射後 float timeline sink（drill / close 時 kill）
     _mobileLastDrilledNumber: null,   // close 時 3-tier silent-switch 還原 lightbox 用
     _mobileLastDrilledItem: null,     // snapshot 被點卡資料（tier2/3 fallback；similarResults 已被替換時仍可取）
+    _mobileEnterTl: null,             // 83b-T3: in-flight 進場 ghost timeline（close 中途打斷時 kill）
+    _mobileEnterGhost: null,          // 83b-T3: in-flight 進場 ghost 節點（close 打斷時顯式 cleanup）
+    _mobileEnterResolve: null,        // 83b-T3: _openMobilePanel enter await resolver（close 打斷時直接解除，.kill() 不 fire onInterrupt）
 
     // 揭露給 Alpine template（x-for="anchor in SIMILAR_ANCHORS"）
     SIMILAR_ANCHORS,
@@ -1256,7 +1259,11 @@ export function stateSimilar() {
       this._mobileLastDrilledNumber = null;
       this._mobilePanelRunId++;
 
-      // 設中央主圖 src（FlipReplace 落點 + Burst 原點）
+      // 83b-T3：enter 前先讀 lightbox cover rect（panel .show 前才有效，否則面板遮住 lightbox）
+      const lightboxCoverEl = this.$refs && this.$refs.lightboxCoverImg;
+
+      // 設中央主圖 src（FlipReplace 落點 + Burst 原點；83b-T3 邊界：enter 前設 src，
+      // onComplete 後只 cleanup ghost，不依賴 onComplete 設 src 以支援中途中斷場景）
       const coverEl = this.$refs.mobilePanelCoverImg;
       if (coverEl) coverEl.src = this.currentLightboxVideo.cover_url || '';
 
@@ -1270,8 +1277,40 @@ export function stateSimilar() {
       const panelEl = document.querySelector('.similar-mobile-panel');
       if (panelEl) panelEl.classList.add('show');
 
-      // 等 x-for 渲染 6 卡 → collect → 爆射
+      // 等 x-for 渲染 6 卡 + layout flush（$nextTick 讓 mobilePanelCoverImg rect 有效）
       await this.$nextTick();
+
+      // 83b-T3：進場 ghost 飛行（similarModeAnimating 保持 true 直到飛行完成）
+      if (window.GhostFly && window.BurstPicker &&
+          !window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS) &&
+          lightboxCoverEl && coverEl) {
+        // P1-T3fix：把 enter timeline + ghost ref + await resolver 暫存於 state，供 closeMobilePanel
+        // 中途打斷時 kill + 顯式 cleanup + 解除本 await（防 enter onComplete 在 exit 飛行中誤還原
+        // mobileCoverEl opacity → ~333ms 雙圖）。GSAP 3 .kill() 不保證 fire onInterrupt，故
+        // closeMobilePanel 直接呼叫存下的 resolver（_mobileEnterResolve），不依賴 onInterrupt。
+        const self = this;
+        await new Promise(function (res) {
+          self._mobileEnterResolve = res;   // 供 closeMobilePanel 中途打斷時直接解除 await
+          self._mobileEnterTl = window.GhostFly.playMobilePanelEnter(lightboxCoverEl, coverEl, {
+            onGhostReady: function (ghost) { self._mobileEnterGhost = ghost; },
+            onComplete: function (ghost) {
+              self._mobileEnterTl = null;
+              self._mobileEnterGhost = null;
+              self._mobileEnterResolve = null;
+              // ghost === null：rect.width===0 或 src 空，直接繼續（src 已在 show 前設好）
+              if (ghost) {
+                // Correction A：到達後 cleanup ghost + 還原 coverImgEl + mobileCoverEl opacity
+                window.GhostFly.cleanupGhost(ghost, lightboxCoverEl, coverEl);
+              }
+              res();
+            }
+          });
+          // 同步路徑（gsap undefined / ghost null）：playMobilePanelEnter 已直接呼叫 onComplete →
+          // res() 已觸發，_mobileEnterTl / _mobileEnterResolve 為 null（onComplete 內清掉）。await 立即 resolve。
+        });
+      }
+      // PRM 降級 or GhostFly unavailable：直接顯示（src 已設，面板已 .show），無需額外動作
+
       const cards = [...document.querySelectorAll('.similar-mobile-burst-card')];
       const runId = this._mobilePanelRunId;
       if (window.BurstPicker && !window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS)) {
@@ -1486,10 +1525,11 @@ export function stateSimilar() {
     },
 
     /**
-     * closeMobilePanel — 點主圖 / ✕ / Esc 關面板。Core 無轉場（直隱）。
+     * closeMobilePanel — 點主圖 / ✕ / Esc 關面板。83b-T3 加 exit ghost 飛行（async）。
      * 絕對不呼叫 closeSimilarMode()（CD-4 / R3：桌面 close 在 similarCards={} 時 await playExit 永不 resolve → 凍結）。
+     * 呼叫方（handleKeydown Esc / matchMedia change / close button）fire-and-forget，不需 await。
      */
-    closeMobilePanel() {
+    async closeMobilePanel() {
       // kill float tweens（R5）
       this._mobileFloatTweens.forEach(t => t && t.kill && t.kill());
       this._mobileFloatTweens = [];
@@ -1503,7 +1543,40 @@ export function stateSimilar() {
       // 83b-T1fix1: 清掉仍在墜落的 detached fixed 舊卡（ExitAll Promise 尚未 resolve 時關面板），避免殘留 overlay
       document.querySelectorAll('.similar-mobile-card-detached').forEach(el => el.remove());
 
-      // 直隱面板（移 .show + flag false → lightbox trap 重新生效、焦點還原）
+      // P1-T3fix（中途中斷 race）：若 enter ghost 仍在飛，先 kill enter timeline + 顯式 cleanup
+      // enter ghost（GSAP 3 .kill() 不保證 fire onInterrupt，故不依賴 onInterrupt 還原 opacity），
+      // 在 exit 起飛「之前」同步還原 lightboxCoverImg + mobilePanelCoverImg opacity:1。
+      // 否則 enter onComplete 會在 exit 飛行中誤把 mobileCoverEl 還原 → ~333ms 雙圖。
+      if (this._mobileEnterTl) {
+        this._mobileEnterTl.kill();
+        this._mobileEnterTl = null;
+      }
+      if (this._mobileEnterGhost) {
+        const _lbCover = this.$refs && this.$refs.lightboxCoverImg;
+        const _mbCover = this.$refs && this.$refs.mobilePanelCoverImg;
+        if (window.GhostFly) {
+          window.GhostFly.cleanupGhost(this._mobileEnterGhost, _lbCover, _mbCover);
+        }
+        this._mobileEnterGhost = null;
+      }
+      // GSAP 3 .kill() 不 fire onInterrupt → 顯式解除 _openMobilePanel 的 enter await（防 async 懸掛）
+      if (this._mobileEnterResolve) {
+        const _res = this._mobileEnterResolve;
+        this._mobileEnterResolve = null;
+        _res();
+      }
+
+      // 83b-T3：退場 ghost 飛行（GhostFly available + 非 PRM → await 後才移 .show）
+      if (window.GhostFly && window.BurstPicker &&
+          !window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS)) {
+        const coverImgEl = this.$refs && this.$refs.lightboxCoverImg;
+        const mobileCoverEl = this.$refs && this.$refs.mobilePanelCoverImg;
+        await new Promise(function (res) {
+          window.GhostFly.playMobilePanelExit(mobileCoverEl, coverImgEl, { onComplete: res });
+        });
+      }
+
+      // exit 完成後（或 PRM 直接跳過）才隱藏面板（移 .show + flag false → lightbox trap 重新生效）
       const panelEl = document.querySelector('.similar-mobile-panel');
       if (panelEl) panelEl.classList.remove('show');
       this.similarModeMobileOpen = false;

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -1300,7 +1300,6 @@ export function stateSimilar() {
       if (this.similarModeAnimating) return;   // lock-before-await 防連點空窗
       if (!item) return;
       this.similarModeAnimating = true;
-      this._mobilePanelRunId++;
 
       const pickedCard = $event.currentTarget;
       const coverEl = this.$refs.mobilePanelCoverImg;
@@ -1329,22 +1328,23 @@ export function stateSimilar() {
       this._mobileFloatTweens.forEach(t => t && t.kill && t.kill());
       this._mobileFloatTweens = [];
 
-      const runId = this._mobilePanelRunId;
       const skip = window.BurstPicker && window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS);
       const oldOtherCards = oldCards.filter(c => c !== pickedCard);
 
-      // 83b-T1fix1: detach-before-swap（技術要點 3）。reactive similarResults swap +
-      // Alpine keyed x-for 會移除舊卡 DOM；若直接對原節點 playPickerExitAll，swap 後節點已脫離
-      // → 墜落動畫對「已移除（不可見）」節點跑 → 卡直接消失（非可見墜落，違反 spec AC-4）。
-      // 修法：swap 前把每張 oldOtherCard 凍結在當前 viewport rect、設 position:fixed、re-parent
-      // 到面板下（脫離 x-for 控制），再對 detached 節點跑 ExitAll，Promise resolve 後移除（清乾淨）。
-      // pickedCard 不 detach（FlipReplace 自建 fixed ghost、隱藏原節點，對原節點被移除免疫）。
+      // 83b-T1fix3: clone-based detach（Opus 裁決，推翻 T1fix1/2 的 re-parent 模型）。
+      // 驗證鏈：Alpine 3.15.12 keyed x-for reconcile 對 removed key 直接 raw Node.remove()，
+      // 無 parentElement===container 守衛 → re-parent 到 panelEl 的「原節點」一樣會被 Alpine 拔走
+      // → T1fix2 的可見淡出跑在已脫離 document 的孤兒上 → 不可見。
+      // 修法：不搬原節點，改 deep clone。每張 oldOtherCard 凍結在當前 viewport rect 後 cloneNode(true)，
+      // clone 加 .similar-mobile-card-detached + position:fixed + 凍結 rect，appendChild 到面板下。
+      // clone 非 Alpine-tracked → composite key churn 6 原節點都不影響 clone → 退場動畫完全脫離 Alpine 生命週期。
+      // 原 card 留在原位不動，Alpine swap 時自然 .remove() 它（正確、無害，clone 在同一 rect 接手）。
+      // pickedCard 不 clone（FlipReplace 自建 fixed ghost、隱藏原節點，對原節點被移除免疫）。
       //
-      // H1 順序鐵律：FlipReplace 必須在 detach loop 之前呼叫。playPickerFlipReplace 在 call 當下
-      // 同步讀 pickedCard 的 getBoundingClientRect()；若先 detach 5 張 sibling，grid
-      // （repeat(3,minmax(0,1fr)) + justify-items:center）會 reflow，pickedCard 塌進第一格 →
-      // ghost 從錯誤版位起飛。先建 FlipReplace ghost（讀真實 tapped rect、隱原節點），
-      // 之後 detach 其餘 5 張不影響已建好的 fixed ghost。
+      // H1 順序鐵律：FlipReplace 必須在 clone loop 之前呼叫。playPickerFlipReplace 在 call 當下
+      // 同步讀 pickedCard 的 getBoundingClientRect()；維持 FlipReplace-before-clone 既有順序即可
+      // （clone 不移除原節點 → grid 不 reflow，但保留順序以策安全）。
+      // 先建 FlipReplace ghost（讀真實 tapped rect、隱原節點），之後 clone 其餘 5 張不影響已建好的 fixed ghost。
       const flip = (window.BurstPicker && coverEl)
         ? window.BurstPicker.playPickerFlipReplace(pickedCard, coverEl, _MOBILE_PICKER_PARAMS)
         : Promise.resolve();
@@ -1354,15 +1354,34 @@ export function stateSimilar() {
       if (panelEl) {
         oldOtherCards.forEach(card => {
           const r = card.getBoundingClientRect();
-          card.classList.add('similar-mobile-card-detached');
-          card.style.position = 'fixed';
-          card.style.margin = '0';
-          card.style.top = r.top + 'px';
-          card.style.left = r.left + 'px';
-          card.style.width = r.width + 'px';
-          card.style.height = r.height + 'px';
-          panelEl.appendChild(card);   // re-parent 脫離 x-for；keyed diff 移除的是新建節點
-          detachedOldCards.push(card);
+          const clone = card.cloneNode(true);   // deep clone：非 Alpine-tracked，退場動畫脫離 keyed diff
+          // 83b-T1fix3-fix：cloneNode 連 Alpine directive 屬性（:src / @click）一起複製，
+          // appendChild 後 Alpine 的 MutationObserver 會 auto-init 這個 clone、evaluate `item.cover_url`，
+          // 但 clone 在 x-for scope 之外 → `item is not defined` 洪水錯誤 + 破壞 render。
+          // 故 strip 掉 clone（含子孫）所有 Alpine directive（x-* / : / @），讓它變純惰性 DOM 節點。
+          [clone, ...clone.querySelectorAll('*')].forEach(el => {
+            [...el.attributes].forEach(attr => {
+              const n = attr.name;
+              if (n.startsWith('x-') || n.startsWith(':') || n.startsWith('@')) {
+                el.removeAttribute(n);
+              }
+            });
+          });
+          // 保險：把 resolved cover src 顯式複製到 clone img（:src 被 strip 後仍顯示原圖）
+          const cloneImg = clone.querySelector('img');
+          const srcImg = card.querySelector('img');
+          if (cloneImg && srcImg) cloneImg.src = srcImg.src;
+          clone.classList.add('similar-mobile-card-detached');
+          clone.style.position = 'fixed';
+          clone.style.margin = '0';
+          clone.style.top = r.top + 'px';
+          clone.style.left = r.left + 'px';
+          clone.style.width = r.width + 'px';
+          clone.style.height = r.height + 'px';
+          clone.style.pointerEvents = 'none';
+          panelEl.appendChild(clone);   // clone 在 panel 動畫；原節點交給 Alpine swap 自然移除
+          detachedOldCards.push(clone);
+          gsap.set(card, { opacity: 0 });   // 原節點即將被 Alpine 移除，先隱避免 clone 接手前 1-frame 重疊
         });
       }
       const cleanupDetached = () => {
@@ -1398,6 +1417,12 @@ export function stateSimilar() {
       }).then(cleanupDetached, cleanupDetached);
 
       // reactive swap → 新卡 DOM
+      // _mobilePanelRunId 必須在 reactive swap 前一刻才 bump——card key 依賴它，提早 bump 會在
+      // await 期間觸發 keyed re-render 把 pickedCard 變 stale → FlipReplace no-op（83b-T1fix3-fix2）。
+      // 在 swap 同一 tick bump：await 全程 key 維持舊 runId（pickedCard 存活 → flip 正常飛 + 換封面），
+      // 此處 bump 後 6 張 key 全新 → Alpine 重建 6 張全新節點 → 全部 burst（issue-2「6 卡」修法保留）。
+      this._mobilePanelRunId++;
+      const runId = this._mobilePanelRunId;   // burst token：反映 swap 後的新世代
       this.similarResults = items;
       // 中央主圖 src 換成被點卡封面（drill 落點）。BurstPicker 在場時 playPickerFlipReplace
       // 已在 ghost 抵達時 swap coverImg.src（含 cache-bust），這裡再設會觸發第二次冗餘 fetch；

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -46,6 +46,20 @@ import { BreathingManager } from '@/shared/constellation/breathing.js';
 // T6 (CD-T6-1)：hover corridor half-width（與 motion-lab host 同值 40px）
 const HOVER_DISTANCE = 40;
 
+// 83b-T1: 行動 Photo Picker 爆射參數（CD-2）。
+// 複製 stateLightbox 閉包私有的 _PICKER_PARAMS 7 個 baseline 值——
+// _PICKER_PARAMS 未 export、不在 this 上，stateSimilar 直接引用會 ReferenceError，故自帶一份。
+// 不含 reducedMotionSim（mirror _PICKER_PARAMS；PRM 走 window.OpenAver.prefersReducedMotion）。
+const _MOBILE_PICKER_PARAMS = {
+  arcOvershoot: 1.3,
+  arcDuration: 0.75,
+  floatAmplY: 8,
+  floatAmplRot: 2.5,
+  floatDuration: 1.5,
+  hoverScale: 1.08,
+  exitGravity: 1200,
+};
+
 /**
  * pointToSegmentDist — 點到線段最短距離（T6 CD-T6-1）
  * 與 motion-lab/constellation-host.js 內 helper 同義；shared/constellation/anchors.js
@@ -98,7 +112,13 @@ export function stateSimilar() {
     _similarMainBreathTween: null,
     _similarLastDrilledNumber: null,   // T5/T6 closeSimilarMode silent switch 用（T4 不讀）
     _similarLastDrilledItem: null,    // 56c-fix-v2：snapshot clickedItem，避免 similarResults 替換後找不到
-    similarModeMobileOpen: false,     // 56c-T7：手機 x-collapse toggle
+    similarModeMobileOpen: false,     // 56c-T7→83b-T1：語義改為「全螢幕行動面板開」（CD-7 沿用 flag）
+
+    // 83b-T1: 行動相似探索面板 state（similarModeMobileOpen 沿用既有 flag，不新增）
+    _mobilePanelRunId: 0,             // drill burst race token（每次 drill ++）
+    _mobileFloatTweens: [],           // 爆射後 float timeline sink（drill / close 時 kill）
+    _mobileLastDrilledNumber: null,   // close 時 3-tier silent-switch 還原 lightbox 用
+    _mobileLastDrilledItem: null,     // snapshot 被點卡資料（tier2/3 fallback；similarResults 已被替換時仍可取）
 
     // 揭露給 Alpine template（x-for="anchor in SIMILAR_ANCHORS"）
     SIMILAR_ANCHORS,
@@ -226,23 +246,10 @@ export function stateSimilar() {
       if (this.showFavoriteActresses) return;     // CD-56C-13 fail-safe
       if (!this.currentLightboxVideo) return;     // 無 lightbox video metadata 時 no-op
 
-      // 56c-T7：手機降級 — viewport < 960px 不進 constellation
+      // 83b-T1：手機 <960px → 全螢幕行動相似探索面板（Mobile Photo Picker 爆射）。
+      // 取代舊 x-collapse 寄生 block。Core 無轉場（飛行轉場留 T3）。
       if (window.innerWidth < 960) {
-        if (this.similarModeAnimating) return;
-        if (this.similarModeMobileOpen) {
-          this.similarModeMobileOpen = false;   // toggle：再點收合
-          return;
-        }
-        this.similarModeAnimating = true;
-        try {
-          const data = await this._fetchSimilarResults(this.currentLightboxVideo.number);
-          this.similarResults = data.results;
-          this.similarQueryVideo = data.query_video;
-          this.similarModeMobileOpen = true;    // 展開 x-collapse
-        } catch (_err) {
-          // _fetchSimilarResults 已 showToast；similarModeMobileOpen 保持 false
-        }
-        this.similarModeAnimating = false;
+        await this._openMobilePanel();
         return;
       }
 
@@ -1217,57 +1224,204 @@ export function stateSimilar() {
       }
     },
 
-    // ── T5 新增 method ─────────────────────────────────────────────────────
+    // ── 83b-T1: 行動相似探索面板（Mobile Photo Picker 爆射）──────────────────
 
     /**
-     * onSimilarMobileCardClick — 手機 mobile card 點擊：fetch 新一批 + swap + silent switch
-     * 56c-T7 CD-56C-8：手機無動畫 takeover，直接 reactive swap + silent switch（同 CD-56C-12 邏輯）
+     * _openMobilePanel — openSimilarMode 的 <960px 分支：fetch → preload → 顯示面板 → 6 卡爆射。
+     * Core 無轉場（直顯；飛行轉場留 T3）。lock-before-await + stale-check（面板開期間 lightbox 已關則中止）。
      */
-    onSimilarMobileCardClick(item) {
-      if (this.similarModeAnimating) return;
-      if (!item) return;
-      // T7 codex-fix1: 對齊 onSimilarCardClick race guard，fetch 前鎖定防連點覆蓋
-      this.similarModeAnimating = true;
-      this._fetchSimilarResults(item.number).then(data => {
-        this.similarResults = data.results;
-        this.similarQueryVideo = data.query_video;
-        // Alpine x-for 自動 reactive，畫面 swap
+    async _openMobilePanel() {
+      this.similarModeAnimating = true;   // await 前鎖
+      let data;
+      try {
+        data = await this._fetchSimilarResults(this.currentLightboxVideo.number);
+      } catch (_err) {
+        this.similarModeAnimating = false;   // _fetchSimilarResults 已 showToast
+        return;
+      }
+      const items = data.results.slice(0, 6);   // CD-6 固定 6 張
+      await this._preloadImages(items.map(r => r.cover_url));
 
-        // BUGfix-mobile-similar-stale-cover: 三層 fallback（tier 1→2→3）
-        // tier 1: 命中 _filteredVideos → _setLightboxIndex（含自動清 similarExitVideo=null）
-        if (!this._silentSwitchLightboxByNumber(item.number)) {
-          // tier 2: 在 _videos（庫內、被 filter 排除）→ standalone，完整 metadata + path
-          const vIdx = _videos.findIndex(v => v.number === item.number);
-          if (vIdx >= 0) {
-            this.similarExitVideo = _videos[vIdx];
-          } else {
-            // tier 3: 孤兒列 / demo — 前端只有 similar API 的 5 欄 snapshot
-            const actressStr = Array.isArray(item.actresses)
-              ? item.actresses.join(', ') : (item.actresses || '');
-            this.similarExitVideo = {
-              number: item.number, title: item.title,
-              cover_url: item.cover_url,
-              cover_full_url: item.cover_full_url || '',  // 必帶 || ''：確保 .lb-full @load fire
-              actresses: actressStr,
-              // path 故意 undefined → play/open-folder/user-tags 靠 ?. guard 靜默不渲染
-            };
-          }
-          // tier 2 + 3 共用收尾：standalone housekeeping + blur-up reset
-          this.currentLightboxVideo = this.similarExitVideo;
-          this.currentLightboxActress = null;
-          this._videoChipsExpanded = false;
-          this.addingLbTag = false;
-          this._refreshLbFullBlurUp();
-        }
-
-        // P3: _similarLastDrilled* 在 fetch 成功後設（非 fetch 前），退場 exit 目標正確
-        this._similarLastDrilledNumber = item.number;
-        this._similarLastDrilledItem = item;
-      }).catch(() => {
-        // _fetchSimilarResults 已 showToast；x-for 不刷新，留原 4 張
-      }).finally(() => {
+      // stale-check：await 期間 lightbox 已關 → 中止（不顯示面板）。
+      // closeLightbox() 同步翻 lightboxOpen=false，但 currentLightboxVideo 走 250ms timer 才清，
+      // 故須查 lightboxOpen（否則 fetch/preload 空窗期關 lightbox 會漏接）。
+      if (!this.lightboxOpen || !this.currentLightboxVideo) {
         this.similarModeAnimating = false;
-      });
+        return;
+      }
+
+      // 填資料 + 重置 drill 歷史
+      this.similarResults = items;
+      this.similarQueryVideo = data.query_video;
+      this._mobileLastDrilledNumber = null;
+      this._mobilePanelRunId++;
+
+      // 設中央主圖 src（FlipReplace 落點 + Burst 原點）
+      const coverEl = this.$refs.mobilePanelCoverImg;
+      if (coverEl) coverEl.src = this.currentLightboxVideo.cover_url || '';
+
+      // 顯示面板：flag（trigger x-trap）+ DOM .show（CSS default-hidden → 顯示）
+      this.similarModeMobileOpen = true;
+      const panelEl = document.querySelector('.similar-mobile-panel');
+      if (panelEl) panelEl.classList.add('show');
+
+      // 等 x-for 渲染 6 卡 → collect → 爆射
+      await this.$nextTick();
+      const cards = [...document.querySelectorAll('.similar-mobile-burst-card')];
+      const runId = this._mobilePanelRunId;
+      if (window.BurstPicker && !window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS)) {
+        await window.BurstPicker.playPickerBurst(cards, coverEl, _MOBILE_PICKER_PARAMS, {
+          streamMode: 'instant',
+          floatTimerSink: this._mobileFloatTweens,
+          runId,
+          getRunId: () => this._mobilePanelRunId,
+        });
+      } else if (window.BurstPicker) {
+        // PRM：shouldSkip 內建瞬顯，仍呼叫以確保卡片 opacity:1 終態
+        await window.BurstPicker.playPickerBurst(cards, coverEl, _MOBILE_PICKER_PARAMS, { streamMode: 'instant' });
+      }
+
+      this.similarModeAnimating = false;
+    },
+
+    /**
+     * onMobileDrillClick — 點相似卡：被點卡 FlipReplace 回中央 + 舊卡墜落 + 新 6 卡爆射（三者同時，CD-5）。
+     * lock-before-await + stale-check + old/new card partition（R2）+ float tween kill（R5）。
+     * commit（3-tier silent-switch）延到 Promise.all resolve 後（裁決 2）。
+     * @param {object} item   被點卡資料（含 number / cover_url）
+     * @param {Event}  $event @click 事件（currentTarget = 被點 .similar-mobile-burst-card）
+     */
+    async onMobileDrillClick(item, $event) {
+      if (this.similarModeAnimating) return;   // lock-before-await 防連點空窗
+      if (!item) return;
+      this.similarModeAnimating = true;
+      this._mobilePanelRunId++;
+
+      const pickedCard = $event.currentTarget;
+      const coverEl = this.$refs.mobilePanelCoverImg;
+      // await 前 snapshot oldCards（partition 用，R2）
+      const oldCards = [...document.querySelectorAll('.similar-mobile-burst-card')];
+
+      let data;
+      try {
+        data = await this._fetchSimilarResults(item.number);
+      } catch (_err) {
+        this.similarModeAnimating = false;   // _fetchSimilarResults 已 showToast；面板維持當前狀態
+        return;
+      }
+      const items = data.results.slice(0, 6);   // CD-6
+      await this._preloadImages(items.map(r => r.cover_url));
+
+      // stale-check：await 期間關面板 → 中止、不 commit
+      if (!this.similarModeMobileOpen) {
+        this.similarModeAnimating = false;
+        return;
+      }
+
+      // kill 舊 float tweens（R5）
+      this._mobileFloatTweens.forEach(t => t && t.kill && t.kill());
+      this._mobileFloatTweens = [];
+
+      const runId = this._mobilePanelRunId;
+      const skip = window.BurstPicker && window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS);
+      const oldOtherCards = oldCards.filter(c => c !== pickedCard);
+
+      // 三動畫並行（不 await 個別）
+      const flip = (window.BurstPicker && coverEl)
+        ? window.BurstPicker.playPickerFlipReplace(pickedCard, coverEl, _MOBILE_PICKER_PARAMS)
+        : Promise.resolve();
+      const exit = window.BurstPicker
+        ? window.BurstPicker.playPickerExitAll(oldOtherCards, _MOBILE_PICKER_PARAMS)
+        : Promise.resolve();
+
+      // reactive swap → 新卡 DOM
+      this.similarResults = items;
+      // 中央主圖 src 換成被點卡封面（drill 落點）。BurstPicker 在場時 playPickerFlipReplace
+      // 已在 ghost 抵達時 swap coverImg.src（含 cache-bust），這裡再設會觸發第二次冗餘 fetch；
+      // 故只在 no-BurstPicker fallback（flip 退化成 Promise.resolve）才手動補設。
+      if (!(window.BurstPicker && coverEl) && coverEl && item.cover_url) {
+        coverEl.src = item.cover_url;
+      }
+      await this.$nextTick();
+      const newCards = [...document.querySelectorAll('.similar-mobile-burst-card')]
+        .filter(el => !oldCards.includes(el));
+      const burst = window.BurstPicker
+        ? window.BurstPicker.playPickerBurst(newCards, coverEl, _MOBILE_PICKER_PARAMS, {
+            streamMode: 'instant',
+            floatTimerSink: skip ? undefined : this._mobileFloatTweens,
+            runId,
+            getRunId: () => this._mobilePanelRunId,
+          })
+        : Promise.resolve();
+
+      await Promise.all([flip, exit, burst]);
+
+      // commit（onComplete 後）：3-tier silent-switch 還原底層 lightbox（裁決 2）
+      this._mobileSilentSwitch(item);
+      this._mobileLastDrilledNumber = item.number;
+
+      this.similarModeAnimating = false;
+    },
+
+    /**
+     * closeMobilePanel — 點主圖 / ✕ / Esc 關面板。Core 無轉場（直隱）。
+     * 絕對不呼叫 closeSimilarMode()（CD-4 / R3：桌面 close 在 similarCards={} 時 await playExit 永不 resolve → 凍結）。
+     */
+    closeMobilePanel() {
+      // kill float tweens（R5）
+      this._mobileFloatTweens.forEach(t => t && t.kill && t.kill());
+      this._mobileFloatTweens = [];
+
+      // 直隱面板（移 .show + flag false → lightbox trap 重新生效、焦點還原）
+      const panelEl = document.querySelector('.similar-mobile-panel');
+      if (panelEl) panelEl.classList.remove('show');
+      this.similarModeMobileOpen = false;
+
+      // 3-tier silent-switch 還原 lightbox 到最後 drill 那片（mirror closeSimilarMode tail）
+      if (this._mobileLastDrilledNumber && this._mobileLastDrilledItem) {
+        this._mobileSilentSwitch(this._mobileLastDrilledItem);
+      }
+
+      // reset
+      this._mobileLastDrilledNumber = null;
+      this._mobileLastDrilledItem = null;
+      this.similarModeAnimating = false;
+      // 焦點回 lightbox：x-trap 因 similarModeMobileOpen=false 自動還原（L548 trap 重新生效）
+    },
+
+    /**
+     * _mobileSilentSwitch — 3-tier silent-switch（複用 closeSimilarMode / 舊 onSimilarMobileCardClick
+     * 已驗證的 tier1→2→3 邏輯，CD-3 不重新發明資料層）。把底層 lightbox 切到 item 那片影片。
+     * tier1: _filteredVideos 命中 → _setLightboxIndex；tier2: _videos standalone；tier3: 5 欄 snapshot。
+     */
+    _mobileSilentSwitch(item) {
+      if (!item) return;
+      // 記 snapshot 供 close-tail 還原（mirror _similarLastDrilledItem）
+      this._mobileLastDrilledItem = item;
+      // tier 1: 命中 _filteredVideos → _setLightboxIndex（含自動清 similarExitVideo=null）
+      if (this._silentSwitchLightboxByNumber(item.number)) return;
+      // tier 2: 在 _videos（庫內、被 filter 排除）→ standalone，完整 metadata + path
+      const vIdx = _videos.findIndex(v => v.number === item.number);
+      if (vIdx >= 0) {
+        this.similarExitVideo = _videos[vIdx];
+      } else {
+        // tier 3: 孤兒列 / demo — 前端只有 similar API 的 5 欄 snapshot
+        const actressStr = Array.isArray(item.actresses)
+          ? item.actresses.join(', ') : (item.actresses || '');
+        this.similarExitVideo = {
+          number: item.number, title: item.title,
+          cover_url: item.cover_url,
+          cover_full_url: item.cover_full_url || '',  // 必帶 || ''：確保 .lb-full @load fire
+          actresses: actressStr,
+          // path 故意 undefined → play/open-folder/user-tags 靠 ?. guard 靜默不渲染
+        };
+      }
+      // tier 2 + 3 共用收尾：standalone housekeeping + blur-up reset
+      this.currentLightboxVideo = this.similarExitVideo;
+      this.currentLightboxActress = null;
+      this._videoChipsExpanded = false;
+      this.addingLbTag = false;
+      this._refreshLbFullBlurUp();
     },
 
     /**

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -1262,6 +1262,11 @@ export function stateSimilar() {
 
       // 顯示面板：flag（trigger x-trap）+ DOM .show（CSS default-hidden → 顯示）
       this.similarModeMobileOpen = true;
+      // 83b-T1fix2 (1a): scope ghost z-index 抬高到「面板開啟期間」。CSS
+      // `body.similar-mobile-active [data-picker-ghost]{z-index:1600!important}`
+      // 讓飛行 ghost 在 scrim 前方銳利（覆蓋 burst-picker.js inline z-index:1000）；
+      // 面板未開時不存在此 class → 女優 picker 共用 ghost 不受影響（F1 歸零）。
+      document.body.classList.add('similar-mobile-active');
       const panelEl = document.querySelector('.similar-mobile-panel');
       if (panelEl) panelEl.classList.add('show');
 
@@ -1299,8 +1304,10 @@ export function stateSimilar() {
 
       const pickedCard = $event.currentTarget;
       const coverEl = this.$refs.mobilePanelCoverImg;
-      // await 前 snapshot oldCards（partition 用，R2）
-      const oldCards = [...document.querySelectorAll('.similar-mobile-burst-card')];
+      // await 前 snapshot oldCards（partition 用，R2）。排除前一輪仍在墜落的 detached 卡
+      // （:not(.similar-mobile-card-detached)），避免快速 drill 把 falling 孤兒重新 freeze/double-animate。
+      const oldCards = [...document.querySelectorAll(
+        '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')];
 
       let data;
       try {
@@ -1326,13 +1333,69 @@ export function stateSimilar() {
       const skip = window.BurstPicker && window.BurstPicker.shouldSkip(_MOBILE_PICKER_PARAMS);
       const oldOtherCards = oldCards.filter(c => c !== pickedCard);
 
-      // 三動畫並行（不 await 個別）
+      // 83b-T1fix1: detach-before-swap（技術要點 3）。reactive similarResults swap +
+      // Alpine keyed x-for 會移除舊卡 DOM；若直接對原節點 playPickerExitAll，swap 後節點已脫離
+      // → 墜落動畫對「已移除（不可見）」節點跑 → 卡直接消失（非可見墜落，違反 spec AC-4）。
+      // 修法：swap 前把每張 oldOtherCard 凍結在當前 viewport rect、設 position:fixed、re-parent
+      // 到面板下（脫離 x-for 控制），再對 detached 節點跑 ExitAll，Promise resolve 後移除（清乾淨）。
+      // pickedCard 不 detach（FlipReplace 自建 fixed ghost、隱藏原節點，對原節點被移除免疫）。
+      //
+      // H1 順序鐵律：FlipReplace 必須在 detach loop 之前呼叫。playPickerFlipReplace 在 call 當下
+      // 同步讀 pickedCard 的 getBoundingClientRect()；若先 detach 5 張 sibling，grid
+      // （repeat(3,minmax(0,1fr)) + justify-items:center）會 reflow，pickedCard 塌進第一格 →
+      // ghost 從錯誤版位起飛。先建 FlipReplace ghost（讀真實 tapped rect、隱原節點），
+      // 之後 detach 其餘 5 張不影響已建好的 fixed ghost。
       const flip = (window.BurstPicker && coverEl)
         ? window.BurstPicker.playPickerFlipReplace(pickedCard, coverEl, _MOBILE_PICKER_PARAMS)
         : Promise.resolve();
-      const exit = window.BurstPicker
-        ? window.BurstPicker.playPickerExitAll(oldOtherCards, _MOBILE_PICKER_PARAMS)
-        : Promise.resolve();
+
+      const panelEl = document.querySelector('.similar-mobile-panel');
+      const detachedOldCards = [];
+      if (panelEl) {
+        oldOtherCards.forEach(card => {
+          const r = card.getBoundingClientRect();
+          card.classList.add('similar-mobile-card-detached');
+          card.style.position = 'fixed';
+          card.style.margin = '0';
+          card.style.top = r.top + 'px';
+          card.style.left = r.left + 'px';
+          card.style.width = r.width + 'px';
+          card.style.height = r.height + 'px';
+          panelEl.appendChild(card);   // re-parent 脫離 x-for；keyed diff 移除的是新建節點
+          detachedOldCards.push(card);
+        });
+      }
+      const cleanupDetached = () => {
+        detachedOldCards.forEach(card => card.remove());
+        detachedOldCards.length = 0;
+      };
+
+      // 83b-T1fix2 (1b): caller 端可見退場取代 playPickerExitAll。ExitAll 固定重力向下墜，
+      // 但這 6 卡 bottom-anchored（容器 bottom:calc(4vh+safe-area)）→ 下墜瞬間掉出視口下緣 →
+      // 退場幾乎不可見（owner 真機回饋）。改成「原地淡出 + 縮小 + 略上移」，bottom-anchored 可見。
+      // 不碰 burst-picker.js（ExitAll 模組本體 + 其桌面星空 / 女優 picker 用途 + axis 守衛皆不動）。
+      const exitEls = panelEl ? detachedOldCards : oldOtherCards;
+      const exit = new Promise((resolve) => {
+        if (skip) {
+          // PRM 短路：瞬移除（同 ExitAll reduced-motion 行為）
+          if (exitEls.length) gsap.set(exitEls, { opacity: 0 });
+          resolve();
+          return;
+        }
+        if (exitEls.length) {
+          gsap.to(exitEls, {
+            opacity: 0,
+            scale: 0.7,
+            y: '-=36',
+            duration: 0.4,
+            stagger: 0.04,
+            ease: 'power2.out',
+            onComplete: resolve,
+          });
+        } else {
+          resolve();
+        }
+      }).then(cleanupDetached, cleanupDetached);
 
       // reactive swap → 新卡 DOM
       this.similarResults = items;
@@ -1343,7 +1406,8 @@ export function stateSimilar() {
         coverEl.src = item.cover_url;
       }
       await this.$nextTick();
-      const newCards = [...document.querySelectorAll('.similar-mobile-burst-card')]
+      const newCards = [...document.querySelectorAll(
+        '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
         .filter(el => !oldCards.includes(el));
       const burst = window.BurstPicker
         ? window.BurstPicker.playPickerBurst(newCards, coverEl, _MOBILE_PICKER_PARAMS, {
@@ -1372,10 +1436,15 @@ export function stateSimilar() {
       this._mobileFloatTweens.forEach(t => t && t.kill && t.kill());
       this._mobileFloatTweens = [];
 
+      // 83b-T1fix1: 清掉仍在墜落的 detached fixed 舊卡（ExitAll Promise 尚未 resolve 時關面板），避免殘留 overlay
+      document.querySelectorAll('.similar-mobile-card-detached').forEach(el => el.remove());
+
       // 直隱面板（移 .show + flag false → lightbox trap 重新生效、焦點還原）
       const panelEl = document.querySelector('.similar-mobile-panel');
       if (panelEl) panelEl.classList.remove('show');
       this.similarModeMobileOpen = false;
+      // 83b-T1fix2 (1a): 移除 ghost z-index scope（與 _openMobilePanel 對稱）
+      document.body.classList.remove('similar-mobile-active');
 
       // 3-tier silent-switch 還原 lightbox 到最後 drill 那片（mirror closeSimilarMode tail）
       if (this._mobileLastDrilledNumber && this._mobileLastDrilledItem) {

--- a/web/static/js/shared/ghost-fly.js
+++ b/web/static/js/shared/ghost-fly.js
@@ -283,6 +283,170 @@
         return tl;
     }
 
+    // ─── 83b-T3: 行動相似面板 封面飛行進 / 退場 helper ──────────────────────
+
+    /**
+     * 83b-T3: Lightbox cover → Mobile panel center 進場
+     *
+     * 從 lightbox cover img（coverImgEl）起飛，飛到行動面板中央主圖（mobileCoverEl）
+     * 位置；只顯示右半邊（cropMode: 'right-half'）。
+     * 抵達時 ghost 不自 cleanup（由 caller 在 onComplete 接管：set src + cleanupGhost）。
+     *
+     * Correction A：飛行期間同時隱藏 destination（mobileCoverEl），讓 ghost 到達後才顯示
+     * 真圖，避免「ghost 飛到已可見的目標上方 → 視覺重複」。
+     *
+     * P1-T3fix（中途中斷 race）：回傳的 timeline 有穩定 id 'mobilePanelEnter'，且透過
+     * opts.onGhostReady 同步把 enter ghost ref 交給 caller。closeMobilePanel 中途打斷時
+     * 必須先 kill 此 timeline 並（GSAP 3 .kill() 不保證 fire onInterrupt）顯式
+     * cleanupGhost(enterGhost, coverImgEl, mobileCoverEl) 還原雙端 opacity，再起飛 exit ghost。
+     *
+     * @param {HTMLImageElement} coverImgEl   - lightbox 內 cover img（$refs.lightboxCoverImg）
+     * @param {HTMLImageElement} mobileCoverEl - 行動面板中央主圖（$refs.mobilePanelCoverImg）
+     * @param {object} [opts] - { onComplete?: (ghost) => void, onGhostReady?: (ghost) => void }
+     * @returns {gsap.core.Timeline|null}
+     */
+    function playMobilePanelEnter(coverImgEl, mobileCoverEl, opts) {
+        opts = opts || {};
+        if (!coverImgEl || !mobileCoverEl) {
+            if (typeof opts.onComplete === 'function') opts.onComplete(null);
+            return null;
+        }
+        if (typeof gsap === 'undefined') {
+            if (typeof opts.onComplete === 'function') opts.onComplete(null);
+            return null;
+        }
+
+        // P2-T3fix（rect 讀取在 .show 之後）：caller 在 panelEl.classList.add('show') +
+        // $nextTick 後才呼叫本函式，故此 rect 讀取在 .show 之後。安全：面板靠
+        // opacity/visibility:hidden 隱藏（非 display:none），lightbox cover 的 layout
+        // 幾何不受 .show 影響，source rect 與 .show 前一致。
+        var rect = coverImgEl.getBoundingClientRect();
+        var src = coverImgEl.src;
+
+        // C25 順序鐵律：先建 ghost（createCoverGhost 內部 cleanupStaleGhosts() 會還原
+        // 所有 [data-ghost-hidden] 元素 opacity，故必須在 hide 之前呼叫）
+        var ghost = createCoverGhost(src, rect, { cropMode: 'right-half' });
+        if (!ghost) {
+            // rect.width === 0 or src empty → graceful skip
+            if (typeof opts.onComplete === 'function') opts.onComplete(null);
+            return null;
+        }
+        // P1-T3fix：同步把 enter ghost ref 交 caller，供中途打斷時顯式 cleanup
+        if (typeof opts.onGhostReady === 'function') opts.onGhostReady(ghost);
+
+        // 隱藏來源（lightbox cover）
+        coverImgEl.setAttribute('data-ghost-hidden', 'true');
+        gsap.set(coverImgEl, { opacity: 0 });
+
+        // Correction A：同時隱藏目標（mobile center cover），防 ghost 飛抵時雙圖重疊
+        mobileCoverEl.setAttribute('data-ghost-hidden', 'true');
+        gsap.set(mobileCoverEl, { opacity: 0 });
+
+        // 讀目標 rect（面板 .show 後、$nextTick 後呼叫，此時 rect 已有效）
+        var targetRect = mobileCoverEl.getBoundingClientRect();
+
+        // duration guard chain（與桌面函式 L199-200 完全一致）
+        var dur = (window.OpenAver && window.OpenAver.motion &&
+                   window.OpenAver.motion.DURATION && window.OpenAver.motion.DURATION.medium) || 0.333;
+
+        // race 防護
+        gsap.killTweensOf(ghost);
+
+        var tl = gsap.timeline({
+            id: 'mobilePanelEnter',
+            onComplete: function () {
+                // ghost 留著交 caller 接管（mirror 桌面 constellation enter L208-209 pattern）
+                // caller 負責：mobileCoverEl.src = src + cleanupGhost(ghost, coverImgEl, mobileCoverEl)
+                if (typeof opts.onComplete === 'function') opts.onComplete(ghost);
+            },
+            onInterrupt: function () {
+                // race / 中途中斷：cleanup ghost + 還原 coverImgEl + mobileCoverEl opacity
+                // （idempotent：closeMobilePanel 亦會顯式 cleanup，cleanupGhost 以 parentNode 守衛）
+                cleanupGhost(ghost, coverImgEl, mobileCoverEl);
+            }
+        });
+
+        tl.to(ghost, {
+            x: targetRect.left, y: targetRect.top,
+            width: targetRect.width, height: targetRect.height,
+            duration: dur,
+            ease: 'fluent-decel'
+        }, 0);
+
+        return tl;
+    }
+
+    /**
+     * 83b-T3: Mobile panel center → Lightbox cover 退場
+     *
+     * mobileCoverEl（面板中央主圖）起飛，飛回 coverImgEl（lightbox cover）位置。
+     * 動畫完成（或被打斷）都 cleanup ghost + 還原兩端 opacity。
+     *
+     * @param {HTMLImageElement} mobileCoverEl - 面板中央主圖（$refs.mobilePanelCoverImg）
+     * @param {HTMLImageElement} coverImgEl    - lightbox cover img（飛回目標）
+     * @param {object} [opts] - { onComplete?: () => void }
+     * @returns {gsap.core.Timeline|null}
+     */
+    function playMobilePanelExit(mobileCoverEl, coverImgEl, opts) {
+        opts = opts || {};
+        if (!mobileCoverEl || !coverImgEl) {
+            if (typeof opts.onComplete === 'function') opts.onComplete();
+            return null;
+        }
+        if (typeof gsap === 'undefined') {
+            if (typeof opts.onComplete === 'function') opts.onComplete();
+            return null;
+        }
+
+        var exitSrc = mobileCoverEl.src;
+        var exitRect = mobileCoverEl.getBoundingClientRect();
+
+        // C25 順序鐵律：先建 ghost，再 hide source
+        var ghost = createCoverGhost(exitSrc, exitRect, { cropMode: 'right-half' });
+        if (!ghost) {
+            // src 空 or rect.width === 0 → graceful skip
+            if (typeof opts.onComplete === 'function') opts.onComplete();
+            return null;
+        }
+
+        // 隱藏來源（mobile center cover）
+        mobileCoverEl.setAttribute('data-ghost-hidden', 'true');
+        gsap.set(mobileCoverEl, { opacity: 0 });
+
+        // 讀目標 rect（lightbox 需已可見）
+        var targetRect = coverImgEl.getBoundingClientRect();
+
+        // objectPosition 平滑過渡（mirror play56cConstellationExit L258-259）
+        var dur = (window.OpenAver && window.OpenAver.motion &&
+                   window.OpenAver.motion.DURATION && window.OpenAver.motion.DURATION.medium) || 0.333;
+        ghost.style.transition = 'object-position ' + dur + 's ease';
+        ghost.style.objectPosition = 'center center';
+
+        // race 防護
+        gsap.killTweensOf(ghost);
+
+        var tl = gsap.timeline({
+            id: 'mobilePanelExit',
+            onComplete: function () {
+                cleanupGhost(ghost, mobileCoverEl, coverImgEl);
+                if (typeof opts.onComplete === 'function') opts.onComplete();
+            },
+            onInterrupt: function () {
+                // race 防護：onInterrupt 也 cleanup
+                cleanupGhost(ghost, mobileCoverEl, coverImgEl);
+            }
+        });
+
+        tl.to(ghost, {
+            x: targetRect.left, y: targetRect.top,
+            width: targetRect.width, height: targetRect.height,
+            duration: dur,
+            ease: 'fluent-accel'
+        }, 0);
+
+        return tl;
+    }
+
     /**
      * 56c-T2 (CD-56C-2): Similar Scan Preview — lightbox 點 .bi-magic 時的 0.4s 預覽動畫
      *
@@ -368,6 +532,10 @@
         play56cConstellationEnter: play56cConstellationEnter,
         play56cConstellationExit: play56cConstellationExit,
         play56cSimilarScanPreview: play56cSimilarScanPreview,
+
+        // 83b-T3: 行動相似面板封面飛行進 / 退場
+        playMobilePanelEnter: playMobilePanelEnter,
+        playMobilePanelExit: playMobilePanelExit,
 
         /**
          * Grid → Lightbox ghost fly

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -40,7 +40,8 @@
                          : (currentLightboxVideo()?.cover ? `/api/proxy-image?url=${encodeURIComponent(currentLightboxVideo().cover)}` : '')"
                      :alt="actressLightboxMode() ? actressProfile?.name : currentLightboxVideo()?.number"
                      x-show="!_heroLightboxImageError"
-                     @error="_heroLightboxImageError = true">
+                     @error="_heroLightboxImageError = true"
+                     @load="_setCoverAspect($event)">
                 <!-- A6-1: Lightbox fallback placeholder -->
                 <div x-show="_heroLightboxImageError"
                      class="cover-error-placeholder">

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1196,7 +1196,7 @@
             </div>
             <!-- 相似卡（從中央爆射；右半裁切；無文字） -->
             <div class="similar-mobile-cards">
-                <template x-for="item in similarResults" :key="item.video_id">
+                <template x-for="item in similarResults" :key="_mobilePanelRunId + '-' + item.video_id">
                     <div class="similar-mobile-burst-card"
                          @click="onMobileDrillClick(item, $event)">
                         <img :src="item.cover_url" alt="" aria-hidden="true">

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -545,12 +545,12 @@
         <!-- Lightbox (M3a) -->
         <div class="showcase-lightbox"
              :class="{ 'show': lightboxOpen }"
-             x-trap.inert="lightboxOpen && !sampleGalleryOpen && !removeActressModalOpen && !rescrapeOpen && !deleteVideoModalOpen"
+             x-trap.inert="lightboxOpen && !sampleGalleryOpen && !removeActressModalOpen && !rescrapeOpen && !deleteVideoModalOpen && !similarModeMobileOpen"
              @touchstart.passive="_lbTouchStart($event)"
              @touchend.passive="_lbTouchEnd($event)"
              @click="handleLightboxBackdropClick($event)">
 
-            <div class="lightbox-content" @click.stop :class="{ 'similar-open': similarModeMobileOpen }">
+            <div class="lightbox-content" @click.stop>
                 <!-- Close Button (shared between actress and video branches) -->
                 <button class="lightbox-close"
                         @click="closeLightbox()"
@@ -732,23 +732,8 @@
                             </div>
                         </div>
 
-                        <!-- 手機 < 960px（75a-US3b）相似模式降級：cosine 前 4 張 collapse（x-collapse 需 @alpinejs/collapse plugin，已在 base.html 行 640 載入）。75a-US4：置於 cover 與 metadata 之間，主片 + 4 相似一眼可見 -->
-                        <div class="lightbox-similar-mobile"
-                             x-show="similarModeMobileOpen"
-                             x-collapse>
-                          <div class="similar-mobile-grid">
-                            <template x-for="item in similarResults.slice(0, 4)" :key="item.video_id">
-                              <div class="similar-mobile-card"
-                                   @click="onSimilarMobileCardClick(item)">
-                                <img :src="item.cover_url" :alt="item.title" loading="lazy">
-                                <div class="similar-mobile-meta">
-                                  <div class="similar-mobile-number" x-text="item.number"></div>
-                                  <div class="similar-mobile-title" x-text="item.title"></div>
-                                </div>
-                              </div>
-                            </template>
-                          </div>
-                        </div>
+                        <!-- 83b-T1：舊寄生 .lightbox-similar-mobile x-collapse block 已移除，
+                             改為獨立全螢幕 .similar-mobile-panel（page-level sibling，見 .similar-stage 之後）。 -->
 
                         <!-- Metadata Panel（緊湊版，匹配原版 gallery） -->
                         <div class="lightbox-metadata">
@@ -1193,6 +1178,39 @@
              同 stacking context 內 main static z=11 < play button z=12 → 點 button
              命中 button、點 main static 非 button 區命中 onSimilarMainImgClick → closeSimilarMode。 -->
     </div><!-- /.similar-stage -->
+
+    <!-- 83b-T1: 行動相似探索面板（Mobile Photo Picker 爆射）
+         page-level sibling of .showcase-lightbox（source order 晚於 lightbox trap，
+         確保 test_t7_xtrap_releases_on_delete_modal 的第一個 x-trap.inert 仍抓 lightbox）。
+         <960px only（CSS @media gate + ≥960 display:none 安全網）。Core 無轉場（飛行轉場留 T3）。 -->
+    <div class="similar-mobile-panel"
+         x-trap.inert="similarModeMobileOpen"
+         :aria-hidden="!similarModeMobileOpen">
+        <!-- scrim：overlay 30px 模糊完全遮住 lightbox（CD-10） -->
+        <div class="similar-mobile-scrim" @click="closeMobilePanel()"></div>
+        <!-- stage：burst origin frame -->
+        <div class="similar-mobile-stage">
+            <!-- 中央右半裁切主圖（FlipReplace 落點 + Burst 原點；點主圖關面板，無文字） -->
+            <div class="similar-mobile-cover" @click="closeMobilePanel()">
+                <img x-ref="mobilePanelCoverImg" alt="" aria-hidden="true">
+            </div>
+            <!-- 相似卡（從中央爆射；右半裁切；無文字） -->
+            <div class="similar-mobile-cards">
+                <template x-for="item in similarResults" :key="item.video_id">
+                    <div class="similar-mobile-burst-card"
+                         @click="onMobileDrillClick(item, $event)">
+                        <img :src="item.cover_url" alt="" aria-hidden="true">
+                    </div>
+                </template>
+            </div>
+        </div>
+        <!-- 右上 ✕ 關閉鈕（x-trap Tab 目標） -->
+        <button class="similar-mobile-panel-close"
+                @click="closeMobilePanel()"
+                :aria-label="t('similar_mode.close')">
+            <i class="bi bi-x-lg" aria-hidden="true"></i>
+        </button>
+    </div><!-- /.similar-mobile-panel -->
 
     <!-- TASK-52.3.3: Remove Actress Confirm Modal（取代原 window.confirm）
          Esc 雙重防線：handleKeydown 入口攔截 + dialog 自身 @keydown.escape.window 冗餘

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -680,6 +680,7 @@
                             <img x-ref="lightboxCoverImg"
                                  :src="currentLightboxVideo?.cover_url"
                                  :alt="currentLightboxVideo?.number"
+                                 @load="_setCoverAspect($event)"
                                  @error="handleCoverError(currentLightboxVideo, $event)">
                             <!-- 71-T6 blur-up: overlay 層=cover_full_url（原圖）。@load 後 opacity 0→1 就地淡入蓋上 base；
                                  用 CSS opacity 切換（非 x-show — display:none 的 img 不載入、@load 永不 fire）；

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1191,8 +1191,17 @@
         <!-- stage：burst origin frame -->
         <div class="similar-mobile-stage">
             <!-- 中央右半裁切主圖（FlipReplace 落點 + Burst 原點；點主圖關面板，無文字） -->
+            <!-- T4: cover 不設 overflow:hidden（已移至 img），讓 play-btn 子元素不被裁切 -->
             <div class="similar-mobile-cover" @click="closeMobilePanel()">
                 <img x-ref="mobilePanelCoverImg" alt="" aria-hidden="true">
+                <!-- T4: 播放按鈕 — cover 子元素；@click.stop 阻冒泡防觸發 cover 的 closeMobilePanel() -->
+                <button class="similar-mobile-play-btn"
+                        x-show="!!currentLightboxVideo?.path"
+                        :disabled="similarModeAnimating"
+                        @click.stop="playVideo(currentLightboxVideo?.path)"
+                        :aria-label="t('showcase.action.play')">
+                    <i class="bi bi-play-fill" aria-hidden="true"></i>
+                </button>
             </div>
             <!-- 相似卡（從中央爆射；右半裁切；無文字） -->
             <div class="similar-mobile-cards">


### PR DESCRIPTION
## Summary

- **83a 封面比例自適應**：燈箱封面改採 aspect-box/modal-hug 模型，寬比例（橫版）封面自動填滿容器不留空白，AR 不污染女優模式，搜尋燈箱/詳情頁同步
- **83b 行動相似探索面板**：手機/平板燈箱新增全螢幕相似探索，六張卡爆射 + 封面 ghost-fly 進/退場 + 主圖播放按鈕 + drill 並發硬化（runId guard）
- **ghost-hide CSS fix**：`img[data-ghost-hidden] ~ .similar-mobile-play-btn` 確保飛行期間按鈕不懸空/不可點（Codex P1）

## Test plan

- [x] 全套 pytest 4686 passed, 2 skipped（+36 vs 0.10.9）
- [x] `ruff check .` 綠
- [x] `npm run lint`（eslint + stylelint）綠
- [x] 來源金絲雀 7 PASS / 1 SKIP（fc2 unreachable，已知）
- [x] Gemini 三群：83a LGTM、83b-rest Approved、83b-T1 Codex 三審通過
- [x] Codex P1 ghost-hide 已修並補守衛
- [ ] 手機真機驗收（T3 飛行動畫 + T4 播放按鈕位置）—— owner pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)