### PR TITLE
feat(84): Windows installer bat + Help page update button

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*-Windows-*.zip
+          files: |
+            dist/*-Windows-*.zip
+            OpenAver-Windows-Setup.bat
           draft: false
           prerelease: false
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.11] - 2026-06-24
+
+本版主軸：**Windows 一鍵安裝捷徑 + Help 頁更新按鈕**（feature/84）——兩條並行：84a 新增 `OpenAver-Windows-Setup.bat` 雙擊即可觸發 PowerShell 安裝流程（配合 `chcp 65001` 確保中文正常顯示）；84b 在 Help 頁（限桌面 App）新增「更新」按鈕，偵測安裝路徑後以 confirm modal 導引用戶操作（情況 A 預設路徑 / 情況 B 非預設路徑），確認後開外部終端執行安裝腳本。
+
+### Added
+#### 🪟 Windows 雙擊安裝捷徑（84a）
+- 🎯 **`OpenAver-Windows-Setup.bat`**：新增於 repo root，雙擊即呼叫 PowerShell 以 `irm | iex` 方式執行安裝腳本；加入 `chcp 65001` 確保 UTF-8 終端顯示；CI Release 同步上傳此 bat 至 GitHub Release Assets。
+
+#### ⬆️ Help 頁一鍵更新（84b）
+- 🎯 **桌面 App 專屬更新按鈕**：偵測到有新版時，Help 頁出現「更新」按鈕（`is_desktop` Jinja gate，桌面 App 才顯示）。
+- 🎯 **路徑分流 confirm modal**：點更新先呼叫 `/api/install-context` 偵測是否裝在預設路徑——情況 A（預設）顯示「關閉後依畫面提示繼續」；情況 B（非預設）顯示需手動搬移步驟——確認後呼叫 `/api/trigger-update` 開外部終端執行安裝腳本，操作結果以 toast 回饋。
+- 🎯 **後端新增三個元件**：`_is_mac_desktop()`（macOS 桌面 App 偵測）；`GET /api/install-context`（路徑比對，非桌面回 403）；`POST /api/trigger-update`（Windows → PowerShell `CREATE_NEW_CONSOLE`，macOS → osascript Terminal；不揭露給 AI agent）。
+
+### 測試
+- 全套 pytest **4735 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較 0.10.10 的 4710 +25：`_is_mac_desktop()` 真值表 + install-context 路徑算法 + trigger-update subprocess/403 + capabilities 守衛 + Help 頁 Alpine binding 守衛）+ `ruff check .` 綠 + `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（含 avsox/dmm/javdb 全綠）。
+- Gemini 3.1 Pro 審查：3 條 advisory（hardcoded URL 設計取捨、路徑推斷 fallback 保護、macOS fire-and-forget 設計），無 P1/BLOCKER。
+- Codex PR review P1 × 2 已修：API `HTTPException.detail` 改固定中文字串；`_showHelpToast()` 改用 `_toast` Alpine state + `showToast()` 並補 toast DOM。
+
 ## [0.10.10] - 2026-06-24
 
 本版主軸：**封面比例自適應 + 行動相似探索面板**（feature/83）——兩條並行：83a 讓燈箱封面不留空白（寬比例作品自動填滿容器、AR 不污染女優模式）；83b 在行動裝置新增相似探索面板（全螢幕疊加 + 六張爆射卡 + 封面飛行進/退場 + 主圖播放按鈕）。

--- a/OpenAver-Windows-Setup.bat
+++ b/OpenAver-Windows-Setup.bat
@@ -1,0 +1,4 @@
+@echo off
+chcp 65001
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/slive777/OpenAver/main/install.ps1 | iex"
+pause

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.10.10"
+__version__ = "0.10.11"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -1192,6 +1192,16 @@
       "version_load_failed": "無法載入",
       "check_update_failed": "檢查失敗，請稍後再試",
       "check_update_network_error": "無法連線，請稍後再試"
+    },
+    "update_modal": {
+      "trigger_btn": "更新",
+      "title": "即將開啟安裝視窗",
+      "case_a_body": "安裝程式開啟後，請依畫面提示先關閉 OpenAver，再繼續更新。",
+      "case_b_body": "您目前不是安裝在預設位置。\n安裝程式會先把新版本安裝到預設目錄，安裝期間不需要先關閉目前的 OpenAver。\n\n安裝完成後，請依序操作：\n1. 關閉 OpenAver\n2. 刪除舊安裝目錄中的 python 資料夾\n3. 將新版本的所有檔案複製覆蓋回原本的安裝位置\n\nOpenAver 不需要重新安裝或重新設定，直接覆蓋檔案即可使用。",
+      "cancel_btn": "取消",
+      "confirm_btn": "確認更新",
+      "toast_success": "安裝視窗已開啟，請依畫面提示完成更新",
+      "toast_error": "啟動安裝程式失敗，請手動執行安裝腳本"
     }
   },
   "tutorial": {

--- a/tests/integration/test_installer_api.py
+++ b/tests/integration/test_installer_api.py
@@ -1,0 +1,21 @@
+"""
+tests/integration/test_installer_api.py — install-context / trigger-update 端點 403 gate
+"""
+from fastapi.testclient import TestClient
+from web.app import app
+
+
+def test_install_context_non_desktop_returns_403(monkeypatch):
+    """dev/uvicorn 裸跑（無 OPENAVER_STANDALONE）→ 403。"""
+    monkeypatch.delenv("OPENAVER_STANDALONE", raising=False)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/install-context")
+    assert resp.status_code == 403
+
+
+def test_trigger_update_non_desktop_returns_403(monkeypatch):
+    """dev/uvicorn 裸跑（無 OPENAVER_STANDALONE）→ 403。"""
+    monkeypatch.delenv("OPENAVER_STANDALONE", raising=False)
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post("/api/trigger-update")
+    assert resp.status_code == 403

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -15255,3 +15255,81 @@ class TestSimilarMobilePanelT4Guard:
             "ghost-hide 規則須含 opacity: 0"
         assert "pointer-events: none" in body, \
             "ghost-hide 規則須含 pointer-events: none（飛行期間防誤點）"
+
+
+class TestHelpUpdateButtonGuard:
+    """84-T3: Help 頁「更新」按鈕 + confirm modal 靜態守衛
+
+    契約：
+    1. {% if is_desktop %} gate 存在於 help.html（按鈕被正確 gate）
+    2. 「更新」按鈕的 @click="triggerUpdate()" 存在於 gate 內
+    3. triggerUpdate() DOM binding 不應出現在 gate 外
+    4. help.js 定義 triggerUpdate function
+    5. modal 的 x-show="showUpdateModal" binding 存在
+    6. modal 內含 confirm / cancel 按鈕
+    """
+
+    HELP_HTML = PROJECT_ROOT / "web" / "templates" / "help.html"
+    HELP_JS   = PROJECT_ROOT / "web" / "static" / "js" / "pages" / "help.js"
+
+    def _html(self):
+        return self.HELP_HTML.read_text(encoding="utf-8")
+
+    def _js(self):
+        return self.HELP_JS.read_text(encoding="utf-8")
+
+    def test_is_desktop_gate_exists_in_help_html(self):
+        """help.html 含 {% if is_desktop %} gate（確保按鈕被正確 gate）"""
+        html = self._html()
+        assert '{% if is_desktop %}' in html, \
+            "help.html 缺 {% if is_desktop %} gate — 更新按鈕必須在此 gate 內"
+
+    def test_trigger_update_click_inside_desktop_gate(self):
+        """@click="triggerUpdate()" 必須在 {% if is_desktop %} block 內"""
+        import re
+        html = self._html()
+        gate_pattern = re.compile(
+            r'\{%-?\s*if\s+is_desktop\s*-?%\}(.*?)\{%-?\s*endif\s*-?%\}',
+            re.DOTALL,
+        )
+        gates = gate_pattern.findall(html)
+        assert gates, "help.html: 找不到 {% if is_desktop %} block"
+        found = any('triggerUpdate()' in block for block in gates)
+        assert found, (
+            '@click="triggerUpdate()" 必須在 {% if is_desktop %} block 內 '
+            '（非桌面客戶端不應看到此按鈕）'
+        )
+
+    def test_trigger_update_not_outside_gate(self):
+        """triggerUpdate() DOM binding 不應出現在 {% if is_desktop %} gate 外"""
+        import re
+        html = self._html()
+        gate_pattern = re.compile(
+            r'\{%-?\s*if\s+is_desktop\s*-?%\}.*?\{%-?\s*endif\s*-?%\}',
+            re.DOTALL,
+        )
+        stripped = gate_pattern.sub('', html)
+        assert 'triggerUpdate()' not in stripped, (
+            'triggerUpdate() 出現在 {% if is_desktop %} gate 外 — '
+            '非桌面情境不應渲染此 DOM'
+        )
+
+    def test_trigger_update_defined_in_help_js(self):
+        """help.js 定義 triggerUpdate function（防函數遺漏導致 Alpine 報錯）"""
+        js = self._js()
+        assert 'triggerUpdate' in js, \
+            "help.js 缺 triggerUpdate 定義 — Alpine @click 呼叫的函數不存在"
+
+    def test_update_modal_x_show_binding_exists(self):
+        """modal 含 x-show="showUpdateModal" binding（防按鈕存在但 modal 永不出現）"""
+        html = self._html()
+        assert 'showUpdateModal' in html, \
+            "help.html 缺 showUpdateModal binding — update confirm modal 無法顯示"
+
+    def test_update_modal_has_confirm_and_cancel(self):
+        """modal 內含 confirmUpdate() 和 cancelUpdate() 呼叫（confirm/cancel 按鈕齊全）"""
+        html = self._html()
+        assert 'confirmUpdate()' in html, \
+            "help.html 缺 confirmUpdate() — modal 確認按鈕不存在"
+        assert 'cancelUpdate()' in html, \
+            "help.html 缺 cancelUpdate() — modal 取消按鈕不存在"

--- a/tests/unit/test_installer_api.py
+++ b/tests/unit/test_installer_api.py
@@ -1,0 +1,189 @@
+"""
+tests/unit/test_installer_api.py — _is_mac_desktop() 真值表、/api/install-context、
+/api/trigger-update、capabilities 守衛（全 mock，不需真 desktop 環境）
+"""
+import json
+import pytest
+from pathlib import Path
+from unittest import mock
+from fastapi.testclient import TestClient
+
+import web.app as _web_app
+
+
+@pytest.fixture
+def client():
+    return TestClient(_web_app.app, raise_server_exceptions=False)
+
+
+# ─────────────────────────────────────────────────────────
+# 1. _is_mac_desktop() 真值表
+# ─────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("standalone_val,platform_val,expected", [
+    ("1",  "darwin", True),   # 桌面 macOS → True
+    ("1",  "win32",  False),  # standalone 但非 darwin → False
+    ("1",  "linux",  False),  # standalone 但非 darwin → False
+    ("0",  "darwin", False),  # darwin 但非 standalone → False
+    (None, "darwin", False),  # env 未設 + darwin → False
+])
+def test_is_mac_desktop_truth_table(standalone_val, platform_val, expected, monkeypatch):
+    """五象限：OPENAVER_STANDALONE × sys.platform"""
+    monkeypatch.delenv("OPENAVER_STANDALONE", raising=False)
+    if standalone_val is not None:
+        monkeypatch.setenv("OPENAVER_STANDALONE", standalone_val)
+    monkeypatch.setattr(_web_app.sys, "platform", platform_val)
+
+    assert _web_app._is_mac_desktop() is expected, (
+        f"standalone_val={standalone_val!r}, platform={platform_val!r} → expected {expected}"
+    )
+
+
+# ─────────────────────────────────────────────────────────
+# 2. GET /api/install-context
+# ─────────────────────────────────────────────────────────
+
+def test_install_context_non_desktop_returns_403(client, monkeypatch):
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: False)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+    resp = client.get("/api/install-context")
+    assert resp.status_code == 403
+
+
+def test_install_context_windows_default_path(client, monkeypatch):
+    """Windows desktop：sys.executable 在 ~/OpenAver/python/pythonw.exe → is_default_path=True"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: True)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+
+    home = Path.home()
+    fake_exe = home / "OpenAver" / "python" / "pythonw.exe"
+    monkeypatch.setattr(_web_app.sys, "platform", "win32")
+    monkeypatch.setattr(_web_app.sys, "executable", str(fake_exe))
+
+    resp = client.get("/api/install-context")
+    assert resp.status_code == 200
+    assert resp.json() == {"is_default_path": True}
+
+
+def test_install_context_windows_non_default_path(client, monkeypatch):
+    """Windows desktop：sys.executable 在非預設路徑 → is_default_path=False"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: True)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+
+    fake_exe = "/custom/path/python/pythonw.exe"
+    monkeypatch.setattr(_web_app.sys, "platform", "win32")
+    monkeypatch.setattr(_web_app.sys, "executable", fake_exe)
+
+    resp = client.get("/api/install-context")
+    assert resp.status_code == 200
+    assert resp.json() == {"is_default_path": False}
+
+
+def test_install_context_macos_default_path(client, monkeypatch):
+    """macOS desktop：sys.executable 在 ~/OpenAver/python/bin/python3 → is_default_path=True"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: False)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: True)
+
+    home = Path.home()
+    fake_exe = home / "OpenAver" / "python" / "bin" / "python3"
+    monkeypatch.setattr(_web_app.sys, "platform", "darwin")
+    monkeypatch.setattr(_web_app.sys, "executable", str(fake_exe))
+
+    resp = client.get("/api/install-context")
+    assert resp.status_code == 200
+    assert resp.json() == {"is_default_path": True}
+
+
+def test_install_context_path_exception_fallback(client, monkeypatch):
+    """路徑計算異常 → fallback is_default_path=True（保守）"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: True)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+    monkeypatch.setattr(_web_app.sys, "platform", "win32")
+
+    # Path("") 會導致 Path.parent.parent 算出 "." / "." 而非 OSError，
+    # 所以改 patch Path 本身拋出例外
+    original_path = _web_app.Path
+
+    def raise_path(*args, **kwargs):
+        if args and args[0] == _web_app.sys.executable:
+            raise OSError("simulated path error")
+        return original_path(*args, **kwargs)
+
+    monkeypatch.setattr("web.app.Path", raise_path)
+    monkeypatch.setattr(_web_app.sys, "executable", "/some/exe")
+
+    resp = client.get("/api/install-context")
+    assert resp.status_code == 200
+    assert resp.json() == {"is_default_path": True}
+
+
+# ─────────────────────────────────────────────────────────
+# 3. POST /api/trigger-update
+# ─────────────────────────────────────────────────────────
+
+def test_trigger_update_non_desktop_returns_403(client, monkeypatch):
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: False)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+    resp = client.post("/api/trigger-update")
+    assert resp.status_code == 403
+
+
+def test_trigger_update_windows_calls_powershell(client, monkeypatch):
+    """Windows → subprocess.Popen 以 powershell.exe + CREATE_NEW_CONSOLE 呼叫"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: True)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+    monkeypatch.setattr(_web_app.sys, "platform", "win32")
+
+    # CREATE_NEW_CONSOLE (0x10) 在 Linux 上不存在，以 mock.patch.object(create=True) 跨平台 patch
+    CREATE_NEW_CONSOLE = 0x00000010
+    with mock.patch.object(_web_app.subprocess, "CREATE_NEW_CONSOLE", CREATE_NEW_CONSOLE, create=True), \
+         mock.patch("web.app.subprocess.Popen") as mock_popen:
+        resp = client.post("/api/trigger-update")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"success": True}
+    mock_popen.assert_called_once()
+    call_args, call_kwargs = mock_popen.call_args
+    cmd = call_args[0]
+    assert cmd[0] == "powershell.exe"
+    assert call_kwargs.get("creationflags") == CREATE_NEW_CONSOLE
+
+
+def test_trigger_update_macos_calls_osascript(client, monkeypatch):
+    """macOS → subprocess.Popen 以 osascript 呼叫"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: False)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: True)
+    monkeypatch.setattr(_web_app.sys, "platform", "darwin")
+
+    with mock.patch("web.app.subprocess.Popen") as mock_popen:
+        resp = client.post("/api/trigger-update")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"success": True}
+    mock_popen.assert_called_once()
+    call_args, _ = mock_popen.call_args
+    cmd = call_args[0]
+    assert cmd[0] == "osascript"
+
+
+def test_trigger_update_subprocess_oserror_returns_500(client, monkeypatch):
+    """subprocess.Popen 拋 OSError → HTTP 500"""
+    monkeypatch.setattr("web.app._is_windows_desktop", lambda: True)
+    monkeypatch.setattr("web.app._is_mac_desktop", lambda: False)
+    monkeypatch.setattr(_web_app.sys, "platform", "win32")
+
+    with mock.patch("web.app.subprocess.Popen", side_effect=OSError("not found")):
+        resp = client.post("/api/trigger-update")
+
+    assert resp.status_code == 500
+
+
+# ─────────────────────────────────────────────────────────
+# 4. capabilities 守衛：trigger-update 不在 blob
+# ─────────────────────────────────────────────────────────
+
+def test_trigger_update_not_in_capabilities(client):
+    """capabilities JSON blob 不得含 trigger-update（不揭露給 AI agent）"""
+    blob = json.dumps(client.get("/api/capabilities").json(), ensure_ascii=False).lower()
+    assert "trigger-update" not in blob, "capabilities 不得揭露 trigger-update"
+    assert "/api/trigger-update" not in blob, "capabilities 不得揭露 /api/trigger-update"

--- a/web/app.py
+++ b/web/app.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 import os
 import re
+import subprocess
 import sys
 
 # issue #66：全域保險，涵蓋 /static 以外的裸 FileResponse 也用 WHATWG canonical MIME。
@@ -13,7 +14,7 @@ mimetypes.add_type("text/javascript", ".js")
 mimetypes.add_type("text/javascript", ".mjs")
 mimetypes.add_type("text/css", ".css")
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse, RedirectResponse
 from web.static_cache import NoCacheStaticFiles
@@ -195,6 +196,11 @@ def _is_windows_desktop() -> bool:
     return os.environ.get("OPENAVER_STANDALONE") == "1" and sys.platform == "win32"
 
 
+def _is_mac_desktop() -> bool:
+    """True 僅限 macOS 桌面 App（OPENAVER_STANDALONE=1 AND darwin）。"""
+    return os.environ.get("OPENAVER_STANDALONE") == "1" and sys.platform == "darwin"
+
+
 def get_common_context(request: Request) -> dict:
     """取得共用的模板 Context (包含設定)"""
     from core.config import load_config, mutate_config
@@ -274,6 +280,7 @@ def get_common_context(request: Request) -> dict:
         "merged_translations": merged_translations,
         "t": _t_bound,
         "is_windows_desktop": _is_windows_desktop(),
+        "is_desktop": _is_windows_desktop() or _is_mac_desktop(),
     }
 
 
@@ -442,3 +449,46 @@ async def check_update():
     except Exception as e:
         logger.error("檢查更新失敗: %s", e)
         return {"success": False, "error": "檢查更新失敗"}
+
+
+@app.get("/api/install-context")
+async def get_install_context():
+    """取得安裝路徑資訊，供 Help 頁更新 modal 分流使用（僅 desktop App）。"""
+    if not (_is_windows_desktop() or _is_mac_desktop()):
+        raise HTTPException(status_code=403, detail="not_desktop")
+    try:
+        exe = Path(sys.executable)
+        if sys.platform == "darwin":
+            install_dir = exe.parent.parent.parent  # python/bin/python3 → OpenAver/
+        else:
+            install_dir = exe.parent.parent          # python\pythonw.exe → OpenAver\
+        default_dir = Path.home() / "OpenAver"
+        is_default_path = install_dir == default_dir
+    except Exception:
+        is_default_path = True  # 偵測失敗視同情況 A（保守）
+    return {"is_default_path": is_default_path}
+
+
+@app.post("/api/trigger-update")
+async def trigger_update():
+    """開啟外部終端視窗執行安裝 TUI（僅 desktop App，不揭露給 AI agent）。"""
+    if not (_is_windows_desktop() or _is_mac_desktop()):
+        raise HTTPException(status_code=403, detail="not_desktop")
+    try:
+        if sys.platform == "win32":
+            subprocess.Popen(
+                ["powershell.exe", "-ExecutionPolicy", "Bypass", "-NoProfile",
+                 "-Command",
+                 "irm https://raw.githubusercontent.com/slive777/OpenAver/main/install.ps1 | iex"],
+                creationflags=subprocess.CREATE_NEW_CONSOLE,
+            )
+        else:
+            subprocess.Popen(
+                ["osascript", "-e",
+                 "tell application \"Terminal\" to do script "
+                 "\"curl -fsSL https://raw.githubusercontent.com/slive777/OpenAver/main/install.sh | bash\""]
+            )
+    except Exception as e:
+        logger.error("trigger-update 啟動外部終端失敗: %s", e)
+        raise HTTPException(status_code=500, detail="trigger_failed")
+    return {"success": True}

--- a/web/app.py
+++ b/web/app.py
@@ -490,5 +490,5 @@ async def trigger_update():
             )
     except Exception as e:
         logger.error("trigger-update 啟動外部終端失敗: %s", e)
-        raise HTTPException(status_code=500, detail="trigger_failed")
+        raise HTTPException(status_code=500, detail="trigger_failed") from e
     return {"success": True}

--- a/web/app.py
+++ b/web/app.py
@@ -455,7 +455,7 @@ async def check_update():
 async def get_install_context():
     """取得安裝路徑資訊，供 Help 頁更新 modal 分流使用（僅 desktop App）。"""
     if not (_is_windows_desktop() or _is_mac_desktop()):
-        raise HTTPException(status_code=403, detail="not_desktop")
+        raise HTTPException(status_code=403, detail="此功能僅限桌面應用程式使用")
     try:
         exe = Path(sys.executable)
         if sys.platform == "darwin":
@@ -473,7 +473,7 @@ async def get_install_context():
 async def trigger_update():
     """開啟外部終端視窗執行安裝 TUI（僅 desktop App，不揭露給 AI agent）。"""
     if not (_is_windows_desktop() or _is_mac_desktop()):
-        raise HTTPException(status_code=403, detail="not_desktop")
+        raise HTTPException(status_code=403, detail="此功能僅限桌面應用程式使用")
     try:
         if sys.platform == "win32":
             subprocess.Popen(
@@ -490,5 +490,5 @@ async def trigger_update():
             )
     except Exception as e:
         logger.error("trigger-update 啟動外部終端失敗: %s", e)
-        raise HTTPException(status_code=500, detail="trigger_failed") from e
+        raise HTTPException(status_code=500, detail="啟動更新失敗，請查看日誌") from e
     return {"success": True}

--- a/web/static/js/pages/help.js
+++ b/web/static/js/pages/help.js
@@ -13,6 +13,8 @@ function helpPage() {
         showUpdateModal: false,
         isDefaultPath: true,
         updateLoading: false,
+        _toast: { message: '', type: 'info', visible: false },
+        _toastTimer: null,
 
         init() {
             this.loadVersion();
@@ -107,10 +109,19 @@ function helpPage() {
             this.showUpdateModal = false;
         },
 
+        showToast(message, type = 'info', duration = 2500) {
+            this._toast.message = message;
+            this._toast.type = type;
+            this._toast.visible = true;
+            if (this._toastTimer) clearTimeout(this._toastTimer);
+            this._toastTimer = setTimeout(() => {
+                this._toast.visible = false;
+                this._toastTimer = null;
+            }, duration);
+        },
+
         _showHelpToast(msg) {
-            if (window.__notifyBus) {
-                window.__notifyBus.dispatch('notify', { message: msg, type: 'info' });
-            }
+            this.showToast(msg, 'info');
         },
     };
 }

--- a/web/static/js/pages/help.js
+++ b/web/static/js/pages/help.js
@@ -10,6 +10,9 @@ function helpPage() {
         downloadUrl: '',
         errorMsg: '',
         checkDone: false,
+        showUpdateModal: false,
+        isDefaultPath: true,
+        updateLoading: false,
 
         init() {
             this.loadVersion();
@@ -68,6 +71,45 @@ function helpPage() {
             } finally {
                 this.checkUpdateLoading = false;
                 this.checkDone = true;
+            }
+        },
+
+        async triggerUpdate() {
+            // fetch install-context to determine default path scenario
+            try {
+                const resp = await fetch('/api/install-context');
+                const data = await resp.json();
+                this.isDefaultPath = data.is_default_path !== false;  // fallback true
+            } catch (e) {
+                this.isDefaultPath = true;  // 保守 fallback
+            }
+            this.showUpdateModal = true;
+        },
+
+        async confirmUpdate() {
+            this.updateLoading = true;
+            try {
+                const resp = await fetch('/api/trigger-update', { method: 'POST' });
+                if (resp.ok) {
+                    this._showHelpToast(window.t('help.update_modal.toast_success'));
+                } else {
+                    this._showHelpToast(window.t('help.update_modal.toast_error'));
+                }
+            } catch (e) {
+                this._showHelpToast(window.t('help.update_modal.toast_error'));
+            } finally {
+                this.updateLoading = false;
+                this.showUpdateModal = false;
+            }
+        },
+
+        cancelUpdate() {
+            this.showUpdateModal = false;
+        },
+
+        _showHelpToast(msg) {
+            if (window.__notifyBus) {
+                window.__notifyBus.dispatch('notify', { message: msg, type: 'info' });
             }
         },
     };

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -738,6 +738,14 @@
         </div>
     </dialog>
     {% endif %}
+
+    <!-- Toast 通知（update 成功/失敗回饋） -->
+    <div class="toast toast-end toast-top z-[9999]" x-show="_toast.visible" x-cloak x-transition>
+        <div class="alert" :class="`alert-${_toast.type}`">
+            <span x-text="_toast.message"></span>
+            <button type="button" class="btn btn-sm btn-circle btn-ghost" @click="_toast.visible = false">✕</button>
+        </div>
+    </div>
 </div>
 
 {% endblock %}

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -42,6 +42,16 @@
                             <i class="bi bi-download"></i> {{ t('help.hero.update_available_prefix') }} <span x-text="latestVersion"></span> {{ t('help.hero.update_available_suffix') }}
                         </a>
                     </template>
+                    {% if is_desktop %}
+                    <template x-if="checkDone && !errorMsg && hasUpdate">
+                        <button class="btn btn-warning btn-sm"
+                                @click="triggerUpdate()"
+                                :disabled="updateLoading">
+                            <span x-show="updateLoading" class="loading loading-spinner loading-sm"></span>
+                            {{ t('help.update_modal.trigger_btn') }}
+                        </button>
+                    </template>
+                    {% endif %}
                     <template x-if="checkDone && !errorMsg && !hasUpdate">
                         <span class="text-base-content/50 text-sm">
                             <i class="bi bi-check-circle"></i> {{ t('help.hero.up_to_date') }}
@@ -697,6 +707,37 @@
             </ul>
         </div>
     </div>
+    {% if is_desktop %}
+    <dialog class="modal fluent-modal"
+            :class="{ 'modal-open': showUpdateModal }"
+            @click.self="!updateLoading && cancelUpdate()"
+            @keydown.escape.window="!updateLoading && cancelUpdate()">
+        <div class="modal-box fluent-modal-box">
+            <h3 class="fluent-modal-title">{{ t('help.update_modal.title') }}</h3>
+            <!-- 情況 A：預設路徑 -->
+            <p x-show="isDefaultPath" class="fluent-modal-body text-sm">
+                {{ t('help.update_modal.case_a_body') }}
+            </p>
+            <!-- 情況 B：非預設路徑（whitespace-pre-line 保留換行） -->
+            <p x-show="!isDefaultPath" class="fluent-modal-body text-sm whitespace-pre-line">
+                {{ t('help.update_modal.case_b_body') }}
+            </p>
+            <div class="modal-action fluent-modal-actions">
+                <button type="button" class="btn btn-ghost btn-sm"
+                        @click="cancelUpdate()"
+                        :disabled="updateLoading">
+                    {{ t('help.update_modal.cancel_btn') }}
+                </button>
+                <button type="button" class="btn btn-warning btn-sm"
+                        @click="confirmUpdate()"
+                        :disabled="updateLoading">
+                    <span x-show="updateLoading" class="loading loading-spinner loading-sm"></span>
+                    {{ t('help.update_modal.confirm_btn') }}
+                </button>
+            </div>
+        </div>
+    </dialog>
+    {% endif %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- **84a** 新增 `OpenAver-Windows-Setup.bat` 至 repo root，雙擊即觸發 PowerShell 安裝流程（加 `chcp 65001`）；CI `build.yml` 同步上傳至 Release Assets
- **84b** Help 頁（`is_desktop` gate）新增更新按鈕：偵測 `/api/install-context` 路徑後分流 confirm modal（情況 A 預設路徑 / B 非預設路徑），確認後 `/api/trigger-update` 開外部終端執行安裝腳本
- 後端：`_is_mac_desktop()`、`GET /api/install-context`（路徑比對 + fallback）、`POST /api/trigger-update`（Windows PowerShell `CREATE_NEW_CONSOLE` / macOS osascript，不揭露 AI agent）
- Codex P1 × 2 已修：API detail 改固定中文字串；toast 改 `_toast` Alpine state

## Test plan

- [ ] 全套 pytest **4735 passed, 2 skipped** ✅
- [ ] `ruff check .` 綠 ✅
- [ ] `npm run lint` (eslint + stylelint) 綠 ✅
- [ ] 8 源金絲雀全 PASS ✅
- [ ] Gemini 3.1 Pro 審查：3 advisory，無 P1/BLOCKER ✅
- [ ] 手動驗收（Windows VM）：雙擊 bat → PowerShell 視窗跳出 → 安裝流程啟動（已由 owner 測試 POC）
- [ ] 手動驗收（桌面 App）：Help 頁有更新時按鈕顯示 → modal 路徑分流正確 → 外部終端跳出

🤖 Generated with [Claude Code](https://claude.com/claude-code)