### PR TITLE
fix(mobile-ux): 行動版 UX 優化合輯（T1–T5）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - 修正 83a/83b-T1 引入後 `TestCoverLoadingUx67Guard` 四條守衛因 `:class has-cover` 新屬性 + T1 注釋位移雙因導致正則 stale。
 
+### Fixed（行動 UX 優化合輯，fix/0.10-mobile-ux-polish）
+- 🎯 **封面牆行動搜尋 toolbar 滾動自動收合**：≤480px 往下滾超過 50px（相對 toolbar 展開當下位置）且搜尋欄位為空時自動收合；有搜尋文字不收。
+- 🎯 **封面牆 header 行動搜尋 icon 搜尋中顯示 ✕**：有搜尋條件（tag 點擊 / 女優 / 文字）時 navbar 搜尋 icon 切換為 ✕，點擊一鍵清除所有篩選；URL / persisted state 帶入的初始搜尋也正確同步 icon 狀態。
+- 🎯 **Settings toast 行動版移至底部**：≤480px 時 toast 不再從頂部彈出（易被行動瀏覽器 chrome 遮住），改固定於底部顯示。
+- 🎯 **伺服器模式切換加確認彈窗**：避免誤觸；點確認才執行切換，點取消維持原狀；同模式不觸發彈窗。
+- 🎯 **搜尋列輸入法 compose 態 icon 互斥**：compose 態時隱藏 Grid toggle，避免三個 icon 同時顯示擠爆搜尋列空間。
+
 ### 測試
-- 全套 pytest **4686 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較 0.10.9 的 4650 +36）+ `ruff check .` 綠 + `npm run lint`（eslint + stylelint）綠。
-- 來源金絲雀：**7 PASS、1 SKIP**（fc2 unreachable，已知正常）。
-- Gemini 3.1 Pro 三群審查：83a LGTM、83b-rest Approved、83b-T1 Codex 三審已通過（Gemini payload 邊界 timeout）。
-- Codex PR review P1（行動播放按鈕未接 ghost-hide 流程）已修（CSS sibling selector）。
+- 全套 pytest **4710 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較初版 4686 +24：行動 UX 守衛 + 伺服器模式確認守衛 + icon 互斥守衛）+ `ruff check .` 綠 + `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**7 PASS、1 SKIP**（jav321 unreachable，已知正常）。
+- Gemini 3.1 Pro 審查：LGTM；P2（同模式觸發彈窗）已修（early return guard）。
+- Codex PR review P2（showcaseHasSearch 初始化缺漏）已修（init-time sync 補齊）。
 
 ## [0.10.9] - 2026-06-22
 

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -311,6 +311,12 @@
       "remote_only": "伺服器模式只能在執行 OpenAver 的主機電腦上切換。",
       "autostart_failed": "重新啟動後無法自動開啟 LAN 伺服器模式，請至設定重新開啟。"
     },
+    "server_mode_confirm": {
+      "title": "切換伺服器模式",
+      "body_on": "切到「伺服器」模式後，同一區網的裝置可連線本機。確認切換？",
+      "body_off": "切回「單機」模式後，區網裝置將立即無法連線。確認切換？",
+      "confirm": "確認切換"
+    },
     "section": {
       "search": "搜尋與刮削",
       "scraper_advanced": "進階刮削設定",

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -13135,7 +13135,7 @@ class TestServerModeToggleGuard:
     def test_settings_server_mode_segmented_in_header(self):
         """.settings-server-mode 在標題左 cluster（.settings-header-left）內，是 <h4> 的
         cluster-sibling，且含 .settings-sources-segmented + 2 個 button
-        （setServerMode(false)/setServerMode(true)）。
+        （requestServerModeChange(false)/requestServerModeChange(true)，T4 改為確認 modal）。
 
         81b-T1（CD-1）：膠囊從 .settings-header-actions 搬到 .settings-header-left。
         mutation：膠囊搬回 .settings-header-actions → 「不在 actions」斷言 RED；
@@ -13152,10 +13152,10 @@ class TestServerModeToggleGuard:
         assert len(buttons) == 2, \
             f".settings-sources-segmented 應有 2 個 button，實際 {len(buttons)} 個"
         click_attrs = [b.get("@click", "") for b in buttons]
-        assert any("setServerMode(false)" in a for a in click_attrs), \
-            "segmented 缺少 @click=\"setServerMode(false)\" button（單機態）"
-        assert any("setServerMode(true)" in a for a in click_attrs), \
-            "segmented 缺少 @click=\"setServerMode(true)\" button（伺服器態）"
+        assert any("requestServerModeChange(false)" in a for a in click_attrs), \
+            "segmented 缺少 @click=\"requestServerModeChange(false)\" button（單機態）"
+        assert any("requestServerModeChange(true)" in a for a in click_attrs), \
+            "segmented 缺少 @click=\"requestServerModeChange(true)\" button（伺服器態）"
         # 81b-T1（CD-1）：位置斷言 — 膠囊在標題左 cluster，h4 sibling，搬離 actions
         left = soup.find(class_="settings-header-left")
         assert left is not None, \

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -5418,17 +5418,19 @@ class TestSearchCssHardcoded:
         # 83a-T3-fix P1：在 L810（T9-port 前）插入 lightbox overflow block（~12 行）：945→957。
         # 83a2-T4：在 L102（detail cover scope 區）插入 ~22 行 + mobile block 插入 ~5 行（皆在 957 上方）：957→984。
         # 83a2-T4 Codex P2 fix：loading-placeholder fallback 併入（comment+第二 selector）+4 行：984→988。
-        90: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
-        988: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
+        # fix/T5：在 L27 插入 .spotlight-search .btn-icon block（5 行）：90→95、988→993。
+        95: "drop-shadow rgba 0.3 — §2 例外（drop-shadow 跟封面去背形狀，非矩形 box-shadow 無法用 --fluent-shadow-* token）",
+        993: "var(--bg-card, rgba(0, 0, 0, 0.05)) fallback — defensive fallback，非硬編碼違規",
     }
 
     SIX_PX_ALLOWLIST = {
         # 75b-T2 search.css US1 重排插入 ~54 行（@ ~L107）後行號順移：235→282、524→576、579→631（皆在插入點下方）。
         # 83a2-T4：detail cover scope +22 行（L102 上方）+ mobile block +5 行（L519 上方）後順移：282→304、576→603、631→658。
         # 83a2-T4 Codex P2 fix：loading-placeholder fallback +4 行後順移：304→308、603→607、658→662。
-        308: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
-        607: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
-        662: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
+        # fix/T5：在 L27 插入 .spotlight-search .btn-icon block（5 行）：308→313、607→612、662→667。
+        313: "row inline btn optical 6px — T2.2 加 optical 註記（btn-sm 12px padding 對 row inline 太寬）",
+        612: ".batch-progress-bar height: 6px — intrinsic dimension（非 §4 spacing）",
+        667: "chip optical 6px — T2.2 加 optical 註記（對齊 showcase .lb-tag-add-btn）",
     }
 
     def _scan(self, regex: str, allowlist=None):

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -13429,19 +13429,21 @@ class TestMobileToolbarToggle:
         return BASE_HTML_T76.read_text(encoding="utf-8")
 
     def test_store_registered_in_alpine_init(self):
-        """base.html 在 alpine:init 監聽內註冊 Alpine.store('ui', { toolbarOpen: false })。"""
+        """base.html 在 alpine:init 監聽內註冊 Alpine.store('ui', { toolbarOpen: false, showcaseHasSearch: false })。"""
         html = self._base()
         assert "alpine:init" in html, "base.html missing alpine:init listener"
         assert "Alpine.store('ui'" in html, "base.html missing Alpine.store('ui') registration"
         assert "toolbarOpen" in html, "base.html missing toolbarOpen store field"
+        # T2: showcaseHasSearch 欄位必須在同一 store 定義內
+        assert "showcaseHasSearch" in html, "base.html missing showcaseHasSearch store field"
         # 註冊字串與 alpine:init 監聽同段（store 註冊掛在 alpine:init callback 內）
         assert re.search(
             r"alpine:init['\"]\s*,\s*\(\)\s*=>\s*\{\s*Alpine\.store\(\s*['\"]ui['\"]\s*,\s*\{\s*toolbarOpen:\s*false",
             html,
-        ), "base.html: Alpine.store('ui', { toolbarOpen: false }) 須在 alpine:init callback 內註冊"
+        ), "base.html: Alpine.store('ui', { toolbarOpen: false ... }) 須在 alpine:init callback 內註冊"
 
     def test_navbar_search_button(self):
-        """navbar 搜尋 button：navbar-search-btn + lg:hidden + bi-search + @click 翻轉 $store.ui.toolbarOpen。"""
+        """navbar 搜尋 button：navbar-search-btn + lg:hidden + bi-search + @click 條件分支（T2）。"""
         from bs4 import BeautifulSoup
         html = self._base()
         btns = BeautifulSoup(html, "html.parser").select("button.navbar-search-btn")
@@ -13449,11 +13451,17 @@ class TestMobileToolbarToggle:
         btn = btns[0]
         classes = btn.get("class", [])
         assert "lg:hidden" in classes, "navbar-search-btn 須有 lg:hidden（≤1023px gate）"
-        icons = btn.select("i.bi.bi-search")
-        assert icons, "navbar-search-btn 內須有 <i class='bi bi-search'>"
+        # T2: icon 改為 Alpine 動態 :class 綁定，BS4 CSS selector 無法匹配；改用字串檢查
+        btn_html = str(btn)
+        assert "bi-search" in btn_html, "navbar-search-btn 內須包含 bi-search（靜態 class 或動態 :class 均可）"
         click = btn.get("@click", "")
+        # T2: @click 改為條件分支 — showcaseHasSearch 判斷 + dispatch + toolbarOpen 仍在 else 分支
+        assert "$store.ui.showcaseHasSearch" in click, \
+            f"navbar-search-btn @click 須包含 $store.ui.showcaseHasSearch 條件（實得 {click!r}）"
+        assert "showcase:clear-search" in click, \
+            f"navbar-search-btn @click 須 dispatch showcase:clear-search（實得 {click!r}）"
         assert "$store.ui.toolbarOpen" in click, \
-            f"navbar-search-btn @click 須翻轉 $store.ui.toolbarOpen（實得 {click!r}）"
+            f"navbar-search-btn @click 須包含 $store.ui.toolbarOpen（else 分支保留舊行為，實得 {click!r}）"
 
     def test_navbar_search_button_jinja_gated(self):
         """搜尋 button 被 {% if page == 'showcase' %} Jinja gate（僅 showcase 渲染，不含 search）。"""

--- a/tests/unit/test_search_icon_mutex.py
+++ b/tests/unit/test_search_icon_mutex.py
@@ -1,0 +1,37 @@
+"""T5: Search 搜尋列 icon 互斥守衛"""
+from pathlib import Path
+
+
+class TestSearchIconMutex:
+
+    def _read_search_html(self):
+        return Path("web/templates/search.html").read_text()
+
+    def _read_search_css(self):
+        return Path("web/static/css/pages/search.css").read_text()
+
+    def test_grid_toggle_has_is_composing_guard(self):
+        """Grid toggle x-show 必須含 !isComposing() 條件"""
+        content = self._read_search_html()
+        assert "isComposing()" in content
+        # x-show 同一行需含 actress/prefix 和 isComposing
+        lines = content.split('\n')
+        matching = [l for l in lines if 'isComposing' in l and ('actress' in l or 'prefix' in l)]
+        assert matching, "Grid toggle x-show 須同時含 actress/prefix 和 isComposing"
+
+    def test_btn_icon_has_flex_shrink(self):
+        """.spotlight-search .btn-icon 必須有 flex-shrink: 0"""
+        content = self._read_search_css()
+        # Must have a .spotlight-search .btn-icon block with flex-shrink
+        lines = content.split('\n')
+        in_block = False
+        found = False
+        for line in lines:
+            if '.spotlight-search .btn-icon' in line:
+                in_block = True
+            if in_block and '}' in line:
+                in_block = False
+            if in_block and 'flex-shrink' in line:
+                found = True
+                break
+        assert found, ".spotlight-search .btn-icon 區塊須含 flex-shrink: 0"

--- a/tests/unit/test_settings_mobile_toast.py
+++ b/tests/unit/test_settings_mobile_toast.py
@@ -1,0 +1,29 @@
+"""T3: Settings 頁行動版 toast 底部定位守衛"""
+from pathlib import Path
+
+
+class TestSettingsMobileToast:
+    def _read_settings_css(self):
+        return Path("web/static/css/pages/settings.css").read_text()
+
+    def test_mobile_toast_media_query_exists(self):
+        """settings.css 必須有 max-width: 480px media query"""
+        content = self._read_settings_css()
+        assert "max-width: 480px" in content
+
+    def test_mobile_toast_targets_toast_top(self):
+        """media query 必須針對 .toast.toast-top"""
+        content = self._read_settings_css()
+        assert ".toast.toast-top" in content
+
+    def test_mobile_toast_sets_bottom(self):
+        """media query 必須設定 bottom 屬性"""
+        content = self._read_settings_css()
+        assert "bottom" in content
+
+    def test_mobile_toast_inside_media_query(self):
+        """bottom 設定必須在 @media 區塊內（桌面不受影響）"""
+        content = self._read_settings_css()
+        media_idx = content.find("@media (max-width: 480px)")
+        bottom_idx = content.find("bottom", media_idx)
+        assert media_idx != -1 and bottom_idx > media_idx

--- a/tests/unit/test_settings_server_mode_confirm.py
+++ b/tests/unit/test_settings_server_mode_confirm.py
@@ -1,0 +1,55 @@
+"""T4: 伺服器模式切換確認彈窗守衛"""
+from pathlib import Path
+import json
+
+
+class TestServerModeConfirm:
+
+    def _read_settings_html(self):
+        return Path("web/templates/settings.html").read_text()
+
+    def _read_state_ui(self):
+        return Path("web/static/js/pages/settings/state-ui.js").read_text()
+
+    def _read_state_config(self):
+        return Path("web/static/js/pages/settings/state-config.js").read_text()
+
+    def _read_zh_tw(self):
+        return Path("locales/zh_TW.json").read_text()
+
+    def test_button_click_uses_request_server_mode_change(self):
+        """settings.html 按鈕必須改用 requestServerModeChange（不再直接 setServerMode）"""
+        content = self._read_settings_html()
+        assert "requestServerModeChange(false)" in content
+        assert "requestServerModeChange(true)" in content
+        assert "@click=\"setServerMode(false)\"" not in content
+        assert "@click=\"setServerMode(true)\"" not in content
+
+    def test_modal_exists_in_settings_html(self):
+        """settings.html 必須有 serverModeConfirmOpen modal"""
+        content = self._read_settings_html()
+        assert "serverModeConfirmOpen" in content
+
+    def test_modal_has_confirm_and_cancel_buttons(self):
+        """modal 必須有 confirmServerModeChange 和 cancelServerModeChange 兩個 handler"""
+        content = self._read_settings_html()
+        assert "confirmServerModeChange()" in content
+        assert "cancelServerModeChange()" in content
+
+    def test_i18n_keys_in_zh_tw(self):
+        """zh_TW.json 必須有 settings.server_mode_confirm 區塊"""
+        content = self._read_zh_tw()
+        assert "server_mode_confirm" in content
+
+    def test_state_ui_has_confirm_state(self):
+        """state-ui.js 必須有 serverModeConfirmOpen 和 serverModeConfirmValue"""
+        content = self._read_state_ui()
+        assert "serverModeConfirmOpen" in content
+        assert "serverModeConfirmValue" in content
+
+    def test_state_config_has_three_methods(self):
+        """state-config.js 必須有三個 confirm 相關方法"""
+        content = self._read_state_config()
+        assert "requestServerModeChange" in content
+        assert "confirmServerModeChange" in content
+        assert "cancelServerModeChange" in content

--- a/tests/unit/test_settings_server_mode_confirm.py
+++ b/tests/unit/test_settings_server_mode_confirm.py
@@ -18,7 +18,9 @@ class TestServerModeConfirm:
         return Path("locales/zh_TW.json").read_text()
 
     def test_button_click_uses_request_server_mode_change(self):
-        """settings.html 按鈕必須改用 requestServerModeChange（不再直接 setServerMode）"""
+        """settings.html 按鈕必須改用 requestServerModeChange（不再直接 setServerMode）
+        [transient-guard] setServerMode 直呼叫遷移至 requestServerModeChange，milestone 前刪除負向 assert。
+        """
         content = self._read_settings_html()
         assert "requestServerModeChange(false)" in content
         assert "requestServerModeChange(true)" in content

--- a/tests/unit/test_showcase_mobile_search.py
+++ b/tests/unit/test_showcase_mobile_search.py
@@ -90,3 +90,9 @@ class TestShowcaseHeaderSearchIcon:
         """state-base.js 必須有 $watch('actressSearch') 更新 showcaseHasSearch（mutation guard）"""
         content = self._read_state_base()
         assert "$watch('actressSearch'" in content or '$watch("actressSearch"' in content
+
+    def test_init_sync_showcase_has_search_after_watchers(self):
+        """init() 必須在 $watch 登記後有 init-time 同步賦值（restoreState 在 $watch 前執行）"""
+        content = self._read_state_base()
+        # 直接斷言 init sync 語句存在，防止只靠 $watch 而漏掉初始值路徑
+        assert "Alpine.store('ui').showcaseHasSearch = (this.search !== '' || this.actressSearch !== '')" in content

--- a/tests/unit/test_showcase_mobile_search.py
+++ b/tests/unit/test_showcase_mobile_search.py
@@ -38,6 +38,14 @@ class TestShowcaseScrollCollapse:
         content = self._read_state_base()
         assert "_toolbarOpenY" in content
 
+    def test_scroll_collapse_resets_baseline_on_auto_close(self):
+        """auto-close 後必須立即 reset _toolbarOpenY，防止 reopen 時 stale baseline 立即再收"""
+        content = self._read_state_base()
+        # toolbarOpen = false 之後的 80 字元內必須有 _toolbarOpenY = null
+        idx_close = content.index("toolbarOpen = false")
+        idx_reset = content.index("_toolbarOpenY = null", idx_close)
+        assert idx_reset < idx_close + 120, "auto-close 後未在同一 block 立即 reset _toolbarOpenY"
+
     def test_scroll_listener_cleanup(self):
         """cleanup callback 必須移除 scroll listener"""
         content = self._read_state_base()

--- a/tests/unit/test_showcase_mobile_search.py
+++ b/tests/unit/test_showcase_mobile_search.py
@@ -43,3 +43,50 @@ class TestShowcaseScrollCollapse:
         content = self._read_state_base()
         assert "removeEventListener" in content
         assert "_scrollHideHandler" in content
+
+
+class TestShowcaseHeaderSearchIcon:
+    """T2: Showcase header 行動搜尋 icon 在有搜尋時顯示 X"""
+
+    def _read_base_html(self):
+        return Path("web/templates/base.html").read_text()
+
+    def _read_showcase_html(self):
+        return Path("web/templates/showcase.html").read_text()
+
+    def _read_state_base(self):
+        return Path("web/static/js/pages/showcase/state-base.js").read_text()
+
+    def _read_state_lightbox(self):
+        return Path("web/static/js/pages/showcase/state-lightbox.js").read_text()
+
+    def test_store_has_showcase_has_search(self):
+        """$store.ui 必須包含 showcaseHasSearch 欄位"""
+        content = self._read_base_html()
+        assert "showcaseHasSearch" in content
+
+    def test_button_dispatches_clear_search(self):
+        """navbar button 在有搜尋時必須 dispatch showcase:clear-search"""
+        content = self._read_base_html()
+        assert "showcase:clear-search" in content
+
+    def test_showcase_has_window_listener(self):
+        """showcase.html 必須有 @showcase:clear-search.window listener"""
+        content = self._read_showcase_html()
+        assert "showcase:clear-search" in content
+
+    def test_search_from_metadata_sets_this_search(self):
+        """searchFromMetadata 必須仍設 this.search（防止重構靜默斷開 showcaseHasSearch 路徑）"""
+        content = self._read_state_lightbox()
+        assert "this.search = " in content
+
+    def test_watch_search_updates_showcase_has_search(self):
+        """state-base.js 必須有 $watch('search') 更新 showcaseHasSearch（mutation guard）"""
+        content = self._read_state_base()
+        assert "$watch('search'" in content or '$watch("search"' in content
+        assert "showcaseHasSearch" in content
+
+    def test_watch_actress_search_updates_showcase_has_search(self):
+        """state-base.js 必須有 $watch('actressSearch') 更新 showcaseHasSearch（mutation guard）"""
+        content = self._read_state_base()
+        assert "$watch('actressSearch'" in content or '$watch("actressSearch"' in content

--- a/tests/unit/test_showcase_mobile_search.py
+++ b/tests/unit/test_showcase_mobile_search.py
@@ -1,0 +1,45 @@
+"""
+T1: Showcase scroll-triggered toolbar collapse guard
+守衛 state-base.js 包含 scroll listener、toolbarOpen 條件、search/actressSearch 條件、
+相對基準 Y 追蹤（_toolbarOpenY）、以及 cleanup。
+"""
+from pathlib import Path
+
+
+class TestShowcaseScrollCollapse:
+    """T1: Showcase scroll-triggered toolbar collapse guard"""
+
+    def _read_state_base(self):
+        p = Path("web/static/js/pages/showcase/state-base.js")
+        return p.read_text()
+
+    def test_scroll_listener_registered(self):
+        """state-base.js 必須包含 scroll listener 登記（passive）"""
+        content = self._read_state_base()
+        assert "addEventListener('scroll'" in content or 'addEventListener("scroll"' in content
+
+    def test_scroll_collapse_checks_toolbar_open(self):
+        """scroll handler 必須檢查 toolbarOpen 才能收合"""
+        content = self._read_state_base()
+        assert "toolbarOpen" in content
+
+    def test_scroll_collapse_checks_empty_search(self):
+        """scroll handler 必須在 search 為空時才收合"""
+        content = self._read_state_base()
+        assert "search !== ''" in content or "search === ''" in content
+
+    def test_scroll_collapse_checks_actress_search(self):
+        """scroll handler 必須同時保護 actressSearch 非空情況"""
+        content = self._read_state_base()
+        assert "actressSearch" in content
+
+    def test_scroll_collapse_uses_relative_threshold(self):
+        """scroll handler 使用相對基準 Y（_toolbarOpenY）而非絕對位置"""
+        content = self._read_state_base()
+        assert "_toolbarOpenY" in content
+
+    def test_scroll_listener_cleanup(self):
+        """cleanup callback 必須移除 scroll listener"""
+        content = self._read_state_base()
+        assert "removeEventListener" in content
+        assert "_scrollHideHandler" in content

--- a/web/static/css/pages/search.css
+++ b/web/static/css/pages/search.css
@@ -24,6 +24,11 @@
     --spotlight-right-slot: 10.5rem;
 }
 
+/* T5: compose 態 icon 互斥 — btn-icon 不縮（三個 icon 共存時不擠壓彼此） */
+.spotlight-search .btn-icon {
+    flex-shrink: 0;
+}
+
 /* 結果區域（外層容器，包含所有狀態頁 + 結果卡片） */
 .result-area {
     flex: 1;

--- a/web/static/css/pages/settings.css
+++ b/web/static/css/pages/settings.css
@@ -1194,3 +1194,11 @@ html.theme-transition-active::view-transition-new(root) {
         transition: none;
     }
 }
+
+/* T3: 行動版 toast 移至底部（避免被 mobile browser chrome 遮住） */
+@media (max-width: 480px) {
+  .toast.toast-top {
+    top: auto;
+    bottom: 1rem;
+  }
+}

--- a/web/static/js/pages/settings/state-config.js
+++ b/web/static/js/pages/settings/state-config.js
@@ -402,6 +402,20 @@ export function stateConfig() {
             return `${this.lanIp}:${this.lanPort}`;
         },
 
+        requestServerModeChange(val) {
+            this.serverModeConfirmValue = val;
+            this.serverModeConfirmOpen = true;
+        },
+        async confirmServerModeChange() {
+            const val = this.serverModeConfirmValue;  // capture before clearing（防 await 期間再次觸發覆蓋）
+            this.serverModeConfirmOpen = false;
+            this.serverModeConfirmValue = null;
+            await this.setServerMode(val);
+        },
+        cancelServerModeChange() {
+            this.serverModeConfirmOpen = false;
+            this.serverModeConfirmValue = null;
+        },
         async setServerMode(val) {
             try {
                 const resp = await fetch('/api/config/general/server_mode', {

--- a/web/static/js/pages/settings/state-config.js
+++ b/web/static/js/pages/settings/state-config.js
@@ -403,6 +403,7 @@ export function stateConfig() {
         },
 
         requestServerModeChange(val) {
+            if (this.serverMode === val) return;  // 同模式不觸發確認
             this.serverModeConfirmValue = val;
             this.serverModeConfirmOpen = true;
         },

--- a/web/static/js/pages/settings/state-ui.js
+++ b/web/static/js/pages/settings/state-ui.js
@@ -29,6 +29,10 @@ export function stateUI() {
         // 71b-T2: 關閉封面縮圖快取 Confirm Modal State
         thumbCacheDisableConfirmOpen: false,
 
+        // T4: 伺服器模式切換 Confirm Modal State
+        serverModeConfirmOpen: false,
+        serverModeConfirmValue: null,
+
         // B1: Scanner directory link state
         favoriteScannerLink: null,   // null=隱藏, {linked, matched_directory}=已查
         showDirDropdown: false,

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -281,6 +281,8 @@ export function stateBase() {
             this.$watch('actressSearch', val => {
                 Alpine.store('ui').showcaseHasSearch = (this.search !== '' || val !== '')
             })
+            // T2 init sync: restoreState() 在 $watch 前執行，初始 search/actressSearch 不觸發 watcher
+            Alpine.store('ui').showcaseHasSearch = (this.search !== '' || this.actressSearch !== '')
         },
 
         clearSearch() {

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -216,6 +216,7 @@ export function stateBase() {
                         if (this.lightboxOpen) document.body.classList.remove('overflow-hidden');
                         this._resetPicker();                                  // 53a-T1: 清場 picker 狀態
                         window.GhostFly?.cleanupStaleGhosts?.();              // 53a-T1: 移除殘留 ghost（沿 v0.8.1 T4 optional-chaining pattern）
+                        if (this._scrollHideHandler) window.removeEventListener('scroll', this._scrollHideHandler);  // T1: cleanup scroll collapse listener
                     }
                 });
             }
@@ -256,6 +257,22 @@ export function stateBase() {
                     }
                 });
             }
+
+            // T1: Mobile scroll-to-collapse — 往下滾超過 50px（相對 toolbar 展開當下 Y）自動收合（≤480px，搜尋空白時）
+            let _toolbarOpenY = null
+            const COLLAPSE_THRESHOLD = 50
+            const _scrollHandler = () => {
+                if (!window.matchMedia('(max-width: 480px)').matches) return
+                const isOpen = Alpine.store('ui').toolbarOpen
+                if (!isOpen) { _toolbarOpenY = null; return }
+                if (_toolbarOpenY === null) _toolbarOpenY = window.scrollY
+                if (this.search !== '' || this.actressSearch !== '') return  // actressSearch 來自 state-actress.js merge
+                if (window.scrollY - _toolbarOpenY > COLLAPSE_THRESHOLD) {
+                    Alpine.store('ui').toolbarOpen = false
+                }
+            }
+            window.addEventListener('scroll', _scrollHandler, { passive: true })
+            this._scrollHideHandler = _scrollHandler
         },
 
         // --- 狀態恢復 (M2c) ---

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -273,6 +273,22 @@ export function stateBase() {
             }
             window.addEventListener('scroll', _scrollHandler, { passive: true })
             this._scrollHideHandler = _scrollHandler
+
+            // T2: 有效搜尋時 header icon 切換為 X
+            this.$watch('search', val => {
+                Alpine.store('ui').showcaseHasSearch = (val !== '' || this.actressSearch !== '')
+            })
+            this.$watch('actressSearch', val => {
+                Alpine.store('ui').showcaseHasSearch = (this.search !== '' || val !== '')
+            })
+        },
+
+        clearSearch() {
+            this.search = ''
+            this.actressSearch = ''
+            this.onSearchChange()
+            this.onActressSearchChange()
+            Alpine.store('ui').toolbarOpen = false
         },
 
         // --- 狀態恢復 (M2c) ---

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -269,6 +269,7 @@ export function stateBase() {
                 if (this.search !== '' || this.actressSearch !== '') return  // actressSearch 來自 state-actress.js merge
                 if (window.scrollY - _toolbarOpenY > COLLAPSE_THRESHOLD) {
                     Alpine.store('ui').toolbarOpen = false
+                    _toolbarOpenY = null  // reset: 下次 reopen 從新基準計，防 stale baseline 立即再收
                 }
             }
             window.addEventListener('scroll', _scrollHandler, { passive: true })

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -498,10 +498,11 @@
         <div class="navbar-end">
             {% if page == 'showcase' %}
             <!-- 81-T2: mobile 搜尋 icon（僅 showcase）→ toggle toolbar；search 頁 Spotlight 中央輸入維持原樣（owner 2026-06-22 拍板，spec §3.1 末句優先） -->
-            <button type="button"
-                    class="navbar-search-btn lg:hidden"
-                    @click="$store.ui.toolbarOpen = !$store.ui.toolbarOpen">
-                <i class="bi bi-search"></i>
+            <button type="button" class="navbar-search-btn lg:hidden"
+                    @click="$store.ui.showcaseHasSearch
+                        ? $dispatch('showcase:clear-search')
+                        : ($store.ui.toolbarOpen = !$store.ui.toolbarOpen)">
+                <i :class="$store.ui.showcaseHasSearch ? 'bi bi-x-lg' : 'bi bi-search'"></i>
             </button>
             {% endif %}
             <!-- 53b-T4: mobile 鈴鐺 -->
@@ -730,7 +731,7 @@
     <!-- 81-T2: 行動搜尋 toolbar 跨 component 共享狀態（navbar icon ↔ page toolbar）。
          非 defer，掛 alpine:init（早於任何 x-data init）→ store 必先於 page component 求值 -->
     <script>
-      document.addEventListener('alpine:init', () => { Alpine.store('ui', { toolbarOpen: false }); });
+      document.addEventListener('alpine:init', () => { Alpine.store('ui', { toolbarOpen: false, showcaseHasSearch: false }); });
     </script>
     <!-- Alpine Plugins (must load before Alpine Core) — 53a: 釘版 3.15.12，新增 focus + intersect -->
     <script defer src="/static/vendor/alpine/persist.min.js"></script>

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -284,7 +284,7 @@
                     <!-- T2a/T3a: Grid / Detail Toggle -->
                     <button type="button"
                             class="btn-icon rotating-border-spotlight active"
-                            x-show="listMode === 'search' && (currentMode === 'actress' || currentMode === 'prefix')"
+                            x-show="listMode === 'search' && (currentMode === 'actress' || currentMode === 'prefix') && !isComposing()"
                             @click="toggleDisplayMode()"
                             :title="displayMode === 'detail' ? t('search.action.toggle_grid') : t('search.action.toggle_detail')">
                         <i class="bi" :class="displayMode === 'detail' ? 'bi-grid-3x3' : 'bi-list-ul'"></i>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -20,13 +20,13 @@
                     <button type="button"
                             data-mode="local"
                             :class="{ 'is-on': !serverMode }"
-                            @click="setServerMode(false)"
+                            @click="requestServerModeChange(false)"
                             x-text="window.t('settings.mode.local')">
                     </button>
                     <button type="button"
                             data-mode="server"
                             :class="{ 'is-on': serverMode }"
-                            @click="setServerMode(true)"
+                            @click="requestServerModeChange(true)"
                             x-text="window.t('settings.mode.server')">
                     </button>
                 </div>
@@ -1208,6 +1208,31 @@
                 </button>
                 <button type="button" class="btn btn-error" @click="confirmThumbCacheDisable()">
                     {{ t('settings.thumbnail_cache.disable_modal.confirm') }}
+                </button>
+            </div>
+        </div>
+    </dialog>
+
+    <!-- T4: 伺服器模式切換 Confirm Modal -->
+    <dialog class="modal fluent-modal"
+            :class="{ 'modal-open': serverModeConfirmOpen }"
+            @click.self="cancelServerModeChange()"
+            @keydown.escape.window="serverModeConfirmOpen && cancelServerModeChange()">
+        <div class="modal-box fluent-modal-box">
+            <h3 class="fluent-modal-title">
+                <i class="bi bi-wifi"></i>
+                {{ t('settings.server_mode_confirm.title') }}
+            </h3>
+            <p class="fluent-modal-body"
+               x-text="serverModeConfirmValue
+                   ? window.t('settings.server_mode_confirm.body_on')
+                   : window.t('settings.server_mode_confirm.body_off')"></p>
+            <div class="modal-action fluent-modal-actions">
+                <button type="button" class="btn btn-ghost" @click="cancelServerModeChange()">
+                    {{ t('common.action.cancel') }}
+                </button>
+                <button type="button" class="btn btn-primary" @click="confirmServerModeChange()">
+                    {{ t('settings.server_mode_confirm.confirm') }}
                 </button>
             </div>
         </div>

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -15,7 +15,8 @@
 {% block content %}
 <div class="showcase-container ds-gallery-composition"
      x-data="showcase"
-     @keydown.window="handleKeydown($event)">
+     @keydown.window="handleKeydown($event)"
+     x-on:showcase:clear-search.window="clearSearch()">
 
     <!-- Loading State (初始顯示) -->
     <div class="state-page" x-cloak x-show="!showFavoriteActresses && loading && videoCount === 0">


### PR DESCRIPTION
## Summary

- **T1** Showcase 封面牆行動搜尋 toolbar 往下滾 50px 自動收合（_toolbarOpenY 相對閾值；有搜尋文字不收）
- **T2** Showcase header 行動搜尋 icon 有搜尋條件時切換為 ✕ 一鍵清除；修補 URL/persisted 初始狀態 init-time sync 缺漏（Codex P2）
- **T3** Settings toast ≤480px 移至底部，避免被行動瀏覽器 chrome 遮住
- **T4** 伺服器模式切換加確認彈窗，同模式點擊不觸發（Gemini P2 fix）
- **T5** Search 搜尋列 compose 態隱藏 Grid toggle，避免三 icon 擠爆空間

## Test plan

- [x] 全套 pytest **4710 passed, 2 skipped**（unit + integration，排除 smoke / e2e，+24 較 0.10.10 初版）
- [x] `npm run lint`（eslint + stylelint）綠
- [x] 來源金絲雀：7 PASS、1 SKIP（jav321 unreachable，已知正常）
- [x] Codex PR review P2（showcaseHasSearch 初始化缺漏）已修
- [x] Gemini P2（同模式觸發確認彈窗）已修（early return guard）
- [x] 版號不更動；CHANGELOG 摘要追加至 0.10.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)