### PR TITLE
v0.11.1 — JavLibrary 同番號多版本手動切換 (spec-86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-06-28
+
+本版主軸：**JavLibrary 同番號多版本手動切換**（feature/86，spec-86）——AV 番號會被不同片商跨年代重複使用（如 `MIDV-013`：舊片 vs MOODYZ 新片），預設都抓到先收錄的舊片。本版讓你在 JavLibrary 看封面手動挑版本。範圍刻意極小：僅 JavLibrary、僅手動入口、桌面 standalone 限定（需 CF transport），不進批次、不揭露 AI。
+
+### Added
+#### 🎬 JavLibrary 同番號多版本切換器
+- 🎯 **看封面手動挑版本**：同一番號在 JavLibrary 有多個版本（撞號）時，預覽卡出現封面 `‹ ›` 左右切換器 + 琥珀色「找到 X 部同番號作品 N/M」標示，按左右即時翻版本（封面/標題/日期/片商/tags 同步），游標預設停在**最新發行日**那部（多數人要的新片）。一次抓齊所有候選，翻頁不重打。
+- 🎯 **三個手動入口都支援**：
+  - **搜尋框直搜**：進階搜尋選 JavLibrary → 多版本跳預覽卡 + 切換器 → ✓「採用此版本」進結果區（不寫檔）。
+  - **燈箱換來源**：對某片開「換來源」選 JavLibrary → 切換器 → ✓ 寫入選定版本的 NFO/封面（保留「覆蓋不可逆」警告）。
+  - **結果卡替換來源**：先用別的來源找到、再「替換來源」成 JavLibrary 多版本 → 切換器 → ✓「替換此版本」就地替換當前卡（不寫檔）。
+
+### Changed
+- **「找到 X 部」撞號提示改琥珀色**（同不可逆警語色系，「注意」語意）更顯眼。
+- **JavLibrary pill 在搜尋頁進階搜尋解除隱藏**：改由「桌面限定」gate 統一管（非桌面仍灰化不可點）。
+
+### Fixed
+- **搜尋頁挑版本後可再次開啟**：採用某版本後，exact 結果頁保留「再開來源/版本挑選」入口（不再因搜尋框與結果同步而消失）；限搜尋 workflow，批次/檔案模式不受污染。
+- **搜尋頁挑版本路徑同步搜尋框 query**：採用版本後搜尋框、輸入法判斷、工作階段還原不再殘留舊番號。
+- **番號邊界比對補前置**：候選列舉避免把 `AMIDV-010` 之類前置黏連號誤收為 `MIDV-010` 的版本。
+
+### Internal
+- scraper 新增同番號全版本列舉（`search_all_versions` / `fetch_by_detail_url`，新片優先排序）+ helper 抽取；後端 `/api/rescrape/preview` 多版本回 `candidates[]`、`EnrichRequest` 新增 `detail_url`（confirm server-side 重抓，不揭露 AI）；前端 rescrape modal 三入口 candidates 短狀態 + 切換器 partial。
+- `core/scrapers/README.md` 的「JavLibrary 手動版本切換」由 pending → done。
+
+### 測試
+- 全套 pytest **4799 passed, 2 skipped**（unit + integration，排除 smoke / e2e，較 0.11.0 的 4747 +52：scraper 列舉/排序/邊界 + 後端 candidates/detail_url/CF + 前端 state/切換器/入口路由/守衛）+ `ruff check .` 綠 + `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（pre-merge live）。
+- Windows 真機驗收：MIDV-013（3 版本）三入口切換器 + 採用皆通過。
+- Codex PR review P2 × 2（search 採用 query 同步 / file-mode 入口 gate）已修；Gemini 整支 branch 第二意見 P1 × 1（番號前置邊界）已修。
+
 ## [0.11.0] - 2026-06-27
 
 本版主軸：**JavBus 過度泛用清償 + exact 番號搜尋改優先序 cascade**（feature/85，spec-85）——技術債清償與行為修正，預期淨刪碼、不新增使用者功能。核心是讓「來源優先序」這個既有設定**真的被尊重**：以前直接搜番號時，只要 JavBus 有啟用就會搶先回結果（即使你把 DMM 排第一），現在改成嚴格依你拖曳的優先順序逐一查、命中即回。並移除依賴已死端點的 JavBus variant（同番號多版本）探查死碼。

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -321,7 +321,7 @@ def _write_extrafanart(
     return written_uris
 
 
-def enrich_single(  # noqa: ranker-invalidate (only updates nfo_mtime, not a corpus field; corpus writes go via _db_upsert → repo.upsert which already has invalidate)
+def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpus field; corpus writes go via _db_upsert → repo.upsert which already has invalidate)
     file_path: str,
     number: str,
     mode: str = "fill_missing",

--- a/core/scraper.py
+++ b/core/scraper.py
@@ -126,6 +126,17 @@ def expand_partial_number(partial: str) -> List[str]:
 _INTERNAL_NFO_KEYS = ('_summary', '_rating')
 
 
+def internal_nfo_carriers(video) -> dict:
+    """search_jav 注入、to_legacy_dict 刻意省略的內部 NFO carrier（_summary / _rating）。
+
+    NFO writer 的 <plot>/<rating> 吃這組 `_` 前綴 carrier（見 enricher._scraper_to_meta），
+    DB 不收。detail_url 預餵路徑（confirm 多版本）跳過 search_jav，需補同一組以對齊既有
+    javlibrary 重刮的 NFO 輸出，否則 NFO 評分/簡介會掉（CD-63c-5 / PR #89 Codex P2）。
+    key 集合必須與 _INTERNAL_NFO_KEYS 一致。
+    """
+    return {'_summary': video.summary, '_rating': video.rating}
+
+
 def strip_internal_nfo_keys(result_dict: dict) -> dict:
     """移除 internal NFO carrier 鍵（_summary / _rating），回傳 shallow copy。
 
@@ -349,8 +360,7 @@ def search_jav(number: str, source: str = 'auto', proxy_url: str = '', javbus_la
 
     result = main_video.to_legacy_dict()
     result['_source'] = main_video.source  # 保留內部欄位
-    result['_summary'] = main_video.summary  # 63c 新增（NFO 用，不入 DB，CD-63c-5）
-    result['_rating'] = main_video.rating    # 63c 新增（NFO 用，已排除於 to_legacy_dict）
+    result.update(internal_nfo_carriers(main_video))  # _summary / _rating（NFO 用，to_legacy_dict 省略）
     logger.info(f"[Search] {number} 完成，來源: {main_video.source}")
     return result
 

--- a/core/scraper.py
+++ b/core/scraper.py
@@ -360,6 +360,25 @@ def search_jav_single_source(number: str, source: str, proxy_url: str = '') -> O
     return search_jav(number, source=source, proxy_url=proxy_url)
 
 
+def search_javlib_versions(number: str) -> List[Dict[str, Any]]:
+    """javlibrary 同番號全版本列舉 → list[dict]（各版本 to_legacy_dict()）。
+
+    CF 例外（CfChallengeRequired / CfTransportUnavailable）propagate 給呼叫端。
+    """
+    scraper = JavLibraryScraper()
+    videos = scraper.search_all_versions(number)
+    return [v.to_legacy_dict() for v in videos]
+
+
+def fetch_javlib_by_detail_url(detail_url: str, number: str) -> Optional[Video]:
+    """javlibrary 直抓單一 detail URL → Video（confirm 用）。
+
+    CF 例外 propagate 給呼叫端。
+    """
+    scraper = JavLibraryScraper()
+    return scraper.fetch_by_detail_url(detail_url, number)
+
+
 def search_partial(partial: str,
                    status_callback: Optional[Callable[[str, str], None]] = None,
                    result_callback: Optional[Callable[[int, Any], None]] = None,

--- a/core/scrapers/README.md
+++ b/core/scrapers/README.md
@@ -15,7 +15,7 @@
 | `javbus` | JavBus | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | 直打 detail URL；封面無浮水印但**僅右半裁切**；搜尋端點 `/search/` 已 404（站方改版，variant 探查已移除，見 §2） |
 | `jav321` | Jav321 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | keyword 搜尋恆回空，故不入 FUZZY_SEARCH_SOURCES |
 | `javdb` | JavDB | ✅ | ❌ | ❌ | ❌ | ⚠️ | ✅ | 重複 keyword 呼叫觸發 Cloudflare ban，故不入 FUZZY_SEARCH_SOURCES；封面有浮水印 |
-| `javlibrary` | JavLibrary | ✅ | ❌ | ❌ | ❌ | ✅ | [需確認] | **manual_only**：不進 SOURCE_ORDER fan-out；exact-only（CD-70b）；需 CfTransport（桌面版限定）；手動版本切換見 **spec-86（pending）** |
+| `javlibrary` | JavLibrary | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | **manual_only**：不進 SOURCE_ORDER fan-out；exact-only（CD-70b）；需 CfTransport（桌面版限定）；封面 hotlink DMM CDN（`pl.jpg`，同 dmm 無浮水印）；手動版本切換：**eager 全抓、新片優先、僅 lightbox/search 入口**（spec-86 done） |
 
 ### 1.2 無碼來源（UNCENSORED_SOURCES）
 
@@ -54,7 +54,7 @@ core/scrapers/utils.py
 ### 2.2 版本切換現況
 
 - **JavBus variant 探查（spec-85 已移除）**：舊版透過 `/search/` 端點枚舉同番號多版本 ID，但該端點於 2025 年站方改版後已 404。依賴此機制的 `get_all_variant_ids` / `search_by_variant_id` 及前端版本切換 UI 已在 **spec-85 全棧原子清除**。
-- **JavLibrary 手動版本切換（spec-86 pending）**：同番號多版本的使用者可視切換功能移交 spec-86 全新設計（基於 JavLibrary 搜尋列表，非 JavBus 搜尋），尚未上線。
+- **JavLibrary 手動版本切換（spec-86 done）**：同番號多版本的使用者手動切換，基於 JavLibrary 搜尋列表（非 JavBus 搜尋）。開窗時 eager 全抓所有候選的完整 detail、新片優先排序（發行日 desc，預設游標停在最新），僅 lightbox / search 兩個手動入口出現封面 `‹ ›` 切換器；switch-source 入口靜默取最新。不進批次匯入、不揭露 AI agent（detail_url 為內部路由細節，AC9）。
 
 ---
 

--- a/core/scrapers/README.md
+++ b/core/scrapers/README.md
@@ -15,7 +15,7 @@
 | `javbus` | JavBus | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | 直打 detail URL；封面無浮水印但**僅右半裁切**；搜尋端點 `/search/` 已 404（站方改版，variant 探查已移除，見 §2） |
 | `jav321` | Jav321 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | keyword 搜尋恆回空，故不入 FUZZY_SEARCH_SOURCES |
 | `javdb` | JavDB | ✅ | ❌ | ❌ | ❌ | ⚠️ | ✅ | 重複 keyword 呼叫觸發 Cloudflare ban，故不入 FUZZY_SEARCH_SOURCES；封面有浮水印 |
-| `javlibrary` | JavLibrary | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | **manual_only**：不進 SOURCE_ORDER fan-out；exact-only（CD-70b）；需 CfTransport（桌面版限定）；封面 hotlink DMM CDN（`pl.jpg`，同 dmm 無浮水印）；手動版本切換：**eager 全抓、新片優先、僅 lightbox/search 入口**（spec-86 done） |
+| `javlibrary` | JavLibrary | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | **manual_only**：不進 SOURCE_ORDER fan-out；exact-only（CD-70b）；需 CfTransport（桌面版限定）；封面 hotlink DMM CDN（`pl.jpg`，同 dmm 無浮水印）；手動版本切換：**eager 全抓、新片優先、三手動入口（lightbox/search/switch-source）多版本皆出切換器**（spec-86 done，含 T7 switch-source follow-on） |
 
 ### 1.2 無碼來源（UNCENSORED_SOURCES）
 
@@ -54,7 +54,7 @@ core/scrapers/utils.py
 ### 2.2 版本切換現況
 
 - **JavBus variant 探查（spec-85 已移除）**：舊版透過 `/search/` 端點枚舉同番號多版本 ID，但該端點於 2025 年站方改版後已 404。依賴此機制的 `get_all_variant_ids` / `search_by_variant_id` 及前端版本切換 UI 已在 **spec-85 全棧原子清除**。
-- **JavLibrary 手動版本切換（spec-86 done）**：同番號多版本的使用者手動切換，基於 JavLibrary 搜尋列表（非 JavBus 搜尋）。開窗時 eager 全抓所有候選的完整 detail、新片優先排序（發行日 desc，預設游標停在最新），僅 lightbox / search 兩個手動入口出現封面 `‹ ›` 切換器；switch-source 入口靜默取最新。不進批次匯入、不揭露 AI agent（detail_url 為內部路由細節，AC9）。
+- **JavLibrary 手動版本切換（spec-86 done）**：同番號多版本的使用者手動切換，基於 JavLibrary 搜尋列表（非 JavBus 搜尋）。開窗時 eager 全抓所有候選的完整 detail、新片優先排序（發行日 desc，預設游標停在最新）。**三個手動入口遇多版本皆出現封面 `‹ ›` 切換器**讓使用者選版本，採用語意各異：lightbox 寫入選定版本 NFO/封面（保留不可逆警告）、search 採用選定版本進結果列、switch-source 以選定版本就地替換當前結果卡。**switch-source 單版本維持靜默直接替換**（最小驚訝；多版本才開切換器，spec-86 D7 follow-on 已於 T7 實作，反轉原 Non-Goal）。不進批次匯入、不揭露 AI agent（detail_url 為內部路由細節，AC9）。
 
 ---
 

--- a/core/scrapers/javlibrary.py
+++ b/core/scrapers/javlibrary.py
@@ -295,7 +295,10 @@ def _extract_all_detail_urls(html: str, num: str, base_lang_url: str) -> list[st
         if not href:
             continue
         title_attr = el.get("title", "").upper()
-        if not re.search(pattern_str, title_attr):
+        text_attr = el.get_text().upper()
+        # 一致性（對齊 _extract_detail_url :255 的 text OR title）：title 或 link text
+        # 任一 boundary-match 即收。boundary regex 不變，仍嚴格擋鄰號/黏連，故多比對來源不引入 false positive。
+        if not (re.search(pattern_str, title_attr) or re.search(pattern_str, text_attr)):
             continue
         # 正規化相對路徑（同 _extract_detail_url :265-276）
         if href.startswith("http"):

--- a/core/scrapers/javlibrary.py
+++ b/core/scrapers/javlibrary.py
@@ -280,12 +280,14 @@ def _extract_all_detail_urls(html: str, num: str, base_lang_url: str) -> list[st
     """
     從搜尋結果頁收集所有與番號精確相符的 detail URL。
 
-    boundary-aware 比對（避免 MIDV-010 誤收 MIDV-100 等前綴鄰號）。
+    boundary-aware 比對（避免 MIDV-010 誤收 MIDV-100 等前綴鄰號，
+    或 AMIDV-010 / 1MIDV-010 等前置黏連號）。
     去重保序，無相符回 []（不 fallback links[0]）。
     """
     soup = BeautifulSoup(html, "html.parser")
     num_upper = num.upper()
-    pattern_str = re.escape(num_upper) + r'(?![0-9A-Za-z])'
+    # 前後皆需番號邊界：lookbehind 擋前置黏連（AMIDV-010），lookahead 擋後綴鄰號（MIDV-100）
+    pattern_str = r'(?<![0-9A-Za-z])' + re.escape(num_upper) + r'(?![0-9A-Za-z])'
     seen: set[str] = set()
     result: list[str] = []
     for el in soup.select(".video a"):

--- a/core/scrapers/javlibrary.py
+++ b/core/scrapers/javlibrary.py
@@ -276,6 +276,50 @@ def _extract_detail_url(html: str, num: str, base_lang_url: str) -> Optional[str
     return base_lang_url.rstrip("/") + "/" + best
 
 
+def _extract_all_detail_urls(html: str, num: str, base_lang_url: str) -> list[str]:
+    """
+    從搜尋結果頁收集所有與番號精確相符的 detail URL。
+
+    boundary-aware 比對（避免 MIDV-010 誤收 MIDV-100 等前綴鄰號）。
+    去重保序，無相符回 []（不 fallback links[0]）。
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    num_upper = num.upper()
+    pattern_str = re.escape(num_upper) + r'(?![0-9A-Za-z])'
+    seen: set[str] = set()
+    result: list[str] = []
+    for el in soup.select(".video a"):
+        href = el.get("href", "")
+        if not href:
+            continue
+        title_attr = el.get("title", "").upper()
+        if not re.search(pattern_str, title_attr):
+            continue
+        # 正規化相對路徑（同 _extract_detail_url :265-276）
+        if href.startswith("http"):
+            normalized: str = href
+        elif href.startswith("//"):
+            normalized = "https:" + href
+        elif href.startswith("./"):
+            normalized = base_lang_url.rstrip("/") + "/" + href[2:]
+        elif href.startswith("/"):
+            normalized = BASE_URL + href
+        else:
+            normalized = base_lang_url.rstrip("/") + "/" + href
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
+    return result
+
+
+def _raise_if_cf(html: str) -> None:
+    """CF challenge 偵測 helper。偵測到 CF challenge 則拋 CfChallengeRequired。"""
+    soup_title_tag = BeautifulSoup(html, "html.parser").title
+    page_title = soup_title_tag.string if soup_title_tag else ""
+    if _is_cf_challenge(page_title, html):
+        raise CfChallengeRequired("CF challenge detected")
+
+
 # ──────────────────────────────────────────────────────────────
 # JavLibraryScraper
 # ──────────────────────────────────────────────────────────────
@@ -330,12 +374,7 @@ class JavLibraryScraper(BaseScraper):
         # 用 _is_age_gate 會把有效頁面誤判為閘門 → CfChallengeRequired 死循環。
         # Age gate 由 transport.begin_solve（設 over18 cookie）+ is_ready 把關，
         # post-solve fetch 不會再遇 age gate（比照 POC scrape_b 設計）。
-        soup_title_tag = BeautifulSoup(html, "html.parser").title
-        page_title = soup_title_tag.string if soup_title_tag else ""
-        if _is_cf_challenge(page_title, html):
-            raise CfChallengeRequired(
-                "CF challenge detected in search response"
-            )
+        _raise_if_cf(html)
 
         # 步驟 6
         soup = BeautifulSoup(html, "html.parser")
@@ -357,24 +396,36 @@ class JavLibraryScraper(BaseScraper):
             detail_html = transport.fetch(detail_url, cache_key='javlibrary')
 
             # 第二次 fetch 防禦性 CF 檢查（同上，只檢 CF，不檢 age gate）
-            soup_d_title = BeautifulSoup(detail_html, "html.parser").title
-            d_title = soup_d_title.string if soup_d_title else ""
-            if _is_cf_challenge(d_title, detail_html):
-                raise CfChallengeRequired(
-                    "CF challenge detected in detail response"
-                )
+            _raise_if_cf(detail_html)
 
+        return self._video_from_detail_html(detail_html, number, detail_url)
+
+    def search_by_keyword(self, keyword: str, limit: int = 20) -> list[Video]:
+        """永遠回傳空 list（CD-70b：exact-only，不做模糊搜尋）。"""
+        return []
+
+    def _video_from_detail_html(
+        self,
+        detail_html: str,
+        number: str,
+        detail_url: str,
+    ) -> Optional[Video]:
+        """
+        parse_detail + 品質保護 + FIX-5 番號核對 + Video 映射（steps 9-11）。
+        行為與原 search() :367-419 完全相同。
+        """
         # 步驟 9
         fields = parse_detail(detail_html, number)
 
         # 步驟 10：parse 品質保護
         if not fields.get("title") and not fields.get("cover"):
-            logger.info("javlibrary: parse failed for %s (title+cover both empty — selector 失準或頁面結構變動)", number)
+            logger.info(
+                "javlibrary: parse failed for %s (title+cover both empty — selector 失準或頁面結構變動)",
+                number,
+            )
             return None
 
         # FIX-5：番號核對守衛
-        # _extract_detail_url fallback 取 links[0] 可能回到不相關的片子；
-        # parse 出的番號與請求番號 normalize 後不符 → 誠實回 None（優於回錯片資料）。
         parsed_number_norm = self.normalize_number(fields.get("number") or "")
         request_number_norm = self.normalize_number(number)
         if parsed_number_norm and request_number_norm and parsed_number_norm != request_number_norm:
@@ -418,6 +469,52 @@ class JavLibraryScraper(BaseScraper):
             detail_url=detail_url,
         )
 
-    def search_by_keyword(self, keyword: str, limit: int = 20) -> list[Video]:
-        """永遠回傳空 list（CD-70b：exact-only，不做模糊搜尋）。"""
-        return []
+    def search_all_versions(self, number: str) -> list[Video]:
+        """
+        以番號搜尋 JavLibrary，收集全部版本（同番號複數 detail），回傳 list[Video]。
+        新片優先（date desc）。
+
+        - 單一命中 302 → 1-element list
+        - 多版本列表 → boundary-aware 列舉全部 detail URL，各別 fetch parse
+        - 列表頁或 detail fetch 遇 CF challenge → CfChallengeRequired propagate
+        - 無相符 → []
+        """
+        transport = get_cf_transport()
+        if transport is None:
+            raise CfTransportUnavailable(
+                "JavLibrary scraper requires CF transport (desktop standalone only)"
+            )
+        number = self.normalize_number(number)
+        search_url = f'{BASE_URL}/{LANG}/vl_searchbyid.php?keyword={number}'
+        html: str = transport.fetch(search_url, cache_key='javlibrary')
+        _raise_if_cf(html)
+        soup = BeautifulSoup(html, "html.parser")
+        if _is_detail_page(soup):
+            # 單一命中 302（已是 detail 頁）
+            v = self._video_from_detail_html(html, number, "")
+            return [v] if v else []
+        base_lang_url = f'{BASE_URL}/{LANG}'
+        urls = _extract_all_detail_urls(html, number, base_lang_url)
+        out: list[Video] = []
+        for url in urls:
+            dhtml: str = transport.fetch(url, cache_key='javlibrary')
+            _raise_if_cf(dhtml)
+            v = self._video_from_detail_html(dhtml, number, url)
+            if v:
+                out.append(v)
+        out.sort(key=lambda v: v.date or "", reverse=True)  # 新片優先（CD-86-3）
+        return out
+
+    def fetch_by_detail_url(self, detail_url: str, number: str) -> Optional[Video]:
+        """
+        直接以 detail URL 抓取並解析，回傳 Video 或 None。
+        detail_url 會落地在 Video.detail_url。
+        """
+        transport = get_cf_transport()
+        if transport is None:
+            raise CfTransportUnavailable(
+                "JavLibrary scraper requires CF transport (desktop standalone only)"
+            )
+        dhtml: str = transport.fetch(detail_url, cache_key='javlibrary')
+        _raise_if_cf(dhtml)
+        return self._video_from_detail_html(dhtml, self.normalize_number(number), detail_url)

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 VERSION = __version__
 
 # 版本資訊

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -493,6 +493,19 @@ export default [
             "62c-3：switch-source 分支禁賦值 this.searchResults（US5 整包重設路徑，會污染結果列）。" +
             "只替換捕捉的 slot（t.arr[t.idx] = variant），結果列陣列 identity / currentIndex 不變。",
         },
+        {
+          // CD-86-13: confirm 取選定版本 URL 一律用 rescrapePreview.url
+          selector: "MemberExpression[property.name='detail_url'][object.property.name='rescrapePreview']",
+          message:
+            "CD-86-13: confirm 取選定版本 URL 一律用 rescrapePreview.url（detail_url 為 undefined，to_legacy_dict 輸出 key 是 url）。禁止 rescrapePreview.detail_url。",
+        },
+        {
+          // CD-86-14: search 採用分支禁 inline this.searchResults = 賦值（強制走 _commitSearchResults helper）
+          selector:
+            "IfStatement[test.right.value='search'] AssignmentExpression[left.property.name='searchResults']",
+          message:
+            "CD-86-14: search 採用分支禁止 inline 賦值 this.searchResults（會遺漏 pageState/listMode/checkLocalStatus/actressProfile 等）。改呼叫 this._commitSearchResults(...)。",
+        },
       ],
     },
   },

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -711,7 +711,8 @@
       "versions_found": "找到 {count} 部同番號作品",
       "version_prev_aria": "上一個版本",
       "version_next_aria": "下一個版本",
-      "adopt_version": "採用此版本"
+      "adopt_version": "採用此版本",
+      "adopt_switch_source": "替換此版本"
     },
     "placeholder": {
       "search": "搜尋番號、女優、標題..."

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -707,7 +707,11 @@
       "success": "已覆蓋寫入（封面 + NFO）",
       "fail": "重新刮削失敗，請稍後再試。",
       "jl_desktop_only": "僅限桌面應用程式（standalone）可用",
-      "jl_cf_solving": "Cloudflare 驗證中……通過後將自動繼續"
+      "jl_cf_solving": "Cloudflare 驗證中……通過後將自動繼續",
+      "versions_found": "找到 {count} 部同番號作品",
+      "version_prev_aria": "上一個版本",
+      "version_next_aria": "下一個版本",
+      "adopt_version": "採用此版本"
     },
     "placeholder": {
       "search": "搜尋番號、女優、標題..."

--- a/tests/integration/test_api_cf_endpoints.py
+++ b/tests/integration/test_api_cf_endpoints.py
@@ -109,8 +109,9 @@ class TestRescrapePreviewCfExceptions:
 
     def test_cf_challenge_required_returns_cf_needed(self, client, mocker):
         """CfChallengeRequired → {success:false, cf_needed:true}，begin_solve 被呼叫。"""
+        # source=javlibrary 現在走 search_javlib_versions 分支（T2），不再走 search_jav_single_source
         mocker.patch(
-            "web.routers.scraper.search_jav_single_source",
+            "web.routers.scraper.search_javlib_versions",
             side_effect=CfChallengeRequired("CF challenge"),
         )
         mock_transport = MagicMock()
@@ -128,8 +129,9 @@ class TestRescrapePreviewCfExceptions:
 
     def test_cf_transport_unavailable_returns_cf_unavailable(self, client, mocker):
         """CfTransportUnavailable → {success:false, cf_unavailable:true}，begin_solve 不被呼叫。"""
+        # source=javlibrary 現在走 search_javlib_versions 分支（T2），不再走 search_jav_single_source
         mocker.patch(
-            "web.routers.scraper.search_jav_single_source",
+            "web.routers.scraper.search_javlib_versions",
             side_effect=CfTransportUnavailable("no transport"),
         )
         mock_transport = MagicMock()
@@ -147,8 +149,9 @@ class TestRescrapePreviewCfExceptions:
 
     def test_cf_challenge_no_transport_still_returns_cf_needed(self, client, mocker):
         """CfChallengeRequired + get_cf_transport → None → begin_solve 不呼叫，仍回 cf_needed:true。"""
+        # source=javlibrary 現在走 search_javlib_versions 分支（T2），不再走 search_jav_single_source
         mocker.patch(
-            "web.routers.scraper.search_jav_single_source",
+            "web.routers.scraper.search_javlib_versions",
             side_effect=CfChallengeRequired("CF challenge"),
         )
         mocker.patch("web.routers.scraper.get_cf_transport", return_value=None)

--- a/tests/integration/test_rescrape_javlib.py
+++ b/tests/integration/test_rescrape_javlib.py
@@ -144,6 +144,9 @@ class TestEnrichSingleDetailUrl:
             "url": ".../javme3bu7e.html",
             "title": "新片",
         }
+        # P2：detail_url 路徑須補回 to_legacy_dict 省略的 _rating/_summary carrier
+        fake_video.rating = 4.5
+        fake_video.summary = "簡介內容"
 
         with patch('web.routers.scraper.fetch_javlib_by_detail_url',
                    return_value=fake_video) as mock_fetch, \
@@ -162,8 +165,69 @@ class TestEnrichSingleDetailUrl:
             "https://www.javlibrary.com/ja/javme3bu7e.html", "MIDV-010"
         )
         call_kwargs = mock_enrich.call_args.kwargs
-        # scraper_data 為選定版本 to_legacy_dict() 的結果（非 None、且為該 video 的值）
-        assert call_kwargs.get("scraper_data") == fake_video.to_legacy_dict.return_value
+        scraper_data = call_kwargs.get("scraper_data")
+        # scraper_data 為選定版本 to_legacy_dict() + 補回的內部 NFO carrier
+        assert scraper_data is not None
+        assert scraper_data["number"] == "MIDV-010"
+        # P2 mutation guard：_rating/_summary carrier 須補回且值取自 video（否則 NFO 評分掉）
+        assert scraper_data["_rating"] == 4.5
+        assert scraper_data["_summary"] == "簡介內容"
+
+    def test_enrich_single_rejects_non_javlibrary_detail_url(self, client):
+        """
+        P3 SSRF guard：source=javlibrary 但 detail_url 非 javlibrary origin
+        （內網 metadata endpoint / 任意外站 / prefix 繞過）→ success False，
+        且 fetch_javlib_by_detail_url 完全不被呼叫。
+        """
+        malicious_urls = [
+            "http://169.254.169.254/latest/meta-data/",
+            "https://evil.com/x.html",
+            "https://www.javlibrary.com.evil.com/ja/x.html",  # prefix 繞過
+            "http://www.javlibrary.com/ja/x.html",            # scheme 不符
+        ]
+        for bad_url in malicious_urls:
+            with patch('web.routers.scraper.fetch_javlib_by_detail_url') as mock_fetch, \
+                 patch('web.routers.scraper.enrich_single',
+                       return_value=_ok_enrich_result()) as mock_enrich:
+                resp = client.post("/api/enrich-single", json={
+                    "file_path": "file:///fake/MIDV-010.mp4",
+                    "number": "MIDV-010",
+                    "source": "javlibrary",
+                    "detail_url": bad_url,
+                    "mode": "refresh_full",
+                    "overwrite_existing": True,
+                })
+                assert resp.status_code == 200
+                assert resp.json()["success"] is False, f"應拒絕 {bad_url}"
+                mock_fetch.assert_not_called()  # 惡意 URL 絕不進 fetch
+                mock_enrich.assert_not_called()
+
+    def test_enrich_single_accepts_valid_javlibrary_detail_url(self, client):
+        """
+        P3：合法 javlibrary origin 的 detail_url → 正常進 fetch（origin guard 不誤殺）。
+        """
+        from core.scrapers.models import Video
+
+        fake_video = MagicMock(spec=Video)
+        fake_video.to_legacy_dict.return_value = {"number": "MIDV-010", "title": "新片"}
+        fake_video.rating = 3.0
+        fake_video.summary = ""
+
+        with patch('web.routers.scraper.fetch_javlib_by_detail_url',
+                   return_value=fake_video) as mock_fetch, \
+             patch('web.routers.scraper.enrich_single',
+                   return_value=_ok_enrich_result()):
+            resp = client.post("/api/enrich-single", json={
+                "file_path": "file:///fake/MIDV-010.mp4",
+                "number": "MIDV-010",
+                "source": "javlibrary",
+                "detail_url": "https://www.javlibrary.com/ja/?v=javme3bu7e",
+                "mode": "refresh_full",
+                "overwrite_existing": True,
+            })
+
+        assert resp.json()["success"] is True
+        mock_fetch.assert_called_once()
 
     def test_enrich_single_no_detail_url_unchanged(self, client):
         """

--- a/tests/integration/test_rescrape_javlib.py
+++ b/tests/integration/test_rescrape_javlib.py
@@ -1,0 +1,202 @@
+"""
+tests/integration/test_rescrape_javlib.py
+
+/api/rescrape/preview (javlibrary 分支) + /api/enrich-single (detail_url 分支)
+整合測試（FastAPI TestClient round-trip）。
+
+patch target 一律為使用端：
+  - web.routers.scraper.search_javlib_versions
+  - web.routers.scraper.fetch_javlib_by_detail_url
+  - web.routers.scraper.enrich_single
+  - web.routers.scraper.get_cf_transport
+（CD-86-12 / gotchas-backend §1）
+"""
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _ok_enrich_result(**kwargs):
+    """建立成功的 EnrichResult（dataclass）作為 mock 回傳值。
+    endpoint 用 asdict(result)，必須是真實 dataclass 才能序列化。
+    """
+    from core.enricher import EnrichResult
+    defaults = dict(
+        success=True,
+        nfo_written=True,
+        cover_written=True,
+        extrafanart_written=0,
+        fields_filled=[],
+        source_used="javlibrary",
+        error=None,
+    )
+    defaults.update(kwargs)
+    return EnrichResult(**defaults)
+
+
+# ── /api/rescrape/preview javlibrary 分支 ────────────────────────────────────
+
+class TestRescrapePreviewJavlib:
+    def test_preview_javlib_multi_returns_candidates(self, client):
+        """
+        source=javlibrary，search_javlib_versions 回 2 dict
+        → resp 含 "candidates"（len 2），頂層無 "number" key（確認不是單筆 shape）。
+        """
+        two_dicts = [
+            {"number": "MIDV-010", "url": ".../javme3bu7e.html", "title": "新片", "date": "2021-12-07"},
+            {"number": "MIDV-010", "url": ".../javlidaori.html", "title": "舊片", "date": "2009-12-01"},
+        ]
+        with patch('web.routers.scraper.search_javlib_versions', return_value=two_dicts):
+            resp = client.post("/api/rescrape/preview", json={
+                "number": "MIDV-010", "source": "javlibrary",
+            })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert "candidates" in data
+        assert len(data["candidates"]) == 2
+        assert "number" not in data  # 確認非單筆 shape
+
+    def test_preview_javlib_single_backcompat(self, client):
+        """
+        source=javlibrary，search_javlib_versions 回 1 dict
+        → resp 是單筆 shape（含 success + 欄位），無 candidates key（向下相容）。
+        """
+        one_dict = {"number": "MIDV-010", "url": ".../javme3bu7e.html", "title": "新片"}
+        with patch('web.routers.scraper.search_javlib_versions', return_value=[one_dict]):
+            resp = client.post("/api/rescrape/preview", json={
+                "number": "MIDV-010", "source": "javlibrary",
+            })
+
+        data = resp.json()
+        assert data["success"] is True
+        assert "candidates" not in data
+        assert data.get("number") == "MIDV-010"
+
+    def test_preview_javlib_none_notfound(self, client):
+        """
+        source=javlibrary，search_javlib_versions 回 []
+        → {"success": False}。
+        """
+        with patch('web.routers.scraper.search_javlib_versions', return_value=[]):
+            resp = client.post("/api/rescrape/preview", json={
+                "number": "MIDV-010", "source": "javlibrary",
+            })
+
+        assert resp.json() == {"success": False}
+
+    def test_preview_javlib_cf_needed(self, client):
+        """
+        source=javlibrary，search_javlib_versions 拋 CfChallengeRequired
+        → {"success": False, "cf_needed": True}（沿用既有 CF 流程）。
+        """
+        from core.cf_transport import CfChallengeRequired
+
+        with patch('web.routers.scraper.search_javlib_versions',
+                   side_effect=CfChallengeRequired("test")), \
+             patch('web.routers.scraper.get_cf_transport', return_value=None):
+            resp = client.post("/api/rescrape/preview", json={
+                "number": "MIDV-010", "source": "javlibrary",
+            })
+
+        data = resp.json()
+        assert data["success"] is False
+        assert data.get("cf_needed") is True
+
+    def test_preview_nonjavlib_unchanged(self, client):
+        """
+        source=dmm → 走原 search_jav_single_source，不進 javlibrary 分支，
+        回單筆（回歸守衛）。
+        """
+        dmm_result = {
+            "number": "SONE-205", "title": "DMM 片",
+            "_source": "dmm", "_summary": None, "_rating": None,
+        }
+        with patch('web.routers.scraper.search_jav_single_source', return_value=dmm_result), \
+             patch('web.routers.scraper.search_javlib_versions') as mock_jl:
+            resp = client.post("/api/rescrape/preview", json={
+                "number": "SONE-205", "source": "dmm",
+            })
+
+        mock_jl.assert_not_called()  # 確認未觸碰 javlib 分支
+        data = resp.json()
+        assert data["success"] is True
+        assert "candidates" not in data
+
+
+# ── /api/enrich-single detail_url 分支 ───────────────────────────────────────
+
+class TestEnrichSingleDetailUrl:
+    def test_enrich_single_javlib_detail_url(self, client):
+        """
+        source=javlibrary + detail_url 存在：
+          fetch_javlib_by_detail_url 被呼叫
+          → to_legacy_dict() 當 scraper_data 傳給 enrich_single
+          → enrich_single 收到 scraper_data（非 None）。
+        """
+        from core.scrapers.models import Video
+
+        fake_video = MagicMock(spec=Video)
+        fake_video.to_legacy_dict.return_value = {
+            "number": "MIDV-010",
+            "url": ".../javme3bu7e.html",
+            "title": "新片",
+        }
+
+        with patch('web.routers.scraper.fetch_javlib_by_detail_url',
+                   return_value=fake_video) as mock_fetch, \
+             patch('web.routers.scraper.enrich_single',
+                   return_value=_ok_enrich_result()) as mock_enrich:
+            resp = client.post("/api/enrich-single", json={
+                "file_path": "file:///fake/MIDV-010.mp4",
+                "number": "MIDV-010",
+                "source": "javlibrary",
+                "detail_url": "https://www.javlibrary.com/ja/javme3bu7e.html",
+                "mode": "refresh_full",
+                "overwrite_existing": True,
+            })
+
+        mock_fetch.assert_called_once_with(
+            "https://www.javlibrary.com/ja/javme3bu7e.html", "MIDV-010"
+        )
+        call_kwargs = mock_enrich.call_args.kwargs
+        # scraper_data 為選定版本 to_legacy_dict() 的結果（非 None、且為該 video 的值）
+        assert call_kwargs.get("scraper_data") == fake_video.to_legacy_dict.return_value
+
+    def test_enrich_single_no_detail_url_unchanged(self, client):
+        """
+        source=javlibrary 但無 detail_url → scraper_data=None，
+        enrich_single 自行重搜（現況行為不回歸）。
+        fetch_javlib_by_detail_url 不應被呼叫。
+        """
+        with patch('web.routers.scraper.fetch_javlib_by_detail_url') as mock_fetch, \
+             patch('web.routers.scraper.enrich_single',
+                   return_value=_ok_enrich_result()) as mock_enrich:
+            resp = client.post("/api/enrich-single", json={
+                "file_path": "file:///fake/MIDV-010.mp4",
+                "number": "MIDV-010",
+                "source": "javlibrary",
+                "mode": "refresh_full",
+                "overwrite_existing": True,
+            })
+
+        mock_fetch.assert_not_called()
+        call_kwargs = mock_enrich.call_args.kwargs
+        assert call_kwargs.get("scraper_data") is None  # 無預餵，enrich_single 自行重搜
+
+
+# ── capabilities 全檔守衛 ─────────────────────────────────────────────────────
+
+def test_detail_url_not_in_capabilities():
+    """
+    CD-86-10 capabilities 全檔守衛：
+    "detail_url" 字串在整個 web/routers/capabilities.py 完全不出現。
+    EnrichRequest 新增 detail_url 後不可洩露到 capabilities JSON（任何 capability）。
+    """
+    import pathlib
+    src = pathlib.Path("web/routers/capabilities.py").read_text(encoding="utf-8")
+    assert "detail_url" not in src, (
+        "detail_url 不可揭露給 AI agent（CD-86-10 / spec AC9）"
+    )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9067,34 +9067,44 @@ class TestRescrapeVersionStateGuard:
 
     # ── CD-86-P2: javlib search 採用路徑同步 currentQuery ──
 
-    def test_javlib_single_version_search_syncs_current_query(self):
-        """CD-86-P2: rescrapeWithSource search+javlib 單版本採用路徑，在 _commitSearchResults 前
-        必須同步 currentQuery（對齊非 javlib 路徑：advancedSearch 設 currentQuery、:167 設 searchQuery）。
+    def test_javlib_single_version_search_falls_through_to_preview(self):
+        """86 修正（取代過時的 ..._syncs_current_query 守衛）：rescrapeWithSource 的單版本
+        分支（data.success）不再於 search 入口靜默 _commitSearchResults + closeRescrape
+        early-return，而是 fall through 進 preview 卡（rescrapeStep='preview'）。
 
-        element-bound：在 rescrapeWithSource 的 search 單版本分支（data.success）找
-        currentQuery 賦值，確認在同一 if(search) block 的 _commitSearchResults 呼叫之前。
-        mutation 驗證：移除補的同步 → RED。
+        為何過時：原守衛斷言「rescrapeWithSource 單版本 search 分支在 _commitSearchResults
+        前同步 currentQuery」。該 search-entry 早 return commit 已移除（單版本 search 一閃
+        就關被使用者回報「直接跳過」），採用改由 rescrapeConfirm 的 search 分支負責（query
+        同步由 test_javlib_confirm_search_syncs_current_query 涵蓋）。
+
+        element-bound：鎖定 data.success 分支區塊（到 not-found else 的 rescrapeNotFound=true
+        為止），斷言 (a) 進入 preview（rescrapeStep='preview'），(b) 該區塊不含
+        _commitSearchResults / closeRescrape（單版本不再於 rescrapeWithSource commit/關窗）。
+        mutation 驗證：把 _commitSearchResults + closeRescrape 早 return 加回 → RED。
         """
         src = self._rescrape()
-        # 鎖定 rescrapeWithSource 函式體中：
-        # rescrapeEntryPoint==='search' 的單版本分支（data.success block）
-        # 在 _commitSearchResults 呼叫之前必須出現 this.currentQuery = this.rescrapeNumber.trim()
-        # element-bound：先找 data.success 分支的 search 入口 context，再確認 currentQuery 賦值
+        # 取 rescrapeWithSource 內 data.success else-if 區塊（至 not-found else 的 rescrapeNotFound）
         m_ctx = re.search(
-            r"rescrapeWithSource\b.*?data\s*&&\s*data\.success.*?"
-            r"rescrapeEntryPoint\s*===\s*['\"]search['\"]"
-            r"(.*?)_commitSearchResults",
+            r"else\s+if\s*\(\s*data\s*&&\s*data\.success\s*\)\s*\{(.*?)this\.rescrapeNotFound\s*=\s*true",
             src, re.DOTALL,
         )
         assert m_ctx, (
-            "CD-86-P2 違規（rescrapeWithSource 單版本）：未在 data.success search 分支的 "
-            "_commitSearchResults 前找到 currentQuery 同步——"
-            "搜尋框 / compose 判斷 / session restore 會殘留舊 query"
+            "86 修正：未找到 rescrapeWithSource 的 data.success 單版本分支區塊"
         )
         block = m_ctx.group(1)
-        assert re.search(r"\bthis\.currentQuery\s*=", block), (
-            "CD-86-P2 違規（rescrapeWithSource 單版本）：_commitSearchResults 前缺少 "
-            "this.currentQuery = ... 賦值（對齊 advancedSearch :38 的同步語意）"
+        # (a) 單版本 fall through 進 preview
+        assert re.search(r"rescrapeStep\s*=\s*['\"]preview['\"]", block), (
+            "86 修正違規：data.success 單版本分支未進 preview（rescrapeStep='preview' 不可達）"
+        )
+        # (b) 不再於 rescrapeWithSource 單版本分支 commit / 關窗（已移交 rescrapeConfirm）
+        # 比對「呼叫」語法（含 ?. optional chain），避免誤判註解中提及的字串。
+        assert not re.search(r"_commitSearchResults\s*\??\.?\s*\(", block), (
+            "86 修正違規：data.success 單版本分支仍呼叫 _commitSearchResults——"
+            "search 單版本應 fall through 進 preview，採用由 rescrapeConfirm 負責"
+        )
+        assert not re.search(r"\bcloseRescrape\s*\(", block), (
+            "86 修正違規：data.success 單版本分支仍呼叫 closeRescrape early return——"
+            "search 單版本應 fall through 進 preview（一閃就關是回報的 bug）"
         )
 
     def test_javlib_confirm_search_syncs_current_query(self):
@@ -11936,6 +11946,43 @@ class TestSearchAutoSourcePill:
         )
         assert "rescrapeNumber =" in call, (
             f"search-auto-pill @click 缺 rescrapeNumber = 預填；call: {call!r}"
+        )
+
+    def test_auto_pill_xshow_contains_can_reopen_source_pick(self):
+        """自動膠囊 x-show 含 canReopenSourcePick()（CD-86-P2 修正：exact 結果頁再開入口）。
+
+        JavLibrary 採用後 searchQuery == currentQuery → isComposing() false，
+        需要 canReopenSourcePick() 讓 pill 在 exact 結果時常駐。
+        mutation：把 x-show 改回只 isComposing() → 此斷言紅。
+        """
+        call = self._auto_pill_call()
+        xshow_m = re.search(r'x-show=\\?["\']([^"\']*)', call)
+        assert xshow_m, f"search-auto-pill 呼叫缺 x-show binding；call: {call!r}"
+        assert "canReopenSourcePick()" in xshow_m.group(1), (
+            f"search-auto-pill x-show 缺 canReopenSourcePick()；x-show: {xshow_m.group(1)!r}"
+        )
+
+    def test_can_reopen_source_pick_defined_in_search_flow_js(self):
+        """search-flow.js 定義 canReopenSourcePick()，且包含 exact + pageState + searchQuery 三條件。
+
+        mutation：移除 method 或刪任一條件 → 此斷言紅。
+        """
+        js_path = (
+            SEARCH_HTML.parent.parent
+            / "static" / "js" / "pages" / "search" / "state" / "search-flow.js"
+        )
+        js = js_path.read_text(encoding="utf-8")
+        m = re.search(r"canReopenSourcePick\s*\(\s*\)\s*\{(.*?)\n    \},", js, re.DOTALL)
+        assert m, "search-flow.js 找不到 canReopenSourcePick() method 定義"
+        body = m.group(1)
+        assert "pageState" in body and "'result'" in body, (
+            f"canReopenSourcePick body 缺 pageState === 'result' 條件；body: {body!r}"
+        )
+        assert "'exact'" in body, (
+            f"canReopenSourcePick body 缺 currentMode === 'exact' 條件；body: {body!r}"
+        )
+        assert "searchQuery" in body, (
+            f"canReopenSourcePick body 缺 searchQuery 非空條件；body: {body!r}"
         )
 
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11327,6 +11327,29 @@ class TestJavlibraryCfFlowT6Guard:
         assert cf_pos < notfound_pos, \
             "70-T6 違規：cf_needed check 必須在 rescrapeNotFound = true 之前"
 
+    # (5b) P2-2（Codex PR#89）：rescrapeConfirm lightbox 寫檔分支接 cf_needed / cf_unavailable
+    def test_rescrape_confirm_handles_cf(self):
+        """P2-2：rescrapeConfirm 的 lightbox 寫檔分支必須接 result.cf_needed / result.cf_unavailable。
+
+        T2 後 javlibrary && detail_url 走後端 detail 重抓分支，若預覽→確認間 CF session 過期，
+        後端回 {cf_needed} / {cf_unavailable}（已 begin_solve）。confirm 不接 → 卡在模糊「失敗」
+        且不啟動 CF 流程。element-bound：鎖定 rescrapeConfirm body（至 _pollCfThenRetry 定義前）。
+        mutation：拿掉 CF 接法 → RED。
+        """
+        import re as _re
+        js = _STATE_RESCRAPE_JS.read_text(encoding="utf-8")
+        m = _re.search(r"rescrapeConfirm\s*\(\s*\)\s*\{", js)
+        assert m is not None, "P2-2 違規：找不到 rescrapeConfirm() 定義"
+        # _pollCfThenRetry(number) 是其後的方法定義（call site 用 this.rescrapeNumber.trim() 不匹配）
+        end = js.index("_pollCfThenRetry(number)", m.start())
+        body = js[m.start():end]
+        assert "result.cf_unavailable" in body, (
+            "P2-2 違規：rescrapeConfirm lightbox 分支未接 result.cf_unavailable（CF session 過期靜默卡死）"
+        )
+        assert "result.cf_needed" in body, (
+            "P2-2 違規：rescrapeConfirm lightbox 分支未接 result.cf_needed（CF flow 不啟動）"
+        )
+
     # (6) closeRescrape 含 clearInterval（清 CF poll）
     def test_close_rescrape_clears_interval(self):
         js = _STATE_RESCRAPE_JS.read_text(encoding="utf-8")

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9000,18 +9000,71 @@ class TestRescrapeVersionStateGuard:
             "search+javlib 可能仍走早 return advancedSearch 路徑"
         )
 
-    # ── (B) switch-source 取 candidates[0] ──
+    # ── (B) switch-source 多版本切換器（T7） ──
 
     def test_switch_source_takes_candidates_first(self):
-        """CD-86-6: switch-source 收到 candidates 時取 [0]（非 [1]，非整個陣列）。"""
+        """T7（語意反轉）: switch-source 多版本（candidates.length > 1）進 rescrapeStep='preview'，
+        不再直接取 candidates[0] 靜默替換；candidates[0] 僅作單版本 fallback。
+        element-bound: switch-source + candidates.length > 1 後 900 字元內必有 rescrapeStep='preview'
+        （900 < showcase block 距離，mutation A 移除後 next occurrence 在 4000+ 字元外 → RED）。
+        """
         src = self._rescrape()
-        # element-bound：在 switch-source if-block 附近找 candidates[0]
         m = re.search(
-            r"rescrapeEntryPoint\s*===\s*['\"]switch-source['\"].*?candidates\s*\[\s*0\s*\]",
+            r"rescrapeEntryPoint\s*===\s*['\"]switch-source['\"]"
+            r".*?data\.candidates\s*&&\s*data\.candidates\.length\s*>\s*1",
             src, re.DOTALL,
         )
         assert m, (
-            "CD-86-6 違規：switch-source 分支未見 candidates[0] 取用"
+            "T7 違規：switch-source 分支缺 candidates.length > 1 多版本分叉"
+        )
+        # element-bound 900-char window（switch-source multiversion block ~773 chars）
+        window = src[m.end():m.end() + 900]
+        assert re.search(r"rescrapeStep\s*=\s*['\"]preview['\"]", window), (
+            "T7 違規：switch-source candidates.length > 1 分叉（900 字元窗口內）缺 rescrapeStep='preview'——"
+            "多版本應進 preview 切換器，不直接取 candidates[0] 靜默替換"
+        )
+
+    def test_switch_source_multiversion_enters_preview(self):
+        """T7: switch-source 分支 candidates.length > 1 → rescrapeStep = 'preview'。
+        element-bound: 先找 switch-source if-block 起點，再在 900 字元窗口內斷言 rescrapeStep='preview'。
+        （防 DOTALL 跨 block 假綠；showcase block 的 rescrapeStep 距離 4000+ 字元外）
+        """
+        src = self._rescrape()
+        m = re.search(
+            r"rescrapeEntryPoint\s*===\s*['\"]switch-source['\"]"
+            r".*?if\s*\(\s*data\.candidates\s*&&\s*data\.candidates\.length\s*>\s*1\s*\)",
+            src, re.DOTALL,
+        )
+        assert m, (
+            "T7 違規：switch-source if-block 缺 candidates.length > 1 多版本分叉"
+        )
+        # 900-char window covers multiversion block body but stops before showcase block
+        window = src[m.end():m.end() + 900]
+        assert re.search(r"rescrapeStep\s*=\s*['\"]preview['\"]", window), (
+            "T7 違規：switch-source candidates.length > 1 if-block body（900 字元內）缺 rescrapeStep='preview'"
+        )
+
+    def test_switch_source_confirm_branch_present(self):
+        """T7: rescrapeConfirm 必須有 switch-source 分支，body 含 t.arr[t.idx] in-place 替換，
+        不含 _commitSearchResults（in-place 替換語意，非搜尋結果提交）。
+        element-bound: 鎖定 rescrapeConfirm 的 switch-source 分支起點後 800 字元。
+        """
+        src = self._rescrape()
+        m = re.search(
+            r"rescrapeConfirm\s*\(\s*\).*?rescrapeEntryPoint\s*===\s*['\"]switch-source['\"]",
+            src, re.DOTALL,
+        )
+        assert m, (
+            "T7 違規：rescrapeConfirm 中未見 rescrapeEntryPoint === 'switch-source' 分支"
+        )
+        # m.end() 是 switch-source 條件字串結尾，從此往後 800 字元是分支 body
+        block = src[m.end():m.end() + 800]
+        assert re.search(r"t\.arr\s*\[\s*t\.idx\s*\]", block), (
+            "T7 違規：rescrapeConfirm switch-source 分支缺 t.arr[t.idx] in-place 替換"
+        )
+        assert "_commitSearchResults" not in block, (
+            "T7 違規：rescrapeConfirm switch-source 分支不得呼叫 _commitSearchResults"
+            "（in-place 替換語意，非搜尋結果提交）"
         )
 
     # ── (B) confirm: detail_url 取值 .url ──
@@ -11567,6 +11620,39 @@ class TestRescrapeVersionSwitcherGuard:
         indicator_block = extract_block(".rescrape-ver-indicator", css)
         assert "var(--color-warning)" in indicator_block, (
             "86-T6 違規：.rescrape-ver-indicator 的 color 未使用 var(--color-warning)（N/M 指示應為琥珀色）"
+        )
+
+    # ── T7: switch-source confirm-row ──
+
+    def test_switch_source_modal_confirm_row(self):
+        """T7: _rescrape_modal.html 必須有 rescrapeEntryPoint === 'switch-source' confirm-row，
+        含 bi-check-lg icon，且不含 overwrite_warning（只替換結果列 slot，不寫檔）。
+        element-bound: 在 switch-source confirm-row block 內驗 icon + 排除 overwrite_warning。
+        """
+        import re as _re
+        html = self._html()
+        m = _re.search(
+            r'<div[^>]*rescrape-confirm-row[^>]*rescrapeEntryPoint\s*===\s*[\'"]switch-source[\'"][^>]*>(.*?)</div>',
+            html,
+            _re.DOTALL,
+        )
+        assert m, (
+            "T7 違規：_rescrape_modal.html 缺 rescrapeEntryPoint === 'switch-source' confirm-row"
+        )
+        block = m.group(0)
+        assert "bi-check-lg" in block, (
+            "T7 違規：switch-source confirm-row 缺 bi-check-lg icon"
+        )
+        assert "overwrite_warning" not in block, (
+            "T7 違規：switch-source confirm-row 不得含 overwrite_warning（非寫檔操作）"
+        )
+
+    def test_i18n_adopt_switch_source_key_exists(self):
+        """T7: showcase.rescrape.adopt_switch_source key 必須存在於 zh_TW.json。"""
+        data = self._locale()
+        rescrape = data.get("showcase", {}).get("rescrape", {})
+        assert "adopt_switch_source" in rescrape, (
+            "T7 違規：locales/zh_TW.json 缺 showcase.rescrape.adopt_switch_source key"
         )
 
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11963,9 +11963,11 @@ class TestSearchAutoSourcePill:
         )
 
     def test_can_reopen_source_pick_defined_in_search_flow_js(self):
-        """search-flow.js 定義 canReopenSourcePick()，且包含 exact + pageState + searchQuery 三條件。
+        """search-flow.js 定義 canReopenSourcePick()，且包含 listMode + exact + pageState + searchQuery 四條件。
 
-        mutation：移除 method 或刪任一條件 → 此斷言紅。
+        listMode==='search' gate（CD-86-P2 副作用修正）：file/batch mode 也進 result+exact，但 searchQuery
+        切檔不同步，頂部再入口會帶舊番號 → 限定 search workflow。
+        mutation：移除 method 或刪任一條件（含 listMode）→ 此斷言紅。
         """
         js_path = (
             SEARCH_HTML.parent.parent
@@ -11975,6 +11977,9 @@ class TestSearchAutoSourcePill:
         m = re.search(r"canReopenSourcePick\s*\(\s*\)\s*\{(.*?)\n    \},", js, re.DOTALL)
         assert m, "search-flow.js 找不到 canReopenSourcePick() method 定義"
         body = m.group(1)
+        assert "listMode" in body and "'search'" in body, (
+            f"canReopenSourcePick body 缺 listMode === 'search' 條件；body: {body!r}"
+        )
         assert "pageState" in body and "'result'" in body, (
             f"canReopenSourcePick body 缺 pageState === 'result' 條件；body: {body!r}"
         )

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -9065,6 +9065,64 @@ class TestRescrapeVersionStateGuard:
         )
         assert m, "rescrapeBackToPick 必須 reset rescrapeCandidates（lifecycle 對稱）"
 
+    # ── CD-86-P2: javlib search 採用路徑同步 currentQuery ──
+
+    def test_javlib_single_version_search_syncs_current_query(self):
+        """CD-86-P2: rescrapeWithSource search+javlib 單版本採用路徑，在 _commitSearchResults 前
+        必須同步 currentQuery（對齊非 javlib 路徑：advancedSearch 設 currentQuery、:167 設 searchQuery）。
+
+        element-bound：在 rescrapeWithSource 的 search 單版本分支（data.success）找
+        currentQuery 賦值，確認在同一 if(search) block 的 _commitSearchResults 呼叫之前。
+        mutation 驗證：移除補的同步 → RED。
+        """
+        src = self._rescrape()
+        # 鎖定 rescrapeWithSource 函式體中：
+        # rescrapeEntryPoint==='search' 的單版本分支（data.success block）
+        # 在 _commitSearchResults 呼叫之前必須出現 this.currentQuery = this.rescrapeNumber.trim()
+        # element-bound：先找 data.success 分支的 search 入口 context，再確認 currentQuery 賦值
+        m_ctx = re.search(
+            r"rescrapeWithSource\b.*?data\s*&&\s*data\.success.*?"
+            r"rescrapeEntryPoint\s*===\s*['\"]search['\"]"
+            r"(.*?)_commitSearchResults",
+            src, re.DOTALL,
+        )
+        assert m_ctx, (
+            "CD-86-P2 違規（rescrapeWithSource 單版本）：未在 data.success search 分支的 "
+            "_commitSearchResults 前找到 currentQuery 同步——"
+            "搜尋框 / compose 判斷 / session restore 會殘留舊 query"
+        )
+        block = m_ctx.group(1)
+        assert re.search(r"\bthis\.currentQuery\s*=", block), (
+            "CD-86-P2 違規（rescrapeWithSource 單版本）：_commitSearchResults 前缺少 "
+            "this.currentQuery = ... 賦值（對齊 advancedSearch :38 的同步語意）"
+        )
+
+    def test_javlib_confirm_search_syncs_current_query(self):
+        """CD-86-P2: rescrapeConfirm search 採用路徑，在 _commitSearchResults 前
+        必須同步 currentQuery（對齊非 javlib 路徑，防 session restore 回舊 query）。
+
+        element-bound：在 rescrapeConfirm 的 search 分支找 currentQuery 賦值，
+        確認在同一 if(search) block 的 _commitSearchResults 呼叫之前。
+        mutation 驗證：移除補的同步 → RED。
+        """
+        src = self._rescrape()
+        # 鎖定 rescrapeConfirm 函式體中 search 分支，_commitSearchResults 呼叫前的 currentQuery 賦值
+        m_ctx = re.search(
+            r"rescrapeConfirm\b.*?"
+            r"rescrapeEntryPoint\s*===\s*['\"]search['\"]"
+            r"(.*?)_commitSearchResults",
+            src, re.DOTALL,
+        )
+        assert m_ctx, (
+            "CD-86-P2 違規（rescrapeConfirm）：未在 search 分支 _commitSearchResults 前 "
+            "找到 currentQuery 同步——多版本 confirm 採用後 session restore 殘留舊 query"
+        )
+        block = m_ctx.group(1)
+        assert re.search(r"\bthis\.currentQuery\s*=", block), (
+            "CD-86-P2 違規（rescrapeConfirm）：_commitSearchResults 前缺少 "
+            "this.currentQuery = ... 賦值（對齊 advancedSearch :38 的同步語意）"
+        )
+
 
 class TestRescrapeEntryGuard:
     """62b-1 → 74b US4：守衛 Showcase 進階重刮入口接線 contract。

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -8926,6 +8926,146 @@ class TestRescrapeStateGuard:
         )
 
 
+class TestRescrapeVersionStateGuard:
+    """86-T3: state-rescrape.js candidates 短狀態 + routing + confirm contract。"""
+
+    SHARED_DIR = Path(__file__).parent.parent.parent / "web" / "static" / "js" / "shared"
+    SEARCH_STATE_DIR = (
+        Path(__file__).parent.parent.parent
+        / "web" / "static" / "js" / "pages" / "search" / "state"
+    )
+    STATE_RESCRAPE_JS = SHARED_DIR / "state-rescrape.js"
+    ADVANCED_PICKER_JS = SEARCH_STATE_DIR / "advanced-picker.js"
+
+    def _rescrape(self):
+        return self.STATE_RESCRAPE_JS.read_text(encoding="utf-8")
+
+    def _picker(self):
+        return self.ADVANCED_PICKER_JS.read_text(encoding="utf-8")
+
+    # ── (B) advanced-picker.js: _commitSearchResults helper ──
+
+    def test_commit_search_results_helper_exists(self):
+        """CD-86-14: _commitSearchResults method 必須存在於 advanced-picker.js。"""
+        src = self._picker()
+        assert "_commitSearchResults" in src, (
+            "CD-86-14 違規：advanced-picker.js 缺少 _commitSearchResults helper"
+        )
+
+    def test_advanced_search_delegates_to_helper(self):
+        """CD-86-14: advancedSearch 成功分支必須委派給 _commitSearchResults，不 inline 賦值。
+        element-bound：確認 advancedSearch body 內呼叫 _commitSearchResults（不靠字串存在性）。
+        """
+        src = self._picker()
+        m = re.search(
+            r"async\s+advancedSearch\s*\([^)]*\)\s*\{.*?this\._commitSearchResults\s*\(",
+            src, re.DOTALL,
+        )
+        assert m, (
+            "CD-86-14 違規：advancedSearch body 中未找到 this._commitSearchResults( 呼叫"
+        )
+
+    # ── (B) state-rescrape.js: candidates 短狀態 ──
+
+    def test_candidates_state_keys_present(self):
+        """86-T3: rescrapeCandidates / rescrapeVersionIdx 必須平鋪定義。"""
+        src = self._rescrape()
+        for key in ("rescrapeCandidates", "rescrapeVersionIdx"):
+            assert key in src, f"state-rescrape.js missing state key: {key}"
+
+    def test_version_methods_present(self):
+        """86-T3: rescrapeHasVersions / rescrapeVersionGo 必須存在。"""
+        src = self._rescrape()
+        for method in ("rescrapeHasVersions", "rescrapeVersionGo"):
+            assert method in src, f"state-rescrape.js missing method: {method}"
+
+    # ── (B) routing: search 入口 javlib 不早 return ──
+
+    def test_search_javlib_does_not_early_return_advancedSearch(self):
+        """CD-86-8: rescrapeWithSource search+javlib 分支不得無條件 early return advancedSearch。
+        守衛：search early return 必須帶 sourceId !== 'javlibrary' 的判斷（只有非 javlib 才走 advancedSearch）。
+        element-bound：檢測 search 條件 if-block 的前 400 字元內有 javlibrary（防 file-wide false GREEN）。
+        """
+        src = self._rescrape()
+        # 先找 search 分支位置，再在其後 400 字元內確認 javlibrary 出現（不跨函式）
+        m_search = re.search(
+            r"rescrapeEntryPoint\s*===\s*['\"]search['\"]",
+            src,
+        )
+        assert m_search, "rescrapeWithSource 中未見 rescrapeEntryPoint === 'search' 判斷"
+        # 取 search 分支後 400 字元（足夠涵蓋 if block body，不跨到 _pollCfThenRetry）
+        window = src[m_search.start():m_search.start() + 400]
+        assert "javlibrary" in window, (
+            "CD-86-8 違規：rescrapeWithSource search 分支（前 400 字元）未見 javlibrary 判斷——"
+            "search+javlib 可能仍走早 return advancedSearch 路徑"
+        )
+
+    # ── (B) switch-source 取 candidates[0] ──
+
+    def test_switch_source_takes_candidates_first(self):
+        """CD-86-6: switch-source 收到 candidates 時取 [0]（非 [1]，非整個陣列）。"""
+        src = self._rescrape()
+        # element-bound：在 switch-source if-block 附近找 candidates[0]
+        m = re.search(
+            r"rescrapeEntryPoint\s*===\s*['\"]switch-source['\"].*?candidates\s*\[\s*0\s*\]",
+            src, re.DOTALL,
+        )
+        assert m, (
+            "CD-86-6 違規：switch-source 分支未見 candidates[0] 取用"
+        )
+
+    # ── (B) confirm: detail_url 取值 .url ──
+
+    def test_confirm_lightbox_detail_url_from_url_field(self):
+        """CD-86-13: rescrapeConfirm lightbox 分支 detail_url 值必須來自 rescrapePreview.url。"""
+        src = self._rescrape()
+        # 確認 .url 在 confirm context 存在
+        assert re.search(
+            r"rescrapeConfirm.*?detail_url.*?rescrapePreview.*?\.url",
+            src, re.DOTALL,
+        ), (
+            "CD-86-13: rescrapeConfirm 中未見 rescrapePreview.url 取值（detail_url 欄位值）"
+        )
+
+    # ── (B) confirm: search 走 helper 非 inline ──
+
+    def test_confirm_search_calls_commit_helper(self):
+        """CD-86-14: rescrapeConfirm search 分支必須呼叫 _commitSearchResults，禁 inline。
+        element-bound：rescrapeConfirm body 內找 search 分支 + helper 呼叫。
+        """
+        src = self._rescrape()
+        m = re.search(
+            r"rescrapeConfirm.*?rescrapeEntryPoint.*?['\"]search['\"].*?_commitSearchResults",
+            src, re.DOTALL,
+        )
+        assert m, (
+            "CD-86-14 違規：rescrapeConfirm search 分支未呼叫 _commitSearchResults helper"
+        )
+
+    # ── lifecycle 對稱：close/back reset candidates ──
+
+    def test_close_rescrape_resets_candidates(self):
+        """lifecycle 對稱：closeRescrape 必須 reset rescrapeCandidates。
+        element-bound：在 closeRescrape method 體內找 rescrapeCandidates（允許內層 if block）。
+        """
+        src = self._rescrape()
+        # closeRescrape 函式體可能含有內層 if {...} block，故使用 .*? 而非 [^}]*
+        m = re.search(
+            r"closeRescrape\s*\(\s*\)\s*\{.*?rescrapeCandidates",
+            src, re.DOTALL,
+        )
+        assert m, "closeRescrape 必須 reset rescrapeCandidates（lifecycle 對稱）"
+
+    def test_back_to_pick_resets_candidates(self):
+        """lifecycle 對稱：rescrapeBackToPick 必須 reset rescrapeCandidates。"""
+        src = self._rescrape()
+        m = re.search(
+            r"rescrapeBackToPick\s*\(\s*\)\s*\{[^}]*rescrapeCandidates",
+            src, re.DOTALL,
+        )
+        assert m, "rescrapeBackToPick 必須 reset rescrapeCandidates（lifecycle 對稱）"
+
+
 class TestRescrapeEntryGuard:
     """62b-1 → 74b US4：守衛 Showcase 進階重刮入口接線 contract。
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11288,46 +11288,154 @@ class TestJavlibraryCfFlowT6Guard:
         )
 
 
-# ── FIX-2 frontend guard: search 入口隱藏 JL pill ──
+# ── CD-86-7 frontend guard: search 入口 JL pill gate 改用 isJlUnavailable ──
 
 class TestRescrapeModalSearchHideJlPillGuard:
     """
-    FIX-2：_rescrape_modal.html builtin pill 在 search 入口隱藏 manual_only && is_beta pill。
+    CD-86-7：_rescrape_modal.html builtin pill 在 search 入口不再隱藏，改由 isJlUnavailable gate。
 
-    B2-P3-1 hardening: anchor on the full x-show expression from _rescrape_modal.html ~L49
-    instead of the three component strings individually. Each component string exists
-    elsewhere in the modal independently, so individual checks are comment-foolable.
-    Exact expression: x-show="!(s.manual_only && s.is_beta && rescrapeEntryPoint === 'search')"
+    86-T4 rewrite: 舊 search-hide x-show 表達式（FIX-2）已移除（CD-86-7），
+    改交 isJlUnavailable 統一管可點性（非桌面仍 aria-disabled，AC8 不回歸）。
     """
-
-    # The full load-bearing x-show expression (from _rescrape_modal.html ~L49).
-    _XSHOW_EXPR = 'x-show="!(s.manual_only && s.is_beta && rescrapeEntryPoint === \'search\')"'
 
     def _html(self):
         return _MODAL_HTML_70.read_text(encoding="utf-8")
 
-    def test_modal_builtin_pill_has_search_hide_condition(self):
-        """_rescrape_modal.html builtin pill 含 search 入口 x-show 隱藏條件。
-
-        B2-P3-1: anchored on the full x-show expression so removing/changing the
-        condition fails the guard, even if the component strings remain as comments.
+    def test_modal_builtin_pill_search_gate_uses_isJlUnavailable(self):
+        """CD-86-7: search 入口 javlib pill 不再由 manual_only+is_beta+search 隱藏，
+        改由 isJlUnavailable 統一 gate（非桌面仍 aria-disabled）。
+        舊 search-hide 表達式必須已移除。
         """
         html = self._html()
-        assert self._XSHOW_EXPR in html, (
-            "FIX-2 違規：_rescrape_modal.html builtin pill 缺完整 x-show 隱藏表達式 "
-            f"{self._XSHOW_EXPR!r}（~L49）"
+        OLD_HIDE = "s.manual_only && s.is_beta && rescrapeEntryPoint === 'search'"
+        assert OLD_HIDE not in html, (
+            "CD-86-7 違規：_rescrape_modal.html builtin pill 仍含舊 search 入口隱藏條件—"
+            "應已移除，改交 isJlUnavailable gate"
+        )
+        assert "isJlUnavailable" in html, (
+            "CD-86-7 違規：_rescrape_modal.html 移除 search-hide 後必須保留 isJlUnavailable gate"
         )
 
-    def test_modal_builtin_pill_hide_references_manual_only_and_is_beta(self):
-        """_rescrape_modal.html builtin pill x-show 同時含 manual_only 和 is_beta。
-
-        B2-P3-1: also anchored via the full expression (backward-compat assertion —
-        the full x-show expression implicitly covers both; kept for readable error messages).
+    def test_modal_builtin_pill_jl_gate_preserves_aria_disabled(self):
+        """CD-86-7 + AC8: search 入口 javlib pill x-show 放開後，
+        isJlUnavailable gate 必須仍帶 aria-disabled 綁定（非桌面不可點語義不回歸）。
         """
+        import re
         html = self._html()
-        assert self._XSHOW_EXPR in html, (
-            "FIX-2 違規：_rescrape_modal.html builtin pill 完整 x-show 表達式（含 manual_only "
-            "及 is_beta）遺失"
+        assert "isJlUnavailable" in html, (
+            "AC8 違規：_rescrape_modal.html 缺 isJlUnavailable gate"
+        )
+        assert "aria-disabled" in html, (
+            "AC8 違規：_rescrape_modal.html builtin pill 缺 aria-disabled 綁定"
+        )
+        # element-bound: 確認 isJlUnavailable 和 aria-disabled 在同一 template 上下文（pill 區）
+        m = re.search(
+            r"isJlUnavailable.*?aria-disabled|aria-disabled.*?isJlUnavailable",
+            html, re.DOTALL,
+        )
+        assert m, (
+            "AC8 違規：isJlUnavailable 與 aria-disabled 未出現在 pill 相近上下文"
+        )
+
+
+# ── 86-T4 frontend guard: 版本切換器 + i18n + entry-point gate ──
+
+class TestRescrapeVersionSwitcherGuard:
+    """86-T4: _rescrape_modal.html 版本切換器 + i18n + gate 靜態守衛。"""
+
+    TEMPLATES_DIR = Path(__file__).parent.parent.parent / "web" / "templates"
+    LOCALES_DIR = Path(__file__).parent.parent.parent / "locales"
+    MODAL_HTML = TEMPLATES_DIR / "_rescrape_modal.html"
+    ZH_TW_JSON = LOCALES_DIR / "zh_TW.json"
+
+    def _html(self):
+        return self.MODAL_HTML.read_text(encoding="utf-8")
+
+    def _locale(self):
+        import json
+        return json.loads(self.ZH_TW_JSON.read_text(encoding="utf-8"))
+
+    # ── 切換器 x-show binding ──
+
+    def test_version_switcher_uses_rescrapeHasVersions(self):
+        """切換器 ‹ › 鈕必須綁 x-show="rescrapeHasVersions()"（element-bound，防 comment 假陽性）。"""
+        html = self._html()
+        # element-bound: 要求完整屬性綁定出現在非注釋上下文
+        BINDING = 'x-show="rescrapeHasVersions()"'
+        assert html.count(BINDING) >= 2, (
+            f"86-T4 違規：_rescrape_modal.html 缺足夠的 {BINDING!r} 綁定（切換器 ‹ › 各一）"
+        )
+
+    def test_version_switcher_uses_rescrapeVersionGo(self):
+        """切換器 ‹ › 鈕必須綁 @click rescrapeVersionGo。"""
+        html = self._html()
+        assert "rescrapeVersionGo(-1)" in html, (
+            "86-T4 違規：_rescrape_modal.html 缺 rescrapeVersionGo(-1)（‹ 鈕）"
+        )
+        assert "rescrapeVersionGo(1)" in html, (
+            "86-T4 違規：_rescrape_modal.html 缺 rescrapeVersionGo(1)（› 鈕）"
+        )
+
+    # ── versions_found 走 t() 非硬編碼 ──
+
+    def test_versions_found_uses_t_function(self):
+        """「找到 X 部」文字必須走 t('showcase.rescrape.versions_found')，禁硬編碼繁中。"""
+        html = self._html()
+        assert "showcase.rescrape.versions_found" in html, (
+            "86-T4 違規：_rescrape_modal.html 缺 showcase.rescrape.versions_found t() 呼叫"
+        )
+        # 禁止硬編碼
+        assert "找到" not in html, (
+            "86-T4 違規：_rescrape_modal.html 含硬編碼「找到」文字（應走 i18n）"
+        )
+
+    # ── 不可逆警告 entry-point gate ──
+
+    def test_overwrite_warning_gated_by_lightbox_entrypoint(self):
+        """不可逆警告 rescrape-caption 必須以 rescrapeEntryPoint === 'lightbox' gate。"""
+        import re
+        html = self._html()
+        # element-bound: 在同一個 tag 內找 rescrape-caption 和 lightbox gate
+        m = re.search(
+            r'rescrape-caption[^>]*rescrapeEntryPoint[^>]*lightbox'
+            r'|rescrapeEntryPoint[^>]*lightbox[^>]*rescrape-caption',
+            html,
+        )
+        assert m, (
+            "CD-86-9 違規：rescrape-caption（不可逆警告）缺 rescrapeEntryPoint === 'lightbox' gate"
+        )
+
+    # 註：search 入口 javlib gate 改 isJlUnavailable 的回歸守衛（CD-86-7 + AC8）
+    # 由 TestRescrapeModalSearchHideJlPillGuard 兩條改寫守衛涵蓋，此處不重複。
+
+    # ── i18n key 存在性守衛 ──
+
+    def test_i18n_versions_found_key_exists(self):
+        """showcase.rescrape.versions_found key 必須存在於 zh_TW.json，且含 {count} 插值。"""
+        data = self._locale()
+        key_val = data.get("showcase", {}).get("rescrape", {}).get("versions_found", None)
+        assert key_val is not None, (
+            "86-T4 違規：locales/zh_TW.json 缺 showcase.rescrape.versions_found key"
+        )
+        assert "{count}" in key_val, (
+            "CD-86-11 違規：showcase.rescrape.versions_found 缺 {count} 插值"
+        )
+
+    def test_i18n_version_nav_aria_keys_exist(self):
+        """切換器 prev/next aria key 必須存在於 zh_TW.json。"""
+        data = self._locale()
+        rescrape = data.get("showcase", {}).get("rescrape", {})
+        for key in ("version_prev_aria", "version_next_aria"):
+            assert key in rescrape, (
+                f"86-T4 違規：locales/zh_TW.json 缺 showcase.rescrape.{key} key"
+            )
+
+    def test_i18n_adopt_version_key_exists(self):
+        """search 入口「採用此版本」key 必須存在於 zh_TW.json。"""
+        data = self._locale()
+        rescrape = data.get("showcase", {}).get("rescrape", {})
+        assert "adopt_version" in rescrape, (
+            "86-T4 違規：locales/zh_TW.json 缺 showcase.rescrape.adopt_version key"
         )
 
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -11496,6 +11496,69 @@ class TestRescrapeVersionSwitcherGuard:
             "86-T4 違規：locales/zh_TW.json 缺 showcase.rescrape.adopt_version key"
         )
 
+    # ── 86-T6: search adopt 鈕 icon 化 + 琥珀色守衛 ──
+
+    def test_search_adopt_btn_uses_check_icon(self):
+        """86-T6: search 入口 adopt 鈕必須用 bi-check-lg icon，禁 x-text 文字（破版防回流）。
+        element-bound：守衛綁 rescrapeEntryPoint === 'search' 的 confirm-row block。
+        aria-label 必須走 adopt_version key（螢幕報讀不退化）。
+        """
+        import re
+        html = self._html()
+
+        # 截出 search confirm-row block（class=rescrape-confirm-row + search gate 的 div 到 </div>）
+        m = re.search(
+            r'<div[^>]*rescrape-confirm-row[^>]*rescrapeEntryPoint\s*===\s*[\'"]search[\'"][^>]*>(.*?)</div>',
+            html,
+            re.DOTALL,
+        )
+        assert m, (
+            "86-T6 違規：_rescrape_modal.html 缺 rescrapeEntryPoint === 'search' confirm-row block"
+        )
+        block = m.group(0)
+
+        # adopt 鈕含 bi-check-lg icon
+        assert "bi-check-lg" in block, (
+            "86-T6 違規：search adopt 鈕缺 bi-check-lg icon（應鏡射 lightbox ✓ 鈕寫法）"
+        )
+        # 禁 x-text（防文字溢出破版回流）
+        assert "x-text" not in block, (
+            "86-T6 違規：search adopt 鈕不得含 x-text（文字溢出 48px 圓鈕破版）"
+        )
+        # aria-label 走 adopt_version key
+        assert "adopt_version" in block, (
+            "86-T6 違規：search adopt 鈕缺 adopt_version aria-label（螢幕報讀退化）"
+        )
+
+    def test_version_status_uses_warning_color(self):
+        """86-T6: .rescrape-version-status 與 .rescrape-ver-indicator 的 color 必須為 var(--color-warning)。
+        CSS 守衛（正向 require 值：stylelint 不易 require 特定 token 值，pytest 正向斷言合適）。
+        element-bound：綁定該 selector block，避免誤命中其他 selector。
+        """
+        import re
+        css_path = (
+            Path(__file__).parent.parent.parent
+            / "web" / "static" / "css" / "components" / "rescrape-modal.css"
+        )
+        css = css_path.read_text(encoding="utf-8")
+
+        def extract_block(selector: str, text: str) -> str:
+            """擷取 selector 對應的 { ... } block 內容。"""
+            pattern = re.escape(selector) + r"\s*\{([^}]*)\}"
+            m = re.search(pattern, text)
+            assert m, f"86-T6 違規：rescrape-modal.css 缺 {selector!r} selector block"
+            return m.group(1)
+
+        status_block = extract_block(".rescrape-version-status", css)
+        assert "var(--color-warning)" in status_block, (
+            "86-T6 違規：.rescrape-version-status 的 color 未使用 var(--color-warning)（撞號提示應為琥珀色）"
+        )
+
+        indicator_block = extract_block(".rescrape-ver-indicator", css)
+        assert "var(--color-warning)" in indicator_block, (
+            "86-T6 違規：.rescrape-ver-indicator 的 color 未使用 var(--color-warning)（N/M 指示應為琥珀色）"
+        )
+
 
 # ──────────────────────────────────────────────────────────────
 # CD-70c-3: frontend CF poll unavailable contract guard

--- a/tests/unit/test_javlibrary_scraper.py
+++ b/tests/unit/test_javlibrary_scraper.py
@@ -436,6 +436,16 @@ def test_extract_all_detail_urls_collects_all():
     urls4 = _extract_all_detail_urls(prefix_glued_html, "MIDV-010", base)
     assert urls4 == [], f"前置黏連號（AMIDV-010/1MIDV-010）應被 lookbehind 濾掉，got {urls4}"
 
+    # P2-1 一致性：番號只在 link text（title 為空）也應收進（對齊 _extract_detail_url 的 text OR title）
+    # mutation：把 text 比對拿掉 → 此 case RED（urls5 變 []）
+    text_only_html = """\
+<html><body>
+  <div class="video"><a href="./javtextonly.html" title="">MIDV-010 タイトル空</a></div>
+</body></html>"""
+    urls5 = _extract_all_detail_urls(text_only_html, "MIDV-010", base)
+    assert urls5 == [f"{base}/javtextonly.html"], \
+        f"番號在 get_text()（title 空）應被收進（title-OR-text），got {urls5}"
+
 
 def test_search_all_versions_multi():
     """

--- a/tests/unit/test_javlibrary_scraper.py
+++ b/tests/unit/test_javlibrary_scraper.py
@@ -427,6 +427,15 @@ def test_extract_all_detail_urls_collects_all():
     urls3 = _extract_all_detail_urls(no_match_html, "MIDV-010", base)
     assert urls3 == [], f"無相符應回 []，got {urls3}"
 
+    # 前置黏連號濾掉（Gemini P1-A：lookbehind 擋 AMIDV-010 / 1MIDV-010）
+    prefix_glued_html = """\
+<html><body>
+  <div class="video"><a href="./javA.html" title="AMIDV-010 前置字母">AMIDV-010</a></div>
+  <div class="video"><a href="./javB.html" title="1MIDV-010 前置數字">1MIDV-010</a></div>
+</body></html>"""
+    urls4 = _extract_all_detail_urls(prefix_glued_html, "MIDV-010", base)
+    assert urls4 == [], f"前置黏連號（AMIDV-010/1MIDV-010）應被 lookbehind 濾掉，got {urls4}"
+
 
 def test_search_all_versions_multi():
     """

--- a/tests/unit/test_javlibrary_scraper.py
+++ b/tests/unit/test_javlibrary_scraper.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.cf_transport import CfChallengeRequired, CfTransportUnavailable
-from core.scrapers.javlibrary import JavLibraryScraper
+from core.scrapers.javlibrary import JavLibraryScraper, _extract_all_detail_urls
 from core.scrapers.models import Video
 
 # ──────────────────────────────────────
@@ -346,3 +346,224 @@ def test_search_multi_result_correct_number_returns_video():
         f"number 相符的多命中路徑應回 Video，got: {result!r}"
     )
     assert result.number == "TCD-332"
+
+
+# ──────────────────────────────────────
+# T1：_extract_all_detail_urls + search_all_versions + fetch_by_detail_url
+# ──────────────────────────────────────
+
+# 多版本列表頁（模擬 MIDV-010 風格）
+# ─ 含 2 個 MIDV-010 框（各 1 主連結 + 3 href 空的動作連結）
+# ─ 另含 1 個前綴鄰號框（MIDV-100，boundary-match 測試用）
+MULTI_VERSION_LIST_HTML = """\
+<html><head><title>品番検索結果</title></head><body>
+  <div class="video">
+    <a href="./javlidaori.html" title="MIDV-010 Angel Kiss ビアンたちの愛情物語">MIDV-010 Angel Kiss</a>
+    <a href="">これが欲しい</a><a href="">見た</a><a href="">持ってる</a>
+  </div>
+  <div class="video">
+    <a href="./javme3bu7e.html" title="MIDV-010 連続中出しオーガズムSP">MIDV-010 連続...</a>
+    <a href="">これが欲しい</a><a href="">見た</a><a href="">持ってる</a>
+  </div>
+  <div class="video">
+    <a href="./javmidv100.html" title="MIDV-100 隣のお姉さん">MIDV-100 隣の...</a>
+    <a href="">これが欲しい</a><a href="">見た</a><a href="">持ってる</a>
+  </div>
+</body></html>"""
+
+# 舊片 detail（date=2009-12-01）
+OLD_DETAIL_HTML = """\
+<html><head><title>MIDV-010 Angel Kiss</title></head><body>
+  <h3 class="post-title">MIDV-010 Angel Kiss ビアンたちの愛情物語</h3>
+  <div id="video_id"><table><tr><td class="text">MIDV-010</td></tr></table></div>
+  <div id="video_date"><table><tr><td class="text">2009-12-01</td></tr></table></div>
+  <div id="video_maker"><table><tr><td class="text"><span><a>グラフィティジャパン</a></span></td></tr></table></div>
+  <img id="video_jacket_img" src="//pics.dmm.co.jp/mono/midv010old.jpg" />
+</body></html>"""
+
+# 新片 detail（date=2021-12-07）
+NEW_DETAIL_HTML = """\
+<html><head><title>MIDV-010 連続中出し</title></head><body>
+  <h3 class="post-title">MIDV-010 連続中出しオーガズムSP</h3>
+  <div id="video_id"><table><tr><td class="text">MIDV-010</td></tr></table></div>
+  <div id="video_date"><table><tr><td class="text">2021-12-07</td></tr></table></div>
+  <div id="video_maker"><table><tr><td class="text"><span><a>MOODYZ</a></span></td></tr></table></div>
+  <img id="video_jacket_img" src="//pics.dmm.co.jp/mono/midv010new.jpg" />
+</body></html>"""
+
+
+def test_extract_all_detail_urls_collects_all():
+    """
+    多相符 + href 空濾掉 + 前綴鄰號 boundary 濾掉 + 無相符回 []。
+    """
+    base = "https://www.javlibrary.com/ja"
+
+    # 主案例：MIDV-010 多版本列表，MIDV-100 須被 boundary 濾掉
+    urls = _extract_all_detail_urls(MULTI_VERSION_LIST_HTML, "MIDV-010", base)
+    assert len(urls) == 2, f"應收 2 個相符 url（MIDV-100 被 boundary 過濾），got {urls}"
+    assert any("javlidaori" in u for u in urls), "舊片 url 應被收進"
+    assert any("javme3bu7e" in u for u in urls), "新片 url 應被收進"
+    assert not any("javmidv100" in u for u in urls), "MIDV-100 應被 boundary-match 濾掉"
+
+    # href 空的動作連結濾掉
+    href_null_html = """\
+<html><body>
+  <div class="video">
+    <a href="./javtest.html" title="MIDV-010 テスト">MIDV-010 テスト</a>
+    <a href="">これが欲しい</a>
+    <a>見た</a>
+  </div>
+</body></html>"""
+    urls2 = _extract_all_detail_urls(href_null_html, "MIDV-010", base)
+    assert urls2 == [f"{base}/javtest.html"], f"動作連結不應被收進，got {urls2}"
+
+    # 無相符 → []（不 fallback links[0]）
+    no_match_html = """\
+<html><body>
+  <div class="video">
+    <a href="./javother.html" title="ZZZ-999 他の映像">ZZZ-999</a>
+  </div>
+</body></html>"""
+    urls3 = _extract_all_detail_urls(no_match_html, "MIDV-010", base)
+    assert urls3 == [], f"無相符應回 []，got {urls3}"
+
+
+def test_search_all_versions_multi():
+    """
+    多版本列表 → 2 筆相符 detail → 新片在 index 0（date desc）。
+    * index 0 = MOODYZ 2021（新），index 1 = グラフィティ 2009（舊）
+    * MIDV-100 框應被 boundary-match 濾掉（不收進 urls）
+    * href 空的動作連結不收
+    """
+    # fetch 呼叫順序：列表頁 → old detail（javlidaori）→ new detail（javme3bu7e）
+    transport = _make_transport(MULTI_VERSION_LIST_HTML, OLD_DETAIL_HTML, NEW_DETAIL_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        scraper = JavLibraryScraper()
+        versions = scraper.search_all_versions("MIDV-010")
+
+    assert len(versions) == 2
+    assert versions[0].date == "2021-12-07", f"新片應在 index 0，got {versions[0].date!r}"
+    assert versions[1].date == "2009-12-01", f"舊片應在 index 1，got {versions[1].date!r}"
+    assert versions[0].maker == "MOODYZ"
+    # transport.fetch 呼叫：1（列表）+ 2（detail × 2）= 3 次
+    assert transport.fetch.call_count == 3
+
+
+def test_search_all_versions_single_hit_302():
+    """
+    302 單一命中（首次 fetch 已是 detail page）→ 回 1-element list，
+    fetch 只呼叫一次。
+    """
+    transport = _make_transport(DETAIL_HTML)  # 含 #video_id
+    with patch(PATCH_TARGET, return_value=transport):
+        scraper = JavLibraryScraper()
+        versions = scraper.search_all_versions("TCD-332")
+
+    assert len(versions) == 1
+    assert isinstance(versions[0], Video)
+    assert transport.fetch.call_count == 1
+
+
+def test_fetch_by_detail_url():
+    """
+    直接給 detail_url → 正確回傳 Video，detail_url 落地在 Video.detail_url。
+    """
+    transport = _make_transport(DETAIL_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        scraper = JavLibraryScraper()
+        result = scraper.fetch_by_detail_url(
+            "https://www.javlibrary.com/ja/javmezzbqu.html",
+            "TCD-332",
+        )
+
+    assert isinstance(result, Video)
+    assert result.detail_url == "https://www.javlibrary.com/ja/javmezzbqu.html"
+    assert transport.fetch.call_count == 1
+
+
+# ── helper 抽取後 search() 行為零回歸 ──
+
+def test_search_unchanged_regression_single_hit():
+    """helper 抽取後 search() 的 single-hit 行為不變。"""
+    transport = _make_transport(DETAIL_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        result = JavLibraryScraper().search("TCD-332")
+    assert isinstance(result, Video)
+    assert result.detail_url == ""  # FIX-4
+
+
+def test_search_unchanged_regression_multi_result():
+    """helper 抽取後 search() 的 multi-result 行為不變。"""
+    transport = _make_transport(SEARCH_RESULT_HTML, DETAIL_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        result = JavLibraryScraper().search("TCD-332")
+    assert isinstance(result, Video)
+    assert transport.fetch.call_count == 2
+
+
+def test_search_unchanged_regression_not_found():
+    """helper 抽取後 no match → None。"""
+    transport = _make_transport(NO_RESULT_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        result = JavLibraryScraper().search("TCD-332")
+    assert result is None
+
+
+def test_search_unchanged_regression_empty_parse():
+    """helper 抽取後 title+cover 空 → None。"""
+    transport = _make_transport(EMPTY_DETAIL_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        result = JavLibraryScraper().search("TCD-332")
+    assert result is None
+
+
+def test_search_unchanged_regression_number_mismatch():
+    """helper 抽取後 FIX-5 番號不符 → None。"""
+    transport = _make_transport(SEARCH_RESULT_MISMATCH_HTML, WRONG_NUMBER_DETAIL_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        result = JavLibraryScraper().search("TCD-332")
+    assert result is None
+
+
+# ── CF 案例 ──
+
+def test_search_all_versions_list_cf_challenge_raises():
+    """search_all_versions：列表頁遇 CF challenge → CfChallengeRequired。"""
+    transport = _make_transport(CF_CHALLENGE_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        with pytest.raises(CfChallengeRequired):
+            JavLibraryScraper().search_all_versions("MIDV-010")
+
+
+def test_search_all_versions_detail_cf_challenge_raises():
+    """search_all_versions：detail fetch 遇 CF challenge → CfChallengeRequired。"""
+    transport = _make_transport(MULTI_VERSION_LIST_HTML, CF_CHALLENGE_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        with pytest.raises(CfChallengeRequired):
+            JavLibraryScraper().search_all_versions("MIDV-010")
+
+
+def test_search_all_versions_transport_none_raises():
+    """get_cf_transport() None → CfTransportUnavailable。"""
+    with patch(PATCH_TARGET, return_value=None):
+        with pytest.raises(CfTransportUnavailable):
+            JavLibraryScraper().search_all_versions("MIDV-010")
+
+
+def test_fetch_by_detail_url_cf_challenge_raises():
+    """fetch_by_detail_url：detail fetch 遇 CF challenge → CfChallengeRequired。"""
+    transport = _make_transport(CF_CHALLENGE_HTML)
+    with patch(PATCH_TARGET, return_value=transport):
+        with pytest.raises(CfChallengeRequired):
+            JavLibraryScraper().fetch_by_detail_url(
+                "https://www.javlibrary.com/ja/javtest.html", "TCD-332"
+            )
+
+
+def test_fetch_by_detail_url_transport_none_raises():
+    """fetch_by_detail_url：transport None → CfTransportUnavailable。"""
+    with patch(PATCH_TARGET, return_value=None):
+        with pytest.raises(CfTransportUnavailable):
+            JavLibraryScraper().fetch_by_detail_url(
+                "https://www.javlibrary.com/ja/javtest.html", "TCD-332"
+            )

--- a/tests/unit/test_scraper_javlib_wrappers.py
+++ b/tests/unit/test_scraper_javlib_wrappers.py
@@ -1,0 +1,69 @@
+"""
+tests/unit/test_scraper_javlib_wrappers.py
+
+core/scraper.py 薄包裝 unit tests：
+  - search_javlib_versions
+  - fetch_javlib_by_detail_url
+
+patch target：core.scraper.JavLibraryScraper（使用端 binding，符合 gotchas-backend §1）。
+TASK card 原稿指向 core.scrapers.javlibrary.JavLibraryScraper（定義端），
+但 core/scraper.py 透過 `from core.scrapers import JavLibraryScraper` 建立了獨立 binding，
+因此應 patch 使用端 core.scraper.JavLibraryScraper 才生效（CD-86-12 / gotchas-backend §1）。
+"""
+from unittest.mock import patch, MagicMock
+
+
+def test_search_javlib_versions_delegates_and_converts():
+    """
+    search_javlib_versions:
+      - 實例化 JavLibraryScraper → 呼叫 search_all_versions
+      - 各 Video 轉 to_legacy_dict()
+      - 回 list[dict]，len 和 dict 內容正確
+    """
+    from core.scraper import search_javlib_versions
+    from core.scrapers.models import Video
+
+    fake_video = MagicMock(spec=Video)
+    fake_video.to_legacy_dict.return_value = {
+        "number": "MIDV-010",
+        "url": "https://www.javlibrary.com/ja/javme3bu7e.html",
+        "title": "新片",
+    }
+    with patch('core.scraper.JavLibraryScraper') as MockScraper:
+        instance = MockScraper.return_value
+        instance.search_all_versions.return_value = [fake_video]
+        result = search_javlib_versions("MIDV-010")
+
+    assert len(result) == 1
+    assert result[0]["url"] == "https://www.javlibrary.com/ja/javme3bu7e.html"
+    instance.search_all_versions.assert_called_once_with("MIDV-010")
+    fake_video.to_legacy_dict.assert_called_once()
+
+
+def test_search_javlib_versions_empty():
+    """search_all_versions 回 [] → 回 []（不 raise）"""
+    from core.scraper import search_javlib_versions
+
+    with patch('core.scraper.JavLibraryScraper') as MockScraper:
+        MockScraper.return_value.search_all_versions.return_value = []
+        result = search_javlib_versions("MIDV-010")
+
+    assert result == []
+
+
+def test_fetch_javlib_by_detail_url_delegates():
+    """fetch_javlib_by_detail_url：呼叫 scraper.fetch_by_detail_url，回 Video（或 None）"""
+    from core.scraper import fetch_javlib_by_detail_url
+    from core.scrapers.models import Video
+
+    fake_video = MagicMock(spec=Video)
+    with patch('core.scraper.JavLibraryScraper') as MockScraper:
+        MockScraper.return_value.fetch_by_detail_url.return_value = fake_video
+        result = fetch_javlib_by_detail_url(
+            "https://www.javlibrary.com/ja/javme3bu7e.html", "MIDV-010"
+        )
+
+    assert result is fake_video
+    MockScraper.return_value.fetch_by_detail_url.assert_called_once_with(
+        "https://www.javlibrary.com/ja/javme3bu7e.html", "MIDV-010"
+    )

--- a/tests/unit/test_similar_invalidate_completeness.py
+++ b/tests/unit/test_similar_invalidate_completeness.py
@@ -21,7 +21,7 @@ _SQL_PATTERNS = [
     re.compile(r"INSERT\s+INTO\s+videos\b", re.DOTALL | re.IGNORECASE),
 ]
 
-NOQA_MARKER = "# noqa: ranker-invalidate"
+INVALIDATE_OK_MARKER = "# ranker-invalidate-ok"
 
 
 def _has_invalidate_call(funcdef_node: ast.FunctionDef) -> bool:
@@ -62,8 +62,8 @@ def _scan_file(path: Path) -> list[str]:
 
         seg = _get_source_segment(source, node)
 
-        # noqa 豁免
-        if NOQA_MARKER in seg:
+        # 白名單豁免（委派給已自帶 invalidate 的路徑）
+        if INVALIDATE_OK_MARKER in seg:
             continue
 
         # 是否有觸發 SQL pattern
@@ -85,7 +85,7 @@ def _scan_file(path: Path) -> list[str]:
 def test_all_raw_sql_mutations_have_invalidate():
     """所有對 videos 表做 raw SQL mutation 的函式必須呼叫 SimilarRankerCache.invalidate()。
 
-    例外：函式內含 '# noqa: ranker-invalidate' 註解（migration / init 路徑）。
+    例外：函式內含 '# ranker-invalidate-ok' 註解（委派給已自帶 invalidate 的路徑）。
     """
     root = Path(".")
     violations = []

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -522,7 +522,7 @@ def get_stats():
 
 
 @router.delete("/cache")
-def clear_cache():  # noqa: ranker-invalidate (DELETE FROM videos only in docstring; actual deletion delegates to repo.clear_all() which already calls SimilarRankerCache.invalidate())
+def clear_cache():  # ranker-invalidate-ok: (DELETE FROM videos only in docstring; actual deletion delegates to repo.clear_all() which already calls SimilarRankerCache.invalidate())
     """清除所有影片快取（DELETE FROM videos）"""
     try:
         db_path = get_db_path()

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -9,6 +9,7 @@ Scraper API 路由 - 單檔刮削
 import asyncio
 import json
 import os
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
@@ -22,7 +23,7 @@ from core.organizer import organize_file
 from core.path_utils import to_file_uri, uri_to_fs_path, coerce_to_file_uri
 from core.scraper import (
     search_jav, search_jav_single_source, strip_internal_nfo_keys,
-    search_javlib_versions, fetch_javlib_by_detail_url,
+    search_javlib_versions, fetch_javlib_by_detail_url, internal_nfo_carriers,
 )
 from core.source_config import validate_source_id
 from core.cf_transport import get_cf_transport, CfChallengeRequired, CfTransportUnavailable
@@ -35,6 +36,26 @@ from web.routers.notifications import emit_notification as _emit_notif
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["scraper"])
+
+# SSRF 防護：confirm 階段的 detail_url 來自 client（不可信），會被丟給 CF transport
+# （standalone 真瀏覽器 fetch）。限定 scheme+netloc 精確等於 javlibrary origin，
+# 擋掉 169.254.169.254 / evil.com / www.javlibrary.com.evil.com 之類 prefix 繞過
+# （netloc 精確比對，非 startswith 字串）。preview candidates 的 url 是後端自產（可信），
+# 不在此驗證面（PR #89 Codex P3）。
+_JAVLIB_ORIGIN_PARSED = urlparse(JAVLIBRARY_ORIGIN)
+
+
+def _is_javlibrary_url(url: str) -> bool:
+    try:
+        p = urlparse(url)
+    except (ValueError, TypeError):
+        return False
+    # netloc 大小寫不敏感（RFC 3986 host）：lower 後比對，避免大寫合法 URL 被誤拒；
+    # scheme urlparse 已 lower。安全方向不變（netloc 仍精確等於 javlibrary host）。
+    return (
+        p.scheme == _JAVLIB_ORIGIN_PARSED.scheme
+        and p.netloc.lower() == _JAVLIB_ORIGIN_PARSED.netloc.lower()
+    )
 
 
 class ScrapeRequest(BaseModel):
@@ -274,6 +295,10 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
     try:
         scraper_data = None
         if request.source == 'javlibrary' and request.detail_url:
+            # SSRF guard：拒絕非 javlibrary origin 的 detail_url（不 fetch、不洩 URL）
+            if not _is_javlibrary_url(request.detail_url):
+                logger.warning("enrich_single: 拒絕非法 detail_url origin")
+                return {"success": False, "error": "detail_url 來源不合法"}
             try:
                 video = fetch_javlib_by_detail_url(request.detail_url, request.number)
             except CfChallengeRequired:
@@ -289,7 +314,10 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
                 return {"success": False, "cf_unavailable": True}
             if video is None:
                 return {"success": False, "error": "javlibrary 無法取得指定版本資料"}
+            # to_legacy_dict 省略 _summary/_rating 內部 carrier；補回以對齊既有 javlibrary
+            # 重刮的 NFO 輸出（search_jav 走 internal_nfo_carriers 注入同組，PR #89 Codex P2）
             scraper_data = video.to_legacy_dict()
+            scraper_data.update(internal_nfo_carriers(video))
         result = enrich_single(
             file_path=request.file_path,
             number=request.number,

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -20,7 +20,10 @@ from core.db_inflow import try_inflow_upsert
 from core.enricher import enrich_single, fetch_samples_only, resolve_nfo_cover_paths
 from core.organizer import organize_file
 from core.path_utils import to_file_uri, uri_to_fs_path, coerce_to_file_uri
-from core.scraper import search_jav, search_jav_single_source, strip_internal_nfo_keys
+from core.scraper import (
+    search_jav, search_jav_single_source, strip_internal_nfo_keys,
+    search_javlib_versions, fetch_javlib_by_detail_url,
+)
 from core.source_config import validate_source_id
 from core.cf_transport import get_cf_transport, CfChallengeRequired, CfTransportUnavailable
 from core.scrapers.javlibrary import JAVLIBRARY_ORIGIN
@@ -154,6 +157,7 @@ class EnrichRequest(BaseModel):
     overwrite_existing: bool = False
     source: Optional[str] = None
     javbus_lang: Optional[str] = None
+    detail_url: Optional[str] = None
 
 
 class BatchEnrichItem(BaseModel):
@@ -193,7 +197,14 @@ def rescrape_preview_endpoint(request: RescrapePreviewRequest) -> dict:
     proxy_url = search_cfg.get("proxy_url", "")
 
     try:
-        if request.source == "auto":
+        if request.source == 'javlibrary':
+            versions = search_javlib_versions(request.number)  # Cf* 例外由外層 except 接
+            if not versions:
+                return {"success": False}
+            if len(versions) == 1:
+                return {"success": True, **strip_internal_nfo_keys(versions[0])}
+            return {"success": True, "candidates": [strip_internal_nfo_keys(v) for v in versions]}
+        elif request.source == "auto":
             result = search_jav(
                 request.number,
                 source="auto",
@@ -261,6 +272,24 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             )
 
     try:
+        scraper_data = None
+        if request.source == 'javlibrary' and request.detail_url:
+            try:
+                video = fetch_javlib_by_detail_url(request.detail_url, request.number)
+            except CfChallengeRequired:
+                t = get_cf_transport()
+                if t:
+                    try:
+                        t.begin_solve(JAVLIBRARY_ORIGIN, 'javlibrary')
+                    except Exception:
+                        logger.exception("enrich_single: begin_solve 失敗，回 cf_unavailable")
+                        return {"success": False, "cf_unavailable": True}
+                return {"success": False, "cf_needed": True}
+            except CfTransportUnavailable:
+                return {"success": False, "cf_unavailable": True}
+            if video is None:
+                return {"success": False, "error": "javlibrary 無法取得指定版本資料"}
+            scraper_data = video.to_legacy_dict()
         result = enrich_single(
             file_path=request.file_path,
             number=request.number,
@@ -273,6 +302,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             proxy_url=proxy_url,
             source=request.source,
             javbus_lang=request.javbus_lang,
+            scraper_data=scraper_data,
         )
         # feature/71 T8: 換封面成功 → 失效舊縮圖（下次 lazy/prewarm 重生，CD-9 / spec 2.A.7）。
         # request.file_path 已是 DB 的 file:/// URI（前端送 currentLightboxVideo.path /

--- a/web/static/css/components/rescrape-modal.css
+++ b/web/static/css/components/rescrape-modal.css
@@ -262,12 +262,12 @@
     gap: 0.5rem;
     margin-bottom: 0.5rem;
     font-size: 0.76rem;
-    color: var(--text-secondary);
+    color: var(--color-warning);  /* 86-T6: 撞號提示「注意」語意，同 .rescrape-caption */
 }
 
 .rescrape-ver-indicator {
     font-weight: 600;
-    color: var(--text-primary);
+    color: var(--color-warning);  /* 86-T6: N/M 與「找到 X 部」整行統一琥珀 */
 }
 
 .rescrape-preview .pv-cover img {

--- a/web/static/css/components/rescrape-modal.css
+++ b/web/static/css/components/rescrape-modal.css
@@ -5,8 +5,10 @@
  * blur）由 theme.css 的 `.fluent-modal.modal-open` 統一提供（::backdrop 在 class-open 模式不觸發）。
  * 本檔額外處理「從 lightbox 開窗」的層級：見下方 .rescrape-dialog.modal z-index。
  * 視覺忠實移植自 mockup-rescrape-modal.html（CD-62-0「mockup 為準」），
- * 全 token 化（shadow/radius/duration/ease/color）。唯一字面值：.rescrape-confirm-btn.confirm 的
- * #fff 白前景（綠底按鈕慣例；mockup:189）。pill 999px 走 source-pill.css 白名單。
+ * 全 token 化（shadow/radius/duration/ease/color）。字面值白名單：.rescrape-confirm-btn.confirm 的
+ * #fff 白前景（綠底按鈕慣例；mockup:189）；.rescrape-ver-btn:hover 的 rgba(0,0,0,0.5)
+ * （hover 升階 0.5，charter §3 個案保留，同 .lightbox-nav:hover showcase.css:1317）。
+ * pill 999px 走 source-pill.css 白名單。
  *
  * Alpine 行為（fetch/loading/commit/not-found）是 62a-3；本檔僅視覺。
  */
@@ -201,6 +203,71 @@
 
 .rescrape-preview .pv-cover {
     flex-shrink: 0;
+    position: relative;
+}
+
+/* ─── 86-T4: 版本切換器 ‹ › 鈕（CD-86-7 D5；token 對齊 .lightbox-nav 材質）─── */
+.rescrape-ver-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    min-width: 44px;
+    min-height: 44px;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: var(--overlay-control);
+    backdrop-filter: blur(var(--fluent-blur-light));
+    -webkit-backdrop-filter: blur(var(--fluent-blur-light));
+    color: var(--text-inverse);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background var(--fluent-duration-fast) var(--fluent-ease-standard),
+                transform var(--fluent-duration-fast) var(--fluent-ease-standard);
+    z-index: 1;
+}
+
+.rescrape-ver-btn:hover {
+    /* hover 升階 0.5 (charter §3 個案保留，同 .lightbox-nav:hover showcase.css:1317) */
+    background: rgba(0, 0, 0, 0.5);
+    transform: translateY(-50%) scale(1.1);
+}
+
+.rescrape-ver-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.rescrape-ver-btn:disabled {
+    opacity: 0.35;
+    cursor: default;
+}
+
+.rescrape-ver-prev {
+    left: -0.75rem;
+}
+
+.rescrape-ver-next {
+    right: -0.75rem;
+}
+
+/* ─── 86-T4: 版本狀態文字（「找到 X 部」+ N/M 指示）─── */
+.rescrape-version-status {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.76rem;
+    color: var(--text-secondary);
+}
+
+.rescrape-ver-indicator {
+    font-weight: 600;
+    color: var(--text-primary);
 }
 
 .rescrape-preview .pv-cover img {

--- a/web/static/js/pages/search/state/advanced-picker.js
+++ b/web/static/js/pages/search/state/advanced-picker.js
@@ -50,22 +50,8 @@ export function searchStateAdvancedPicker() {
                 if (currentRequestId !== this.requestId) return;
 
                 if (response.ok && data.success && data.data && data.data.length > 0) {
-                    this.currentMode = data.mode || this.currentMode;
-                    this.searchResults = data.data;
-                    this.currentIndex = 0;
-                    this.hasMoreResults = data.has_more || false;
-                    this.actressProfile = data.actress_profile || null;
-                    if (this.actressProfile) this._heroCardImageError = false;
-                    this.listMode = 'search';
-                    this.checkLocalStatus(this.searchResults);
-                    this.pageState = 'result';
-                    this.preloadImages(1, 5);
-                    this.hasContent = this.searchResults.length > 0 || this.fileList.length > 0;
-                    this._searchSnapshot = null;
-                    this._resetCoverState();
-                    this.editingTitle = false;
-                    this.editingChineseTitle = false;
-                    this.addingTag = false;
+                    this._commitSearchResults(data);
+                    return;
                 } else {
                     this._searchSnapshot = null;
                     this.errorText = data.error || window.t('search.error.hint');
@@ -81,6 +67,30 @@ export function searchStateAdvancedPicker() {
                 this.errorText = window.t('search.error.hint');
                 this.pageState = 'error';
             }
+        },
+
+        /**
+         * CD-86-14: 共用搜尋結果提交 helper。
+         * state-rescrape.js search 入口採用路徑可跨 mixin 呼叫此 helper（mergeState 共享 this）。
+         * @param {Object} payload - { data: [...], mode, has_more, actress_profile }
+         */
+        _commitSearchResults(payload) {
+            this.currentMode = payload.mode || this.currentMode;
+            this.searchResults = payload.data;
+            this.currentIndex = 0;
+            this.hasMoreResults = payload.has_more || false;
+            this.actressProfile = payload.actress_profile || null;
+            if (this.actressProfile) this._heroCardImageError = false;
+            this.listMode = 'search';
+            this.checkLocalStatus(this.searchResults);
+            this.pageState = 'result';
+            this.preloadImages(1, 5);
+            this.hasContent = this.searchResults.length > 0 || this.fileList.length > 0;
+            this._searchSnapshot = null;
+            this._resetCoverState();
+            this.editingTitle = false;
+            this.editingChineseTitle = false;
+            this.addingTag = false;
         },
 
         // OQ-3：metatube 來源 + 非番號 + 空結果 → 軟提示（scaffold）

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -582,6 +582,19 @@ export function searchStateSearchFlow() {
     },
 
     /**
+     * 「再開來源/版本挑選」入口可見條件（CD-86-P2 副作用修正）。
+     * JavLibrary 採用後 searchQuery === currentQuery → isComposing() false，
+     * 但使用者仍應可在 exact 結果頁重開 advanced picker 換版本/來源。
+     * 條件：正在看某番號的 exact 結果（pageState='result', currentMode='exact', 搜尋框非空）。
+     * 不修改 isComposing()，避免波及 Grid/Detail Toggle 的 !isComposing() 互斥判斷。
+     */
+    canReopenSourcePick() {
+        return this.pageState === 'result'
+            && this.currentMode === 'exact'
+            && (this.searchQuery || '').trim() !== '';
+    },
+
+    /**
      * 取消搜尋（Fix 2: 恢復到上一個有效狀態）
      */
     cancelSearch() {

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -585,11 +585,16 @@ export function searchStateSearchFlow() {
      * 「再開來源/版本挑選」入口可見條件（CD-86-P2 副作用修正）。
      * JavLibrary 採用後 searchQuery === currentQuery → isComposing() false，
      * 但使用者仍應可在 exact 結果頁重開 advanced picker 換版本/來源。
-     * 條件：正在看某番號的 exact 結果（pageState='result', currentMode='exact', 搜尋框非空）。
+     * 條件：search workflow 正在看某番號的 exact 結果（listMode='search', pageState='result',
+     * currentMode='exact', 搜尋框非空）。
+     * listMode 收斂（CD-86-P2 副作用修正）：file/batch workflow 也會進 pageState='result' +
+     * currentMode='exact'，但 searchQuery 只在載入第一個檔案時設一次、切換檔案不同步，故此頂部入口
+     * 在 file mode 會帶舊番號 → 限定 listMode==='search'。file mode 換來源走結果卡的 switch-source 入口。
      * 不修改 isComposing()，避免波及 Grid/Detail Toggle 的 !isComposing() 互斥判斷。
      */
     canReopenSourcePick() {
-        return this.pageState === 'result'
+        return this.listMode === 'search'
+            && this.pageState === 'result'
             && this.currentMode === 'exact'
             && (this.searchQuery || '').trim() !== '';
     },

--- a/web/static/js/shared/state-rescrape.js
+++ b/web/static/js/shared/state-rescrape.js
@@ -264,18 +264,11 @@ export function rescrapeState() {
                     this._rescrapeCommitSource = sourceId;
                     this.rescrapeStep = 'preview';
                 } else if (data && data.success) {
-                    // 單筆：依入口分流
-                    if (this.rescrapeEntryPoint === 'search') {
-                        // search 入口單版本：採用進結果關窗（不打 enrich-single）
-                        // 對齊 switch-source：strip success，不讓控制旗標流入 result row
-                        // CD-86-P2：同步 searchQuery / currentQuery（對齊非 javlib 路徑 :167 + advancedSearch :38）
-                        this.searchQuery = this.rescrapeNumber.trim();
-                        this.currentQuery = this.rescrapeNumber.trim();
-                        const { success: _s, ...row } = data;
-                        this._commitSearchResults?.({ data: [row], mode: 'exact', has_more: false, actress_profile: null });
-                        this.closeRescrape();
-                        return;
-                    }
+                    // 單版本：search / lightbox 共用 preview 邏輯（CD-86-8 對齊）。
+                    // 86 修正：search 單版本不再於此靜默 _commitSearchResults + closeRescrape
+                    // （一閃就關，使用者回報「直接跳過」），改 fall through 進 preview 卡（無切換器、
+                    // 有 T4「採用此版本」✓ 鈕，x-show="rescrapeEntryPoint==='search'"）。採用由
+                    // rescrapeConfirm 的 search 分支處理（已含 searchQuery/currentQuery 同步 + _commitSearchResults）。
                     // lightbox（現況）：74b US3：預覽膠囊顯示「實際刮到的源」+ 有碼/無碼上色。
                     // lightbox + auto 也會進 preview（無 early return）→ auto 時用後端
                     // 回傳的實際源（data._source）解析，否則顯示「自動」+藍 fallback、無法辨識

--- a/web/static/js/shared/state-rescrape.js
+++ b/web/static/js/shared/state-rescrape.js
@@ -355,6 +355,7 @@ export function rescrapeState() {
          */
         async rescrapeConfirm() {
             if (this._rescraping) return;                            // 連點防護
+            if (this.rescrapeCfWaiting) return;                      // P2-2：CF 等待中不可重入（鏡射 rescrapeWithSource :161）
             this._rescraping = true;
             try {
                 if (this.rescrapeEntryPoint === 'search') {
@@ -407,6 +408,21 @@ export function rescrapeState() {
                     }),
                 });
                 const result = await resp.json();
+                // P2-2（Codex PR#89）：confirm 寫檔分支也接 CF——T2 後 javlibrary && detail_url 會走後端
+                // detail 重抓分支，若預覽→確認之間 CF session 過期，後端回 {cf_needed} / {cf_unavailable}
+                // （已 begin_solve）。鏡射 preview（rescrapeWithSource :203-211）：不接 → 卡在模糊「失敗」
+                // 且 CF flow 不啟動。cf_needed 啟動既有等待輪詢（_pollCfThenRetry 解完 CF 後重跑 preview，
+                // 使用者再按確認）——對不可逆寫檔，CF 後強制重新確認比靜默自動寫入更安全。
+                // 在判 success/失敗之前處理。順序對齊 preview（cf_needed 先、cf_unavailable 後）。
+                if (result.cf_needed) {
+                    this.rescrapeCfWaiting = true;
+                    this._pollCfThenRetry(this.rescrapeNumber.trim());
+                    return;
+                }
+                if (result.cf_unavailable) {
+                    this.showToast(window.t('showcase.rescrape.jl_desktop_only'), 'warning');
+                    return;
+                }
                 if (result.success) {
                     await this.refreshVideoData?.(this._rescrapeVideo);   // CD-62-5（showcase 有、search 無）
                     this.showToast(window.t('showcase.rescrape.success'), 'success');

--- a/web/static/js/shared/state-rescrape.js
+++ b/web/static/js/shared/state-rescrape.js
@@ -268,6 +268,9 @@ export function rescrapeState() {
                     if (this.rescrapeEntryPoint === 'search') {
                         // search 入口單版本：採用進結果關窗（不打 enrich-single）
                         // 對齊 switch-source：strip success，不讓控制旗標流入 result row
+                        // CD-86-P2：同步 searchQuery / currentQuery（對齊非 javlib 路徑 :167 + advancedSearch :38）
+                        this.searchQuery = this.rescrapeNumber.trim();
+                        this.currentQuery = this.rescrapeNumber.trim();
                         const { success: _s, ...row } = data;
                         this._commitSearchResults?.({ data: [row], mode: 'exact', has_more: false, actress_profile: null });
                         this.closeRescrape();
@@ -347,6 +350,9 @@ export function rescrapeState() {
                 if (this.rescrapeEntryPoint === 'search') {
                     // CD-86-9/14：採用選定版本進搜尋結果，不打 enrich-single，不顯示不可逆警告
                     if (!this.rescrapePreview) { return; }
+                    // CD-86-P2：同步 searchQuery / currentQuery（對齊非 javlib 路徑 :167 + advancedSearch :38）
+                    this.searchQuery = this.rescrapeNumber.trim();
+                    this.currentQuery = this.rescrapeNumber.trim();
                     // strip preview-only extras（success/sourceName/sourceCensored）不讓其流入 result row
                     const { success: _s, sourceName: _sn, sourceCensored: _sc, ...adopted } = this.rescrapePreview;
                     this._commitSearchResults?.({ data: [adopted], mode: 'exact', has_more: false, actress_profile: null });

--- a/web/static/js/shared/state-rescrape.js
+++ b/web/static/js/shared/state-rescrape.js
@@ -216,6 +216,22 @@ export function rescrapeState() {
                 // （替換後當前卡顯示的番號 = 下次 tap 查 switchStateMap 的 key；用編輯後實際抓回的番號才對得上）。
                 if (this.rescrapeEntryPoint === 'switch-source') {
                     if (data && data.success) {
+                        // T7: 多版本 → 進 preview + 切換器（不靜默取 [0]）
+                        if (data.candidates && data.candidates.length > 1) {
+                            const previewSourceId = sourceId === 'auto' ? (data._source || data.source || sourceId) : sourceId;
+                            const _previewSrc = this.rescrapeSources.find(x => x.id === previewSourceId);
+                            this.rescrapeCandidates = data.candidates;
+                            this.rescrapeVersionIdx = 0;
+                            this.rescrapePreview = {
+                                ...data.candidates[0],
+                                sourceName: this._resolveSourceName(previewSourceId),
+                                sourceCensored: _previewSrc?.is_censored ?? true,
+                            };
+                            this._rescrapeCommitSource = sourceId;
+                            this.rescrapeStep = 'preview';   // 不關窗
+                            return;
+                        }
+                        // 單版本 → 現有靜默 in-place 替換（race/stale 檢查保留）
                         // ── race 防覆蓋錯卡：await 回來判 slot 是否還在原位（強化 1：含 liveArr 顯式 identity 比對）──
                         const t = this._switchTarget;
                         const liveArr = (t && t.listMode === 'file' && this.fileList[t.fileIndex])
@@ -227,7 +243,8 @@ export function rescrapeState() {
                             || t.idx < 0 || t.idx >= t.arr.length
                             || (t.arr[t.idx] && t.arr[t.idx].number !== t.number);  // 番號比對：防同位置已被別筆佔據
                         if (!stale) {
-                            // CD-86-6：switch-source 收到 candidates → 取 [0] 最新版本
+                            // T7：單版本 fallback——多版本（length>1）已於上方提前 return 進 preview，
+                            // 此處只處理單版本（candidates 無或 length===1）→ 取唯一筆替換。
                             const variant = (() => {
                                 if (data.candidates && data.candidates.length > 0) {
                                     const { success: _s, ...c } = { success: true, ...data.candidates[0] };
@@ -350,6 +367,26 @@ export function rescrapeState() {
                     const { success: _s, sourceName: _sn, sourceCensored: _sc, ...adopted } = this.rescrapePreview;
                     this._commitSearchResults?.({ data: [adopted], mode: 'exact', has_more: false, actress_profile: null });
                     this.closeRescrape();
+                    return;
+                }
+                // T7: switch-source 入口採用選定版本做 in-place 替換（不打 enrich-single，不 _commitSearchResults）
+                if (this.rescrapeEntryPoint === 'switch-source') {
+                    if (!this.rescrapePreview) { return; }
+                    const t = this._switchTarget;
+                    // 採用當下重驗 stale（鏡射 rescrapeWithSource :220-228）
+                    const liveArr = (t && t.listMode === 'file' && this.fileList[t.fileIndex])
+                        ? this.fileList[t.fileIndex].searchResults : this.searchResults;
+                    const stale = !t || liveArr !== t.arr || !Array.isArray(t.arr)
+                        || t.idx < 0 || t.idx >= t.arr.length
+                        || (t.arr[t.idx] && t.arr[t.idx].number !== t.number);
+                    if (!stale) {
+                        const { success: _s, sourceName: _sn, sourceCensored: _sc, ...variant } = this.rescrapePreview;
+                        t.arr[t.idx] = variant;                          // in-place 替換選定版本
+                        this._resetCoverState?.();
+                        this.saveState?.();
+                        window.SearchUI?.seedSwitchState?.(variant.number || t.number, this._rescrapeCommitSource, variant);
+                    }
+                    this.closeRescrape();                                 // stale 靜默丟棄；非 stale 已替換。一律關窗
                     return;
                 }
                 // lightbox（現況）：需既有檔

--- a/web/static/js/shared/state-rescrape.js
+++ b/web/static/js/shared/state-rescrape.js
@@ -38,6 +38,8 @@ export function rescrapeState() {
         rescrapeLoadingSource: null,       // string | null（明確，:disabled 純 boolean）
         rescrapePreview: null,             // transient（CD-62-2）
         rescrapeNotFound: false,
+        rescrapeCandidates: [],            // CD-86-6：多版本候選陣列；單版本/非 javlib 為 []
+        rescrapeVersionIdx: 0,             // 當前 preview 游標
         rescrapeCfWaiting: false,          // 70-T6: CF 等待態（polling 中）
         _cfPollHandle: null,               // 70-T6: setInterval handle；null = 未 polling
 
@@ -60,6 +62,8 @@ export function rescrapeState() {
                 : '';
             this.rescrapeSources = (window.__ADVANCED_SEARCH__ && window.__ADVANCED_SEARCH__.sources) || [];
             this.rescrapePreview = null;
+            this.rescrapeCandidates = [];
+            this.rescrapeVersionIdx = 0;
             this.rescrapeLoadingSource = null;
             this.rescrapeNotFound = false;
             this._rescrapeVideo = video;
@@ -158,12 +162,17 @@ export function rescrapeState() {
             if (!this.rescrapeNumber.trim()) { this.rescrapeNotFound = true; return; }
             // Search 入口（62c-1）：無預覽卡，繞過 /api/rescrape/preview，直接走 B1 advancedSearch
             // 整包贏（GET /api/search?...&source=），結果進正常結果區，彈窗關閉（spec US5）。
+            // CD-86-8：javlibrary 例外——不早 return，繼續走 fetch preview（多版本候選支援）。
             // 番號回寫 searchQuery：讓彈窗內改番號生效（advancedSearch 讀 this.searchQuery）。
             if (this.rescrapeEntryPoint === 'search') {
-                this.searchQuery = this.rescrapeNumber.trim();
-                this.closeRescrape();
-                await this.advancedSearch(sourceId);  // 'auto' 直接傳給 /api/search（後端 merger）
-                return;
+                if (sourceId !== 'javlibrary') {
+                    // 其他 source：維持原路（advancedSearch 整包贏）
+                    this.searchQuery = this.rescrapeNumber.trim();
+                    this.closeRescrape();
+                    await this.advancedSearch(sourceId);  // 'auto' 直接傳給 /api/search（後端 merger）
+                    return;
+                }
+                // javlib：不早 return，繼續走 fetch preview（CD-86-8）
             }
             // 74a US2：switch-source 入口點「自動」= 直接 cycle（picker 關閉 + switchSource 循環）
             // spec-74 §US2：picker「自動」= 原本 🔄 tap 的「換到下一個來源」循環功能。
@@ -218,8 +227,15 @@ export function rescrapeState() {
                             || t.idx < 0 || t.idx >= t.arr.length
                             || (t.arr[t.idx] && t.arr[t.idx].number !== t.number);  // 番號比對：防同位置已被別筆佔據
                         if (!stale) {
-                            // dict shape 已核對與 searchResults row 一致，僅需 strip success key
-                            const { success, ...variant } = data;
+                            // CD-86-6：switch-source 收到 candidates → 取 [0] 最新版本
+                            const variant = (() => {
+                                if (data.candidates && data.candidates.length > 0) {
+                                    const { success: _s, ...c } = { success: true, ...data.candidates[0] };
+                                    return c;
+                                }
+                                const { success, ...v } = data;
+                                return v;
+                            })();
                             t.arr[t.idx] = variant;                               // 整顆替換（對齊 ui.js:248）
                             this._resetCoverState?.();                            // cover 可能變（對齊 ui.js:250）
                             this.saveState?.();                                   // 持久化寫回（對齊 ui.js:259 tap 路徑；防 session restore 回舊卡）。optional-chain：mixin 共用 showcase，switch-source 僅 search 觸發
@@ -232,11 +248,32 @@ export function rescrapeState() {
                     this.rescrapeNotFound = true;
                     return;
                 }
-                // Showcase（lightbox）：找到 → 換頁 preview；找不到 → 留 pick
-                // （Search 入口已在函式開頭提早分流到 advancedSearch，不走到這裡）
+                // Showcase（lightbox）/ search+javlib：找到 → 換頁 preview；找不到 → 留 pick
                 // （cf_needed / cf_unavailable 已在上方統一提前處理，此處不再重複）
-                if (data && data.success) {
-                    // 74b US3：預覽膠囊顯示「實際刮到的源」+ 有碼/無碼上色。
+                if (data && data.candidates && data.candidates.length > 1) {
+                    // CD-86-6：多版本——填 candidates 短狀態 + 進 preview（含 search 入口，CD-86-8）
+                    const previewSourceId = sourceId === 'auto' ? (data._source || data.source || sourceId) : sourceId;
+                    const _previewSrc = this.rescrapeSources.find(x => x.id === previewSourceId);
+                    this.rescrapeCandidates = data.candidates;
+                    this.rescrapeVersionIdx = 0;
+                    this.rescrapePreview = {
+                        ...data.candidates[0],
+                        sourceName: this._resolveSourceName(previewSourceId),
+                        sourceCensored: _previewSrc?.is_censored ?? true,
+                    };
+                    this._rescrapeCommitSource = sourceId;
+                    this.rescrapeStep = 'preview';
+                } else if (data && data.success) {
+                    // 單筆：依入口分流
+                    if (this.rescrapeEntryPoint === 'search') {
+                        // search 入口單版本：採用進結果關窗（不打 enrich-single）
+                        // 對齊 switch-source：strip success，不讓控制旗標流入 result row
+                        const { success: _s, ...row } = data;
+                        this._commitSearchResults?.({ data: [row], mode: 'exact', has_more: false, actress_profile: null });
+                        this.closeRescrape();
+                        return;
+                    }
+                    // lightbox（現況）：74b US3：預覽膠囊顯示「實際刮到的源」+ 有碼/無碼上色。
                     // lightbox + auto 也會進 preview（無 early return）→ auto 時用後端
                     // 回傳的實際源（data._source）解析，否則顯示「自動」+藍 fallback、無法辨識
                     // 實際源（違背 US3「截圖辨識用了哪個源」）。
@@ -260,22 +297,64 @@ export function rescrapeState() {
         },
 
         /**
+         * CD-86-6：是否有多版本候選（切換器顯示條件）。
+         */
+        rescrapeHasVersions() {
+            return this.rescrapeCandidates.length > 1;
+        },
+
+        /**
+         * CD-86-6：切換版本游標（clamp + 重綁 preview/sourceName/sourceCensored）。
+         * @param {number} delta - +1 下一版 / -1 上一版
+         */
+        rescrapeVersionGo(delta) {
+            const len = this.rescrapeCandidates.length;
+            if (len <= 1) return;
+            const newIdx = Math.max(0, Math.min(len - 1, this.rescrapeVersionIdx + delta));
+            if (newIdx === this.rescrapeVersionIdx) return;
+            this.rescrapeVersionIdx = newIdx;
+            const candidate = this.rescrapeCandidates[newIdx];
+            const previewSourceId = this._rescrapeCommitSource === 'auto'
+                ? (candidate._source || candidate.source || this._rescrapeCommitSource)
+                : this._rescrapeCommitSource;
+            const _previewSrc = this.rescrapeSources.find(x => x.id === previewSourceId);
+            this.rescrapePreview = {
+                ...candidate,
+                sourceName: this._resolveSourceName(previewSourceId),
+                sourceCensored: _previewSrc?.is_censored ?? true,
+            };
+        },
+
+        /**
          * 回上一步（保留 number + sources，清 preview 讓用戶重選源）。
          */
         rescrapeBackToPick() {
             this.rescrapeStep = 'pick';
             this.rescrapePreview = null;
+            this.rescrapeCandidates = [];
+            this.rescrapeVersionIdx = 0;
             this.rescrapeNotFound = false;
         },
 
         /**
          * ✓ commit — 自包含覆蓋寫入（POST /api/enrich-single）。鏡像 enrichVideo。
+         * CD-86-9/14：search 入口採用選定版本進搜尋結果，不打 enrich-single，不顯示不可逆警告。
          */
         async rescrapeConfirm() {
             if (this._rescraping) return;                            // 連點防護
-            if (!this._rescrapeVideo || !this._rescrapeVideo.path) return;  // commit 需既有檔（對齊 enrichVideo guard；search 入口無檔不 commit）
             this._rescraping = true;
             try {
+                if (this.rescrapeEntryPoint === 'search') {
+                    // CD-86-9/14：採用選定版本進搜尋結果，不打 enrich-single，不顯示不可逆警告
+                    if (!this.rescrapePreview) { return; }
+                    // strip preview-only extras（success/sourceName/sourceCensored）不讓其流入 result row
+                    const { success: _s, sourceName: _sn, sourceCensored: _sc, ...adopted } = this.rescrapePreview;
+                    this._commitSearchResults?.({ data: [adopted], mode: 'exact', has_more: false, actress_profile: null });
+                    this.closeRescrape();
+                    return;
+                }
+                // lightbox（現況）：需既有檔
+                if (!this._rescrapeVideo || !this._rescrapeVideo.path) return;
                 const commitSource = (this._rescrapeCommitSource === 'auto') ? null : this._rescrapeCommitSource;
                 const resp = await fetch('/api/enrich-single', {
                     method: 'POST',
@@ -288,6 +367,7 @@ export function rescrapeState() {
                         overwrite_existing: true,                    // CD-62-4：唯一合法組合
                         write_nfo: true,
                         write_cover: true,
+                        detail_url: this.rescrapePreview?.url || null,  // CD-86-13: 取 .url 非 .detail_url
                     }),
                 });
                 const result = await resp.json();
@@ -368,6 +448,8 @@ export function rescrapeState() {
             this.rescrapeOpen = false;
             this.rescrapeStep = 'pick';
             this.rescrapePreview = null;
+            this.rescrapeCandidates = [];
+            this.rescrapeVersionIdx = 0;
             this.rescrapeNotFound = false;
             this.rescrapeLoadingSource = null;
             this._switchTarget = null;     // 62c-3：關窗清掉捕捉的 slot（switch-source 入口）

--- a/web/templates/_rescrape_modal.html
+++ b/web/templates/_rescrape_modal.html
@@ -206,6 +206,11 @@
         <button type="button" class="rescrape-confirm-btn confirm" @click="rescrapeConfirm()"
                 :aria-label="t('showcase.rescrape.adopt_version')"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
       </div>
+      {# switch-source 入口：替換此版本單鈕（無不可逆警語；只替換結果列 slot 非寫檔）#}
+      <div class="rescrape-confirm-row" x-show="rescrapeEntryPoint === 'switch-source'">
+        <button type="button" class="rescrape-confirm-btn confirm" @click="rescrapeConfirm()"
+                :aria-label="t('showcase.rescrape.adopt_switch_source')"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
+      </div>
     </div>
 
   </div>

--- a/web/templates/_rescrape_modal.html
+++ b/web/templates/_rescrape_modal.html
@@ -47,7 +47,6 @@
           {# builtin pill：picker 依 usability 不依 promotion（CD-64-A4），恆 data-enabled=true 正常可選，不反映 Settings 開關 #}
           <template x-for="s in rescrapeBuiltinSources()" :key="s.id">
             <button type="button"
-                    x-show="!(s.manual_only && s.is_beta && rescrapeEntryPoint === 'search')"
                     :class="{
                         'source-pill': true,
                         'source-pill--action': !isJlUnavailable(s),
@@ -120,7 +119,7 @@
       </div>
     </div>
 
-    {# ───────── 步驟 2：preview（換頁，只 Showcase 入口接） ───────── #}
+    {# ───────── 步驟 2：preview（換頁，Showcase + search 入口皆可進入；86-T4） ───────── #}
     <div x-show="rescrapeStep === 'preview'" x-cloak>
       <button type="button" class="rescrape-back" @click="rescrapeBackToPick()">
         <i class="bi bi-arrow-left" aria-hidden="true"></i> {{ t('showcase.rescrape.back_to_pick') }}
@@ -134,8 +133,29 @@
              禁直連遠端 URL、禁 DB-only gallery image 端點。內聯建構。 #}
           <img :src="rescrapePreview && ('/api/proxy-image?url=' + encodeURIComponent(rescrapePreview.cover))"
                :alt="rescrapePreview && rescrapePreview.number">
+          {# 86-T4: 版本切換器 ‹ › 鈕（CD-86-7 D5；swipe 不做 CD-86-15） #}
+          <button type="button" class="rescrape-ver-btn rescrape-ver-prev"
+                  x-show="rescrapeHasVersions()"
+                  @click="rescrapeVersionGo(-1)"
+                  :aria-label="t('showcase.rescrape.version_prev_aria')"
+                  :disabled="rescrapeVersionIdx <= 0">
+            <i class="bi bi-chevron-left" aria-hidden="true"></i>
+          </button>
+          <button type="button" class="rescrape-ver-btn rescrape-ver-next"
+                  x-show="rescrapeHasVersions()"
+                  @click="rescrapeVersionGo(1)"
+                  :aria-label="t('showcase.rescrape.version_next_aria')"
+                  :disabled="rescrapeVersionIdx >= rescrapeCandidates.length - 1">
+            <i class="bi bi-chevron-right" aria-hidden="true"></i>
+          </button>
         </div>
         <div class="lightbox-metadata">
+          {# 86-T4: versions_found + N/M 指示（CD-86-7 D5；多版本才顯示） #}
+          <div class="rescrape-version-status" x-show="rescrapeHasVersions()">
+            <span x-text="t('showcase.rescrape.versions_found', { count: rescrapeCandidates.length })"></span>
+            <span class="rescrape-ver-indicator"
+                  x-text="(rescrapeVersionIdx + 1) + '/' + rescrapeCandidates.length"></span>
+          </div>
           <div class="lb-title" x-text="rescrapePreview && rescrapePreview.title"></div>
           <div class="lb-otitle" x-show="rescrapePreview && rescrapePreview.original_title"
                x-text="rescrapePreview && rescrapePreview.original_title"></div>
@@ -169,15 +189,22 @@
         </div>
       </div>
 
-      {# 一律覆蓋（拿掉 toggle）：小字提示不可逆 + ✗/✓ 兩圓鈕 #}
-      <div class="rescrape-caption">
+      {# 86-T4 CD-86-9: lightbox 入口顯示不可逆警告 + ✗/✓；search 入口顯示「採用此版本」單鈕 #}
+      {# lightbox 入口：不可逆提示（僅 lightbox 入口顯示） #}
+      <div class="rescrape-caption" x-show="rescrapeEntryPoint === 'lightbox'">
         <i class="bi bi-exclamation-octagon-fill" aria-hidden="true"></i> {{ t('showcase.rescrape.overwrite_warning') }}
       </div>
-      <div class="rescrape-confirm-row">
+      {# lightbox 入口：✗/✓ 兩圓鈕 #}
+      <div class="rescrape-confirm-row" x-show="rescrapeEntryPoint === 'lightbox'">
         <button type="button" class="rescrape-confirm-btn cancel" @click="rescrapeBackToPick()"
                 :aria-label="t('showcase.rescrape.back_to_pick')"><i class="bi bi-x-lg"></i></button>
         <button type="button" class="rescrape-confirm-btn confirm" @click="rescrapeConfirm()"
                 :aria-label="t('showcase.rescrape.confirm')"><i class="bi bi-check-lg"></i></button>
+      </div>
+      {# search 入口：採用此版本單鈕（無不可逆警告，CD-86-9） #}
+      <div class="rescrape-confirm-row" x-show="rescrapeEntryPoint === 'search'">
+        <button type="button" class="rescrape-confirm-btn confirm" @click="rescrapeConfirm()"
+                x-text="t('showcase.rescrape.adopt_version')"></button>
       </div>
     </div>
 

--- a/web/templates/_rescrape_modal.html
+++ b/web/templates/_rescrape_modal.html
@@ -201,10 +201,10 @@
         <button type="button" class="rescrape-confirm-btn confirm" @click="rescrapeConfirm()"
                 :aria-label="t('showcase.rescrape.confirm')"><i class="bi bi-check-lg"></i></button>
       </div>
-      {# search 入口：採用此版本單鈕（無不可逆警告，CD-86-9） #}
+      {# search 入口：採用此版本單鈕（✓ icon，無不可逆警告，CD-86-9；86-T6 icon 化防破版） #}
       <div class="rescrape-confirm-row" x-show="rescrapeEntryPoint === 'search'">
         <button type="button" class="rescrape-confirm-btn confirm" @click="rescrapeConfirm()"
-                x-text="t('showcase.rescrape.adopt_version')"></button>
+                :aria-label="t('showcase.rescrape.adopt_version')"><i class="bi bi-check-lg" aria-hidden="true"></i></button>
       </div>
     </div>
 

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -299,7 +299,7 @@
                         variant='action',
                         icon='bi-stars',
                         extra_classes='search-auto-pill',
-                        attrs='x-show="isComposing()" x-cloak @click="openRescrape(null, \'search\'); rescrapeNumber = (searchQuery || \'\').trim()" :title="t(\'search.auto_pill.tooltip\')"'
+                        attrs='x-show="isComposing() || canReopenSourcePick()" x-cloak @click="openRescrape(null, \'search\'); rescrapeNumber = (searchQuery || \'\').trim()" :title="t(\'search.auto_pill.tooltip\')"'
                     ) }}
                     <button type="submit" id="btnSubmit" class="btn-icon active" title="{{ t('search.action.search') }}">
                         <i class="bi bi-arrow-right"></i>


### PR DESCRIPTION
## 概要

JavLibrary 同番號多版本手動切換（feature/86，spec-86）。AV 番號會被不同片商跨年代重複使用（如 `MIDV-013`：舊片 vs MOODYZ 新片），預設都抓到先收錄的舊片。本版讓使用者在 JavLibrary 看封面手動挑版本。

**範圍刻意極小**：僅 JavLibrary、僅手動入口、桌面 standalone 限定（需 CF transport）、不進批次、不揭露 AI。

## 功能

同番號多版本（撞號）時，預覽卡出現封面 `‹ ›` 切換器 + 琥珀「找到 X 部同番號作品 N/M」標示，游標預設停在**最新發行日**那部。三個手動入口都支援：

- **搜尋框直搜** → ✓「採用此版本」進結果區（不寫檔）
- **燈箱換來源** → ✓ 寫入選定版本 NFO/封面（保留不可逆警告）
- **結果卡替換來源** → ✓「替換此版本」就地替換當前卡（不寫檔）

## Task 拆分（10 task commits + pre-merge）

| Task | 內容 |
|------|------|
| T1 | scraper 同番號全版本列舉（`search_all_versions`/`fetch_by_detail_url`，新片優先）+ helper 抽取 |
| T2 | 後端 `/api/rescrape/preview` 回 `candidates[]` + `EnrichRequest.detail_url`（confirm server-side 重抓，不揭露 AI）|
| T3 | 前端 candidates 短狀態 + 三入口路由 + confirm 分流 |
| T4 | 切換器 partial + 不可逆 gate + i18n（zh_TW）|
| T5 | `core/scrapers/README.md` 手動版本切換 pending→done |
| T6 | 撞號提示琥珀色 + adopt 鈕 ✓ icon 化（真機驗收修正）|
| T7 | switch-source 多版本切換器（實作 spec-86 D7 follow-on，owner 授權反轉 Non-Goal）|
| fix | Codex P2×2（search 採用 query 同步 / file-mode 入口 gate）+ Gemini P1×1（番號前置邊界）|

## 測試

- 全套 pytest **4799 passed, 2 skipped**（unit + integration，排除 smoke/e2e；+52 vs 0.11.0）
- `ruff check .` + `npm run lint`（eslint + stylelint）綠
- 來源金絲雀 **8/8 PASS**（live）
- **Windows 真機驗收**：MIDV-013（3 版本）三入口切換器 + 採用皆通過
- Codex PR review P2×2 已修；Gemini 整支 branch 第二意見 P1×1 已修

🤖 Generated with [Claude Code](https://claude.com/claude-code)