### PR TITLE
feature/88: 唯讀來源生成本地媒體庫（off 風味, v0.11.3）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - 2026-07-01
+
+本版主軸：**唯讀來源生成本地媒體庫（off 風味）**（feature/88，spec-88）——為 scanner 來源新增「唯讀」模式：勾了就不寫回來源夾，改在你指定的本地輸出夾生成一個「每片一資料夾」的媒體庫（nfo + 封面 + 劇照），並直接寫進 DB。適合把影片放在唯讀網盤／NAS 共享／Alist 掛載（不能改名搬移）的人——OpenAver 讀來源、產出整理好的本地庫，來源一個 bit 都不動，之後在 OpenAver 就能瀏覽、串流播放雲端原檔。對雲端足跡極輕（只列目錄 + 真的點播才讀那一部）。接停更的 MDCX 的棒，但預設走純文字產物、零權限門檻。
+
+> media-server 風味（多吐 `.strm` 給 Emby/Jellyfin/Kodi 掃）＋一批 UI 調整延後至下一 branch（feature/89）；本版先交付 OpenAver 自瀏覽的完整體驗。
+
+### Added
+#### 🎯 唯讀來源 → 本地媒體庫生成（off 風味）
+- **每個 scanner 來源可勾「唯讀」＋設輸出夾**：勾唯讀後不寫回來源，按既有「產生」就對該來源刮削 metadata、線上下載封面/劇照，在輸出夾生成每片一資料夾（`-poster`/`-fanart` ＋ extrafanart），並寫進 DB（`path`＝雲端原始路徑、`cover_path`/劇照指本地）。OpenAver 立即可瀏覽、從 DB 串流播放雲端原檔，封面走本地。**來源零寫入、零讀圖**（只列目錄 + 真的點播才讀那一部）。
+- **手動增量、一鍵到底**：往雲盤丟新片後回 OpenAver 對該來源按「產生」，只處理新片（以 DB 為準跳過已生成的）；不背景輪詢雲盤（避免觸發網盤風控）。跑完顯示「新增／略過／刮不到／失敗」四數摘要。
+- **同番號多版本防撞**：同一番號的不同版本（各自獨立 `path`）各落入獨立子資料夾、不互相覆蓋。
+
+### Changed
+- **唯讀來源整理入口給明確提示**：對唯讀來源觸發「整理（搬移/改名）」時，回明確提示「此來源唯讀，請改用生成本地媒體庫」，而非靜默失敗（含 canonical `file:///` 輸入亦正確攔截）。
+- **產生完成通知反映來源失敗**：唯讀來源若整源無法存取，完成通知與 toast 走警告（不再誤報全部成功）。
+
+### Internal
+- 新增獨立 producer 服務 `core/readonly_producer.py`（全新 code surface，不重用/不碰既有搬檔 `organize_file` 與寫來源旁 `enrich_single`）；`GalleryConfig.directories` 由 `List[str]` 升級為帶 `readonly`/`output_path` 的 `DirectoryConfig`（`load_config` 加法式向後相容遷移，舊純字串 config 照常載入）＋集中存取 helper（所有 call site 走 helper，禁手寫型別判斷）；`generate_avlist` SSE 迴圈以 thread/queue 橋接 producer（worker 例外顯式接手、不靜默吞）；`/api/gallery/image` 白名單納入各來源輸出夾。DB schema／API 端點／capabilities 零變更。
+
+### 測試
+- 全套 pytest **5031 passed, 2 skipped**（unit + integration，排除 smoke/e2e，較 0.11.2 的 4848 +183：config schema/helper/向後相容遷移 + producer 列檔/增量跳過/防撞葉層/寫檔/upsert + SSE thread-queue 橋接/四數摘要/來源級例外契約 + image 白名單 + organize guard(含 file:/// 邊界) + off 風味端到端驗收）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（pre-merge live 健康檢查）。
+
 ## [0.11.2] - 2026-06-30
 
 本版主軸：**core/database.py 模組化拆分**（feature/87，spec-87）——把 2,152 行的單一 `core/database.py` 重構成 `core/database/` 套件，降低 AI 輔助編輯時的長 context 出錯率。**零行為變更、零使用者可見影響、零 API/schema/SQL 變動**。分兩階段：87a 純機械搬移、87b 消除兩個鏡像 repo 的重複碼。對外 `from core.database import X` 路徑字面不變（永久 facade）。

--- a/core/config.py
+++ b/core/config.py
@@ -556,6 +556,13 @@ def iter_gallery_sources(gallery_config) -> List[DirectoryConfig]:
     元素: str / dict / DirectoryConfig 皆可 —— 永久容忍裸 str（舊 config、測試 fixture）。
     回傳: List[DirectoryConfig]，呼叫端永遠拿到帶 .path/.readonly/.output_path 的物件。
     未知型別元素（如 42、None）跳過，不阻斷、不拋例外。
+
+    安全性：丟棄沒有「可用非空字串 path」的元素（缺 path / path=null / path=""
+    / path 非字串）。空 path 會被 to_file_uri('') 變成 'file:///'，而 file:/// 是
+    任意 file URI 的前綴 —— 會讓 image/video proxy allowlist、showcase 篩選、
+    settings-link 比對全部命中任意路徑（CWE-allowlist bypass）。故在這個讀取路徑
+    chokepoint 直接 skip。readonly / output_path 欄位型別不對（如 null）則容忍降級，
+    不讓單一髒元素拋 ValidationError 連坐所有 consumer。
     """
     if gallery_config is None:
         return []
@@ -567,14 +574,25 @@ def iter_gallery_sources(gallery_config) -> List[DirectoryConfig]:
     out: List[DirectoryConfig] = []
     for d in raw or []:
         if isinstance(d, DirectoryConfig):
-            out.append(d)
+            if d.path:
+                out.append(d)
         elif isinstance(d, str):
-            out.append(DirectoryConfig(path=d))
+            if d:
+                out.append(DirectoryConfig(path=d))
         elif isinstance(d, dict):
+            path = d.get('path')
+            if not isinstance(path, str) or not path:
+                continue  # 缺 path / null / 空 / 非字串 → skip（避免 file:/// allowlist 全命中）
+            readonly = d.get('readonly', False)
+            if not isinstance(readonly, bool):
+                readonly = False  # null / 型別錯誤 → 降級 False
+            output_path = d.get('output_path', '')
+            if not isinstance(output_path, str):
+                output_path = ''  # null / 型別錯誤 → 降級 ''
             out.append(DirectoryConfig(
-                path=d.get('path', ''),
-                readonly=d.get('readonly', False),
-                output_path=d.get('output_path', ''),
+                path=path,
+                readonly=readonly,
+                output_path=output_path,
             ))
         # 其他型別跳過（不阻斷）
     return out

--- a/core/config.py
+++ b/core/config.py
@@ -135,7 +135,17 @@ class DirectoryConfig(BaseModel):
 
 
 class GalleryConfig(BaseModel):
-    directories: List[str] = []
+    directories: List[DirectoryConfig] = []
+
+    @field_validator("directories", mode="before")
+    @classmethod
+    def _coerce_directories(cls, v):
+        """容忍三型元素：str（舊/測試 fixture）、dict（遷移後 raw）、DirectoryConfig。
+        裸 str → {"path": s}，其餘原樣交給 Pydantic 驗證。"""
+        if not isinstance(v, list):
+            return v
+        return [{"path": e} if isinstance(e, str) else e for e in v]
+
     output_dir: str = "output"
     output_filename: str = "gallery_output.html"
     path_mappings: dict = {}
@@ -223,6 +233,27 @@ def _load_config_unlocked() -> dict:
                 g['min_size_mb'] = int(round(g.get('min_size_kb', 0) / 1024))
                 del g['min_size_kb']
                 need_save = True
+
+        # Migration: gallery.directories 純字串 → DirectoryConfig 物件（feature/88）
+        # 加法式、冪等：已是完整 dict 的元素原樣保留；裸 str 升級成物件。
+        # 排在 avlist→gallery 遷移之後，確保 avlist 搬來的 directories 也被正規化。
+        if 'gallery' in raw_config and isinstance(raw_config['gallery'].get('directories'), list):
+            new_dirs = []
+            for d in raw_config['gallery']['directories']:
+                if isinstance(d, str):
+                    new_dirs.append({"path": d, "readonly": False, "output_path": ""})
+                    need_save = True
+                elif isinstance(d, dict):
+                    # 已是物件：補缺省欄位（向前相容未來新欄位）
+                    if 'readonly' not in d or 'output_path' not in d:
+                        d.setdefault('readonly', False)
+                        d.setdefault('output_path', "")
+                        need_save = True
+                    new_dirs.append(d)
+                # 其他型別（理論上不該出現）原樣保留，不阻斷載入
+                else:
+                    new_dirs.append(d)
+            raw_config['gallery']['directories'] = new_dirs
 
         # Migration: translate 扁平結構 -> 嵌套結構
         if 'translate' in raw_config:

--- a/core/config.py
+++ b/core/config.py
@@ -122,6 +122,18 @@ class TranslateConfig(BaseModel):
     ollama_model: Optional[str] = None
 
 
+class DirectoryConfig(BaseModel):
+    """Scanner 來源目錄設定（feature/88）。
+
+    舊 config 的 directories 是純字串清單；本模型把每個目錄升級為帶
+    readonly / output_path 的物件。load_config() 的加法式遷移負責 str → object（T-3
+    落地），iter_gallery_sources helper 則讓呼叫端永遠拿到帶欄位的物件（T-1 起）。
+    """
+    path: str                  # 來源路徑（FS 路徑或 file:/// URI）
+    readonly: bool = False     # 唯讀模式：不寫回來源（88b/88c 才實作生成分流）
+    output_path: str = ""      # 此來源的本地媒體庫輸出根目錄；空 = 未設定
+
+
 class GalleryConfig(BaseModel):
     directories: List[str] = []
     output_dir: str = "output"
@@ -501,3 +513,45 @@ def reset_config_file() -> None:
     with _config_write_lock:
         if CONFIG_PATH.exists():
             CONFIG_PATH.unlink()
+
+
+# ============ Gallery source helpers（feature/88, plan §3）============
+
+
+def iter_gallery_sources(gallery_config) -> List[DirectoryConfig]:
+    """把 gallery 設定的 directories 正規化成 DirectoryConfig 清單。
+
+    gallery_config: dict（load_config 回傳的 raw gallery 段）或 GalleryConfig 模型皆可。
+    元素: str / dict / DirectoryConfig 皆可 —— 永久容忍裸 str（舊 config、測試 fixture）。
+    回傳: List[DirectoryConfig]，呼叫端永遠拿到帶 .path/.readonly/.output_path 的物件。
+    未知型別元素（如 42、None）跳過，不阻斷、不拋例外。
+    """
+    if gallery_config is None:
+        return []
+    raw = (
+        gallery_config.get('directories', [])
+        if isinstance(gallery_config, dict)
+        else getattr(gallery_config, 'directories', [])
+    )
+    out: List[DirectoryConfig] = []
+    for d in raw or []:
+        if isinstance(d, DirectoryConfig):
+            out.append(d)
+        elif isinstance(d, str):
+            out.append(DirectoryConfig(path=d))
+        elif isinstance(d, dict):
+            out.append(DirectoryConfig(
+                path=d.get('path', ''),
+                readonly=d.get('readonly', False),
+                output_path=d.get('output_path', ''),
+            ))
+        # 其他型別跳過（不阻斷）
+    return out
+
+
+def get_gallery_source_paths(gallery_config) -> List[str]:
+    """只取來源 path 字串清單（給只關心路徑的舊 call site）。
+
+    行為與舊「純字串 directories 清單」逐位元等價。
+    """
+    return [d.path for d in iter_gallery_sources(gallery_config)]

--- a/core/database/video.py
+++ b/core/database/video.py
@@ -558,6 +558,22 @@ class VideoRepository:
         finally:
             conn.close()
 
+    def get_cover_index(self) -> dict:
+        """取得 {path: cover_path} 索引，供唯讀 producer 增量比對（feature/88）。
+
+        Additive read-only method; does NOT change get_mtime_index() shape (CD-88b-2).
+        cover_path may be '' or None for rows without a cover — callers must handle both.
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute("SELECT path, cover_path FROM videos")
+            rows = cursor.fetchall()
+            return {row[0]: row[1] for row in rows}
+        finally:
+            conn.close()
+
     def delete_by_paths(self, paths: List[str]) -> int:
         """批次刪除
 

--- a/core/db_inflow.py
+++ b/core/db_inflow.py
@@ -6,7 +6,7 @@ Search 頁整理完成後，條件式將影片寫入 DB（in-flow upsert）。
 """
 from __future__ import annotations
 
-from core.config import load_config
+from core.config import load_config, get_gallery_source_paths
 from core.database import Video, VideoRepository
 from core.gallery_scanner import VideoScanner
 from core.logger import get_logger
@@ -102,7 +102,6 @@ def try_inflow_upsert(
     try:
         config = load_config()
         gallery_cfg = config.get("gallery", {})
-        directories: list = gallery_cfg.get("directories", [])
         path_mappings: dict | None = gallery_cfg.get("path_mappings") or None
 
         # 步驟 2.5：算 old_uri（禁止手拼 file:///，依 CLAUDE.md 路徑規則）
@@ -113,7 +112,7 @@ def try_inflow_upsert(
             old_uri = to_file_uri(old_file_path, path_mappings)
 
         # 步驟 1：確認檔案在 Scanner 追蹤範圍內
-        matched = find_matched_directory(target_file_path, directories, path_mappings)
+        matched = find_matched_directory(target_file_path, get_gallery_source_paths(gallery_cfg), path_mappings)
         if matched is None:
             logger.debug(
                 "try_inflow_upsert: %r 不在任何 Scanner directory，skip",

--- a/core/path_utils.py
+++ b/core/path_utils.py
@@ -479,14 +479,18 @@ def is_path_under_dir(path: str, dir_uri: str) -> bool:
     prefix = dir_uri if dir_uri.endswith('/') else dir_uri + '/'
     return path.startswith(prefix)
 
-def coerce_to_file_uri(value: str) -> str:
+def coerce_to_file_uri(value: str, path_mappings: dict = None) -> str:
     """Idempotent file URI 轉換：value 可能是 FS path 或已是 file:/// URI。
 
     已是 file:/// 開頭→ 原樣回傳，否則 to_file_uri()。
     用於 DB cover_path / video.path 這類格式不確定的場合，避免在 caller 做 startswith 判斷。
+
+    Args:
+        value: FS path 或已是 file:/// URI。
+        path_mappings: 路徑映射表（WSL 環境用）；僅在 value 為 FS path 時傳入 to_file_uri。
     """
     if not value:
         return value
     if value.startswith("file:///"):
         return value
-    return to_file_uri(value)
+    return to_file_uri(value, path_mappings)

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -220,6 +220,21 @@ def _build_owners(cover_index: dict) -> dict:
     return owners
 
 
+def _producer_uris(repo) -> set:
+    """Return the set of ALL source_uris that already have a DB row.
+
+    A row for source_uri means the producer generated it on a prior run — even
+    when its cover_path is '' (cold title / cover download failed, which
+    _build_cover_index/_build_owners drop). _movie_dir uses this to reuse an
+    existing on-disk movie folder for such no-cover rows instead of treating it
+    as foreign and spawning a hashed sibling on every re-generate (Codex P2-1).
+
+    Reuses the same bulk query as _build_cover_index: get_cover_index() returns
+    all rows (cover-bearing or not), so this adds no per-file query.
+    """
+    return set(repo.get_cover_index())
+
+
 def _movie_leaf_base(number: str, source_uri: str) -> str:
     """Return the leaf directory name for a single movie. (plan §4.2 / card §5)
 
@@ -245,6 +260,7 @@ def _movie_dir(
     source_uri: str,
     config: dict,
     owners: dict,
+    producer_uris: set | None = None,
 ) -> Path:
     """Return the per-movie directory Path, registering source_uri in owners.
 
@@ -253,6 +269,18 @@ def _movie_dir(
     - If candidate exists on disk but is not in owners → treat as foreign, hash.
     - Idempotent: same source_uri → same dir (owner == source_uri → no hash).
     - owners is mutated in-place; callers pass a persistent dict across calls.
+
+    No-cover re-gen idempotency (Codex P2-1):
+    - `owners` is built from cover-bearing rows only (a no-cover row has cover_path=''
+      and is dropped by _build_cover_index). So on a re-generate, a folder this source
+      itself produced on a prior no-cover run is absent from `owners` and would be
+      mis-detected as `<foreign>` → hashed sibling every run.
+    - `producer_uris` is the set of source_uris that already have a DB row (cover-bearing
+      or not). When the on-disk candidate is not owned by a cover-bearing sibling but
+      THIS source_uri already has a DB row, the folder is our own prior output — the leaf
+      is deterministic from (number, source_uri), so the freshly-recomputed candidate IS
+      last run's folder. Treat it as owned-by-self (reuse in place, no hash). Genuinely
+      foreign folders (no DB row for this source) still hash.
     """
     parts = _folder_parts(format_data, config)
     leaf = _movie_leaf_base(format_data['number'], source_uri)
@@ -260,7 +288,12 @@ def _movie_dir(
 
     owner = owners.get(str(candidate))
     if owner is None and candidate.exists():
-        owner = "<foreign>"        # disk-orphan: not in owners but exists on disk
+        # Not claimed by a cover-bearing sibling. Reuse if it is our own prior
+        # (no-cover) output; otherwise treat as a foreign folder and hash.
+        if producer_uris and source_uri in producer_uris:
+            owner = source_uri
+        else:
+            owner = "<foreign>"    # disk-orphan: not in owners, not ours → foreign
 
     if owner not in (None, source_uri):
         h = hashlib.sha1(source_uri.encode()).hexdigest()[:8]
@@ -420,6 +453,8 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
 
     cover_index = _build_cover_index(repo, output_uri)
     owners = _build_owners(cover_index)
+    # All rows (incl. no-cover) so re-gen reuses its own folder, not a hashed sibling (P2-1).
+    producer_uris = _producer_uris(repo)
 
     files = _list_source_videos(source.path, set(DEFAULT_VIDEO_EXTENSIONS), _min_size_bytes(gallery))
 
@@ -448,7 +483,7 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
 
         try:
             fd = _format_data(meta, fi["path"], scraper_cfg)
-            movie_dir = _movie_dir(output_root, fd, src_uri, scraper_cfg, owners)
+            movie_dir = _movie_dir(output_root, fd, src_uri, scraper_cfg, owners, producer_uris)
             assets = _write_movie_assets(str(movie_dir), meta, fd, fi["path"], scraper_cfg)
             _upsert_db(repo, src_uri, fi, meta, assets, path_mappings)
             result.created += 1

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -1,0 +1,97 @@
+"""readonly_producer — T-1 skeleton: dataclasses + listing + incremental skip.
+
+Pure backend module. NO API, NO UI, NO frontend. (feature/88b)
+
+Canonical Decisions enforced here:
+  CD-88b-1: listing via fast_scan_directory only (CD-88b-1).
+  CD-88b-2: get_cover_index() is the additive read-only bulk query added to
+             VideoRepository; no shape change to get_mtime_index().
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from core.gallery_scanner import fast_scan_directory
+from core.logger import get_logger
+from core.path_utils import is_path_under_dir, normalize_path, uri_to_fs_path
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses (§1.1)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ProduceOutcome:
+    """Single-video result."""
+    source_uri: str
+    status: str           # "created" | "skipped" | "failed" | "no_scrape"
+    movie_dir: str = ""   # generated per-movie directory (FS path); empty on skip/fail
+    number: str = ""
+    error: str = ""
+
+
+@dataclass
+class ProduceResult:
+    """Aggregate result for one source (used by 88c to build SSE summary)."""
+    source_path: str
+    output_path: str
+    created: int = 0
+    skipped: int = 0
+    failed: int = 0
+    no_scrape: int = 0
+    aborted_reason: str = ""
+    outcomes: list = field(default_factory=list)  # List[ProduceOutcome]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (all independently unit-testable)
+# ---------------------------------------------------------------------------
+
+def _min_size_bytes(gallery_config: dict) -> int:
+    """Convert gallery.min_size_mb → bytes. Mirrors scanner.py:221."""
+    return int(gallery_config.get("min_size_mb", 0)) * 1024 * 1024
+
+
+def _list_source_videos(source_path: str, extensions: set, min_size_bytes: int) -> list[dict]:
+    """List video files under source_path. Delegates to fast_scan_directory (CD-88b-1).
+
+    Returns a list of dicts with keys: path, mtime, size, nfo_mtime.
+    nfo_mtime is ignored by this module (guard G1: no source-NFO reads).
+    """
+    fs_dir = normalize_path(source_path)
+    return fast_scan_directory(fs_dir, extensions, min_size_bytes)
+
+
+def _build_cover_index(repo, output_uri: str) -> dict:
+    """Return {source_uri: cover_path} filtered to rows where cover falls under output_uri.
+
+    Calls repo.get_cover_index() (bulk, avoids N+1).
+    Empty / None cover entries are excluded here; _should_skip has a redundant guard.
+    """
+    full = repo.get_cover_index()  # {path: cover_path}
+    return {
+        p: c
+        for p, c in full.items()
+        if c and is_path_under_dir(c, output_uri)
+    }
+
+
+def _should_skip(source_uri: str, output_uri: str, cover_index: dict) -> bool:
+    """B3/P2a three-condition skip predicate.
+
+    Returns True (skip) only when ALL of:
+      1. DB has a row for source_uri with a non-empty cover_path
+      2. cover_path falls under output_uri
+      3. The cover file actually exists on disk
+    Any condition missing → return False (rebuild).
+    """
+    cover = cover_index.get(source_uri)
+    if not cover:
+        return False                                        # no row / no cover → rebuild
+    if not is_path_under_dir(cover, output_uri):           # double-guard (cover_index already filtered)
+        return False
+    return Path(uri_to_fs_path(cover)).exists()            # physical file must exist

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -10,12 +10,24 @@ Canonical Decisions enforced here:
 
 from __future__ import annotations
 
+import hashlib
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from core.gallery_scanner import fast_scan_directory
 from core.logger import get_logger
+from core.organizer import (
+    _detect_suffixes,
+    _detect_vr_cluster,
+    _strip_num_prefixes,
+    format_string,
+    sanitize_filename,
+    truncate_title,
+    truncate_to_chars,
+)
 from core.path_utils import is_path_under_dir, normalize_path, uri_to_fs_path
+from core.scraper import normalize_number
 
 logger = get_logger(__name__)
 
@@ -95,3 +107,160 @@ def _should_skip(source_uri: str, output_uri: str, cover_index: dict) -> bool:
     if not is_path_under_dir(cover, output_uri):           # double-guard (cover_index already filtered)
         return False
     return Path(uri_to_fs_path(cover)).exists()            # physical file must exist
+
+
+# ---------------------------------------------------------------------------
+# T-2: naming + collision-avoidance helpers (pure functions, no I/O except
+#       Path.exists for orphan detection in _movie_dir)
+# ---------------------------------------------------------------------------
+
+def _format_data(meta: dict, source_fs_path: str, config: dict) -> dict:
+    """Build format_data dict from scraped meta (off-mode flavour).
+
+    Replicates organizer.py:859-877 (off branch):
+    - strip number prefixes from title
+    - truncate title to max_title_length
+    - detect suffix once (off: unfiltered suffix_keywords)
+
+    The same truncated title feeds both _folder_parts and _build_basename
+    so the two never drift (CD-88b-3 / Codex P2).
+    """
+    number = meta['number']
+    title = _strip_num_prefixes(meta.get('title', ''), number)
+    title = truncate_title(title, config.get('max_title_length', 50))
+    fd: dict = {
+        'number': number,
+        'title': title,
+        'actors': meta.get('actors', []),
+        'maker': meta.get('maker', ''),
+        'date': meta.get('date', ''),
+    }
+    fd['suffix'] = _detect_suffixes(
+        os.path.basename(source_fs_path),
+        config.get('suffix_keywords', []),
+    )
+    return fd
+
+
+def _folder_parts(format_data: dict, config: dict) -> list:
+    """Return folder layer strings (max 3) replicating organizer.py:915-933."""
+    layers = config.get('folder_layers') or [
+        p.strip()
+        for p in config.get('folder_format', '{num}').replace('\\', '/').split('/')
+        if p.strip()
+    ]
+    max_chars = min(config.get('max_filename_length', 60), 120)
+    parts = []
+    for layer in layers[:3]:
+        part = truncate_to_chars(format_string(layer, format_data, use_fallback=True), max_chars)
+        if part:
+            parts.append(part)
+    return parts
+
+
+def _build_basename(format_data: dict, source_fs_path: str, config: dict) -> str:
+    """Build filename stem (no extension) replicating organizer off-mode filename block.
+
+    Replicates organizer.py:936-971 (off branch):
+    - suffix taken from format_data['suffix'] (not recomputed)
+    - {suffix} two-pass protection when token present in template
+    - vr_tail appended last
+    - final cap to max_chars
+    - NO multipart / part_tail (off is no-op, CD-88b-3)
+    """
+    original_filename = os.path.basename(source_fs_path)
+    original_ext = os.path.splitext(source_fs_path)[1]
+
+    vr_cluster = _detect_vr_cluster(original_filename)
+    vr_tail = f'_{vr_cluster}' if vr_cluster else ''
+
+    # off mode: part_tail always ''
+    reserve = len(vr_tail)
+
+    max_filename_chars = min(config.get('max_filename_length', 60), 120)
+    max_chars = max_filename_chars - len(original_ext)
+
+    filename_template = config.get('filename_format', '{num} {title}')
+    suffix = format_data.get('suffix', '')
+
+    if suffix and '{suffix}' in filename_template:
+        no_suffix_data = dict(format_data, suffix='')
+        base_without_suffix = format_string(filename_template, no_suffix_data)
+        base_budget = max(0, max_chars - len(suffix) - reserve)
+        if base_budget == 0:
+            filename_base = truncate_to_chars(suffix, max(0, max_chars - reserve))
+        else:
+            base_without_suffix = truncate_to_chars(base_without_suffix, base_budget)
+            filename_base = base_without_suffix + suffix
+    else:
+        filename_base = format_string(filename_template, format_data)
+        filename_base = truncate_to_chars(filename_base, max(0, max_chars - reserve))
+
+    filename_base = filename_base + vr_tail
+    filename_base = truncate_to_chars(filename_base, max_chars)
+    return filename_base
+
+
+def _build_owners(cover_index: dict) -> dict:
+    """Build owners map {movie_dir_str: source_uri} from cover_index.
+
+    cover_index is {source_uri: cover_uri}. The parent of the cover file
+    is the movie_dir owned by that source. (plan §4.2)
+    """
+    owners: dict = {}
+    for src, cover in cover_index.items():
+        if cover:
+            movie_dir = str(Path(uri_to_fs_path(cover)).parent)
+            owners[movie_dir] = src
+    return owners
+
+
+def _movie_leaf_base(number: str, source_uri: str) -> str:
+    """Return the leaf directory name for a single movie. (plan §4.2 / card §5)
+
+    Four branches:
+    1. no stem          → number
+    2. stem IS number   → number   (normalised comparison)
+    3. stem CONTAINS number (case-insensitive) → stem   (already includes disambiguator)
+    4. otherwise        → "{number}-{stem}"
+    """
+    stem = sanitize_filename(Path(uri_to_fs_path(source_uri)).stem)
+    if not stem:
+        return number
+    if normalize_number(stem) == number:
+        return number
+    if number and number.upper() in stem.upper():
+        return stem
+    return f"{number}-{stem}"
+
+
+def _movie_dir(
+    output_root: str,
+    format_data: dict,
+    source_uri: str,
+    config: dict,
+    owners: dict,
+) -> Path:
+    """Return the per-movie directory Path, registering source_uri in owners.
+
+    Collision avoidance (CD-88b-4 / P2b):
+    - If candidate is already owned by a DIFFERENT source → append SHA-1 hash suffix.
+    - If candidate exists on disk but is not in owners → treat as foreign, hash.
+    - Idempotent: same source_uri → same dir (owner == source_uri → no hash).
+    - owners is mutated in-place; callers pass a persistent dict across calls.
+    """
+    parts = _folder_parts(format_data, config)
+    leaf = _movie_leaf_base(format_data['number'], source_uri)
+    candidate = Path(output_root, *parts, leaf)
+
+    owner = owners.get(str(candidate))
+    if owner is None and candidate.exists():
+        owner = "<foreign>"        # disk-orphan: not in owners but exists on disk
+
+    if owner not in (None, source_uri):
+        h = hashlib.sha1(source_uri.encode()).hexdigest()[:8]
+        leaf = f"{leaf}-{h}"
+        candidate = Path(output_root, *parts, leaf)
+
+    owners[str(candidate)] = source_uri
+    return candidate

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -310,9 +310,15 @@ def _write_movie_assets(
             if download_image(url, dest):
                 sample_fs.append(dest)
 
-    # 4) NFO — title/fields use full meta (not truncated format_data)
+    # 4) NFO — title/fields use full meta (not truncated format_data).
+    # NFO is a REQUIRED off-complete output: a write failure must NOT be silently
+    # treated as success (generate_nfo swallows its own I/O error and returns False).
+    # Raise so produce_source counts the item as failed and skips _upsert_db — DB never
+    # claims a movie was generated when the NFO is missing ("每片成功生成後寫一筆").
+    # Cover/poster/fanart stay best-effort: a missing cover is acceptable per C6
+    # (cold title with no image) and self-heals on the next incremental run.
     nfo_fs = base_stem + '.nfo'
-    generate_nfo(
+    nfo_ok = generate_nfo(
         number=meta['number'],
         title=meta['title'],
         actors=meta.get('actors', []),
@@ -331,6 +337,8 @@ def _write_movie_assets(
         rating=meta.get('_rating'),
         external_manager=config.get('external_manager', 'off'),
     )
+    if not nfo_ok:
+        raise RuntimeError(f"NFO write failed: {nfo_fs}")
     return {'cover_fs': cover_fs if has_cover else '', 'sample_fs': sample_fs}
 
 
@@ -445,9 +453,12 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
             _upsert_db(repo, src_uri, fi, meta, assets, path_mappings)
             result.created += 1
             _emit(on_progress, result, src_uri, "created", str(movie_dir), number)
-        except Exception as e:
+        except Exception:
             result.failed += 1
-            logger.warning("[readonly_producer] 生成失敗 %s: %s", src_uri, e)
-            _emit(on_progress, result, src_uri, "failed", number=number, error=str(e))
+            # Full detail + traceback to the log (error level, diagnosable);
+            # ProduceOutcome.error is the 88c SSE-bound field — use a fixed message
+            # (repo error policy) so raw exception text (paths, errno) never leaks.
+            logger.exception("[readonly_producer] 生成失敗: %s", src_uri)
+            _emit(on_progress, result, src_uri, "failed", number=number, error="生成失敗")
 
     return result

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -78,8 +78,13 @@ def _list_source_videos(source_path: str, extensions: set, min_size_bytes: int) 
 
     Returns a list of dicts with keys: path, mtime, size, nfo_mtime.
     nfo_mtime is ignored by this module (guard G1: no source-NFO reads).
+
+    source_path may be a native FS path OR a ``file:///`` URI (DirectoryConfig.path
+    accepts both per core/config.py schema). uri_to_fs_path is idempotent on FS-path
+    input and converts URI form to an FS path, so scanning works for both without a
+    hand-rolled ``startswith('file:///')`` check (path-contract compliant).
     """
-    fs_dir = normalize_path(source_path)
+    fs_dir = uri_to_fs_path(source_path)
     return fast_scan_directory(fs_dir, extensions, min_size_bytes)
 
 

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -31,7 +31,8 @@ from core.organizer import (
     truncate_to_chars,
 )
 from core.path_utils import is_path_under_dir, normalize_path, to_file_uri, uri_to_fs_path
-from core.scraper import normalize_number
+from core.scraper import extract_number, normalize_number, search_jav
+from core.video_extensions import DEFAULT_VIDEO_EXTENSIONS
 
 logger = get_logger(__name__)
 
@@ -366,3 +367,87 @@ def _upsert_db(
         nfo_mtime=0.0,
     )
     repo.upsert(v)
+
+
+# ---------------------------------------------------------------------------
+# T-4: _emit helper + produce_source orchestrator (plan §7)
+# ---------------------------------------------------------------------------
+
+def _emit(on_progress, result, source_uri, status, movie_dir="", number="", error=""):
+    """Append a ProduceOutcome to result.outcomes and fire on_progress callback."""
+    outcome = ProduceOutcome(
+        source_uri=source_uri,
+        status=status,
+        movie_dir=movie_dir,
+        number=number,
+        error=error,
+    )
+    result.outcomes.append(outcome)
+    if on_progress is not None:
+        on_progress(outcome)
+
+
+def produce_source(source, config, repo, *, proxy_url="", on_progress=None, should_abort=None) -> ProduceResult:
+    """Orchestrate per-source readonly generation: guard → list → skip → scrape → write → upsert.
+
+    Pure service layer. NO FastAPI, NO SSE, NO router. (CD-88b-8, §1.1)
+    Caller (88c) injects on_progress/should_abort for SSE streaming.
+    """
+    result = ProduceResult(source_path=source.path, output_path=source.output_path or "")
+
+    # G8/D7 guards (CD-88b-6 / Acceptance #11)
+    if not source.readonly:
+        result.aborted_reason = "not_readonly"
+        return result
+    if not (source.output_path or "").strip():
+        result.aborted_reason = "no_output_path"
+        return result
+
+    gallery = config.get("gallery", {})
+    scraper_cfg = config.get("scraper", {})
+    path_mappings = gallery.get("path_mappings", {})
+
+    output_root = normalize_path(source.output_path)
+    output_uri = to_file_uri(output_root, path_mappings)
+
+    cover_index = _build_cover_index(repo, output_uri)
+    owners = _build_owners(cover_index)
+
+    files = _list_source_videos(source.path, set(DEFAULT_VIDEO_EXTENSIONS), _min_size_bytes(gallery))
+
+    for fi in files:
+        if should_abort is not None and should_abort():
+            break
+
+        src_uri = to_file_uri(fi["path"], path_mappings)
+
+        if _should_skip(src_uri, output_uri, cover_index):
+            result.skipped += 1
+            _emit(on_progress, result, src_uri, "skipped")
+            continue
+
+        number = extract_number(os.path.basename(fi["path"]))  # Optional[str]
+        if not number:  # None guard (Codex P2b): search_jav(None) crashes
+            result.no_scrape += 1
+            _emit(on_progress, result, src_uri, "no_scrape")
+            continue
+
+        meta = search_jav(number, source="auto", proxy_url=proxy_url)
+        if not meta:
+            result.no_scrape += 1
+            _emit(on_progress, result, src_uri, "no_scrape")
+            continue
+
+        try:
+            fd = _format_data(meta, fi["path"], scraper_cfg)
+            movie_dir = _movie_dir(output_root, fd, src_uri, scraper_cfg, owners)
+            assets = _write_movie_assets(str(movie_dir), meta, fd, fi["path"], scraper_cfg)
+            _upsert_db(repo, src_uri, fi, meta, assets, path_mappings)
+            result.created += 1
+            _emit(on_progress, result, src_uri, "created", str(movie_dir), number)
+        except Exception as e:
+            result.failed += 1
+            logger.warning("[readonly_producer] 生成失敗 %s: %s", src_uri, e)
+            _emit(on_progress, result, src_uri, "failed", number=number, error=str(e))
+
+    return result

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -15,18 +15,22 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from core.database import Video
 from core.gallery_scanner import fast_scan_directory
 from core.logger import get_logger
 from core.organizer import (
     _detect_suffixes,
     _detect_vr_cluster,
     _strip_num_prefixes,
+    download_image,
     format_string,
+    generate_jellyfin_images,
+    generate_nfo,
     sanitize_filename,
     truncate_title,
     truncate_to_chars,
 )
-from core.path_utils import is_path_under_dir, normalize_path, uri_to_fs_path
+from core.path_utils import is_path_under_dir, normalize_path, to_file_uri, uri_to_fs_path
 from core.scraper import normalize_number
 
 logger = get_logger(__name__)
@@ -264,3 +268,101 @@ def _movie_dir(
 
     owners[str(candidate)] = source_uri
     return candidate
+
+
+# ---------------------------------------------------------------------------
+# T-3: write off-flavor assets + DB upsert (plan §5.2 / §6)
+# ---------------------------------------------------------------------------
+
+def _write_movie_assets(
+    movie_dir: str,
+    meta: dict,
+    format_data: dict,
+    source_fs_path: str,
+    config: dict,
+) -> dict:
+    """Write nfo + cover + -poster/-fanart + extrafanart to movie_dir.
+
+    Returns {'cover_fs': str, 'sample_fs': list[str]}.
+    cover_fs is '' when cover download fails or meta['cover'] is empty.
+    """
+    os.makedirs(movie_dir, exist_ok=True)
+    base = _build_basename(format_data, source_fs_path, config)
+    base_stem = str(Path(movie_dir) / base)
+
+    # 1) Cover: download from remote URL (C6 — always re-scrape, never read source image)
+    cover_fs = base_stem + '.jpg'
+    has_cover = bool(meta.get('cover')) and download_image(meta['cover'], cover_fs)
+
+    # 2) poster/fanart (off mode also produces these — Acceptance #6)
+    imgs = generate_jellyfin_images(cover_fs, base_stem) if has_cover else {}
+    has_poster = imgs.get('poster', False)
+    has_fanart = imgs.get('fanart', False)
+
+    # 3) extrafanart — gated only on config key; per-movie dir already exists (no create_folder)
+    sample_fs: list = []
+    if config.get('download_sample_images'):
+        ef_dir = Path(movie_dir) / 'extrafanart'
+        os.makedirs(ef_dir, exist_ok=True)
+        for i, url in enumerate(meta.get('sample_images', []), 1):
+            dest = str(ef_dir / f'fanart{i}.jpg')
+            if download_image(url, dest):
+                sample_fs.append(dest)
+
+    # 4) NFO — title/fields use full meta (not truncated format_data)
+    nfo_fs = base_stem + '.nfo'
+    generate_nfo(
+        number=meta['number'],
+        title=meta['title'],
+        actors=meta.get('actors', []),
+        tags=meta.get('tags', []),
+        date=meta.get('date', ''),
+        maker=meta.get('maker', ''),
+        url=meta.get('url', ''),
+        output_path=nfo_fs,
+        has_poster=has_poster,
+        has_fanart=has_fanart,
+        director=meta.get('director', ''),
+        duration=meta.get('duration'),
+        series=meta.get('series', ''),
+        label=meta.get('label', ''),
+        summary=meta.get('_summary', ''),
+        rating=meta.get('_rating'),
+        external_manager=config.get('external_manager', 'off'),
+    )
+    return {'cover_fs': cover_fs if has_cover else '', 'sample_fs': sample_fs}
+
+
+def _upsert_db(
+    repo,
+    source_uri: str,
+    file_info: dict,
+    meta: dict,
+    assets: dict,
+    path_mappings: dict,
+) -> None:
+    """Manually construct Video and upsert to repo (CD-88b-7).
+
+    path = source_uri (streaming key).
+    cover_path / sample_images = local output URIs (via to_file_uri).
+    user_tags intentionally omitted → upsert preserves existing DB value.
+    """
+    v = Video(
+        path=source_uri,
+        number=meta['number'],
+        title=meta['title'],
+        actresses=meta.get('actors', []),
+        maker=meta.get('maker', ''),
+        director=meta.get('director', ''),
+        series=meta.get('series') or None,
+        label=meta.get('label', ''),
+        tags=meta.get('tags', []),
+        sample_images=[to_file_uri(p, path_mappings) for p in assets['sample_fs']],
+        duration=meta.get('duration'),
+        size_bytes=file_info['size'],
+        cover_path=to_file_uri(assets['cover_fs'], path_mappings) if assets['cover_fs'] else '',
+        release_date=meta.get('date', ''),
+        mtime=file_info['mtime'],
+        nfo_mtime=0.0,
+    )
+    repo.upsert(v)

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -32,7 +32,7 @@ from core.organizer import (
 )
 from core.path_utils import is_path_under_dir, normalize_path, to_file_uri, uri_to_fs_path
 from core.scraper import extract_number, normalize_number, search_jav
-from core.video_extensions import DEFAULT_VIDEO_EXTENSIONS
+from core.video_extensions import get_video_extensions
 
 logger = get_logger(__name__)
 
@@ -421,7 +421,7 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
     cover_index = _build_cover_index(repo, output_uri)
     owners = _build_owners(cover_index)
 
-    files = _list_source_videos(source.path, set(DEFAULT_VIDEO_EXTENSIONS), _min_size_bytes(gallery))
+    files = _list_source_videos(source.path, get_video_extensions(config), _min_size_bytes(gallery))
 
     for fi in files:
         if should_abort is not None and should_abort():

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -220,21 +220,6 @@ def _build_owners(cover_index: dict) -> dict:
     return owners
 
 
-def _producer_uris(repo) -> set:
-    """Return the set of ALL source_uris that already have a DB row.
-
-    A row for source_uri means the producer generated it on a prior run — even
-    when its cover_path is '' (cold title / cover download failed, which
-    _build_cover_index/_build_owners drop). _movie_dir uses this to reuse an
-    existing on-disk movie folder for such no-cover rows instead of treating it
-    as foreign and spawning a hashed sibling on every re-generate (Codex P2-1).
-
-    Reuses the same bulk query as _build_cover_index: get_cover_index() returns
-    all rows (cover-bearing or not), so this adds no per-file query.
-    """
-    return set(repo.get_cover_index())
-
-
 def _movie_leaf_base(number: str, source_uri: str) -> str:
     """Return the leaf directory name for a single movie. (plan §4.2 / card §5)
 
@@ -260,7 +245,6 @@ def _movie_dir(
     source_uri: str,
     config: dict,
     owners: dict,
-    producer_uris: set | None = None,
 ) -> Path:
     """Return the per-movie directory Path, registering source_uri in owners.
 
@@ -269,18 +253,6 @@ def _movie_dir(
     - If candidate exists on disk but is not in owners → treat as foreign, hash.
     - Idempotent: same source_uri → same dir (owner == source_uri → no hash).
     - owners is mutated in-place; callers pass a persistent dict across calls.
-
-    No-cover re-gen idempotency (Codex P2-1):
-    - `owners` is built from cover-bearing rows only (a no-cover row has cover_path=''
-      and is dropped by _build_cover_index). So on a re-generate, a folder this source
-      itself produced on a prior no-cover run is absent from `owners` and would be
-      mis-detected as `<foreign>` → hashed sibling every run.
-    - `producer_uris` is the set of source_uris that already have a DB row (cover-bearing
-      or not). When the on-disk candidate is not owned by a cover-bearing sibling but
-      THIS source_uri already has a DB row, the folder is our own prior output — the leaf
-      is deterministic from (number, source_uri), so the freshly-recomputed candidate IS
-      last run's folder. Treat it as owned-by-self (reuse in place, no hash). Genuinely
-      foreign folders (no DB row for this source) still hash.
     """
     parts = _folder_parts(format_data, config)
     leaf = _movie_leaf_base(format_data['number'], source_uri)
@@ -288,12 +260,7 @@ def _movie_dir(
 
     owner = owners.get(str(candidate))
     if owner is None and candidate.exists():
-        # Not claimed by a cover-bearing sibling. Reuse if it is our own prior
-        # (no-cover) output; otherwise treat as a foreign folder and hash.
-        if producer_uris and source_uri in producer_uris:
-            owner = source_uri
-        else:
-            owner = "<foreign>"    # disk-orphan: not in owners, not ours → foreign
+        owner = "<foreign>"        # disk-orphan: not in owners but exists on disk
 
     if owner not in (None, source_uri):
         h = hashlib.sha1(source_uri.encode()).hexdigest()[:8]
@@ -453,8 +420,6 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
 
     cover_index = _build_cover_index(repo, output_uri)
     owners = _build_owners(cover_index)
-    # All rows (incl. no-cover) so re-gen reuses its own folder, not a hashed sibling (P2-1).
-    producer_uris = _producer_uris(repo)
 
     files = _list_source_videos(source.path, set(DEFAULT_VIDEO_EXTENSIONS), _min_size_bytes(gallery))
 
@@ -483,7 +448,7 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
 
         try:
             fd = _format_data(meta, fi["path"], scraper_cfg)
-            movie_dir = _movie_dir(output_root, fd, src_uri, scraper_cfg, owners, producer_uris)
+            movie_dir = _movie_dir(output_root, fd, src_uri, scraper_cfg, owners)
             assets = _write_movie_assets(str(movie_dir), meta, fd, fi["path"], scraper_cfg)
             _upsert_db(repo, src_uri, fi, meta, assets, path_mappings)
             result.created += 1

--- a/core/settings_link.py
+++ b/core/settings_link.py
@@ -11,6 +11,7 @@ from core.path_utils import (
     is_path_under_dir,
     normalize_path,
     to_file_uri,
+    uri_to_fs_path,
 )
 
 logger = get_logger(__name__)
@@ -48,10 +49,13 @@ def find_matched_directory(
     fav_normalized = normalize_path(fav_expanded)
     fav_uri = to_file_uri(fav_normalized, path_mappings)
 
-    # directories 端：normalize → to_file_uri（不 expand，CD-58-B1-3b）
+    # directories 端：uri_to_fs_path → to_file_uri（不 expand，CD-58-B1-3b）
+    # directory 可能是 FS 路徑或 file:/// URI（DirectoryConfig.path schema「FS 路徑或
+    # URI」）。uri_to_fs_path 對 URI→FS、FS→FS 皆冪等，取代裸 normalize_path（後者對
+    # URI 原樣通過 → to_file_uri 二次包成 file:///file:/// → 永不命中）(PR#91 同源)。
     for directory in directories:
         try:
-            d_normalized = normalize_path(directory)
+            d_normalized = uri_to_fs_path(directory)
             d_uri = to_file_uri(d_normalized, path_mappings)
         except (ValueError, Exception) as e:
             logger.warning("跳過無效 directory=%r: %s", directory, e)

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -517,6 +517,9 @@
       "empty_line1": "尚未加入任何資料夾",
       "empty_line2": "點擊上方按鈕或拖曳資料夾至此",
       "remove_title": "移除",
+      "readonly_label": "唯讀",
+      "output_path_label": "輸出到",
+      "output_path_placeholder": "本地媒體庫輸出夾路徑...",
       "output_prefix": "輸出:",
       "settings_link": "設定",
       "copy_path": "複製路徑"

--- a/tests/integration/test_api_gallery.py
+++ b/tests/integration/test_api_gallery.py
@@ -110,6 +110,56 @@ class TestImageProxyUNCAllowlist:
         assert response.status_code == 403
 
 
+class TestImageProxyOutputPath:
+    """TASK-88c-T1: /api/gallery/image 白名單納入各來源非空 output_path"""
+
+    def test_cover_under_output_path_allowed(self, client, tmp_path, mocker):
+        """封面在唯讀來源的 output_path 底下 → 200（原 403 → 現 200，Acceptance #16）"""
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cover = out_dir / "MOVIE-001" / "poster.jpg"
+        cover.parent.mkdir()
+        cover.write_bytes(b'\xff\xd8\xff\xe0' + b'\x00' * 50)  # JPEG magic
+
+        mocker.patch('web.routers.scanner.load_config', return_value={
+            'gallery': {
+                'directories': [
+                    {'path': str(src_dir), 'readonly': True, 'output_path': str(out_dir)},
+                ],
+                'path_mappings': {},
+            },
+        })
+
+        response = client.get('/api/gallery/image', params={'path': str(cover)})
+        assert response.status_code == 200
+        assert response.headers['content-type'] == 'image/jpeg'
+
+    def test_file_outside_output_path_still_403(self, client, tmp_path, mocker):
+        """檔案在 output_path 外、且不在任何 src.path 底下 → 403（守衛不退化）"""
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        cover = elsewhere / "poster.jpg"
+        cover.write_bytes(b'\xff\xd8\xff\xe0' + b'\x00' * 50)
+
+        mocker.patch('web.routers.scanner.load_config', return_value={
+            'gallery': {
+                'directories': [
+                    {'path': str(src_dir), 'readonly': True, 'output_path': str(out_dir)},
+                ],
+                'path_mappings': {},
+            },
+        })
+
+        response = client.get('/api/gallery/image', params={'path': str(cover)})
+        assert response.status_code == 403
+
+
 class TestImageProxyPathConversion:
     """測試圖片代理路徑轉換"""
 

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -1156,3 +1156,259 @@ class TestScanPruneThumbnailInvalidation:
         assert deleted_uri in called_args
         # 原樣 URI：未被再次包一層 to_file_uri（否則會變 file:////... 之類）
         assert to_file_uri(deleted_uri) not in called_args or to_file_uri(deleted_uri) == deleted_uri
+
+
+class TestGenerateReadonlyBridge:
+    """TASK-88c-T2 — generate_avlist readonly 分流 + SSE thread/queue 橋接 + 四數摘要。
+
+    mock patch target = web.routers.scanner.produce_source（T-2 import 落點）。
+    """
+
+    def _readonly_config(self, tmp_path, sources, proxy_url="http://proxy:8080"):
+        """組一份 config：sources 為 [(readonly, output_path 或 None), ...]。"""
+        output_dir = tmp_path / "html_out"
+        output_dir.mkdir(exist_ok=True)
+        directories = []
+        for i, (readonly, out) in enumerate(sources):
+            src_dir = tmp_path / f"src{i}"
+            src_dir.mkdir(exist_ok=True)
+            directories.append({
+                "path": str(src_dir),
+                "readonly": readonly,
+                "output_path": out if out is not None else "",
+            })
+        return {
+            "gallery": {
+                "directories": directories,
+                "output_dir": str(output_dir),
+                "path_mappings": {},
+                "min_size_mb": 0,
+            },
+            "search": {"proxy_url": proxy_url},
+            "general": {"theme": "light"},
+            "scraper": {"video_extensions": [".mp4"]},
+        }
+
+    def _result(self, tmp_path, **kw):
+        from core.readonly_producer import ProduceResult
+        out = str(tmp_path / "out")
+        return ProduceResult(source_path=str(tmp_path / "src0"), output_path=out, **kw)
+
+    # 1. 分流互斥（正向）：readonly → produce_source 呼叫一次，args + proxy_url kwarg 正確
+    def test_readonly_source_calls_produce_source_once(self, client, tmp_path, monkeypatch, mocker):
+        cfg = self._readonly_config(tmp_path, [(True, str(tmp_path / "out0"))])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mock_ps = mocker.patch("web.routers.scanner.produce_source",
+                               return_value=self._result(tmp_path))
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        assert mock_ps.call_count == 1
+        call = mock_ps.call_args
+        src_arg = call.args[0]
+        assert src_arg.readonly is True
+        assert src_arg.path == str(tmp_path / "src0")
+        # config + repo 位置參數
+        assert call.args[1] is cfg
+        from core.database import VideoRepository
+        assert isinstance(call.args[2], VideoRepository)
+        # proxy_url kwarg 正確傳入
+        assert call.kwargs["proxy_url"] == "http://proxy:8080"
+        assert call.kwargs["should_abort"] is None
+
+    # 2. 分流互斥（反向）：非 readonly → produce_source 未被呼叫
+    def test_non_readonly_does_not_call_produce_source(self, client, tmp_path, monkeypatch, mocker):
+        cfg = self._readonly_config(tmp_path, [(False, "")])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mock_ps = mocker.patch("web.routers.scanner.produce_source")
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        mock_ps.assert_not_called()
+
+    # 3. SSE 逐片橋接：on_progress 連發 3 outcome → SSE 出 3 條對應 log；sentinel 後續下一來源
+    def test_sse_per_outcome_streaming(self, client, tmp_path, monkeypatch, mocker, parse_sse_events):
+        from core.readonly_producer import ProduceOutcome
+        cfg = self._readonly_config(tmp_path, [
+            (True, str(tmp_path / "out0")),
+            (True, str(tmp_path / "out1")),
+        ])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+
+        def side_effect(source, config, repo, *, proxy_url="", on_progress=None, should_abort=None):
+            from core.readonly_producer import ProduceResult
+            if source.path == str(tmp_path / "src0"):
+                on_progress(ProduceOutcome(source_uri="uri1", status="created", number="ABC-001"))
+                on_progress(ProduceOutcome(source_uri="uri2", status="skipped", number="ABC-002"))
+                on_progress(ProduceOutcome(source_uri="uri3", status="failed", number="ABC-003", error="生成失敗"))
+                return ProduceResult(source_path=source.path, output_path=source.output_path,
+                                     created=1, skipped=1, failed=1)
+            return ProduceResult(source_path=source.path, output_path=source.output_path)
+
+        mock_ps = mocker.patch("web.routers.scanner.produce_source", side_effect=side_effect)
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+        msgs = [e.get("message", "") for e in events if e.get("type") == "log"]
+        assert any("✓ 生成" in m and "ABC-001" in m for m in msgs)
+        assert any("略過" in m and "ABC-002" in m for m in msgs)
+        assert any("✗ 失敗" in m and "ABC-003" in m for m in msgs)
+        # 第 2 來源也被處理（sentinel 後迴圈續跑）
+        assert mock_ps.call_count == 2
+
+    # 4. 四數摘要累計
+    def test_four_number_summary(self, client, tmp_path, monkeypatch, mocker, parse_sse_events):
+        cfg = self._readonly_config(tmp_path, [(True, str(tmp_path / "out0"))])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mocker.patch("web.routers.scanner.produce_source",
+                     return_value=self._result(tmp_path, created=2, skipped=1, no_scrape=1, failed=1))
+        resp = client.get("/api/gallery/generate")
+        events = parse_sse_events(resp.text)
+        done = [e for e in events if e.get("type") == "done"][-1]
+        rs = done["readonly_stats"]
+        assert rs["created"] == 2 and rs["skipped"] == 1
+        assert rs["no_scrape"] == 1 and rs["failed"] == 1
+        assert rs["sources"] == 1
+        # 該來源小結四數皆出現
+        msgs = [e.get("message", "") for e in events if e.get("type") == "log"]
+        assert any("新增 2" in m and "略過 1" in m and "刮不到 1" in m and "失敗 1" in m for m in msgs)
+
+    # 5. no_output_path 提示
+    def test_no_output_path_prompt(self, client, tmp_path, monkeypatch, mocker, parse_sse_events):
+        cfg = self._readonly_config(tmp_path, [(True, "")])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mocker.patch("web.routers.scanner.produce_source",
+                     return_value=self._result(tmp_path, aborted_reason="no_output_path"))
+        resp = client.get("/api/gallery/generate")
+        events = parse_sse_events(resp.text)
+        msgs = [e.get("message", "") for e in events if e.get("type") == "log"]
+        assert any("請先設定輸出夾" in m for m in msgs)
+        done = [e for e in events if e.get("type") == "done"][-1]
+        rs = done["readonly_stats"]
+        assert rs["no_output"] == 1
+        assert rs["created"] == 0 and rs["skipped"] == 0
+        assert rs["no_scrape"] == 0 and rs["failed"] == 0
+        assert rs["sources"] == 0
+
+    # 6. CRITICAL：source-level 例外傳遞 + 續跑
+    def test_source_level_exception_continues(self, client, tmp_path, monkeypatch, mocker, parse_sse_events):
+        from core.readonly_producer import ProduceResult
+        cfg = self._readonly_config(tmp_path, [
+            (True, str(tmp_path / "out0")),
+            (True, str(tmp_path / "out1")),
+        ])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+
+        def side_effect(source, config, repo, *, proxy_url="", on_progress=None, should_abort=None):
+            if source.path == str(tmp_path / "src0"):
+                raise ValueError("boom (迴圈前 normalize/列檔/DB 逃出)")
+            return ProduceResult(source_path=source.path, output_path=source.output_path, created=3)
+
+        mock_ps = mocker.patch("web.routers.scanner.produce_source", side_effect=side_effect)
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+        # error 事件（type=log, level=error）
+        errs = [e for e in events if e.get("type") == "log" and e.get("level") == "error"]
+        assert any("生成失敗" in e.get("message", "") for e in errs)
+        # source_errors 計數
+        done = [e for e in events if e.get("type") == "done"][-1]
+        assert done["readonly_stats"]["source_errors"] == 1
+        # 迴圈續跑：第二來源仍被呼叫 + 產出摘要
+        assert mock_ps.call_count == 2
+        assert done["readonly_stats"]["created"] == 3
+        assert done["readonly_stats"]["sources"] == 1
+
+    # 7. 跨 thread DB 寫入（回歸鎖，無 ProgrammingError）
+    def test_cross_thread_db_write(self, client, tmp_path, monkeypatch, mocker, parse_sse_events):
+        from core.database import init_db, VideoRepository, Video
+        from core.readonly_producer import ProduceResult
+        db_path = tmp_path / "test.db"
+        init_db(db_path)
+        mocker.patch("web.routers.scanner.get_db_path", return_value=db_path)
+        cfg = self._readonly_config(tmp_path, [(True, str(tmp_path / "out0"))])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+
+        written_uri = to_file_uri(str(tmp_path / "src0" / "worker_written.mp4"))
+
+        def side_effect(source, config, repo, *, proxy_url="", on_progress=None, should_abort=None):
+            # 在 worker frame 用傳入的 repo 寫一筆（per-call 連線）
+            repo.upsert(Video(path=written_uri, number="WK-001", title="worker",
+                              mtime=1.0, nfo_mtime=0.0))
+            return ProduceResult(source_path=source.path, output_path=source.output_path, created=1)
+
+        mocker.patch("web.routers.scanner.produce_source", side_effect=side_effect)
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+        assert [e for e in events if e.get("type") == "done"], "未收到 done event"
+        # 無 ProgrammingError → 寫入成功
+        check = VideoRepository(db_path)
+        assert written_uri in check.get_mtime_index()
+
+    # 8. deletion 安全（readonly continue 早於 deletion → 影片未被誤刪）
+    def test_readonly_video_not_deleted(self, client, tmp_path, monkeypatch, mocker, parse_sse_events):
+        from core.database import init_db, VideoRepository, Video
+        from core.readonly_producer import ProduceResult
+        db_path = tmp_path / "test.db"
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+        src_dir = tmp_path / "src0"
+        src_dir.mkdir()
+        out_dir = tmp_path / "out0"
+        out_dir.mkdir()
+        # RED-able mutation guard：磁碟上放一個「真實但不匹配」的影片檔，讓 normal-scan
+        # 路徑（若 readonly 分流被移除）的 all_files 非空、繞過 :369 空目錄短路 → deletion
+        # 區塊會真的跑。current_paths 只含 other.mp4，DB 預置的 movie.mp4（在同夾下、
+        # 但不在磁碟）就會被 delete_by_paths prune → 移除分流時本測試 RED。
+        (src_dir / "other.mp4").write_bytes(b"x" * 4096)  # 真實檔，掃得到、非 DB 預置那筆
+        # readonly-source 影片：path=來源 URI（movie.mp4，磁碟上不存在），cover 在 output_path 下
+        vid_uri = to_file_uri(str(src_dir / "movie.mp4"))
+        cover_uri = to_file_uri(str(out_dir / "movie" / "movie.jpg"))
+        repo.upsert(Video(path=vid_uri, number="RO-001", title="唯讀影片",
+                          cover_path=cover_uri, mtime=1.0, nfo_mtime=0.0))
+        assert vid_uri in repo.get_mtime_index()
+
+        cfg = {
+            "gallery": {
+                "directories": [{"path": str(src_dir), "readonly": True, "output_path": str(out_dir)}],
+                "output_dir": str(tmp_path / "html_out"),
+                "path_mappings": {},
+                "min_size_mb": 0,
+            },
+            "search": {"proxy_url": ""},
+            "general": {"theme": "light"},
+            "scraper": {"video_extensions": [".mp4"]},
+        }
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mocker.patch("web.routers.scanner.get_db_path", return_value=db_path)
+        # produce_source 空 result，不動 DB
+        mocker.patch("web.routers.scanner.produce_source",
+                     return_value=ProduceResult(source_path=str(src_dir), output_path=str(out_dir)))
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+        assert [e for e in events if e.get("type") == "done"], "未收到 done event"
+        # 未被誤刪
+        assert vid_uri in repo.get_mtime_index(), "readonly 來源影片被誤刪（deletion 未被 continue 繞過）"
+
+    # 9. UNC readonly 來源 → 分流早於 normalize，produce_source 被呼叫
+    def test_unc_readonly_source_reaches_producer(self, client, tmp_path, monkeypatch, mocker):
+        from core.readonly_producer import ProduceResult
+        unc = r"\\server\share"
+        cfg = {
+            "gallery": {
+                "directories": [{"path": unc, "readonly": True, "output_path": str(tmp_path / "out0")}],
+                "output_dir": str(tmp_path / "html_out"),
+                "path_mappings": {},
+                "min_size_mb": 0,
+            },
+            "search": {"proxy_url": ""},
+            "general": {"theme": "light"},
+            "scraper": {"video_extensions": [".mp4"]},
+        }
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mock_ps = mocker.patch("web.routers.scanner.produce_source",
+                               return_value=ProduceResult(source_path=unc, output_path=str(tmp_path / "out0")))
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        assert mock_ps.call_count == 1
+        assert mock_ps.call_args.args[0].path == unc

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -1412,3 +1412,32 @@ class TestGenerateReadonlyBridge:
         assert resp.status_code == 200
         assert mock_ps.call_count == 1
         assert mock_ps.call_args.args[0].path == unc
+
+    # 10. 88c-P2：來源級失敗 → 完成通知走 warn（非純 success）
+    def test_source_level_failure_completion_notif_is_warn(
+        self, client, tmp_path, monkeypatch, mocker, parse_sse_events
+    ):
+        """readonly 來源整源拋錯（source_errors>0）→ 最終完成通知必須是 warn/
+        scanner_done_with_errors，不可 success/scanner_done（Codex P2）。"""
+        cfg = self._readonly_config(tmp_path, [(True, str(tmp_path / "out0"))])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mocker.patch("web.routers.scanner.produce_source",
+                     side_effect=ValueError("boom（迴圈前逃出）"))
+        mock_notif = mocker.patch("web.routers.scanner._emit_notif")
+
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        # drain SSE 讓 generator 跑完（完成通知在 done 之前 emit）
+        parse_sse_events(resp.text)
+
+        # 完成通知（scanner_generate task_type，排除 scanner_started）
+        completion_calls = [
+            c for c in mock_notif.call_args_list
+            if c.kwargs.get("task_type") == "scanner_generate"
+            and c.args and c.args[1] != "notif.scanner_started"
+        ]
+        assert completion_calls, "未發出完成通知"
+        final = completion_calls[-1]
+        assert final.args[0] == "warn", f"完成通知應為 warn，實得 {final.args[0]}"
+        assert final.args[1] == "notif.scanner_done_with_errors"
+        assert "來源失敗" in final.kwargs.get("message", "")

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -1441,3 +1441,43 @@ class TestGenerateReadonlyBridge:
         assert final.args[0] == "warn", f"完成通知應為 warn，實得 {final.args[0]}"
         assert final.args[1] == "notif.scanner_done_with_errors"
         assert "來源失敗" in final.kwargs.get("message", "")
+
+    # 11. PR#91 ②：個別影片失敗（readonly failed>0, source_errors=0）→ 完成通知走 warn
+    def test_per_video_failure_completion_notif_is_warn(
+        self, client, tmp_path, monkeypatch, mocker, parse_sse_events
+    ):
+        """produce_source 未拋錯（source_errors=0）但回傳 failed>0（例如 NFO 寫入失敗）
+        → 完成通知仍須 warn/scanner_done_with_errors，不可純 success（PR#91 ②）。
+        no fix → failed-only 的完成通知會報 success，本測試 RED。"""
+        from core.readonly_producer import ProduceResult
+        cfg = self._readonly_config(tmp_path, [(True, str(tmp_path / "out0"))])
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: cfg)
+        mocker.patch(
+            "web.routers.scanner.produce_source",
+            return_value=ProduceResult(
+                source_path=str(tmp_path / "src0"),
+                output_path=str(tmp_path / "out0"),
+                created=1, failed=2,
+            ),
+        )
+        mock_notif = mocker.patch("web.routers.scanner._emit_notif")
+
+        resp = client.get("/api/gallery/generate")
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+
+        # readonly_stats 帶 failed=2、source_errors=0
+        done = [e for e in events if e.get("type") == "done"][-1]
+        assert done["readonly_stats"]["failed"] == 2
+        assert done["readonly_stats"]["source_errors"] == 0
+
+        completion_calls = [
+            c for c in mock_notif.call_args_list
+            if c.kwargs.get("task_type") == "scanner_generate"
+            and c.args and c.args[1] != "notif.scanner_started"
+        ]
+        assert completion_calls, "未發出完成通知"
+        final = completion_calls[-1]
+        assert final.args[0] == "warn", f"完成通知應為 warn，實得 {final.args[0]}"
+        assert final.args[1] == "notif.scanner_done_with_errors"
+        assert "2 部失敗" in final.kwargs.get("message", "")

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -127,6 +127,36 @@ class TestScannerAPI:
 
         assert response.status_code == 403
 
+    def test_get_video_output_path_not_allowed(self, client, tmp_path, monkeypatch):
+        """TASK-88c-T1 回歸鎖：唯讀來源 output_path 底下的影片 → /api/gallery/video 仍 403
+
+        證明 get_video call site 未被 88c-T1 波及（get_image 開放 output_path、
+        get_video 刻意不對稱，spec P1a 明令）。
+        """
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        video_file = out_dir / "test.mp4"
+        video_file.write_bytes(b'fake_video_content')
+
+        test_config = {
+            "gallery": {
+                "directories": [
+                    {"path": str(src_dir), "readonly": True, "output_path": str(out_dir)},
+                ],
+                "path_mappings": {},
+            },
+            "scraper": {"video_extensions": [".mp4"]},
+        }
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: test_config)
+
+        path_arg = to_file_uri(str(video_file))
+        response = client.get(f"/api/gallery/video?path={quote(path_arg)}")
+
+        assert response.status_code == 403
+        assert "不在允許的資料夾範圍內" in response.text
+
     def test_get_player_success(self, client):
         """測試 /api/gallery/player 回傳正確的 HTML"""
         video_path = to_file_uri("C:/videos/test.mp4")

--- a/tests/integration/test_readonly_offflavor_e2e.py
+++ b/tests/integration/test_readonly_offflavor_e2e.py
@@ -1,0 +1,400 @@
+"""TASK-88c-T4: off-flavor readonly end-to-end acceptance.
+
+Full-stack integration test wiring T-1 (`/api/gallery/image` output_path
+whitelist) + T-2 (`generate_avlist` readonly branch + SSE bridge) + 88b
+(`produce_source` real run). Runs the REAL `produce_source` via
+`GET /api/gallery/generate`; only the producer's four external side-effects are
+mocked at ``core.readonly_producer.*`` (their import landing point):
+
+    search_jav / download_image / generate_jellyfin_images / generate_nfo
+
+The mock side-effects WRITE REAL FILES so the on-disk media-library structure
+can be asserted. `produce_source`, `_movie_dir` collision-avoidance, `_upsert_db`,
+the SSE thread/queue bridge, and the image-proxy whitelist all run for real
+against a real tmp output dir and a real tmp sqlite DB.
+
+Acceptance §6 items covered here: 1, 5, 6, 7, 13, 16, 17 (+ incremental idempotency).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from core.database import VideoRepository
+from core.path_utils import to_file_uri, uri_to_fs_path
+
+# Baseline `videos` schema (Acceptance #7 — no new columns from 88b write path).
+_BASELINE_VIDEO_COLUMNS = {
+    "id", "path", "number", "title", "original_title", "actresses", "maker",
+    "director", "series", "label", "tags", "sample_images", "user_tags",
+    "duration", "size_bytes", "cover_path", "release_date", "mtime", "nfo_mtime",
+    "created_at", "updated_at",
+}
+
+_FAKE_COVER_BYTES = b"\xff\xd8\xff\xe0FAKE-COVER-JPEG"
+_FAKE_IMG_BYTES = b"\xff\xd8\xff\xe0FAKE-IMG"
+
+
+# ---------------------------------------------------------------------------
+# Mock side-effects (write real files) — the contract that makes the on-disk
+# acceptance assertions meaningful (card §"mock 必須寫真檔").
+# ---------------------------------------------------------------------------
+
+def _fake_search_jav(number, source="auto", proxy_url=""):
+    """Return a scraped-meta dict per number. NO network."""
+    return {
+        "number": number,
+        "title": f"Title {number}",
+        "actors": ["Actress A", "Actress B"],
+        "cover": f"http://fake.local/{number}/cover.jpg",  # non-empty → triggers cover download
+        "sample_images": [
+            f"http://fake.local/{number}/s1.jpg",
+            f"http://fake.local/{number}/s2.jpg",
+        ],
+        "tags": ["Tag1", "Tag2"],
+        "date": "2024-01-01",
+        "maker": "FakeMaker",
+    }
+
+
+def _fake_download_image(url, dest):
+    """side_effect: actually create `dest` (cover or extrafanart) + return True."""
+    p = Path(dest)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(_FAKE_COVER_BYTES)
+    return True
+
+
+def _fake_generate_jellyfin_images(cover_fs, base_stem):
+    """side_effect: create `<base_stem>-poster.jpg` + `-fanart.jpg` + return dict."""
+    Path(base_stem + "-poster.jpg").write_bytes(_FAKE_IMG_BYTES)
+    Path(base_stem + "-fanart.jpg").write_bytes(_FAKE_IMG_BYTES)
+    return {"poster": True, "fanart": True}
+
+
+def _fake_generate_nfo(**kwargs):
+    """side_effect: create the nfo file (minimal XML) + return True.
+
+    producer calls generate_nfo(..., output_path=nfo_fs, ...) entirely by keyword.
+    """
+    dest = kwargs["output_path"]
+    Path(dest).write_text(
+        f"<movie><title>{kwargs.get('title', '')}</title>"
+        f"<num>{kwargs.get('number', '')}</num></movie>",
+        encoding="utf-8",
+    )
+    return True
+
+
+def _install_producer_mocks(monkeypatch):
+    """Patch the four externals at their producer import landing point.
+
+    Target MUST be ``core.readonly_producer.*`` (the import landing point), NOT
+    ``core.organizer.*`` / ``core.scraper.*`` — patching the source modules would
+    miss the already-bound references and let real network/IO run (§8 risk 6).
+    """
+    monkeypatch.setattr("core.readonly_producer.search_jav", _fake_search_jav)
+    monkeypatch.setattr("core.readonly_producer.download_image", _fake_download_image)
+    monkeypatch.setattr("core.readonly_producer.generate_jellyfin_images", _fake_generate_jellyfin_images)
+    monkeypatch.setattr("core.readonly_producer.generate_nfo", _fake_generate_nfo)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _make_source_dir(base: Path, name: str, numbers: list[str]) -> Path:
+    """Create a source dir with one tiny fake .mp4 per number."""
+    d = base / name
+    d.mkdir(parents=True, exist_ok=True)
+    for num in numbers:
+        (d / f"{num}.mp4").write_bytes(b"FAKE-VIDEO-BYTES")
+    return d
+
+
+def _make_config(sources: list[dict], html_out: Path, download_samples: bool = False) -> dict:
+    """Build a readonly + off-flavor gallery config with the given sources.
+
+    Each `sources` element: {"path": str, "output_path": str, "readonly": bool}.
+    folder_layers=[] → per-movie subdir is the movie leaf directly under output_root.
+    """
+    return {
+        "gallery": {
+            "directories": sources,
+            "path_mappings": {},
+            "min_size_mb": 0,
+            "output_dir": str(html_out),  # absolute → stays out of the repo tree
+            "output_filename": "gallery_output.html",
+        },
+        "scraper": {
+            "external_manager": "off",
+            "folder_layers": [],
+            "folder_format": "",
+            "filename_format": "{num}",
+            "max_title_length": 50,
+            "max_filename_length": 60,
+            "suffix_keywords": [],
+            "download_sample_images": download_samples,
+        },
+        "search": {"proxy_url": ""},
+        "general": {"theme": "light"},
+    }
+
+
+def _wire(monkeypatch, config: dict, db_path: Path):
+    """Patch load_config + get_db_path in the scanner router; install producer mocks."""
+    monkeypatch.setattr("web.routers.scanner.load_config", lambda: config)
+    monkeypatch.setattr("web.routers.scanner.get_db_path", lambda: db_path)
+    _install_producer_mocks(monkeypatch)
+
+
+def _snapshot(root: Path) -> dict:
+    """Recursive {relpath: (size, mtime_ns)} snapshot for zero-write diffing."""
+    snap: dict = {}
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            fp = Path(dirpath) / f
+            st = fp.stat()
+            snap[str(fp.relative_to(root))] = (st.st_size, st.st_mtime_ns)
+    return snap
+
+
+def _all_extensions(root: Path) -> set[str]:
+    exts: set[str] = set()
+    for _dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            exts.add(os.path.splitext(f)[1].lower())
+    return exts
+
+
+def _run_generate(client, parse_sse_events):
+    resp = client.get("/api/gallery/generate")
+    assert resp.status_code == 200
+    return parse_sse_events(resp.text)
+
+
+def _done_event(events: list) -> dict:
+    for e in events:
+        if e.get("type") == "done":
+            return e
+    raise AssertionError("no done event in SSE stream")
+
+
+# ---------------------------------------------------------------------------
+# Case 1/5/6/7/13/16: happy path (single source, ~5 movies, samples ON)
+# ---------------------------------------------------------------------------
+
+class TestOffFlavorHappyPath:
+    def _setup(self, tmp_path, monkeypatch, download_samples=True):
+        numbers = ["ABC-001", "ABC-002", "ABC-003", "ABC-004", "ABC-005"]
+        src = _make_source_dir(tmp_path / "src", "movies", numbers)
+        output = tmp_path / "output"
+        output.mkdir()
+        html_out = tmp_path / "htmlout"
+        db_path = tmp_path / "test.db"
+        config = _make_config(
+            [{"path": str(src), "output_path": str(output), "readonly": True}],
+            html_out,
+            download_samples=download_samples,
+        )
+        _wire(monkeypatch, config, db_path)
+        return numbers, src, output, db_path
+
+    def test_per_movie_assets_and_no_strm(self, tmp_path, monkeypatch, client, parse_sse_events):
+        """#5/#6: each movie → subdir with .nfo + cover + -poster + -fanart + extrafanart; NO .strm."""
+        numbers, src, output, db_path = self._setup(tmp_path, monkeypatch)
+        _run_generate(client, parse_sse_events)
+
+        for num in numbers:
+            movie_dir = output / num
+            assert movie_dir.is_dir(), f"missing movie dir for {num}"
+            assert (movie_dir / f"{num}.nfo").exists(), f"missing nfo {num}"
+            assert (movie_dir / f"{num}.jpg").exists(), f"missing cover {num}"
+            assert (movie_dir / f"{num}-poster.jpg").exists(), f"missing poster {num}"
+            assert (movie_dir / f"{num}-fanart.jpg").exists(), f"missing fanart {num}"
+            # samples ON → extrafanart/fanart1.jpg
+            assert (movie_dir / "extrafanart" / "fanart1.jpg").exists(), f"missing extrafanart {num}"
+
+        # Acceptance #5: off-flavor produces NO .strm anywhere under output.
+        assert ".strm" not in _all_extensions(output)
+
+    def test_db_path_cover_sample_pointers(self, tmp_path, monkeypatch, client, parse_sse_events):
+        """#6: DB path == source URI; cover_path/sample_images under output_path."""
+        numbers, src, output, db_path = self._setup(tmp_path, monkeypatch)
+        _run_generate(client, parse_sse_events)
+
+        repo = VideoRepository(str(db_path))
+        output_uri = to_file_uri(str(output), {})
+        for num in numbers:
+            src_uri = to_file_uri(str(src / f"{num}.mp4"), {})
+            v = repo.get_by_path(src_uri)
+            assert v is not None, f"no DB row for {num}"
+            assert v.path == src_uri  # streaming key = source URI
+            assert v.cover_path.startswith(output_uri), f"cover not under output: {v.cover_path}"
+            assert v.sample_images, f"expected samples for {num}"
+            for s in v.sample_images:
+                assert s.startswith(output_uri), f"sample not under output: {s}"
+
+    def test_schema_no_new_columns(self, tmp_path, monkeypatch, client, parse_sse_events):
+        """#7: videos table column set unchanged (no schema drift from 88b write path)."""
+        numbers, src, output, db_path = self._setup(tmp_path, monkeypatch)
+        _run_generate(client, parse_sse_events)
+
+        repo = VideoRepository(str(db_path))
+        conn = repo._get_connection()
+        try:
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(videos)")}
+        finally:
+            conn.close()
+        assert cols == _BASELINE_VIDEO_COLUMNS
+
+    def test_source_dir_zero_write(self, tmp_path, monkeypatch, client, parse_sse_events):
+        """#1: source dir recursive snapshot identical before/after generate."""
+        numbers, src, output, db_path = self._setup(tmp_path, monkeypatch)
+        before = _snapshot(src)
+        _run_generate(client, parse_sse_events)
+        after = _snapshot(src)
+        assert before == after, "source directory was modified (zero-write violated)"
+
+    def test_sse_readonly_stats_four_numbers(self, tmp_path, monkeypatch, client, parse_sse_events):
+        """#13: done event readonly_stats four numbers match landed movie count."""
+        numbers, src, output, db_path = self._setup(tmp_path, monkeypatch)
+        events = _run_generate(client, parse_sse_events)
+        stats = _done_event(events)["readonly_stats"]
+
+        # actual landed = per-movie subdirs that contain an nfo
+        landed = sum(1 for num in numbers if (output / num / f"{num}.nfo").exists())
+        assert landed == len(numbers)
+        assert stats["created"] == landed
+        assert stats["skipped"] == 0
+        assert stats["no_scrape"] == 0
+        assert stats["failed"] == 0
+
+    def test_cover_via_image_proxy_200_and_bytes(self, tmp_path, monkeypatch, client, parse_sse_events):
+        """#16 (chains T-1): DB cover_path → /api/gallery/image → 200 + real bytes; outside → 403."""
+        numbers, src, output, db_path = self._setup(tmp_path, monkeypatch)
+        _run_generate(client, parse_sse_events)
+
+        repo = VideoRepository(str(db_path))
+        src_uri = to_file_uri(str(src / f"{numbers[0]}.mp4"), {})
+        cover_uri = repo.get_by_path(src_uri).cover_path
+        # frontend/showcase convention: proxy receives the fs path (file:/// stripped)
+        cover_fs = uri_to_fs_path(cover_uri)
+
+        r = client.get("/api/gallery/image", params={"path": cover_fs})
+        assert r.status_code == 200, r.text
+        assert r.content == _FAKE_COVER_BYTES
+
+        # Reverse lock: a .jpg outside any source/output dir → 403 (whitelist not degraded).
+        outside = tmp_path / "outside" / "x.jpg"
+        outside.parent.mkdir()
+        outside.write_bytes(_FAKE_COVER_BYTES)
+        r403 = client.get("/api/gallery/image", params={"path": str(outside)})
+        assert r403.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Case: samples OFF (gated extrafanart behavior)
+# ---------------------------------------------------------------------------
+
+def test_samples_off_no_extrafanart(tmp_path, monkeypatch, client, parse_sse_events):
+    """download_sample_images=False → no extrafanart dir, DB sample_images empty."""
+    numbers = ["DEF-010", "DEF-011"]
+    src = _make_source_dir(tmp_path / "src", "movies", numbers)
+    output = tmp_path / "output"
+    output.mkdir()
+    db_path = tmp_path / "test.db"
+    config = _make_config(
+        [{"path": str(src), "output_path": str(output), "readonly": True}],
+        tmp_path / "htmlout",
+        download_samples=False,
+    )
+    _wire(monkeypatch, config, db_path)
+    _run_generate(client, parse_sse_events)
+
+    repo = VideoRepository(str(db_path))
+    for num in numbers:
+        assert (output / num / f"{num}.nfo").exists()
+        assert not (output / num / "extrafanart").exists()
+        src_uri = to_file_uri(str(src / f"{num}.mp4"), {})
+        assert repo.get_by_path(src_uri).sample_images == []
+
+
+# ---------------------------------------------------------------------------
+# Case 17: same-number across two sources → two distinct leaf subdirs
+# ---------------------------------------------------------------------------
+
+def test_same_number_two_sources_collision(tmp_path, monkeypatch, client, parse_sse_events):
+    """#17: two readonly sources each with ABC-123.mp4 → two non-overwriting leaf dirs."""
+    src_a = _make_source_dir(tmp_path / "srcA", "a", ["ABC-123"])
+    src_b = _make_source_dir(tmp_path / "srcB", "b", ["ABC-123"])
+    output = tmp_path / "output"
+    output.mkdir()
+    db_path = tmp_path / "test.db"
+    config = _make_config(
+        [
+            {"path": str(src_a), "output_path": str(output), "readonly": True},
+            {"path": str(src_b), "output_path": str(output), "readonly": True},
+        ],
+        tmp_path / "htmlout",
+    )
+    _wire(monkeypatch, config, db_path)
+    events = _run_generate(client, parse_sse_events)
+
+    # Two distinct leaf subdirs under output_root, both named ABC-123*
+    leaf_dirs = sorted(p.name for p in output.iterdir() if p.is_dir())
+    abc_dirs = [d for d in leaf_dirs if d.startswith("ABC-123")]
+    assert len(abc_dirs) == 2, f"expected 2 distinct leaf dirs, got {abc_dirs}"
+    assert "ABC-123" in abc_dirs
+    hashed = [d for d in abc_dirs if d != "ABC-123"]
+    assert len(hashed) == 1 and hashed[0].startswith("ABC-123-"), abc_dirs
+
+    # Each complete + non-overwriting (distinct dirs, each with its own nfo + cover).
+    # Filenames are derived from the number ("{num}" template), not the (hashed) leaf dir.
+    for d in abc_dirs:
+        assert (output / d / "ABC-123.nfo").exists(), f"missing nfo in {d}"
+        assert (output / d / "ABC-123.jpg").exists(), f"missing cover in {d}"
+
+    stats = _done_event(events)["readonly_stats"]
+    assert stats["created"] == 2
+
+    # Both source URIs present in DB, pointing at distinct output covers.
+    repo = VideoRepository(str(db_path))
+    uri_a = to_file_uri(str(src_a / "ABC-123.mp4"), {})
+    uri_b = to_file_uri(str(src_b / "ABC-123.mp4"), {})
+    va, vb = repo.get_by_path(uri_a), repo.get_by_path(uri_b)
+    assert va is not None and vb is not None
+    assert va.cover_path != vb.cover_path
+
+
+# ---------------------------------------------------------------------------
+# Case (bonus): incremental idempotency
+# ---------------------------------------------------------------------------
+
+def test_incremental_idempotent(tmp_path, monkeypatch, client, parse_sse_events):
+    """Run generate twice → second run all skipped, output not rewritten, DB row count stable."""
+    numbers = ["GHI-020", "GHI-021", "GHI-022"]
+    src = _make_source_dir(tmp_path / "src", "movies", numbers)
+    output = tmp_path / "output"
+    output.mkdir()
+    db_path = tmp_path / "test.db"
+    config = _make_config(
+        [{"path": str(src), "output_path": str(output), "readonly": True}],
+        tmp_path / "htmlout",
+    )
+    _wire(monkeypatch, config, db_path)
+
+    events1 = _run_generate(client, parse_sse_events)
+    assert _done_event(events1)["readonly_stats"]["created"] == len(numbers)
+
+    out_snap = _snapshot(output)
+    repo = VideoRepository(str(db_path))
+    count1 = repo.count()
+
+    events2 = _run_generate(client, parse_sse_events)
+    stats2 = _done_event(events2)["readonly_stats"]
+    assert stats2["created"] == 0
+    assert stats2["skipped"] == len(numbers)
+
+    assert _snapshot(output) == out_snap, "output rewritten on idempotent re-run"
+    assert VideoRepository(str(db_path)).count() == count1

--- a/tests/integration/test_readonly_offflavor_e2e.py
+++ b/tests/integration/test_readonly_offflavor_e2e.py
@@ -398,3 +398,93 @@ def test_incremental_idempotent(tmp_path, monkeypatch, client, parse_sse_events)
 
     assert _snapshot(output) == out_snap, "output rewritten on idempotent re-run"
     assert VideoRepository(str(db_path)).count() == count1
+
+
+# ---------------------------------------------------------------------------
+# PR#91 P2-D: DirectoryConfig.path as a file:/// URI (schema「FS 路徑或 URI」).
+# A URI source path must be handled idempotently everywhere it is converted:
+#   - generate_avlist configured_dir_uris (post-loop) → readonly rows must NOT
+#     be double-wrapped-and-filtered out of the generated gallery list.
+#   - get_video / get_image allowlists (_dir_candidate_forms) → a file under a
+#     URI source must PASS (not 403 from a file:///file:/// double-wrap).
+# RED against the pre-fix code (to_file_uri / normalize_path on a URI input).
+# ---------------------------------------------------------------------------
+
+class TestUriSourcePathIdempotent:
+    def test_readonly_rows_appear_in_generated_list_uri_source(
+        self, tmp_path, monkeypatch, client, parse_sse_events
+    ):
+        """URI source path → readonly-generated rows land in the gallery list.
+
+        done.video_count is the DB row set filtered by configured_dir_uris; the
+        pre-fix double-wrap (to_file_uri('file:///…') = 'file:///file:///…')
+        filters every readonly row out → video_count == 0 (RED).
+        """
+        numbers = ["URI-001", "URI-002", "URI-003"]
+        src = _make_source_dir(tmp_path / "src", "movies", numbers)
+        output = tmp_path / "output"
+        output.mkdir()
+        db_path = tmp_path / "test.db"
+        # Source `path` stored as a file:/// URI (not an FS path).
+        config = _make_config(
+            [{"path": to_file_uri(str(src), {}), "output_path": str(output), "readonly": True}],
+            tmp_path / "htmlout",
+        )
+        _wire(monkeypatch, config, db_path)
+
+        events = _run_generate(client, parse_sse_events)
+        done = _done_event(events)
+
+        # readonly producer still created every movie (source scanning already
+        # URI-safe via _list_source_videos), ...
+        assert done["readonly_stats"]["created"] == len(numbers)
+        # ... and the post-loop configured_dir_uris filter keeps them in the list.
+        assert done["video_count"] == len(numbers)
+
+    def test_video_proxy_allows_file_under_uri_source(self, tmp_path, monkeypatch, client):
+        """A video under a URI-form source dir passes the get_video allowlist (not 403)."""
+        from urllib.parse import quote
+
+        src = _make_source_dir(tmp_path / "src", "movies", ["URI-100"])
+        video_file = src / "URI-100.mp4"
+
+        test_config = {
+            "gallery": {
+                "directories": [to_file_uri(str(src), {})],  # URI source path
+                "path_mappings": {},
+            },
+            "scraper": {"video_extensions": [".mp4"]},
+        }
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: test_config)
+
+        path_arg = to_file_uri(str(video_file), {})
+        resp = client.get(f"/api/gallery/video?path={quote(path_arg)}")
+        assert resp.status_code == 200, resp.text
+        assert resp.content == b"FAKE-VIDEO-BYTES"
+
+    def test_image_proxy_allows_file_under_uri_source(self, tmp_path, monkeypatch, client):
+        """A cover under a URI-form source dir passes the get_image allowlist (not 403);
+        an outside .jpg still 403 (whitelist not degraded)."""
+        src = tmp_path / "src"
+        src.mkdir()
+        cover = src / "cover.jpg"
+        cover.write_bytes(_FAKE_COVER_BYTES)
+
+        test_config = {
+            "gallery": {
+                "directories": [{"path": to_file_uri(str(src), {}), "output_path": ""}],
+                "path_mappings": {},
+            },
+            "scraper": {},
+        }
+        monkeypatch.setattr("web.routers.scanner.load_config", lambda: test_config)
+
+        r = client.get("/api/gallery/image", params={"path": str(cover)})
+        assert r.status_code == 200, r.text
+        assert r.content == _FAKE_COVER_BYTES
+
+        outside = tmp_path / "outside" / "x.jpg"
+        outside.parent.mkdir()
+        outside.write_bytes(_FAKE_COVER_BYTES)
+        r403 = client.get("/api/gallery/image", params={"path": str(outside)})
+        assert r403.status_code == 403

--- a/tests/integration/test_search_inflow_upsert.py
+++ b/tests/integration/test_search_inflow_upsert.py
@@ -367,6 +367,37 @@ def test_scrape_single_readonly_message_descriptive(client):
     assert len(error) > 15  # 非單一 code，描述清楚
 
 
+# case 7: file_path 是 canonical file:/// URI（DB / 鄰近寫入路徑格式）在 readonly
+#          來源下 → guard 仍須觸發（Codex P1：to_file_uri 會雙重包 file:///file:///
+#          繞過 guard；coerce_to_file_uri 對已是 URI 原樣回才能命中）。
+def test_scrape_single_readonly_file_uri_input_blocks_organize(client):
+    from core.path_utils import to_file_uri
+    # DB canonical file:/// URI（drive-letter，真實 Windows/WSL 部署形態）。
+    # 舊碼 to_file_uri 對它再包一層 → file:///file:/// → guard 繞過（RED）；
+    # coerce_to_file_uri 對已是 URI 原樣回 → guard 命中（GREEN）。
+    src_path = "C:/ro_src"
+    file_uri = to_file_uri("C:/ro_src/ABC-001.mp4", {})  # 'file:///C:/ro_src/ABC-001.mp4'
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value=_readonly_gallery_config(src_path)),
+        patch("web.routers.scraper.organize_file") as mock_org,
+        patch("web.routers.scraper.search_jav") as mock_search,
+        patch("core.scraper.extract_number", return_value="ABC-001") as mock_extract,
+    ):
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_body_no_metadata(file_uri, number=None),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is False
+    assert "唯讀" in data["error"]
+    mock_org.assert_not_called()
+    mock_search.assert_not_called()
+    mock_extract.assert_not_called()
+
+
 # ─── B1 helpers ──────────────────────────────────────────────────────────────
 
 def _seed_old_card_b1(repo, old_uri: str, user_tags=None, created_at_str: str = None):

--- a/tests/integration/test_search_inflow_upsert.py
+++ b/tests/integration/test_search_inflow_upsert.py
@@ -211,6 +211,162 @@ def test_scrape_single_db_sync_status_not_linked_on_missing_filename(client):
     MockRepo.return_value.repath.assert_not_called()
 
 
+# ─── T-3: U7 readonly organize guard ─────────────────────────────────────────
+#
+# guard 插在 handler 最前段（file_path = request.file_path 之後、extract_number/
+# search_jav/organize_file 之前）。只依 file_path 判斷所屬來源是否 readonly。
+#
+# patch targets:
+#   organize_file  → web.routers.scraper.organize_file
+#   search_jav     → web.routers.scraper.search_jav
+#   extract_number → core.scraper.extract_number（handler 內 function-local import）
+#   config 注入    → web.routers.scraper.load_config（iter_gallery_sources 用 real）
+
+
+def _readonly_gallery_config(path, path_mappings=None, readonly=True):
+    return {
+        "gallery": {
+            "directories": [{"path": path, "readonly": readonly}],
+            "path_mappings": path_mappings or {},
+        }
+    }
+
+
+def _scrape_body_no_metadata(file_path, number="ABC-001"):
+    """不帶 metadata → 非 readonly 時會走 search_jav（讓 assert_not_called 有意義）。"""
+    body = {"file_path": file_path}
+    if number is not None:
+        body["number"] = number
+    return body
+
+
+# case 1: readonly 來源擋 organize（核心）— 三下游 assert_not_called
+def test_scrape_single_readonly_blocks_organize(client):
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value=_readonly_gallery_config("/tmp/ro_src")),
+        patch("web.routers.scraper.organize_file") as mock_org,
+        patch("web.routers.scraper.search_jav") as mock_search,
+        patch("core.scraper.extract_number", return_value="ABC-001") as mock_extract,
+    ):
+        # number=None → 無 guard 時 `if not number:` 為真 → extract_number 會被呼叫；
+        # 有 guard 時 guard 早於番號解析 → 三下游皆 assert_not_called 皆為 live lock。
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_body_no_metadata("/tmp/ro_src/ABC-001.mp4", number=None),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is False
+    assert "唯讀" in data["error"]
+    mock_org.assert_not_called()
+    mock_search.assert_not_called()
+    mock_extract.assert_not_called()
+
+
+# case 2: 無番號 + 檔名不可解析 在 readonly 來源下 → 仍回唯讀提示（Acceptance #12 哨兵）
+def test_scrape_single_readonly_no_number_still_readonly_prompt(client):
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value=_readonly_gallery_config("/tmp/ro_src")),
+        patch("web.routers.scraper.organize_file") as mock_org,
+        patch("web.routers.scraper.search_jav") as mock_search,
+    ):
+        # 不帶 number、檔名不可解析番號；不 patch extract_number（用 real）
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_body_no_metadata("/tmp/ro_src/random.mp4", number=None),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is False
+    assert "唯讀" in data["error"]
+    assert "無法識別番號" not in data["error"]
+    mock_org.assert_not_called()
+    mock_search.assert_not_called()
+
+
+# case 3: UNC readonly 來源 → guard 不拋 ValueError（Codex P2 哨兵）
+def test_scrape_single_readonly_unc_no_valueerror(client):
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value=_readonly_gallery_config(r"\\server\share")),
+        patch("web.routers.scraper.organize_file") as mock_org,
+        patch("web.routers.scraper.search_jav") as mock_search,
+    ):
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_body_no_metadata(r"\\server\share\ABC-001.mp4"),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is False
+    assert "唯讀" in data["error"]
+    mock_org.assert_not_called()
+    mock_search.assert_not_called()
+
+
+# case 4: 非 readonly 來源放行 → 走既有 organize
+def test_scrape_single_non_readonly_passes_through(client):
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value=_readonly_gallery_config("/tmp/rw_src", readonly=False)),
+        patch("web.routers.scraper.organize_file",
+              return_value=_organize_ok("/tmp/rw_src/ABC-001/ABC-001.mp4")) as mock_org,
+        patch("web.routers.scraper.search_jav"),
+    ):
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_request_body(file_path="/tmp/rw_src/ABC-001.mp4"),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    mock_org.assert_called_once()
+
+
+# case 5: 不屬任何來源放行 → guard 不誤擋
+def test_scrape_single_no_matching_source_passes_through(client):
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value={"gallery": {"directories": [], "path_mappings": {}}}),
+        patch("web.routers.scraper.organize_file",
+              return_value=_organize_ok("/elsewhere/ABC-001/ABC-001.mp4")) as mock_org,
+        patch("web.routers.scraper.search_jav"),
+    ):
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_request_body(file_path="/elsewhere/ABC-001.mp4"),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    mock_org.assert_called_once()
+
+
+# case 6: 訊息描述清楚（AI 友善）
+def test_scrape_single_readonly_message_descriptive(client):
+    with (
+        patch("web.routers.scraper.load_config",
+              return_value=_readonly_gallery_config("/tmp/ro_src")),
+        patch("web.routers.scraper.organize_file"),
+        patch("web.routers.scraper.search_jav"),
+    ):
+        resp = client.post(
+            "/api/scrape-single",
+            json=_scrape_body_no_metadata("/tmp/ro_src/ABC-001.mp4"),
+        )
+
+    error = resp.json()["error"]
+    assert "唯讀" in error
+    assert len(error) > 15  # 非單一 code，描述清楚
+
+
 # ─── B1 helpers ──────────────────────────────────────────────────────────────
 
 def _seed_old_card_b1(repo, old_uri: str, user_tags=None, created_at_str: str = None):

--- a/tests/unit/test_core_config.py
+++ b/tests/unit/test_core_config.py
@@ -69,7 +69,7 @@ class TestMigrationAvlistToGallery:
 
         assert "gallery" in result
         assert "avlist" not in result
-        assert result["gallery"]["directories"] == ["/videos"]
+        assert result["gallery"]["directories"] == [{"path": "/videos", "readonly": False, "output_path": ""}]
 
     def test_avlist_not_renamed_when_gallery_exists(self, tmp_path, monkeypatch):
         """若 gallery 已存在，不覆蓋"""
@@ -83,7 +83,7 @@ class TestMigrationAvlistToGallery:
 
         result = load_config()
 
-        assert result["gallery"]["directories"] == ["/new"]
+        assert result["gallery"]["directories"] == [{"path": "/new", "readonly": False, "output_path": ""}]
         assert "avlist" in result  # 保留未搬移的 avlist
 
 
@@ -1409,3 +1409,95 @@ class TestMigrationCloseAction:
         # migration must have persisted the corrected value
         written = _read_config(config_path)
         assert written.get("general", {}).get("close_action") == "ask"
+
+
+# ============ TASK-88a-T3：gallery.directories str → DirectoryConfig object migration ============
+
+class TestMigrationDirectoriesToObject:
+    """gallery.directories 純字串清單 → DirectoryConfig 物件遷移（TASK-88a-T3）"""
+
+    def test_str_list_migrated_to_object_list(self, tmp_path, monkeypatch):
+        """純字串 directories → load_config 後每個元素升級為完整物件"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {"gallery": {"directories": ["/videos"]}})
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert result["gallery"]["directories"] == [
+            {"path": "/videos", "readonly": False, "output_path": ""}
+        ]
+
+    def test_migration_idempotent(self, tmp_path, monkeypatch, mocker):
+        """已是完整物件的 config 再 load，第二次不觸發 _save_config_unlocked（冪等）。
+
+        使用 AppConfig().model_dump() 作基底，確保 scraper/source_links/general 等
+        各段 key 都存在，避免不相關的 migration 在第二次 load 重複觸發。
+        第一次 load 可能因 ollama_url strip / javlibrary additive 觸發一次 save；
+        第二次 load 所有 migration 皆已滿足，directories 已是物件形態 → 不觸發 save。
+        """
+        import core.config as core_config_module
+        config_path = tmp_path / "config.json"
+        # Build a full base config so unrelated migrations don't re-fire on second load
+        base = core_config_module.AppConfig().model_dump()
+        base["gallery"]["directories"] = [
+            {"path": "/videos", "readonly": False, "output_path": ""}
+        ]
+        _write_config(config_path, base)
+        monkeypatch.setattr(core_config_module, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config_module, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        spy = mocker.spy(core_config_module, "_save_config_unlocked")
+
+        # First load: may trigger other migrations (ollama_url strip, javlibrary additive);
+        # directories migration must NOT add to need_save (directories already complete objects).
+        result1 = core_config_module.load_config()
+        assert result1["gallery"]["directories"] == [
+            {"path": "/videos", "readonly": False, "output_path": ""}
+        ]
+        count_after_first = spy.call_count
+
+        # Second load: all migrations already applied; directories still complete objects →
+        # _save_config_unlocked must NOT be called again.
+        result2 = core_config_module.load_config()
+        assert result2["gallery"]["directories"] == [
+            {"path": "/videos", "readonly": False, "output_path": ""}
+        ]
+        assert spy.call_count == count_after_first, (
+            f"second load must not re-save for directories reason "
+            f"(call_count went from {count_after_first} to {spy.call_count})"
+        )
+
+    def test_mixed_list_preserved(self, tmp_path, monkeypatch):
+        """混合清單：str 升級；dict 的 readonly/output_path 值保留"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {
+            "gallery": {
+                "directories": [
+                    "/a",
+                    {"path": "/b", "readonly": True, "output_path": "/out"},
+                ]
+            }
+        })
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        dirs = result["gallery"]["directories"]
+        assert dirs[0] == {"path": "/a", "readonly": False, "output_path": ""}
+        assert dirs[1] == {"path": "/b", "readonly": True, "output_path": "/out"}
+
+    def test_avlist_chain(self, tmp_path, monkeypatch):
+        """avlist.directories 字串清單 → avlist→gallery 遷移後再經 directories 遷移 → 完整物件"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {"avlist": {"directories": ["/x"]}})
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert result["gallery"]["directories"] == [
+            {"path": "/x", "readonly": False, "output_path": ""}
+        ]

--- a/tests/unit/test_dir_candidate_forms.py
+++ b/tests/unit/test_dir_candidate_forms.py
@@ -1,0 +1,64 @@
+"""test_dir_candidate_forms.py — `_dir_candidate_forms` URI-idempotency (PR#91 P2-D).
+
+`_dir_candidate_forms` backs BOTH the /api/gallery/image and /api/gallery/video
+directory allowlists. DirectoryConfig.path may be an FS path OR a file:/// URI
+(schema「FS 路徑或 URI」). A URI input must yield the SAME candidate URI as the
+equivalent FS input — never a double-wrapped `file:///file:///…` (which the
+pre-fix `to_file_uri(os.path.normpath(raw_dir))` produced for URI input).
+
+Pure function; each call uses a distinct raw_dir so the module-level TTL cache
+(keyed on raw_dir) never cross-contaminates between assertions.
+"""
+
+import os
+
+from core.path_utils import is_path_under_dir, to_file_uri
+from web.routers.scanner import _dir_candidate_forms
+
+
+class TestDirCandidateFormsUriIdempotent:
+    def test_uri_input_not_double_wrapped(self, tmp_path):
+        """URI-form dir → candidate URIs contain no 'file:///file:///' double-wrap."""
+        d = tmp_path / "srcU1"
+        d.mkdir()
+        uri = to_file_uri(str(d), {})
+
+        forms = _dir_candidate_forms(uri, {})
+
+        assert forms, "expected at least one candidate form"
+        for f in forms:
+            assert f.startswith("file:///")
+            # no double-wrap in any form (actual pre-fix bug was file:///file:/…)
+            assert not f.removeprefix("file:///").startswith("file:")
+
+    def test_uri_and_fs_input_agree(self, tmp_path):
+        """URI-form and FS-form of the same dir produce matching candidate URIs."""
+        d = tmp_path / "srcU2"
+        d.mkdir()
+
+        fs_forms = set(_dir_candidate_forms(str(d), {}))
+        uri_forms = set(_dir_candidate_forms(to_file_uri(str(d), {}), {}))
+
+        assert fs_forms == uri_forms
+
+    def test_uri_dir_matches_child_file(self, tmp_path):
+        """A file under a URI-form source dir is recognised as under one candidate form."""
+        d = tmp_path / "srcU3"
+        d.mkdir()
+        child = d / "movie.mp4"
+        child.write_bytes(b"x")
+
+        forms = _dir_candidate_forms(to_file_uri(str(d), {}), {})
+        child_uri = to_file_uri(os.path.realpath(str(child)), {})
+
+        assert any(is_path_under_dir(child_uri, f) for f in forms)
+
+    def test_fs_input_still_dual_form(self, tmp_path):
+        """FS input keeps working (normpath + realpath dual-form preserved)."""
+        d = tmp_path / "srcU4"
+        d.mkdir()
+
+        forms = _dir_candidate_forms(str(d), {})
+        expected = to_file_uri(os.path.realpath(str(d)), {})
+
+        assert expected in forms

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2894,6 +2894,25 @@ class TestLongPathWarning:
         assert "debug.log" in window, "scanner/state-scan.js long_paths toast missing: 'debug.log'"
 
 
+class TestReadonlySourceErrorToastGuard:
+    """88c-P2: scanner/state-scan.js done handler 的完成 toast 須依 source_errors 分流。
+
+    唯讀來源整源失敗（readonly_stats.source_errors > 0）時 toast 不可純 success，
+    須走 warn；後端完成通知已同步納入 source_errors（Codex P2）。
+    """
+
+    def test_done_toast_consults_source_errors(self):
+        js = SCANNER_SCAN_JS.read_text(encoding="utf-8")
+        assert "data.readonly_stats" in js and "source_errors" in js, \
+            "scanner/state-scan.js done toast 未 consult readonly_stats.source_errors"
+        # 完成 toast 區塊須有依 source_errors 分流的 warn 分支
+        idx = js.find("const srcErrors")
+        assert idx != -1, "scanner/state-scan.js 缺 srcErrors 分流變數"
+        window = js[idx:idx + 500]
+        assert "'warn'" in window or '"warn"' in window, \
+            "scanner/state-scan.js source_errors 分支缺 warn toast"
+
+
 class TestSearchFileJsSubtitleHelper:
     """48a T2 a2 — 前端 extractChineseTitle 同步套用 stripSubtitleMarkers helper（對齊 Python 端）"""
 

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -2908,9 +2908,21 @@ class TestReadonlySourceErrorToastGuard:
         # 完成 toast 區塊須有依 source_errors 分流的 warn 分支
         idx = js.find("const srcErrors")
         assert idx != -1, "scanner/state-scan.js 缺 srcErrors 分流變數"
-        window = js[idx:idx + 500]
+        window = js[idx:idx + 800]
         assert "'warn'" in window or '"warn"' in window, \
             "scanner/state-scan.js source_errors 分支缺 warn toast"
+
+    def test_done_toast_consults_per_video_failed(self):
+        """PR#91 ②：完成 toast 也須 consult 個別影片失敗數（readonly_stats.failed），
+        failed>0 時走 warn 而非純 success。"""
+        js = SCANNER_SCAN_JS.read_text(encoding="utf-8")
+        idx = js.find("const srcErrors")
+        assert idx != -1, "scanner/state-scan.js 缺 srcErrors 分流變數"
+        window = js[idx:idx + 800]
+        assert ".failed" in window, \
+            "scanner/state-scan.js 完成 toast 未 consult readonly_stats.failed"
+        assert "'warn'" in window or '"warn"' in window, \
+            "scanner/state-scan.js failed 分支缺 warn toast"
 
 
 class TestSearchFileJsSubtitleHelper:

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -15865,3 +15865,105 @@ class TestHelpUpdateButtonGuard:
             "help.html 缺 confirmUpdate() — modal 確認按鈕不存在"
         assert 'cancelUpdate()' in html, \
             "help.html 缺 cancelUpdate() — modal 取消按鈕不存在"
+
+
+class TestDirPathHelperGuard:
+    """TASK-88a-T2: dirPath helper 簽章守衛 + directory-row template 綁定守衛。
+
+    1. shared/dir-path.js 存在且 export function dirPath
+    2. state-scan.js / state-ui.js 各自 import dirPath
+    3. scanner.html directory-row 已用 dirPath(dir)（不殘留裸 x-text="dir"）
+    4. settings.html directory-row 四處已全 dirPath(dir) 化（:key/:title/@click/x-text）
+    5. 無裸 :key="dir" 殘留（settings.html）
+    """
+
+    _ROOT = Path(__file__).parent.parent.parent
+
+    def _dir_path_js(self):
+        return (self._ROOT / "web" / "static" / "js" / "shared" / "dir-path.js").read_text(encoding="utf-8")
+
+    def _state_scan(self):
+        return (self._ROOT / "web" / "static" / "js" / "pages" / "scanner" / "state-scan.js").read_text(encoding="utf-8")
+
+    def _state_ui(self):
+        return (self._ROOT / "web" / "static" / "js" / "pages" / "settings" / "state-ui.js").read_text(encoding="utf-8")
+
+    def _scanner_html(self):
+        return (self._ROOT / "web" / "templates" / "scanner.html").read_text(encoding="utf-8")
+
+    def _settings_html(self):
+        return (self._ROOT / "web" / "templates" / "settings.html").read_text(encoding="utf-8")
+
+    def test_dir_path_js_exists_and_exports(self):
+        """shared/dir-path.js 存在且含 export function dirPath"""
+        src = self._dir_path_js()
+        assert 'export function dirPath' in src, \
+            "shared/dir-path.js 缺 export function dirPath"
+
+    def test_state_scan_imports_dir_path(self):
+        """state-scan.js 從 @/shared/dir-path.js import dirPath"""
+        src = self._state_scan()
+        assert "import { dirPath } from '@/shared/dir-path.js'" in src, \
+            "state-scan.js 缺 import { dirPath } from '@/shared/dir-path.js'"
+
+    def test_state_ui_imports_dir_path(self):
+        """state-ui.js 從 @/shared/dir-path.js import dirPath"""
+        src = self._state_ui()
+        assert "import { dirPath } from '@/shared/dir-path.js'" in src, \
+            "state-ui.js 缺 import { dirPath } from '@/shared/dir-path.js'"
+
+    def test_state_scan_exposes_dir_path_on_state(self):
+        """state-scan.js 把 dirPath 揭露成 state 屬性（否則 template dirPath(dir) runtime throw）"""
+        src = self._state_scan()
+        assert 'dirPath,' in src, \
+            "state-scan.js 未把 dirPath 揭露成 state 屬性（import 不夠，template 求值會 throw）"
+
+    def test_state_ui_exposes_dir_path_on_state(self):
+        """state-ui.js 把 dirPath 揭露成 state 屬性（否則 template dirPath(dir) runtime throw）"""
+        src = self._state_ui()
+        assert 'dirPath,' in src, \
+            "state-ui.js 未把 dirPath 揭露成 state 屬性（import 不夠，template 求值會 throw）"
+
+    def test_scanner_html_uses_dir_path(self):
+        """scanner.html directory-row 已用 dirPath(dir)（不殘留裸 x-text="dir"）"""
+        html = self._scanner_html()
+        assert 'x-text="dirPath(dir)"' in html, \
+            'scanner.html folder-path span 缺 x-text="dirPath(dir)"'
+
+    def test_scanner_html_no_bare_xtext_dir(self):
+        """scanner.html folder-path 不殘留裸 x-text="dir"（directory-row）"""
+        html = self._scanner_html()
+        assert 'x-text="dir"' not in html, \
+            'scanner.html 殘留裸 x-text="dir" — 應改為 x-text="dirPath(dir)"'
+
+    def test_settings_html_key_uses_dir_path(self):
+        """settings.html directory-row :key 已改為 dirPath(dir)"""
+        html = self._settings_html()
+        # The scanner-dir-dropdown x-for must use dirPath
+        assert ':key="dirPath(dir)"' in html, \
+            'settings.html 缺 :key="dirPath(dir)" — [object Object] key bug 未修'
+
+    def test_settings_html_no_bare_key_dir(self):
+        """settings.html directory-row 不殘留裸 :key=dir（應改為 :key="dirPath(dir)"）"""
+        html = self._settings_html()
+        assert ':key="dir"' not in html, \
+            'settings.html 殘留裸 :key="dir" — 應改為 :key="dirPath(dir)"'
+
+    def test_settings_html_title_uses_dir_path(self):
+        """settings.html directory-row :title 已改為 dirPath(dir)"""
+        html = self._settings_html()
+        assert ':title="dirPath(dir)"' in html, \
+            'settings.html 缺 :title="dirPath(dir)"'
+
+    def test_settings_html_click_uses_dir_path(self):
+        """settings.html directory-row @click 已改為 pickScannerDirectory(dirPath(dir))"""
+        html = self._settings_html()
+        assert '@click="pickScannerDirectory(dirPath(dir))"' in html, \
+            'settings.html 缺 @click="pickScannerDirectory(dirPath(dir))"'
+
+    def test_settings_html_xtext_uses_dir_path(self):
+        """settings.html directory-row x-text 已改為 dirPath(dir)"""
+        html = self._settings_html()
+        # The dropdown button x-text must use dirPath
+        assert 'x-text="dirPath(dir)"' in html, \
+            'settings.html 缺 x-text="dirPath(dir)"'

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -15967,3 +15967,54 @@ class TestDirPathHelperGuard:
         # The dropdown button x-text must use dirPath
         assert 'x-text="dirPath(dir)"' in html, \
             'settings.html 缺 x-text="dirPath(dir)"'
+
+
+class TestDirReadonlyUIGuard:
+    """TASK-88a-T4: 唯讀 checkbox + 輸出夾 input Alpine 綁定守衛。
+
+    1. scanner.html 含 x-model="dir.readonly"（checkbox 綁定）
+    2. scanner.html 含 x-model="dir.output_path"（輸出夾 input 綁定）
+    3. scanner.html 含 x-show="dir.readonly"（條件顯示輸出夾列）
+    4. state-scan.js 的 push 包含 readonly 與 output_path 屬性（物件形態，非 bare string）
+    """
+
+    _ROOT = Path(__file__).parent.parent.parent
+
+    def _scanner_html(self):
+        return (self._ROOT / "web" / "templates" / "scanner.html").read_text(encoding="utf-8")
+
+    def _state_scan(self):
+        return (self._ROOT / "web" / "static" / "js" / "pages" / "scanner" / "state-scan.js").read_text(encoding="utf-8")
+
+    def test_scanner_html_readonly_checkbox(self):
+        """scanner.html 含 x-model="dir.readonly"（唯讀 checkbox 綁定）"""
+        html = self._scanner_html()
+        assert 'x-model="dir.readonly"' in html, \
+            'scanner.html 缺 x-model="dir.readonly" — 唯讀 checkbox 未加'
+
+    def test_scanner_html_output_path_input(self):
+        """scanner.html 含 x-model="dir.output_path"（輸出夾 input 綁定）"""
+        html = self._scanner_html()
+        assert 'x-model="dir.output_path"' in html, \
+            'scanner.html 缺 x-model="dir.output_path" — 輸出夾 input 未加'
+
+    def test_scanner_html_output_row_xshow(self):
+        """scanner.html 含 x-show="dir.readonly"（條件顯示輸出夾列，非 x-if）"""
+        html = self._scanner_html()
+        assert 'x-show="dir.readonly"' in html, \
+            'scanner.html 缺 x-show="dir.readonly" — 應用 x-show 而非 x-if 控制輸出夾列'
+
+    def test_state_scan_push_has_readonly(self):
+        """state-scan.js 的 directories.push 包含 readonly 屬性（物件形態）"""
+        src = self._state_scan()
+        assert 'readonly' in src and 'directories.push' in src, \
+            "state-scan.js directories.push 缺 readonly 屬性 — 應改為物件 push"
+        # 確認不是 bare push(string)：push 之後必須有物件結構 { path: ..., readonly: ...
+        assert '{ path:' in src or '{ path :' in src, \
+            "state-scan.js directories.push 應推入 {path, readonly, output_path} 物件"
+
+    def test_state_scan_push_has_output_path(self):
+        """state-scan.js 的 directories.push 包含 output_path 屬性（物件形態）"""
+        src = self._state_scan()
+        assert 'output_path' in src, \
+            "state-scan.js 缺 output_path 屬性 — push 物件應含 {path, readonly, output_path}"

--- a/tests/unit/test_gallery_source_helpers.py
+++ b/tests/unit/test_gallery_source_helpers.py
@@ -220,3 +220,85 @@ class TestDirectoryConfigModel:
         dc = DirectoryConfig(path="/p", readonly=False, output_path="/out")
         assert dc.readonly is False
         assert dc.output_path == "/out"
+
+
+# ---------------------------------------------------------------------------
+# Robustness / security hardening (P1 + P2 findings)
+# ---------------------------------------------------------------------------
+
+class TestRobustness:
+    """Verify that iter_gallery_sources DROPS entries without a usable non-empty string path
+    and coerces null/wrong-type optional fields instead of crashing.
+
+    P1: empty/missing path must not yield '' which becomes file:/// (universal allowlist bypass).
+    P2: path=null must not raise ValidationError (dict key present with None value).
+    """
+
+    def test_dict_missing_path_key_skipped(self):
+        """Dict entry with no 'path' key is dropped entirely."""
+        dirs = [{"readonly": True}, {"path": "/valid"}]
+        result = iter_gallery_sources({"directories": dirs})
+        assert len(result) == 1
+        assert result[0].path == "/valid"
+
+    def test_dict_path_none_skipped_no_exception(self):
+        """{'path': None} must be silently skipped — not raise ValidationError (P2)."""
+        result = iter_gallery_sources({"directories": [{"path": None}]})
+        assert result == []
+
+    def test_dict_path_empty_string_skipped(self):
+        """{'path': ''} must be silently skipped (P1: empty path → file:/// bypass)."""
+        result = iter_gallery_sources({"directories": [{"path": ""}]})
+        assert result == []
+
+    def test_str_empty_string_skipped(self):
+        """Bare empty string element must be silently skipped."""
+        result = iter_gallery_sources({"directories": [""]})
+        assert result == []
+
+    def test_dict_readonly_none_coerced_to_false(self):
+        """readonly=null must NOT crash; coerced to False."""
+        result = iter_gallery_sources({"directories": [{"path": "/x", "readonly": None}]})
+        assert len(result) == 1
+        assert result[0].readonly is False
+
+    def test_dict_output_path_none_coerced_to_empty(self):
+        """output_path=null must NOT crash; coerced to ''."""
+        result = iter_gallery_sources({"directories": [{"path": "/x", "output_path": None}]})
+        assert len(result) == 1
+        assert result[0].output_path == ""
+
+    def test_dict_readonly_wrong_type_coerced_to_false(self):
+        """readonly with wrong type (str) is coerced to False, not passed to Pydantic."""
+        result = iter_gallery_sources({"directories": [{"path": "/x", "readonly": "true"}]})
+        assert len(result) == 1
+        assert result[0].readonly is False
+
+    def test_mixed_bad_and_good_entries_only_good_emitted(self):
+        """Mix of bad entries (missing/null/empty path) plus valid ones — only valid survive."""
+        dirs = [
+            {"readonly": True},           # missing path
+            {"path": None},               # null path
+            {"path": ""},                 # empty path
+            "",                            # bare empty string
+            {"path": "/good1"},
+            "/good2",
+        ]
+        result = iter_gallery_sources({"directories": dirs})
+        assert len(result) == 2
+        assert result[0].path == "/good1"
+        assert result[1].path == "/good2"
+
+    def test_get_gallery_source_paths_never_yields_empty_or_none(self):
+        """get_gallery_source_paths must never include '' or None in its output."""
+        dirs = [
+            {"path": None},
+            {"path": ""},
+            "",
+            {"readonly": False},
+            {"path": "/ok"},
+        ]
+        paths = get_gallery_source_paths({"directories": dirs})
+        assert "" not in paths
+        assert None not in paths
+        assert paths == ["/ok"]

--- a/tests/unit/test_gallery_source_helpers.py
+++ b/tests/unit/test_gallery_source_helpers.py
@@ -1,0 +1,222 @@
+"""Unit tests for iter_gallery_sources / get_gallery_source_paths helpers.
+
+TDD-lite: each test is written to go RED if the helper logic is broken.
+"""
+
+from core.config import DirectoryConfig, GalleryConfig, iter_gallery_sources, get_gallery_source_paths
+
+
+# ---------------------------------------------------------------------------
+# Container-type edge cases
+# ---------------------------------------------------------------------------
+
+class TestContainerTypes:
+    def test_none_returns_empty(self):
+        assert iter_gallery_sources(None) == []
+
+    def test_empty_dict_returns_empty(self):
+        assert iter_gallery_sources({}) == []
+
+    def test_dict_missing_directories_key_returns_empty(self):
+        assert iter_gallery_sources({"other_key": "value"}) == []
+
+    def test_gallery_config_empty_directories_returns_empty(self):
+        gc = GalleryConfig()
+        assert iter_gallery_sources(gc) == []
+
+    def test_dict_with_empty_directories_returns_empty(self):
+        assert iter_gallery_sources({"directories": []}) == []
+
+    def test_dict_with_null_directories_returns_empty(self):
+        # key present but value is null (not missing) — `raw or []` guard must hold
+        assert iter_gallery_sources({"directories": None}) == []
+
+
+# ---------------------------------------------------------------------------
+# Element-type: str
+# ---------------------------------------------------------------------------
+
+class TestStrElement:
+    def test_str_coerced_to_directory_config(self):
+        result = iter_gallery_sources({"directories": ["/videos"]})
+        assert len(result) == 1
+        assert isinstance(result[0], DirectoryConfig)
+        assert result[0].path == "/videos"
+
+    def test_str_defaults_readonly_false(self):
+        result = iter_gallery_sources({"directories": ["/videos"]})
+        assert result[0].readonly is False
+
+    def test_str_defaults_output_path_empty(self):
+        result = iter_gallery_sources({"directories": ["/videos"]})
+        assert result[0].output_path == ""
+
+
+# ---------------------------------------------------------------------------
+# Element-type: dict
+# ---------------------------------------------------------------------------
+
+class TestDictElement:
+    def test_full_dict_element_preserved(self):
+        elem = {"path": "/x", "readonly": True, "output_path": "/out"}
+        result = iter_gallery_sources({"directories": [elem]})
+        assert len(result) == 1
+        dc = result[0]
+        assert dc.path == "/x"
+        assert dc.readonly is True
+        assert dc.output_path == "/out"
+
+    def test_dict_missing_readonly_defaults_false(self):
+        elem = {"path": "/x", "output_path": "/out"}
+        result = iter_gallery_sources({"directories": [elem]})
+        assert result[0].readonly is False
+
+    def test_dict_missing_output_path_defaults_empty(self):
+        elem = {"path": "/x", "readonly": True}
+        result = iter_gallery_sources({"directories": [elem]})
+        assert result[0].output_path == ""
+
+    def test_dict_missing_both_optional_fields(self):
+        elem = {"path": "/x"}
+        result = iter_gallery_sources({"directories": [elem]})
+        dc = result[0]
+        assert dc.path == "/x"
+        assert dc.readonly is False
+        assert dc.output_path == ""
+
+
+# ---------------------------------------------------------------------------
+# Element-type: DirectoryConfig instance
+# ---------------------------------------------------------------------------
+
+class TestDirectoryConfigElement:
+    def test_directory_config_instance_passed_through(self):
+        dc_in = DirectoryConfig(path="/z", readonly=True, output_path="/out2")
+        result = iter_gallery_sources({"directories": [dc_in]})
+        assert len(result) == 1
+        assert result[0] is dc_in
+
+    def test_directory_config_instance_via_gallery_config(self):
+        gc = GalleryConfig(directories=["/z"])  # GalleryConfig.directories is List[str]
+        result = iter_gallery_sources(gc)
+        assert len(result) == 1
+        assert result[0].path == "/z"
+
+
+# ---------------------------------------------------------------------------
+# Unknown element types — must be skipped, not crash
+# ---------------------------------------------------------------------------
+
+class TestUnknownElementTypes:
+    def test_integer_element_skipped(self):
+        result = iter_gallery_sources({"directories": [42]})
+        assert result == []
+
+    def test_none_element_skipped(self):
+        result = iter_gallery_sources({"directories": [None]})
+        assert result == []
+
+    def test_unknown_mixed_with_valid_skips_unknown(self):
+        result = iter_gallery_sources({"directories": ["/a", 42, None, "/b"]})
+        assert len(result) == 2
+        assert result[0].path == "/a"
+        assert result[1].path == "/b"
+
+
+# ---------------------------------------------------------------------------
+# Mixed list: all three types together, order preserved
+# ---------------------------------------------------------------------------
+
+class TestMixedList:
+    def test_mixed_str_dict_directoryconfig_order_preserved(self):
+        dc = DirectoryConfig(path="/c", readonly=False, output_path="")
+        dirs = [
+            "/a",
+            {"path": "/b", "readonly": True, "output_path": "/out"},
+            dc,
+        ]
+        result = iter_gallery_sources({"directories": dirs})
+        assert len(result) == 3
+        assert result[0].path == "/a"
+        assert result[1].path == "/b"
+        assert result[1].readonly is True
+        assert result[2] is dc
+
+    def test_order_preserved_multiple_strings(self):
+        result = iter_gallery_sources({"directories": ["/z", "/a", "/m"]})
+        paths = [d.path for d in result]
+        assert paths == ["/z", "/a", "/m"]
+
+
+# ---------------------------------------------------------------------------
+# GalleryConfig container (model instance)
+# ---------------------------------------------------------------------------
+
+class TestGalleryConfigContainer:
+    def test_gallery_config_with_string_directories(self):
+        gc = GalleryConfig(directories=["/foo", "/bar"])
+        result = iter_gallery_sources(gc)
+        assert len(result) == 2
+        assert result[0].path == "/foo"
+        assert result[1].path == "/bar"
+
+
+# ---------------------------------------------------------------------------
+# get_gallery_source_paths — thin wrapper equivalence
+# ---------------------------------------------------------------------------
+
+class TestGetGallerySourcePaths:
+    def test_returns_list_of_strings(self):
+        paths = get_gallery_source_paths({"directories": ["/a", "/b"]})
+        assert paths == ["/a", "/b"]
+
+    def test_bit_exact_equivalence_with_old_string_list(self):
+        """get_gallery_source_paths must produce the same list as a raw str directories list."""
+        old_style = ["/a", "/b"]
+        result = get_gallery_source_paths({"directories": old_style})
+        assert result == old_style
+
+    def test_none_returns_empty_list(self):
+        assert get_gallery_source_paths(None) == []
+
+    def test_empty_dict_returns_empty_list(self):
+        assert get_gallery_source_paths({}) == []
+
+    def test_matches_iter_gallery_sources_paths(self):
+        cfg = {"directories": ["/x", "/y"]}
+        via_iter = [d.path for d in iter_gallery_sources(cfg)]
+        via_helper = get_gallery_source_paths(cfg)
+        assert via_helper == via_iter
+
+    def test_dict_element_path_extracted(self):
+        cfg = {"directories": [{"path": "/x", "readonly": True, "output_path": ""}]}
+        assert get_gallery_source_paths(cfg) == ["/x"]
+
+    def test_directory_config_element_path_extracted(self):
+        dc = DirectoryConfig(path="/z", readonly=False, output_path="")
+        cfg = {"directories": [dc]}
+        assert get_gallery_source_paths(cfg) == ["/z"]
+
+
+# ---------------------------------------------------------------------------
+# DirectoryConfig model: field defaults & combinations
+# ---------------------------------------------------------------------------
+
+class TestDirectoryConfigModel:
+    def test_default_readonly_false(self):
+        dc = DirectoryConfig(path="/p")
+        assert dc.readonly is False
+
+    def test_default_output_path_empty(self):
+        dc = DirectoryConfig(path="/p")
+        assert dc.output_path == ""
+
+    def test_readonly_true_with_empty_output_path_valid(self):
+        dc = DirectoryConfig(path="/p", readonly=True, output_path="")
+        assert dc.readonly is True
+        assert dc.output_path == ""
+
+    def test_readonly_false_with_nonempty_output_path_valid(self):
+        dc = DirectoryConfig(path="/p", readonly=False, output_path="/out")
+        assert dc.readonly is False
+        assert dc.output_path == "/out"

--- a/tests/unit/test_image_whitelist_dirs.py
+++ b/tests/unit/test_image_whitelist_dirs.py
@@ -1,0 +1,62 @@
+"""
+test_image_whitelist_dirs.py — `_image_whitelist_dirs` 純函式候選目錄推導測試（TASK-88c-T1）
+
+驗證 `/api/gallery/image` 白名單「候選 raw 目錄清單」的推導真值：
+- 每來源的 `src.path` 進候選
+- 非空 `src.output_path` 進候選
+- `""` output_path **不**進候選（防 `to_file_uri('') = 'file:///'` 根路徑 bypass 哨兵）
+- 多來源聚合、空 config 不拋
+
+純函式、無 IO、免 HTTP、免 mock。
+"""
+
+from web.routers.scanner import _image_whitelist_dirs
+
+
+class TestImageWhitelistDirs:
+    def test_output_path_included_alongside_src_path(self):
+        """readonly 來源含非空 output_path → 候選同時含 path 與 output_path"""
+        gallery_config = {
+            'directories': [
+                {'path': '/src/movies', 'readonly': True, 'output_path': '/out/movies'},
+            ],
+        }
+        dirs = _image_whitelist_dirs(gallery_config)
+        assert '/src/movies' in dirs
+        assert '/out/movies' in dirs
+
+    def test_empty_output_path_excluded(self):
+        """output_path == "" → 候選只含 path，不含 ""（防 file:/// bypass 哨兵）
+
+        若把 `if src.output_path` 過濾拿掉，"" 會進候選 → 此測試 RED。
+        """
+        gallery_config = {
+            'directories': [
+                {'path': '/src/movies', 'readonly': False, 'output_path': ''},
+            ],
+        }
+        dirs = _image_whitelist_dirs(gallery_config)
+        assert '/src/movies' in dirs
+        assert '' not in dirs
+
+    def test_multi_source_aggregation(self):
+        """多來源混合（一有 output_path、一沒有）→ 正確聚合"""
+        gallery_config = {
+            'directories': [
+                {'path': '/a', 'readonly': True, 'output_path': '/a-out'},
+                {'path': '/b', 'readonly': False, 'output_path': ''},
+            ],
+        }
+        dirs = _image_whitelist_dirs(gallery_config)
+        assert set(dirs) == {'/a', '/a-out', '/b'}
+
+    def test_empty_config_returns_empty_list(self):
+        """空 gallery_config / 無 directories → 空清單（不拋）"""
+        assert _image_whitelist_dirs({}) == []
+        assert _image_whitelist_dirs({'directories': []}) == []
+
+    def test_bare_string_source_no_output_path(self):
+        """裸字串來源（無 output_path）→ 只有 path 進候選"""
+        gallery_config = {'directories': ['/plain/dir']}
+        dirs = _image_whitelist_dirs(gallery_config)
+        assert dirs == ['/plain/dir']

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -511,6 +511,69 @@ class TestMovieDir:
         assert dir_a != dir_b
 
 
+class TestNoCoverRegenNoSibling:
+    """Codex P2-1: a no-cover title must reuse its folder on re-generate.
+
+    RED against pre-fix code: the second gen sees the on-disk folder, finds it
+    absent from `owners` (built from cover-bearing rows only — the no-cover row's
+    cover_path='' is dropped), treats it as <foreign> and spawns a hashed sibling.
+    GREEN after fix: _producer_uris marks the source as already-generated, so
+    _movie_dir reuses the same leaf.
+    """
+
+    def test_second_gen_no_hashed_sibling(self, tmp_path, temp_db):
+        from core.database import VideoRepository
+        from core.readonly_producer import produce_source
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "ABC-123.mp4").write_bytes(b"x" * 4096)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        source = _make_source(readonly=True, output_path=str(out_dir), path=str(src_dir))
+        # folder_format='' → no folder layers → movie leaf sits directly under out_dir,
+        # so a hashed sibling shows up as a top-level dir next to the real one.
+        config = {
+            "gallery": {},
+            "scraper": {
+                "folder_format": "",
+                "filename_format": "{num} {title}",
+                "max_filename_length": 60,
+                "max_title_length": 50,
+                "suffix_keywords": [],
+            },
+        }
+        meta = {
+            "number": "ABC-123", "title": "T", "cover": "", "actors": [], "tags": [],
+            "date": "", "maker": "", "director": "", "series": "", "label": "",
+            "sample_images": [], "duration": 0, "url": "",
+        }
+
+        def run():
+            # Fresh repo handle each run (same underlying temp_db file → persisted rows).
+            repo = VideoRepository(temp_db)
+            with patch("core.readonly_producer.search_jav", return_value=meta), \
+                 patch("core.readonly_producer.download_image", return_value=False), \
+                 patch("core.readonly_producer.generate_nfo", return_value=True):
+                return produce_source(source, config, repo)
+
+        r1 = run()
+        assert r1.created == 1
+        first_dir = r1.outcomes[0].movie_dir
+        dirs_after_first = sorted(p.name for p in out_dir.iterdir() if p.is_dir())
+        assert len(dirs_after_first) == 1
+
+        r2 = run()
+        assert r2.created == 1
+        dirs_after_second = sorted(p.name for p in out_dir.iterdir() if p.is_dir())
+
+        # No new/hashed sibling: still exactly one movie dir, and it is the same folder.
+        assert dirs_after_second == dirs_after_first
+        assert len(dirs_after_second) == 1
+        assert r2.outcomes[0].movie_dir == first_dir
+
+
 # ---------------------------------------------------------------------------
 # T-3 tests: _write_movie_assets, _upsert_db
 # ---------------------------------------------------------------------------
@@ -974,6 +1037,7 @@ class TestProduceSourceNoneNumberGuard:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -997,6 +1061,7 @@ class TestProduceSourceNoneNumberGuard:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1046,6 +1111,7 @@ class TestProduceSourceMixedStats:
         with patch("core.readonly_producer._list_source_videos", return_value=self.FILES), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", side_effect=fake_should_skip), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1095,6 +1161,7 @@ class TestProduceSourceOnProgress:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1130,6 +1197,7 @@ class TestProduceSourceShouldAbort:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1173,6 +1241,7 @@ class TestProduceSourceExceptionDoesNotAbort:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1211,6 +1280,7 @@ class TestProduceSourceFailureContract:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -1,0 +1,189 @@
+"""Unit tests for core/readonly_producer.py (TDD-lite, T-1 scope).
+
+All filesystem / DB access is mocked — zero real I/O.
+"""
+import inspect
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Guard test: producer must not contain forbidden names (DoD / CD-88b-1)
+# ---------------------------------------------------------------------------
+
+def test_guard_no_forbidden_names():
+    """Producer source code must not reference organize_file / enrich_single / scan_file."""
+    import core.readonly_producer as mod
+    src = inspect.getsource(mod)
+    for name in ("organize_file", "enrich_single", "scan_file"):
+        assert name not in src, (
+            f"core/readonly_producer.py must not import or call '{name}' (CD-88b-1)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _min_size_bytes
+# ---------------------------------------------------------------------------
+
+class TestMinSizeBytes:
+    def test_zero_when_not_set(self):
+        from core.readonly_producer import _min_size_bytes
+        assert _min_size_bytes({}) == 0
+
+    def test_converts_mb_to_bytes(self):
+        from core.readonly_producer import _min_size_bytes
+        assert _min_size_bytes({"min_size_mb": 2}) == 2 * 1024 * 1024
+
+    def test_truncates_float(self):
+        from core.readonly_producer import _min_size_bytes
+        # int() truncates
+        assert _min_size_bytes({"min_size_mb": 1.9}) == 1 * 1024 * 1024
+
+    def test_zero_explicit(self):
+        from core.readonly_producer import _min_size_bytes
+        assert _min_size_bytes({"min_size_mb": 0}) == 0
+
+
+# ---------------------------------------------------------------------------
+# _list_source_videos
+# ---------------------------------------------------------------------------
+
+FAKE_FILES = [
+    {"path": "/src/a.mp4", "mtime": 1.0, "size": 100, "nfo_mtime": 0.0},
+    {"path": "/src/b.mkv", "mtime": 2.0, "size": 200, "nfo_mtime": 0.0},
+]
+
+
+class TestListSourceVideos:
+    def test_calls_fast_scan_with_normalised_path(self):
+        """_list_source_videos must delegate to fast_scan_directory (no direct read)."""
+        from core.readonly_producer import _list_source_videos
+
+        with patch("core.readonly_producer.fast_scan_directory", return_value=FAKE_FILES) as mock_scan, \
+             patch("core.readonly_producer.normalize_path", return_value="/src") as mock_norm:
+            result = _list_source_videos("/src", {".mp4", ".mkv"}, 0)
+
+        mock_norm.assert_called_once_with("/src")
+        mock_scan.assert_called_once_with("/src", {".mp4", ".mkv"}, 0)
+        assert result == FAKE_FILES
+
+    def test_returns_raw_list_unchanged(self):
+        from core.readonly_producer import _list_source_videos
+
+        with patch("core.readonly_producer.fast_scan_directory", return_value=FAKE_FILES), \
+             patch("core.readonly_producer.normalize_path", return_value="/src"):
+            result = _list_source_videos("/src", {".mp4"}, 1024)
+
+        assert result is FAKE_FILES
+
+
+# ---------------------------------------------------------------------------
+# _should_skip  (truth table — 4 cases)
+# ---------------------------------------------------------------------------
+
+class TestShouldSkip:
+    OUTPUT_URI = "file:///output"
+    COVER_URI = "file:///output/movie/cover.jpg"
+    SOURCE_URI = "file:///src/a.mp4"
+
+    def test_no_row_returns_false(self):
+        """cover_index has no entry for source_uri → rebuild."""
+        from core.readonly_producer import _should_skip
+        cover_index = {}
+        assert _should_skip(self.SOURCE_URI, self.OUTPUT_URI, cover_index) is False
+
+    def test_cover_under_output_but_file_missing_returns_false(self):
+        """cover is under output but file does not exist on disk → rebuild."""
+        from core.readonly_producer import _should_skip
+        cover_index = {self.SOURCE_URI: self.COVER_URI}
+
+        with patch("core.readonly_producer.is_path_under_dir", return_value=True), \
+             patch("core.readonly_producer.uri_to_fs_path", return_value="/output/movie/cover.jpg"), \
+             patch("core.readonly_producer.Path") as mock_path_cls:
+            mock_path_inst = MagicMock()
+            mock_path_inst.exists.return_value = False
+            mock_path_cls.return_value = mock_path_inst
+            result = _should_skip(self.SOURCE_URI, self.OUTPUT_URI, cover_index)
+
+        assert result is False
+
+    def test_cover_not_under_output_returns_false(self):
+        """cover is not under this output_uri → rebuild."""
+        from core.readonly_producer import _should_skip
+        cover_index = {self.SOURCE_URI: "file:///other/cover.jpg"}
+
+        with patch("core.readonly_producer.is_path_under_dir", return_value=False):
+            result = _should_skip(self.SOURCE_URI, self.OUTPUT_URI, cover_index)
+
+        assert result is False
+
+    def test_all_conditions_met_returns_true(self):
+        """cover under output AND file exists → skip."""
+        from core.readonly_producer import _should_skip
+        cover_index = {self.SOURCE_URI: self.COVER_URI}
+
+        with patch("core.readonly_producer.is_path_under_dir", return_value=True), \
+             patch("core.readonly_producer.uri_to_fs_path", return_value="/output/movie/cover.jpg"), \
+             patch("core.readonly_producer.Path") as mock_path_cls:
+            mock_path_inst = MagicMock()
+            mock_path_inst.exists.return_value = True
+            mock_path_cls.return_value = mock_path_inst
+            result = _should_skip(self.SOURCE_URI, self.OUTPUT_URI, cover_index)
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# _build_cover_index
+# ---------------------------------------------------------------------------
+
+class TestBuildCoverIndex:
+    OUTPUT_URI = "file:///output"
+
+    def _make_repo(self, full_index: dict) -> MagicMock:
+        repo = MagicMock()
+        repo.get_cover_index.return_value = full_index
+        return repo
+
+    def test_filters_out_empty_cover(self):
+        from core.readonly_producer import _build_cover_index
+        repo = self._make_repo({
+            "file:///src/a.mp4": "",
+            "file:///src/b.mp4": "file:///output/b/cover.jpg",
+        })
+        with patch("core.readonly_producer.is_path_under_dir",
+                   side_effect=lambda c, o: c.startswith("file:///output")):
+            result = _build_cover_index(repo, self.OUTPUT_URI)
+
+        # empty cover must be excluded
+        assert "file:///src/a.mp4" not in result
+        assert "file:///src/b.mp4" in result
+
+    def test_filters_out_cover_not_under_output(self):
+        from core.readonly_producer import _build_cover_index
+        repo = self._make_repo({
+            "file:///src/a.mp4": "file:///other/cover.jpg",
+            "file:///src/b.mp4": "file:///output/b/cover.jpg",
+        })
+        with patch("core.readonly_producer.is_path_under_dir",
+                   side_effect=lambda c, o: c.startswith("file:///output")):
+            result = _build_cover_index(repo, self.OUTPUT_URI)
+
+        assert "file:///src/a.mp4" not in result
+        assert "file:///src/b.mp4" in result
+
+    def test_empty_db_returns_empty(self):
+        from core.readonly_producer import _build_cover_index
+        repo = self._make_repo({})
+        with patch("core.readonly_producer.is_path_under_dir", return_value=True):
+            result = _build_cover_index(repo, self.OUTPUT_URI)
+        assert result == {}
+
+    def test_null_cover_filtered(self):
+        """None cover_path must be treated as falsy and excluded."""
+        from core.readonly_producer import _build_cover_index
+        repo = self._make_repo({
+            "file:///src/a.mp4": None,
+        })
+        with patch("core.readonly_producer.is_path_under_dir", return_value=True):
+            result = _build_cover_index(repo, self.OUTPUT_URI)
+        assert result == {}

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -3,6 +3,7 @@
 All filesystem / DB access is mocked — zero real I/O.
 """
 import inspect
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -187,3 +188,321 @@ class TestBuildCoverIndex:
         with patch("core.readonly_producer.is_path_under_dir", return_value=True):
             result = _build_cover_index(repo, self.OUTPUT_URI)
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# T-2 tests: _format_data, _folder_parts, _build_basename, _movie_dir
+# ---------------------------------------------------------------------------
+
+class TestFormatData:
+    """Tests for _format_data (organizer off-mode format_data construction)."""
+
+    BASE_CONFIG = {
+        'max_title_length': 20,
+        'suffix_keywords': ['-C', '-U'],
+        'filename_format': '{num} {title}',
+        'max_filename_length': 60,
+    }
+
+    def test_long_title_truncated(self):
+        from core.readonly_producer import _format_data
+        meta = {'number': 'ABC-123', 'title': 'A' * 30}
+        fd = _format_data(meta, '/src/ABC-123.mp4', self.BASE_CONFIG)
+        assert len(fd['title']) <= 20
+        assert fd['title'].endswith('...')
+
+    def test_prefix_stripped_from_title(self):
+        from core.readonly_producer import _format_data
+        meta = {'number': 'ABC-123', 'title': '[ABC-123]Original Title'}
+        fd = _format_data(meta, '/src/ABC-123.mp4', self.BASE_CONFIG)
+        assert 'ABC-123' not in fd['title']
+        assert 'Original Title' in fd['title']
+
+    def test_suffix_detected_from_basename(self):
+        from core.readonly_producer import _format_data
+        meta = {'number': 'ABC-123', 'title': 'Some Title'}
+        fd = _format_data(meta, '/src/ABC-123-C.mp4', self.BASE_CONFIG)
+        assert '-c' in fd['suffix'].lower()
+
+    def test_no_suffix_when_no_match(self):
+        from core.readonly_producer import _format_data
+        meta = {'number': 'ABC-123', 'title': 'Some Title'}
+        fd = _format_data(meta, '/src/ABC-123.mp4', self.BASE_CONFIG)
+        assert fd['suffix'] == ''
+
+    def test_truncated_title_consistent_in_folder_and_basename(self):
+        """Same truncated title feeds both _folder_parts and _build_basename (no drift)."""
+        from core.readonly_producer import _build_basename, _folder_parts, _format_data
+        long_title = 'VeryLong' * 5
+        meta = {'number': 'ABC-123', 'title': long_title}
+        config = {
+            'max_title_length': 15,
+            'suffix_keywords': [],
+            'filename_format': '{num} {title}',
+            'max_filename_length': 60,
+            'folder_layers': ['{title}'],
+        }
+        fd = _format_data(meta, '/src/ABC-123.mp4', config)
+        folder = _folder_parts(fd, config)
+        basename = _build_basename(fd, '/src/ABC-123.mp4', config)
+        # folder parts include the title
+        assert folder[0] == fd['title']
+        # basename also includes the same truncated title
+        assert fd['title'] in basename
+
+
+class TestFolderParts:
+    """Tests for _folder_parts."""
+
+    def test_two_layers(self):
+        from core.readonly_producer import _folder_parts
+        config = {'folder_layers': ['{actor}', '{num}'], 'max_filename_length': 60}
+        fd = {'number': 'ABC-123', 'title': 'Title', 'actors': ['Actress'], 'maker': '', 'date': '', 'suffix': ''}
+        parts = _folder_parts(fd, config)
+        assert len(parts) == 2
+
+    def test_more_than_3_layers_capped(self):
+        from core.readonly_producer import _folder_parts
+        config = {
+            'folder_layers': ['{num}', '{num}', '{num}', '{num}'],
+            'max_filename_length': 60,
+        }
+        fd = {'number': 'ABC-123', 'title': '', 'actors': [], 'maker': '', 'date': '', 'suffix': ''}
+        parts = _folder_parts(fd, config)
+        assert len(parts) <= 3
+
+    def test_empty_layer_skipped(self):
+        from core.readonly_producer import _folder_parts
+        # An empty-string layer formats to '' and must be dropped by the `if part` guard.
+        config = {'folder_layers': ['{num}', ''], 'max_filename_length': 60}
+        fd = {'number': 'ABC-123', 'title': 'Title', 'actors': [], 'maker': '', 'date': '', 'suffix': ''}
+        parts = _folder_parts(fd, config)
+        # empty layer dropped → only the number layer survives (RED if `if part` guard removed)
+        assert parts == ['ABC-123']
+
+    def test_folder_format_fallback(self):
+        """When folder_layers is empty, folder_format is used."""
+        from core.readonly_producer import _folder_parts
+        config = {
+            'folder_layers': [],
+            'folder_format': '{num}',
+            'max_filename_length': 60,
+        }
+        fd = {'number': 'ABC-123', 'title': '', 'actors': [], 'maker': '', 'date': '', 'suffix': ''}
+        parts = _folder_parts(fd, config)
+        assert parts == ['ABC-123']
+
+    def test_no_layers_no_folder_format_defaults_num(self):
+        from core.readonly_producer import _folder_parts
+        config = {'max_filename_length': 60}
+        fd = {'number': 'XYZ-001', 'title': '', 'actors': [], 'maker': '', 'date': '', 'suffix': ''}
+        parts = _folder_parts(fd, config)
+        assert parts == ['XYZ-001']
+
+
+class TestBuildBasename:
+    """Tests for _build_basename (off-mode filename stem generation)."""
+
+    BASE_FD = {
+        'number': 'ABC-123',
+        'title': 'Normal Title',
+        'actors': [],
+        'maker': '',
+        'date': '',
+        'suffix': '',
+    }
+    BASE_CONFIG = {
+        'filename_format': '{num} {title}',
+        'max_filename_length': 60,
+        'suffix_keywords': [],
+    }
+
+    def test_vr_tail_present_for_vr_file(self):
+        from core.readonly_producer import _build_basename
+        with patch('core.readonly_producer._detect_vr_cluster', return_value='180_LR'):
+            result = _build_basename(self.BASE_FD, '/src/ABC-123_180_LR.mp4', self.BASE_CONFIG)
+        assert result.endswith('_180_LR')
+
+    def test_no_vr_tail_for_normal_file(self):
+        from core.readonly_producer import _build_basename
+        with patch('core.readonly_producer._detect_vr_cluster', return_value=None):
+            result = _build_basename(self.BASE_FD, '/src/ABC-123.mp4', self.BASE_CONFIG)
+        # BASE_FD title has no underscore → any '_' means an erroneous VR tail (RED if injected)
+        assert '_' not in result
+
+    def test_suffix_not_truncated_in_two_pass(self):
+        """When {suffix} in template, suffix is not cut off by truncation."""
+        from core.readonly_producer import _build_basename
+        fd = dict(self.BASE_FD, suffix='-C', title='X' * 60)
+        config = dict(self.BASE_CONFIG, filename_format='{num} {title}{suffix}', max_filename_length=30)
+        with patch('core.readonly_producer._detect_vr_cluster', return_value=None):
+            result = _build_basename(fd, '/src/ABC-123-C.mp4', config)
+        # suffix '-c' / '-C' should survive truncation
+        assert result.endswith('-c') or result.endswith('-C') or '-c' in result.lower()
+
+    def test_plain_num_title_no_vr_tail(self):
+        from core.readonly_producer import _build_basename
+        with patch('core.readonly_producer._detect_vr_cluster', return_value=None):
+            result = _build_basename(self.BASE_FD, '/src/ABC-123.mp4', self.BASE_CONFIG)
+        assert result == 'ABC-123 Normal Title'
+
+
+class TestBuildOwners:
+    """Tests for _build_owners."""
+
+    def test_builds_dir_to_source_map(self):
+        from core.readonly_producer import _build_owners
+        cover_index = {
+            'file:///src/a.mp4': 'file:///output/MovieA/cover.jpg',
+        }
+        with patch('core.readonly_producer.uri_to_fs_path', side_effect=lambda u: u[7:]):
+            owners = _build_owners(cover_index)
+        assert '/output/MovieA' in owners
+        assert owners['/output/MovieA'] == 'file:///src/a.mp4'
+
+    def test_empty_cover_skipped(self):
+        from core.readonly_producer import _build_owners
+        cover_index = {'file:///src/a.mp4': ''}
+        owners = _build_owners(cover_index)
+        assert owners == {}
+
+    def test_none_cover_skipped(self):
+        from core.readonly_producer import _build_owners
+        cover_index = {'file:///src/a.mp4': None}
+        owners = _build_owners(cover_index)
+        assert owners == {}
+
+
+class TestMovieLeafBase:
+    """Tests for _movie_leaf_base."""
+
+    def test_empty_stem_returns_number(self):
+        from core.readonly_producer import _movie_leaf_base
+        # sanitize_filename of an empty stem returns ''
+        with patch('core.readonly_producer.uri_to_fs_path', return_value='/'), \
+             patch('core.readonly_producer.sanitize_filename', return_value=''):
+            result = _movie_leaf_base('ABC-123', 'file:///')
+        assert result == 'ABC-123'
+
+    def test_stem_equals_number_normalised(self):
+        from core.readonly_producer import _movie_leaf_base
+        with patch('core.readonly_producer.uri_to_fs_path', return_value='/src/ABC-123.mp4'), \
+             patch('core.readonly_producer.normalize_number', return_value='ABC-123'), \
+             patch('core.readonly_producer.sanitize_filename', side_effect=lambda x: x):
+            result = _movie_leaf_base('ABC-123', 'file:///src/ABC-123.mp4')
+        assert result == 'ABC-123'
+
+    def test_stem_contains_number_returns_stem(self):
+        from core.readonly_producer import _movie_leaf_base
+        with patch('core.readonly_producer.uri_to_fs_path', return_value='/src/ABC-123-VR.mp4'), \
+             patch('core.readonly_producer.normalize_number', return_value='ABC-123-VR'), \
+             patch('core.readonly_producer.sanitize_filename', side_effect=lambda x: x):
+            result = _movie_leaf_base('ABC-123', 'file:///src/ABC-123-VR.mp4')
+        # stem 'ABC-123-VR' contains 'ABC-123'
+        assert result == 'ABC-123-VR'
+
+    def test_unrelated_stem_prefixes_number(self):
+        from core.readonly_producer import _movie_leaf_base
+        with patch('core.readonly_producer.uri_to_fs_path', return_value='/src/random_name.mp4'), \
+             patch('core.readonly_producer.normalize_number', return_value='RANDOM_NAME'), \
+             patch('core.readonly_producer.sanitize_filename', side_effect=lambda x: x):
+            result = _movie_leaf_base('ABC-123', 'file:///src/random_name.mp4')
+        assert result == 'ABC-123-random_name'
+
+
+class TestMovieDir:
+    """Tests for _movie_dir collision-avoidance."""
+
+    OUTPUT_ROOT = '/output'
+    BASE_CONFIG = {
+        'folder_layers': [],
+        'folder_format': '{num}',
+        'max_filename_length': 60,
+        'filename_format': '{num} {title}',
+    }
+
+    def _fd(self, number='ABC-123'):
+        return {'number': number, 'title': 'Title', 'actors': [], 'maker': '', 'date': '', 'suffix': ''}
+
+    def _patch_leaf(self, leaf):
+        return patch('core.readonly_producer._movie_leaf_base', return_value=leaf)
+
+    def _patch_exists(self, exists=False):
+        return patch('core.readonly_producer.Path.exists', return_value=exists)
+
+    def test_same_number_two_paths_distinct_dirs(self):
+        """Same number → same leaf for two source URIs in ONE run → second collides → hashed dir."""
+        from core.readonly_producer import _movie_dir
+        fd = self._fd('ABC-123')
+        owners: dict = {}
+        src_a = 'file:///a/ABC-123.mp4'
+        src_b = 'file:///b/ABC-123.mp4'
+
+        # both resolve to the SAME leaf → exercises the in-run collision/hash branch
+        with patch('core.readonly_producer._movie_leaf_base', return_value='ABC-123'), \
+             self._patch_exists(False):
+            dir_a = _movie_dir(self.OUTPUT_ROOT, fd, src_a, self.BASE_CONFIG, owners)
+            dir_b = _movie_dir(self.OUTPUT_ROOT, fd, src_b, self.BASE_CONFIG, owners)
+
+        assert dir_a.name == 'ABC-123'                 # first source: bare leaf, no hash
+        assert dir_b != dir_a                          # collision → hashed (RED if hash branch removed)
+        assert dir_b.name.startswith('ABC-123-')       # hash suffix present
+        assert owners[str(dir_a)] == src_a             # first owner not overwritten by second
+
+    def test_cross_run_existing_owner_not_overwritten(self):
+        """owners pre-seeded with movie_dir→srcA; srcB hashes to new dir, srcA entry unchanged."""
+        from core.readonly_producer import _movie_dir
+        fd = self._fd('ABC-123')
+        src_a = 'file:///a/ABC-123.mp4'
+        src_b = 'file:///b/ABC-123.mp4'
+        movie_dir_a = str(Path(self.OUTPUT_ROOT, 'ABC-123'))
+        owners = {movie_dir_a: src_a}
+
+        with self._patch_leaf('ABC-123'), self._patch_exists(False):
+            dir_b = _movie_dir(self.OUTPUT_ROOT, fd, src_b, self.BASE_CONFIG, owners)
+
+        assert str(dir_b) != movie_dir_a
+        assert owners[movie_dir_a] == src_a  # not overwritten
+
+    def test_disk_orphan_gets_hashed_dir(self):
+        """Candidate exists on disk, owners empty → hash suffix applied."""
+        from core.readonly_producer import _movie_dir
+        fd = self._fd('ABC-123')
+        owners: dict = {}
+        src = 'file:///src/ABC-123.mp4'
+
+        with self._patch_leaf('ABC-123'), self._patch_exists(True):
+            result = _movie_dir(self.OUTPUT_ROOT, fd, src, self.BASE_CONFIG, owners)
+
+        # The plain candidate exists → hash suffix; result should not be bare 'ABC-123'
+        assert result.name != 'ABC-123'
+
+    def test_idempotent_same_source(self):
+        """Calling _movie_dir twice with same source_uri → same dir."""
+        from core.readonly_producer import _movie_dir
+        fd = self._fd('ABC-123')
+        owners: dict = {}
+        src = 'file:///src/ABC-123.mp4'
+
+        with self._patch_leaf('ABC-123'), self._patch_exists(False):
+            dir1 = _movie_dir(self.OUTPUT_ROOT, fd, src, self.BASE_CONFIG, owners)
+            dir2 = _movie_dir(self.OUTPUT_ROOT, fd, src, self.BASE_CONFIG, owners)
+
+        assert dir1 == dir2
+
+    def test_leaf_enforcement_different_numbers(self):
+        """folder_layers=['{actor}'], same actor, different numbers → different dirs."""
+        from core.readonly_producer import _movie_dir
+        config = dict(self.BASE_CONFIG, folder_layers=['{actor}'])
+        fd_a = {'number': 'ABC-001', 'title': 'T', 'actors': ['Actress A'], 'maker': '', 'date': '', 'suffix': ''}
+        fd_b = {'number': 'ABC-002', 'title': 'T', 'actors': ['Actress A'], 'maker': '', 'date': '', 'suffix': ''}
+        owners: dict = {}
+        src_a = 'file:///src/ABC-001.mp4'
+        src_b = 'file:///src/ABC-002.mp4'
+
+        with patch('core.readonly_producer._movie_leaf_base', side_effect=['ABC-001', 'ABC-002']), \
+             self._patch_exists(False):
+            dir_a = _movie_dir(self.OUTPUT_ROOT, fd_a, src_a, config, owners)
+            dir_b = _movie_dir(self.OUTPUT_ROOT, fd_b, src_b, config, owners)
+
+        assert dir_a != dir_b

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -800,3 +800,370 @@ class TestUpsertDb:
 
         v = repo.get_by_path(self.SOURCE_URI)
         assert v.sample_images == []
+
+
+# ---------------------------------------------------------------------------
+# T-4 tests: _emit helper + produce_source orchestrator
+# ---------------------------------------------------------------------------
+
+def _fake_to_file_uri(p, m=None):  # path-contract-ok
+    """Fake to_file_uri for mocking in tests. path-contract-ok: this IS the mock target."""
+    return "file:///" + p.lstrip("/")  # path-contract-ok
+
+
+def _make_source(readonly=True, output_path="/output/dest", path="/src/videos"):
+    """Return a MagicMock with source attributes."""
+    src = MagicMock()
+    src.readonly = readonly
+    src.output_path = output_path
+    src.path = path
+    return src
+
+
+def _make_config(scraper_cfg=None, gallery_cfg=None):
+    return {
+        "gallery": gallery_cfg or {},
+        "scraper": scraper_cfg or {},
+    }
+
+
+def _make_file_info(path="/src/videos/ABC-123.mp4", size=1_000_000, mtime=1.0):
+    return {"path": path, "size": size, "mtime": mtime, "nfo_mtime": 0.0}
+
+
+class TestEmit:
+    """Tests for _emit helper."""
+
+    def test_appends_outcome_to_result(self):
+        from core.readonly_producer import ProduceResult, _emit
+
+        result = ProduceResult(source_path="/src", output_path="/out")
+        _emit(None, result, "file:///src/a.mp4", "skipped")
+
+        assert len(result.outcomes) == 1
+        o = result.outcomes[0]
+        assert o.source_uri == "file:///src/a.mp4"
+        assert o.status == "skipped"
+        assert o.movie_dir == ""
+        assert o.number == ""
+        assert o.error == ""
+
+    def test_calls_on_progress_with_outcome(self):
+        from core.readonly_producer import ProduceResult, _emit
+
+        result = ProduceResult(source_path="/src", output_path="/out")
+        received = []
+        _emit(received.append, result, "file:///src/a.mp4", "created", "/out/Movie", "ABC-123")
+
+        assert len(received) == 1
+        assert received[0] is result.outcomes[0]
+        assert received[0].movie_dir == "/out/Movie"
+        assert received[0].number == "ABC-123"
+
+    def test_no_on_progress_is_noop(self):
+        from core.readonly_producer import ProduceResult, _emit
+
+        result = ProduceResult(source_path="/src", output_path="/out")
+        # Must not raise
+        _emit(None, result, "file:///src/a.mp4", "failed", error="boom")
+        assert result.outcomes[0].error == "boom"
+
+
+class TestProduceSourceGuards:
+    """Guard tests for produce_source (CD-88b-6 / Acceptance #11)."""
+
+    def test_not_readonly_returns_aborted(self):
+        """source.readonly=False → aborted_reason='not_readonly', counters all 0."""
+        from core.readonly_producer import produce_source
+
+        source = _make_source(readonly=False)
+        repo = MagicMock()
+        config = _make_config()
+
+        with patch("core.readonly_producer._list_source_videos") as mock_list:
+            result = produce_source(source, config, repo)
+
+        assert result.aborted_reason == "not_readonly"
+        assert result.created == 0
+        assert result.skipped == 0
+        assert result.failed == 0
+        assert result.no_scrape == 0
+        mock_list.assert_not_called()
+
+    def test_empty_output_path_returns_aborted(self):
+        """source.output_path='' → aborted_reason='no_output_path', search_jav not called."""
+        from core.readonly_producer import produce_source
+
+        source = _make_source(output_path="")
+        repo = MagicMock()
+        config = _make_config()
+
+        with patch("core.readonly_producer._list_source_videos") as mock_list, \
+             patch("core.readonly_producer.search_jav") as mock_search:
+            result = produce_source(source, config, repo)
+
+        assert result.aborted_reason == "no_output_path"
+        mock_list.assert_not_called()        # early return blocked all downstream work
+        mock_search.assert_not_called()
+
+    def test_whitespace_output_path_returns_aborted(self):
+        """source.output_path='   ' → aborted_reason='no_output_path'."""
+        from core.readonly_producer import produce_source
+
+        source = _make_source(output_path="   ")
+        repo = MagicMock()
+        config = _make_config()
+
+        with patch("core.readonly_producer._list_source_videos") as mock_list, \
+             patch("core.readonly_producer.search_jav") as mock_search:
+            result = produce_source(source, config, repo)
+
+        assert result.aborted_reason == "no_output_path"
+        mock_list.assert_not_called()
+        mock_search.assert_not_called()
+
+    def test_none_output_path_returns_aborted(self):
+        """source.output_path=None → aborted_reason='no_output_path'."""
+        from core.readonly_producer import produce_source
+
+        source = _make_source(output_path=None)
+        repo = MagicMock()
+        config = _make_config()
+
+        with patch("core.readonly_producer._list_source_videos") as mock_list, \
+             patch("core.readonly_producer.search_jav") as mock_search:
+            result = produce_source(source, config, repo)
+
+        assert result.aborted_reason == "no_output_path"
+        mock_list.assert_not_called()
+        mock_search.assert_not_called()
+
+
+class TestProduceSourceNoneNumberGuard:
+    """extract_number returns None → no_scrape++, search_jav NOT called (Codex P2b)."""
+
+    def test_none_number_no_search_jav(self):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+        files = [_make_file_info(path="/src/videos/nonnumber.mp4")]
+
+        with patch("core.readonly_producer._list_source_videos", return_value=files), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", return_value=False), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", return_value=None) as mock_extract, \
+             patch("core.readonly_producer.search_jav") as mock_search:
+            result = produce_source(source, config, repo)
+
+        assert result.no_scrape == 1
+        assert result.created == 0
+        mock_extract.assert_called_once()
+        mock_search.assert_not_called()
+
+    def test_none_number_emits_no_scrape_outcome(self):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+        files = [_make_file_info(path="/src/videos/nonnumber.mp4")]
+
+        with patch("core.readonly_producer._list_source_videos", return_value=files), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", return_value=False), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", return_value=None):
+            result = produce_source(source, config, repo)
+
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].status == "no_scrape"
+
+
+class TestProduceSourceMixedStats:
+    """5-file run: 2 skipped, 1 None-number, 1 search_jav→None, 1 success → check all counters."""
+
+    FILES = [
+        _make_file_info(path="/src/SKIP-001.mp4"),    # → skipped (cover exists)
+        _make_file_info(path="/src/SKIP-002.mp4"),    # → skipped (cover exists)
+        _make_file_info(path="/src/nonnumber.mp4"),   # → no_scrape (extract_number=None)
+        _make_file_info(path="/src/NOSCRAPE-001.mp4"),  # → no_scrape (search_jav=None)
+        _make_file_info(path="/src/SUCCESS-001.mp4"),   # → created
+    ]
+
+    def _run(self):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+
+        def fake_should_skip(src_uri, output_uri, cover_index):
+            return "SKIP-001" in src_uri or "SKIP-002" in src_uri
+
+        def fake_extract_number(basename):
+            if "nonnumber" in basename:
+                return None
+            return basename.replace(".mp4", "").upper()
+
+        def fake_search_jav(number, source="auto", proxy_url=""):
+            if "NOSCRAPE" in number:
+                return None
+            return {"number": number, "title": "T", "cover": "", "actors": [], "tags": [],
+                    "date": "", "maker": "", "director": "", "series": "", "label": "",
+                    "sample_images": [], "duration": 0, "url": ""}
+
+        mock_movie_dir = MagicMock()
+        mock_movie_dir.__str__ = lambda self: "/output/dest/SUCCESS-001"
+
+        with patch("core.readonly_producer._list_source_videos", return_value=self.FILES), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", side_effect=fake_should_skip), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", side_effect=fake_extract_number), \
+             patch("core.readonly_producer.search_jav", side_effect=fake_search_jav), \
+             patch("core.readonly_producer._format_data", return_value={"number": "X", "title": "T", "actors": [], "maker": "", "date": "", "suffix": ""}), \
+             patch("core.readonly_producer._movie_dir", return_value=mock_movie_dir), \
+             patch("core.readonly_producer._write_movie_assets", return_value={"cover_fs": "/output/dest/SUCCESS-001/cover.jpg", "sample_fs": []}), \
+             patch("core.readonly_producer._upsert_db"):
+            return produce_source(source, config, repo)
+
+    def test_counters(self):
+        result = self._run()
+        assert result.skipped == 2
+        assert result.no_scrape == 2
+        assert result.created == 1
+        assert result.failed == 0
+
+    def test_outcome_count(self):
+        result = self._run()
+        assert len(result.outcomes) == 5
+
+    def test_outcome_statuses(self):
+        result = self._run()
+        statuses = [o.status for o in result.outcomes]
+        assert statuses.count("skipped") == 2
+        assert statuses.count("no_scrape") == 2
+        assert statuses.count("created") == 1
+
+
+class TestProduceSourceOnProgress:
+    """on_progress callback called once per processed file."""
+
+    def test_on_progress_called_per_file(self):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+        files = [
+            _make_file_info(path="/src/A.mp4"),
+            _make_file_info(path="/src/B.mp4"),
+            _make_file_info(path="/src/C.mp4"),
+        ]
+        received = []
+
+        with patch("core.readonly_producer._list_source_videos", return_value=files), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", return_value=False), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", return_value=None):
+            produce_source(source, config, repo, on_progress=received.append)
+
+        # 3 files, all become no_scrape (extract_number=None)
+        assert len(received) == 3
+        assert all(o.status == "no_scrape" for o in received)
+
+
+class TestProduceSourceShouldAbort:
+    """should_abort returning True on 3rd file → loop stops, len(outcomes)==2."""
+
+    def test_abort_stops_loop(self):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+        files = [
+            _make_file_info(path="/src/A.mp4"),
+            _make_file_info(path="/src/B.mp4"),
+            _make_file_info(path="/src/C.mp4"),
+            _make_file_info(path="/src/D.mp4"),
+        ]
+        call_count = [0]
+
+        def abort_on_third():
+            call_count[0] += 1
+            return call_count[0] >= 3  # abort on 3rd call (before 3rd file)
+
+        with patch("core.readonly_producer._list_source_videos", return_value=files), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", return_value=False), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", return_value=None):
+            result = produce_source(source, config, repo, should_abort=abort_on_third)
+
+        assert len(result.outcomes) == 2
+
+
+class TestProduceSourceExceptionDoesNotAbort:
+    """Single-file exception doesn't abort loop: 2nd file raises, 3rd still processed."""
+
+    def test_exception_on_second_file_third_still_processed(self):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+        files = [
+            _make_file_info(path="/src/A-001.mp4"),
+            _make_file_info(path="/src/B-002.mp4"),  # will raise
+            _make_file_info(path="/src/C-003.mp4"),
+        ]
+
+        meta = {"number": "X", "title": "T", "cover": "", "actors": [], "tags": [],
+                "date": "", "maker": "", "director": "", "series": "", "label": "",
+                "sample_images": [], "duration": 0, "url": ""}
+        fd = {"number": "X", "title": "T", "actors": [], "maker": "", "date": "", "suffix": ""}
+
+        call_count = [0]
+
+        def fake_write(movie_dir, meta_arg, fd_arg, src_path, cfg):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise OSError("disk full")
+            return {"cover_fs": "", "sample_fs": []}
+
+        mock_movie_dir = MagicMock()
+        mock_movie_dir.__str__ = lambda self: "/output/dest/X"
+
+        with patch("core.readonly_producer._list_source_videos", return_value=files), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", return_value=False), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", return_value="MOCK-001"), \
+             patch("core.readonly_producer.search_jav", return_value=meta), \
+             patch("core.readonly_producer._format_data", return_value=fd), \
+             patch("core.readonly_producer._movie_dir", return_value=mock_movie_dir), \
+             patch("core.readonly_producer._write_movie_assets", side_effect=fake_write), \
+             patch("core.readonly_producer._upsert_db"):
+            result = produce_source(source, config, repo)
+
+        assert result.failed == 1
+        assert result.created == 2  # files 1 and 3 succeed
+        statuses = [o.status for o in result.outcomes]
+        assert statuses == ["created", "failed", "created"]

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -1,6 +1,7 @@
-"""Unit tests for core/readonly_producer.py (TDD-lite, T-1 scope).
+"""Unit tests for core/readonly_producer.py (TDD-lite, T-1/T-3 scope).
 
-All filesystem / DB access is mocked — zero real I/O.
+All filesystem / DB access is mocked — zero real I/O unless explicitly noted
+(T-3 DB tests use the temp_db fixture for a real SQLite write path).
 """
 import inspect
 from pathlib import Path
@@ -506,3 +507,296 @@ class TestMovieDir:
             dir_b = _movie_dir(self.OUTPUT_ROOT, fd_b, src_b, config, owners)
 
         assert dir_a != dir_b
+
+
+# ---------------------------------------------------------------------------
+# T-3 tests: _write_movie_assets, _upsert_db
+# ---------------------------------------------------------------------------
+
+_T3_META = {
+    'number': 'TEST-001',
+    'title': 'Test Movie Title',
+    'cover': 'https://example.com/cover.jpg',
+    'actors': ['Actress A', 'Actress B'],
+    'tags': ['tag1', 'tag2'],
+    'date': '2024-01-01',
+    'maker': 'Test Maker',
+    'director': 'Test Director',
+    'series': 'Test Series',
+    'label': 'Test Label',
+    'sample_images': [
+        'https://example.com/sample1.jpg',
+        'https://example.com/sample2.jpg',
+    ],
+    'duration': 120,
+    '_summary': 'Test summary',
+    '_rating': 8.5,
+    'url': 'https://example.com/video',
+}
+
+_T3_FILE_INFO = {
+    'size': 1234567890,
+    'mtime': 1704067200.0,
+}
+
+_T3_BASE_CONFIG = {
+    'filename_format': '{num} {title}',
+    'max_filename_length': 60,
+    'max_title_length': 50,
+    'suffix_keywords': [],
+    'external_manager': 'kodi',
+    'download_sample_images': False,
+}
+
+
+def _t3_format_data(meta=None, source_fs_path='/src/TEST-001.mp4', config=None):
+    from core.readonly_producer import _format_data
+    return _format_data(meta or _T3_META, source_fs_path, config or _T3_BASE_CONFIG)
+
+
+class TestWriteMovieAssets:
+    """T-3: write-target containment, re-scrape, extrafanart gate, has_cover=False."""
+
+    def test_write_target_containment(self, tmp_path):
+        """All write targets must be under movie_dir; none under source file's dir."""
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        source_fs_path = '/src/TEST-001.mp4'
+        source_dir = str(Path(source_fs_path).parent)
+        fd = _t3_format_data(source_fs_path=source_fs_path)
+
+        recorded_paths: list = []
+
+        def fake_download(url, save_path, referer=''):
+            recorded_paths.append(save_path)
+            return True
+
+        def fake_jellyfin(cover_path, base_stem):
+            # cover_path is a READ input (source for copy/crop), not a write target — don't record it.
+            recorded_paths.append(base_stem + '-poster.jpg')
+            recorded_paths.append(base_stem + '-fanart.jpg')
+            return {'poster': True, 'fanart': True}
+
+        def fake_nfo(**kwargs):
+            recorded_paths.append(kwargs.get('output_path', ''))
+
+        with patch('core.readonly_producer.download_image', side_effect=fake_download), \
+             patch('core.readonly_producer.generate_jellyfin_images', side_effect=fake_jellyfin), \
+             patch('core.readonly_producer.generate_nfo', side_effect=fake_nfo):
+            _write_movie_assets(movie_dir, _T3_META, fd, source_fs_path, _T3_BASE_CONFIG)
+
+        assert recorded_paths, "No paths were recorded — mocks not called"
+        for p in recorded_paths:
+            if not p:
+                continue
+            assert p.startswith(movie_dir), (
+                f"Write target {p!r} not under movie_dir {movie_dir!r}"
+            )
+            assert not p.startswith(source_dir), (
+                f"Write target {p!r} leaks into source dir {source_dir!r}"
+            )
+
+    def test_rescrape_uses_remote_cover_url(self, tmp_path):
+        """download_image first arg must be the remote cover URL (C6 re-scrape)."""
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        fd = _t3_format_data()
+        download_calls: list = []
+
+        def fake_download(url, save_path, referer=''):
+            download_calls.append(url)
+            return True
+
+        with patch('core.readonly_producer.download_image', side_effect=fake_download), \
+             patch('core.readonly_producer.generate_jellyfin_images',
+                   return_value={'poster': True, 'fanart': True}), \
+             patch('core.readonly_producer.generate_nfo'):
+            _write_movie_assets(movie_dir, _T3_META, fd, '/src/TEST-001.mp4', _T3_BASE_CONFIG)
+
+        assert download_calls, "download_image was never called"
+        assert download_calls[0] == _T3_META['cover'], (
+            "First download_image call must be remote cover URL, not a local path"
+        )
+
+    def test_extrafanart_gate_false(self, tmp_path):
+        """download_sample_images=False → no extrafanart dir, sample_fs==[]."""
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        fd = _t3_format_data()
+        config = dict(_T3_BASE_CONFIG, download_sample_images=False)
+
+        with patch('core.readonly_producer.download_image', return_value=True), \
+             patch('core.readonly_producer.generate_jellyfin_images',
+                   return_value={'poster': True, 'fanart': True}), \
+             patch('core.readonly_producer.generate_nfo'):
+            assets = _write_movie_assets(movie_dir, _T3_META, fd, '/src/TEST-001.mp4', config)
+
+        assert assets['sample_fs'] == []
+        ef_dir = Path(movie_dir) / 'extrafanart'
+        assert not ef_dir.exists()
+
+    def test_extrafanart_gate_true_two_samples(self, tmp_path):
+        """download_sample_images=True + 2 sample URLs → fanart1.jpg + fanart2.jpg, 2 entries."""
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        fd = _t3_format_data()
+        config = dict(_T3_BASE_CONFIG, download_sample_images=True)
+
+        def fake_download(url, save_path, referer=''):
+            return True
+
+        with patch('core.readonly_producer.download_image', side_effect=fake_download), \
+             patch('core.readonly_producer.generate_jellyfin_images',
+                   return_value={'poster': True, 'fanart': True}), \
+             patch('core.readonly_producer.generate_nfo'):
+            assets = _write_movie_assets(movie_dir, _T3_META, fd, '/src/TEST-001.mp4', config)
+
+        assert len(assets['sample_fs']) == 2
+        assert 'fanart1.jpg' in assets['sample_fs'][0]
+        assert 'fanart2.jpg' in assets['sample_fs'][1]
+
+    def test_no_cover_skips_jellyfin_images(self, tmp_path):
+        """meta['cover']='' → generate_jellyfin_images NOT called; cover_fs=''; nfo still written."""
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        meta_no_cover = dict(_T3_META, cover='')
+        fd = _t3_format_data(meta=meta_no_cover)
+
+        jellyfin_mock = MagicMock()
+        nfo_mock = MagicMock()
+
+        with patch('core.readonly_producer.download_image', return_value=False), \
+             patch('core.readonly_producer.generate_jellyfin_images', jellyfin_mock), \
+             patch('core.readonly_producer.generate_nfo', nfo_mock):
+            assets = _write_movie_assets(
+                movie_dir, meta_no_cover, fd, '/src/TEST-001.mp4', _T3_BASE_CONFIG
+            )
+
+        jellyfin_mock.assert_not_called()
+        assert assets['cover_fs'] == ''
+        nfo_mock.assert_called_once()
+
+    def test_generate_nfo_params(self, tmp_path):
+        """generate_nfo: output_path under movie_dir; external_manager passed; has_poster/has_fanart match cover."""
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        fd = _t3_format_data()
+        config = dict(_T3_BASE_CONFIG, external_manager='jellyfin')
+        captured: dict = {}
+
+        def capture_nfo(**kwargs):
+            captured.update(kwargs)
+
+        with patch('core.readonly_producer.download_image', return_value=True), \
+             patch('core.readonly_producer.generate_jellyfin_images',
+                   return_value={'poster': True, 'fanart': True}), \
+             patch('core.readonly_producer.generate_nfo', side_effect=capture_nfo):
+            _write_movie_assets(movie_dir, _T3_META, fd, '/src/TEST-001.mp4', config)
+
+        assert 'output_path' in captured
+        assert captured['output_path'].startswith(movie_dir)
+        assert captured['external_manager'] == 'jellyfin'
+        assert captured['has_poster'] is True
+        assert captured['has_fanart'] is True
+
+
+class TestUpsertDb:
+    """T-3: DB field correctness, cover_path local URI, sample_images local URIs."""
+
+    SOURCE_URI = 'file:///src/TEST-001.mp4'
+
+    def _repo(self, temp_db):
+        from core.database import VideoRepository
+        return VideoRepository(temp_db)
+
+    def test_db_fields_correct(self, tmp_path, temp_db):
+        """After _upsert_db, get_by_path returns Video with all expected fields."""
+        from core.readonly_producer import _upsert_db
+        from core.path_utils import to_file_uri
+
+        cover_fs = str(tmp_path / 'output' / 'TEST-001' / 'TEST-001 Test Movie Title.jpg')
+        assets = {'cover_fs': cover_fs, 'sample_fs': []}
+        repo = self._repo(temp_db)
+
+        _upsert_db(repo, self.SOURCE_URI, _T3_FILE_INFO, _T3_META, assets, None)
+
+        v = repo.get_by_path(self.SOURCE_URI)
+        assert v is not None
+        assert v.path == self.SOURCE_URI
+        assert v.number == _T3_META['number']
+        assert v.title == _T3_META['title']
+        assert v.size_bytes == _T3_FILE_INFO['size']
+        assert v.cover_path == to_file_uri(cover_fs, None)
+        assert v.cover_path != _T3_META['cover']  # must not be the remote URL (CD-88b-7)
+        assert v.actresses == _T3_META['actors']
+        assert v.tags == _T3_META['tags']
+        assert v.mtime == _T3_FILE_INFO['mtime']
+        assert v.nfo_mtime == 0.0
+
+    def test_cover_path_is_local_uri_not_remote(self, tmp_path, temp_db):
+        """cover_path in DB must be a file:/// URI, never the remote cover URL (CD-88b-7)."""
+        from core.readonly_producer import _upsert_db
+
+        cover_fs = str(tmp_path / 'output' / 'TEST-001' / 'cover.jpg')
+        assets = {'cover_fs': cover_fs, 'sample_fs': []}
+        repo = self._repo(temp_db)
+
+        _upsert_db(repo, self.SOURCE_URI, _T3_FILE_INFO, _T3_META, assets, None)
+
+        v = repo.get_by_path(self.SOURCE_URI)
+        assert v.cover_path.startswith('file:///')
+        assert not v.cover_path.startswith('https://')
+        assert v.cover_path != _T3_META['cover']
+
+    def test_sample_images_are_local_uris(self, tmp_path, temp_db):
+        """sample_images in DB must be local file:/// URIs, not remote URLs."""
+        from core.readonly_producer import _upsert_db
+        from core.path_utils import to_file_uri
+
+        ef_dir = tmp_path / 'output' / 'TEST-001' / 'extrafanart'
+        sample1 = str(ef_dir / 'fanart1.jpg')
+        sample2 = str(ef_dir / 'fanart2.jpg')
+        assets = {
+            'cover_fs': str(tmp_path / 'output' / 'TEST-001' / 'cover.jpg'),
+            'sample_fs': [sample1, sample2],
+        }
+        repo = self._repo(temp_db)
+
+        _upsert_db(repo, self.SOURCE_URI, _T3_FILE_INFO, _T3_META, assets, None)
+
+        v = repo.get_by_path(self.SOURCE_URI)
+        assert len(v.sample_images) == 2
+        assert v.sample_images[0] == to_file_uri(sample1, None)
+        assert v.sample_images[1] == to_file_uri(sample2, None)
+        for si in v.sample_images:
+            assert si.startswith('file:///')
+
+    def test_no_cover_stores_empty_string(self, temp_db):
+        """cover_fs='' → DB cover_path must be ''."""
+        from core.readonly_producer import _upsert_db
+
+        assets = {'cover_fs': '', 'sample_fs': []}
+        repo = self._repo(temp_db)
+
+        _upsert_db(repo, self.SOURCE_URI, _T3_FILE_INFO, _T3_META, assets, None)
+
+        v = repo.get_by_path(self.SOURCE_URI)
+        assert v.cover_path == ''
+
+    def test_empty_sample_images_stored_as_empty_list(self, temp_db):
+        """sample_fs=[] → DB sample_images==[]."""
+        from core.readonly_producer import _upsert_db
+
+        assets = {'cover_fs': '', 'sample_fs': []}
+        repo = self._repo(temp_db)
+
+        _upsert_db(repo, self.SOURCE_URI, _T3_FILE_INFO, _T3_META, assets, None)
+
+        v = repo.get_by_path(self.SOURCE_URI)
+        assert v.sample_images == []

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -63,10 +63,10 @@ class TestListSourceVideos:
         from core.readonly_producer import _list_source_videos
 
         with patch("core.readonly_producer.fast_scan_directory", return_value=FAKE_FILES) as mock_scan, \
-             patch("core.readonly_producer.normalize_path", return_value="/src") as mock_norm:
+             patch("core.readonly_producer.uri_to_fs_path", return_value="/src") as mock_coerce:
             result = _list_source_videos("/src", {".mp4", ".mkv"}, 0)
 
-        mock_norm.assert_called_once_with("/src")
+        mock_coerce.assert_called_once_with("/src")
         mock_scan.assert_called_once_with("/src", {".mp4", ".mkv"}, 0)
         assert result == FAKE_FILES
 
@@ -74,10 +74,31 @@ class TestListSourceVideos:
         from core.readonly_producer import _list_source_videos
 
         with patch("core.readonly_producer.fast_scan_directory", return_value=FAKE_FILES), \
-             patch("core.readonly_producer.normalize_path", return_value="/src"):
+             patch("core.readonly_producer.uri_to_fs_path", return_value="/src"):
             result = _list_source_videos("/src", {".mp4"}, 1024)
 
         assert result is FAKE_FILES
+
+    def test_tolerates_file_uri_source_path(self, tmp_path):
+        """PR#91 P2-A regression: a file:/// source path must resolve to the real FS
+        dir and find the videos (DirectoryConfig.path may be an FS path OR URI).
+
+        RED against the old ``normalize_path(source_path)`` code: on Linux/WSL,
+        normalize_path leaves ``file:///...`` literal → fast_scan_directory scans a
+        non-existent relative dir → returns []. GREEN after switching to uri_to_fs_path.
+        """
+        from core.path_utils import to_file_uri
+        from core.readonly_producer import _list_source_videos
+
+        video = tmp_path / "ABC-123.mp4"
+        video.write_bytes(b"x" * 2048)
+
+        source_uri = to_file_uri(str(tmp_path))
+        assert source_uri.startswith("file:///")
+
+        result = _list_source_videos(source_uri, {".mp4"}, 0)
+
+        assert [f["path"] for f in result] == [str(video)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -7,6 +7,8 @@ import inspect
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # Guard test: producer must not contain forbidden names (DoD / CD-88b-1)
@@ -580,6 +582,7 @@ class TestWriteMovieAssets:
 
         def fake_nfo(**kwargs):
             recorded_paths.append(kwargs.get('output_path', ''))
+            return True   # generate_nfo returns bool; True = write ok
 
         with patch('core.readonly_producer.download_image', side_effect=fake_download), \
              patch('core.readonly_producer.generate_jellyfin_images', side_effect=fake_jellyfin), \
@@ -692,6 +695,7 @@ class TestWriteMovieAssets:
 
         def capture_nfo(**kwargs):
             captured.update(kwargs)
+            return True   # generate_nfo returns bool; True = write ok
 
         with patch('core.readonly_producer.download_image', return_value=True), \
              patch('core.readonly_producer.generate_jellyfin_images',
@@ -704,6 +708,23 @@ class TestWriteMovieAssets:
         assert captured['external_manager'] == 'jellyfin'
         assert captured['has_poster'] is True
         assert captured['has_fanart'] is True
+
+    def test_nfo_write_failure_raises(self, tmp_path):
+        """generate_nfo returns False (write failed) → _write_movie_assets raises.
+
+        NFO is a required off-complete output; a swallowed False must not be treated
+        as success (else produce_source counts created + upserts a movie with no NFO).
+        """
+        from core.readonly_producer import _write_movie_assets
+
+        movie_dir = str(tmp_path / 'output' / 'TEST-001')
+        fd = _t3_format_data()
+        with patch('core.readonly_producer.download_image', return_value=True), \
+             patch('core.readonly_producer.generate_jellyfin_images',
+                   return_value={'poster': True, 'fanart': True}), \
+             patch('core.readonly_producer.generate_nfo', return_value=False):
+            with pytest.raises(RuntimeError):
+                _write_movie_assets(movie_dir, _T3_META, fd, '/src/TEST-001.mp4', _T3_BASE_CONFIG)
 
 
 class TestUpsertDb:
@@ -1167,3 +1188,51 @@ class TestProduceSourceExceptionDoesNotAbort:
         assert result.created == 2  # files 1 and 3 succeed
         statuses = [o.status for o in result.outcomes]
         assert statuses == ["created", "failed", "created"]
+
+
+class TestProduceSourceFailureContract:
+    """Required-asset failure → failed (not created), no upsert, fixed error message (P1/P2)."""
+
+    def _run_with_write_failure(self, exc):
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()
+        files = [_make_file_info(path="/src/A-001.mp4")]
+        meta = {"number": "X", "title": "T", "cover": "u", "actors": [], "tags": [],
+                "date": "", "maker": "", "director": "", "series": "", "label": "",
+                "sample_images": [], "duration": 0, "url": ""}
+        fd = {"number": "X", "title": "T", "actors": [], "maker": "", "date": "", "suffix": ""}
+        mock_movie_dir = MagicMock()
+        mock_movie_dir.__str__ = lambda self: "/output/dest/X"
+        upsert_mock = MagicMock()
+
+        with patch("core.readonly_producer._list_source_videos", return_value=files), \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer._should_skip", return_value=False), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
+             patch("core.readonly_producer.extract_number", return_value="MOCK-001"), \
+             patch("core.readonly_producer.search_jav", return_value=meta), \
+             patch("core.readonly_producer._format_data", return_value=fd), \
+             patch("core.readonly_producer._movie_dir", return_value=mock_movie_dir), \
+             patch("core.readonly_producer._write_movie_assets", side_effect=exc), \
+             patch("core.readonly_producer._upsert_db", upsert_mock):
+            result = produce_source(source, config, repo)
+        return result, upsert_mock
+
+    def test_required_asset_failure_counts_failed_and_skips_upsert(self):
+        # NFO/required-asset write failure surfaces as RuntimeError from _write_movie_assets.
+        result, upsert_mock = self._run_with_write_failure(RuntimeError("NFO write failed: /x"))
+        assert result.failed == 1
+        assert result.created == 0
+        upsert_mock.assert_not_called()                 # never claim generated when NFO missing
+        assert result.outcomes[0].status == "failed"
+
+    def test_failed_outcome_error_is_fixed_message(self):
+        # Raw exception text (paths/errno) must NOT reach the SSE-bound error field.
+        result, _ = self._run_with_write_failure(OSError("[Errno 28] No space left on device: '/output/x'"))
+        assert result.outcomes[0].error == "生成失敗"
+        assert "Errno" not in result.outcomes[0].error

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -511,69 +511,6 @@ class TestMovieDir:
         assert dir_a != dir_b
 
 
-class TestNoCoverRegenNoSibling:
-    """Codex P2-1: a no-cover title must reuse its folder on re-generate.
-
-    RED against pre-fix code: the second gen sees the on-disk folder, finds it
-    absent from `owners` (built from cover-bearing rows only — the no-cover row's
-    cover_path='' is dropped), treats it as <foreign> and spawns a hashed sibling.
-    GREEN after fix: _producer_uris marks the source as already-generated, so
-    _movie_dir reuses the same leaf.
-    """
-
-    def test_second_gen_no_hashed_sibling(self, tmp_path, temp_db):
-        from core.database import VideoRepository
-        from core.readonly_producer import produce_source
-
-        src_dir = tmp_path / "src"
-        src_dir.mkdir()
-        (src_dir / "ABC-123.mp4").write_bytes(b"x" * 4096)
-        out_dir = tmp_path / "out"
-        out_dir.mkdir()
-
-        source = _make_source(readonly=True, output_path=str(out_dir), path=str(src_dir))
-        # folder_format='' → no folder layers → movie leaf sits directly under out_dir,
-        # so a hashed sibling shows up as a top-level dir next to the real one.
-        config = {
-            "gallery": {},
-            "scraper": {
-                "folder_format": "",
-                "filename_format": "{num} {title}",
-                "max_filename_length": 60,
-                "max_title_length": 50,
-                "suffix_keywords": [],
-            },
-        }
-        meta = {
-            "number": "ABC-123", "title": "T", "cover": "", "actors": [], "tags": [],
-            "date": "", "maker": "", "director": "", "series": "", "label": "",
-            "sample_images": [], "duration": 0, "url": "",
-        }
-
-        def run():
-            # Fresh repo handle each run (same underlying temp_db file → persisted rows).
-            repo = VideoRepository(temp_db)
-            with patch("core.readonly_producer.search_jav", return_value=meta), \
-                 patch("core.readonly_producer.download_image", return_value=False), \
-                 patch("core.readonly_producer.generate_nfo", return_value=True):
-                return produce_source(source, config, repo)
-
-        r1 = run()
-        assert r1.created == 1
-        first_dir = r1.outcomes[0].movie_dir
-        dirs_after_first = sorted(p.name for p in out_dir.iterdir() if p.is_dir())
-        assert len(dirs_after_first) == 1
-
-        r2 = run()
-        assert r2.created == 1
-        dirs_after_second = sorted(p.name for p in out_dir.iterdir() if p.is_dir())
-
-        # No new/hashed sibling: still exactly one movie dir, and it is the same folder.
-        assert dirs_after_second == dirs_after_first
-        assert len(dirs_after_second) == 1
-        assert r2.outcomes[0].movie_dir == first_dir
-
-
 # ---------------------------------------------------------------------------
 # T-3 tests: _write_movie_assets, _upsert_db
 # ---------------------------------------------------------------------------
@@ -1037,7 +974,6 @@ class TestProduceSourceNoneNumberGuard:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1061,7 +997,6 @@ class TestProduceSourceNoneNumberGuard:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1111,7 +1046,6 @@ class TestProduceSourceMixedStats:
         with patch("core.readonly_producer._list_source_videos", return_value=self.FILES), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", side_effect=fake_should_skip), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1161,7 +1095,6 @@ class TestProduceSourceOnProgress:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1197,7 +1130,6 @@ class TestProduceSourceShouldAbort:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1241,7 +1173,6 @@ class TestProduceSourceExceptionDoesNotAbort:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \
@@ -1280,7 +1211,6 @@ class TestProduceSourceFailureContract:
         with patch("core.readonly_producer._list_source_videos", return_value=files), \
              patch("core.readonly_producer._build_cover_index", return_value={}), \
              patch("core.readonly_producer._build_owners", return_value={}), \
-             patch("core.readonly_producer._producer_uris", return_value=set()), \
              patch("core.readonly_producer._should_skip", return_value=False), \
              patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
              patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri), \

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -960,6 +960,49 @@ class TestProduceSourceGuards:
         mock_search.assert_not_called()
 
 
+class TestProduceSourceVideoExtensions:
+    """produce_source honors user-configured scraper.video_extensions (PR#91 ④)."""
+
+    def test_configured_extensions_passed_to_list(self):
+        """A custom video_extensions config → _list_source_videos gets that exact set."""
+        from core.readonly_producer import produce_source
+
+        source = _make_source()
+        repo = MagicMock()
+        # Custom, non-default extension list (normalized to a set by get_video_extensions)
+        config = _make_config(scraper_cfg={"video_extensions": ["mp4", ".m2ts", "CUSTOM"]})
+
+        with patch("core.readonly_producer._list_source_videos", return_value=[]) as mock_list, \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri):
+            produce_source(source, config, repo)
+
+        mock_list.assert_called_once()
+        passed_exts = mock_list.call_args[0][1]
+        assert passed_exts == {".mp4", ".m2ts", ".custom"}
+
+    def test_missing_config_falls_back_to_defaults(self):
+        """No scraper.video_extensions → _list_source_videos gets the DEFAULT set."""
+        from core.readonly_producer import produce_source
+        from core.video_extensions import DEFAULT_VIDEO_EXTENSIONS
+
+        source = _make_source()
+        repo = MagicMock()
+        config = _make_config()  # empty scraper cfg
+
+        with patch("core.readonly_producer._list_source_videos", return_value=[]) as mock_list, \
+             patch("core.readonly_producer._build_cover_index", return_value={}), \
+             patch("core.readonly_producer._build_owners", return_value={}), \
+             patch("core.readonly_producer.normalize_path", return_value="/output/dest"), \
+             patch("core.readonly_producer.to_file_uri", side_effect=_fake_to_file_uri):
+            produce_source(source, config, repo)
+
+        mock_list.assert_called_once()
+        assert mock_list.call_args[0][1] == set(DEFAULT_VIDEO_EXTENSIONS)
+
+
 class TestProduceSourceNoneNumberGuard:
     """extract_number returns None → no_scrape++, search_jav NOT called (Codex P2b)."""
 

--- a/tests/unit/test_readonly_summary.py
+++ b/tests/unit/test_readonly_summary.py
@@ -1,0 +1,91 @@
+"""TASK-88c-T2 — 純函式真值表：_accumulate_readonly / _outcome_to_sse。
+
+橋接 / 分流 / done 事件 / source-level 例外走 integration（TestClient），見
+tests/integration/test_api_scanner.py::TestGenerateReadonlyBridge。此檔只測無 IO 純函式。
+"""
+import pytest
+
+from web.routers.scanner import _accumulate_readonly, _outcome_to_sse, _yield_source_summary
+from core.readonly_producer import ProduceResult, ProduceOutcome
+
+
+def _empty():
+    return {"created": 0, "skipped": 0, "no_scrape": 0, "failed": 0,
+            "no_output": 0, "sources": 0, "source_errors": 0}
+
+
+class TestAccumulateReadonly:
+    def test_normal_result_accumulates_four_numbers_and_sources(self):
+        s = _empty()
+        _accumulate_readonly(s, ProduceResult(source_path="p", output_path="o",
+                                              created=2, skipped=1, no_scrape=1, failed=1))
+        assert s["sources"] == 1
+        assert (s["created"], s["skipped"], s["no_scrape"], s["failed"]) == (2, 1, 1, 1)
+        assert s["no_output"] == 0
+
+    def test_no_output_path_only_increments_no_output(self):
+        s = _empty()
+        _accumulate_readonly(s, ProduceResult(source_path="p", output_path="",
+                                              aborted_reason="no_output_path"))
+        assert s["no_output"] == 1
+        assert s["sources"] == 0
+        assert s["created"] == 0
+
+    def test_not_readonly_is_not_counted(self):
+        s = _empty()
+        _accumulate_readonly(s, ProduceResult(source_path="p", output_path="o",
+                                              created=5, aborted_reason="not_readonly"))
+        assert s == _empty()
+
+    def test_cross_source_accumulation(self):
+        s = _empty()
+        _accumulate_readonly(s, ProduceResult(source_path="a", output_path="o", created=1))
+        _accumulate_readonly(s, ProduceResult(source_path="b", output_path="o", created=2, failed=1))
+        assert s["sources"] == 2
+        assert s["created"] == 3
+        assert s["failed"] == 1
+
+
+class TestOutcomeToSse:
+    @pytest.mark.parametrize("status,label,level", [
+        ("created", "✓ 生成", "info"),
+        ("skipped", "略過", "info"),
+        ("no_scrape", "刮不到", "info"),
+        ("failed", "✗ 失敗", "warn"),
+    ])
+    def test_status_maps_to_label_and_level(self, status, label, level):
+        d = _outcome_to_sse(ProduceOutcome(source_uri="u", status=status, number="ABC-001"))
+        assert d["type"] == "log"
+        assert d["level"] == level
+        assert label in d["message"]
+        assert "ABC-001" in d["message"]
+
+    def test_failed_appends_error_note(self):
+        d = _outcome_to_sse(ProduceOutcome(source_uri="u", status="failed",
+                                           number="X", error="生成失敗"))
+        assert "生成失敗" in d["message"]
+
+    def test_error_is_fixed_message_no_leak(self):
+        # producer 已 sanitize error 為固定字串；轉發不外洩細節
+        d = _outcome_to_sse(ProduceOutcome(source_uri="u", status="failed",
+                                           number="X", error="生成失敗"))
+        assert "/home/" not in d["message"]
+        assert "Traceback" not in d["message"]
+
+
+class TestYieldSourceSummary:
+    def test_no_output_path_yields_prompt(self):
+        r = ProduceResult(source_path="P", output_path="", aborted_reason="no_output_path")
+        msgs = [m for m in _yield_source_summary(r)]
+        assert len(msgs) == 1
+        assert "請先設定輸出夾" in msgs[0]
+
+    def test_normal_yields_four_number_summary(self):
+        r = ProduceResult(source_path="P", output_path="o", created=2, skipped=1, no_scrape=0, failed=1)
+        msgs = [m for m in _yield_source_summary(r)]
+        assert len(msgs) == 1
+        assert "新增 2" in msgs[0] and "略過 1" in msgs[0] and "失敗 1" in msgs[0]
+
+    def test_not_readonly_yields_nothing(self):
+        r = ProduceResult(source_path="P", output_path="o", aborted_reason="not_readonly")
+        assert list(_yield_source_summary(r)) == []

--- a/tests/unit/test_settings_link.py
+++ b/tests/unit/test_settings_link.py
@@ -41,6 +41,20 @@ class TestExactMatch:
             result = find_matched_directory('/mnt/e/media', ['/mnt/e/media'])
         assert result == '/mnt/e/media'
 
+    def test_uri_form_directory_matched(self):
+        """PR#91: directory 已是 file:/// URI（schema「FS 路徑或 URI」）→ 仍能命中。
+
+        pre-fix `normalize_path` 對 URI 原樣通過 → `to_file_uri` 二次包成
+        file:///file:///… → 永不命中（RED）。改用 uri_to_fs_path 後冪等命中。
+        favorite 端維持 FS 路徑（真實使用者最愛資料夾）。
+        """
+        uri_dir = _real_to_file_uri('/home/user/media')
+        with patch('core.settings_link.expand_env_vars', return_value='/home/user/media/jav'), \
+             patch('core.settings_link.normalize_path', side_effect=lambda x: x), \
+             patch('core.settings_link.to_file_uri', side_effect=_real_to_file_uri):
+            result = find_matched_directory('/home/user/media/jav', [uri_dir])
+        assert result == uri_dir
+
     def test_exact_match_first_of_multiple(self):
         """多個 directories，精確命中第一個"""
         with patch('core.settings_link.expand_env_vars', return_value='/mnt/e/media'), \

--- a/tests/unit/test_showcase_api.py
+++ b/tests/unit/test_showcase_api.py
@@ -564,6 +564,34 @@ class TestShowcaseDirectoryFiltering:
         assert data["total"] == 1
         assert data["videos"][0]["number"] == "SONE-205"
 
+    def test_uri_source_path_filtering(self, client, populated_db, monkeypatch):
+        """PR#91 P2-D: 來源 path 已是 file:/// URI（schema「FS 路徑或 URI」）時，
+        該資料夾底下的列仍要出現在 Showcase。
+
+        pre-fix `to_file_uri('file:///…')` 二次包成 'file:///file:///…' → 過濾掉
+        所有列 → total == 0 (RED)。
+        """
+        def mock_get_db_path():
+            return populated_db
+        monkeypatch.setattr("web.routers.showcase.get_db_path", mock_get_db_path)
+
+        # 來源 path 用 URI 形式（等價 /home/user/media），只設這一個來源
+        def mock_load_config():
+            return {
+                "gallery": {
+                    "directories": [to_file_uri("/home/user/media")],
+                    "path_mappings": {},
+                }
+            }
+        monkeypatch.setattr("web.routers.showcase.load_config", mock_load_config)
+
+        response = client.get("/api/showcase/videos")
+        data = response.json()
+
+        assert data["success"] is True
+        assert data["total"] == 1
+        assert data["videos"][0]["number"] == "SONE-205"
+
     def test_wsl_mount_path_filtering(self, client, temp_db, monkeypatch):
         """WSL /mnt/c/ 設定值能正確匹配 DB 中的 file:///C:/ URI"""
         repo = VideoRepository(temp_db)

--- a/tests/unit/test_video_repository.py
+++ b/tests/unit/test_video_repository.py
@@ -1,10 +1,8 @@
 """測試 VideoRepository 類別"""
 import pytest
 import json
-from pathlib import Path
 
 from core.database import (
-    init_db,
     Video,
     VideoRepository,
     migrate_json_to_sqlite
@@ -178,6 +176,53 @@ class TestVideoRepository:
         assert len(index) == 2
         assert index[to_file_uri("/video1.mp4")] == (100.5, 100.0)
         assert index[to_file_uri("/video2.mp4")] == (200.5, 200.0)
+
+    def test_get_cover_index_empty(self, temp_db):
+        """get_cover_index on empty table returns {}."""
+        repo = VideoRepository(temp_db)
+        assert repo.get_cover_index() == {}
+
+    def test_get_cover_index_multi_row(self, temp_db):
+        """get_cover_index returns {path: cover_path} including empty string and None values."""
+        repo = VideoRepository(temp_db)
+
+        videos = [
+            Video(
+                path=to_file_uri("/video1.mp4"),
+                mtime=100.0,
+                cover_path=to_file_uri("/out/video1.jpg"),
+            ),
+            Video(
+                path=to_file_uri("/video2.mp4"),
+                mtime=200.0,
+                cover_path="",   # empty cover
+            ),
+            Video(
+                path=to_file_uri("/video3.mp4"),
+                mtime=300.0,
+                cover_path=None,  # NULL cover — returned as-is
+            ),
+        ]
+        repo.upsert_batch(videos)
+
+        index = repo.get_cover_index()
+
+        assert len(index) == 3
+        assert index[to_file_uri("/video1.mp4")] == to_file_uri("/out/video1.jpg")
+        assert index[to_file_uri("/video2.mp4")] == ""
+        # None stored as SQL NULL → returned as None (sqlite3 never coerces NULL→"")
+        assert index[to_file_uri("/video3.mp4")] is None
+
+    def test_get_cover_index_returns_cover_path_not_mtime(self, temp_db):
+        """Mutation sentinel: ensure we are reading cover_path, not mtime."""
+        repo = VideoRepository(temp_db)
+        cover = to_file_uri("/out/sentinel.jpg")
+        repo.upsert(Video(path=to_file_uri("/v.mp4"), mtime=9999.0, cover_path=cover))
+
+        index = repo.get_cover_index()
+        # Value must be the cover URI, not the mtime float
+        assert index[to_file_uri("/v.mp4")] == cover
+        assert index[to_file_uri("/v.mp4")] != 9999.0
 
     def test_delete_by_paths(self, temp_db):
         """測試 delete_by_paths"""

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -21,6 +21,7 @@ import asyncio
 import base64
 import json
 import os
+import queue
 import sys
 import threading
 import time
@@ -41,6 +42,7 @@ from core.nfo_updater import check_cache_needs_update, update_videos_generator
 from core.database import VideoRepository, Video, init_db, get_db_path, migrate_json_to_sqlite
 from core.organizer import generate_jellyfin_images, HEADERS as _EMBED_HEADERS
 from core.config import load_config, iter_gallery_sources, get_gallery_source_paths
+from core.readonly_producer import produce_source
 from core import thumbnail_cache
 from core.scraper import smart_search
 from core.source_settings import is_uncensored_mode_effective
@@ -146,6 +148,110 @@ def _emit_long_path_warnings(logger_, long_paths: List[str]) -> None:
         logger_.warning(f"  {p}")
 
 
+# ---------------------------------------------------------------------------
+# TASK-88c-T2: readonly 來源分流 + SSE thread/queue 橋接 + 四數摘要
+# ---------------------------------------------------------------------------
+
+def _outcome_to_sse(o) -> dict:
+    """把 ProduceOutcome 轉一條 SSE log 行 dict（純函式）。
+
+    error 已是固定 "生成失敗"（producer 已 sanitize，:462）→ 直接轉發，
+    不再塞 server-side 細節。failed → warn，其餘 info。
+    """
+    label = {
+        "created": "✓ 生成",
+        "skipped": "略過",
+        "no_scrape": "刮不到",
+        "failed": "✗ 失敗",
+    }.get(o.status, o.status)
+    msg = f"  {label}: {o.number or o.source_uri}"
+    if o.status == "failed" and o.error:
+        msg += f"（{o.error}）"
+    return {"type": "log", "level": "warn" if o.status == "failed" else "info", "message": msg}
+
+
+def _accumulate_readonly(summary: dict, result) -> None:
+    """跨來源累計四數 + no_output（純函式，CD-88c-3）。
+
+    no_output_path → 只 no_output+1；其他非空 aborted_reason（not_readonly 防呆）
+    → 記 log 不計數；正常 → sources+1 並累加 created/skipped/no_scrape/failed。
+    """
+    if result.aborted_reason == "no_output_path":
+        summary["no_output"] += 1
+        return
+    if result.aborted_reason:
+        logger.info("唯讀來源略過（%s）: %s", result.aborted_reason, result.source_path)
+        return
+    summary["sources"] += 1
+    summary["created"] += result.created
+    summary["skipped"] += result.skipped
+    summary["no_scrape"] += result.no_scrape
+    summary["failed"] += result.failed
+
+
+def _yield_source_summary(result) -> Generator[str, None, None]:
+    """該來源小結（產生器）。no_output_path → 「請先設定輸出夾」提示（Acceptance #11）。"""
+    if result.aborted_reason == "no_output_path":
+        yield _sse_event({
+            "type": "log", "level": "warn",
+            "message": f"  {result.source_path}: 請先設定輸出夾，已略過",
+        })
+    elif not result.aborted_reason:
+        yield _sse_event({
+            "type": "log", "level": "info",
+            "message": (
+                f"  {result.source_path}: 新增 {result.created}／略過 {result.skipped}"
+                f"／刮不到 {result.no_scrape}／失敗 {result.failed}"
+            ),
+        })
+
+
+def _run_readonly_source(src, config, repo, proxy_url, summary) -> Generator[str, None, None]:
+    """在 daemon worker thread 跑 produce_source，drain 無界 queue 逐片 yield SSE。
+
+    worker 例外（含 produce_source 迴圈前的 normalize/列檔/DB 拋錯，未被 producer
+    內 try 包覆）顯式接手（CD-88c-1 / Codex P1），不靜默吞：box['error'] → 產生器
+    emit error SSE + source_errors+1 + 續下一來源。
+    """
+    q: "queue.Queue" = queue.Queue()  # 無界：worker 永不阻塞於 put，client 斷線 daemon 自然退出
+    _SENTINEL = object()
+    box: dict = {}
+
+    def _work():
+        try:
+            box['result'] = produce_source(
+                src, config, repo, proxy_url=proxy_url,
+                on_progress=q.put,
+                should_abort=None,
+            )
+        except Exception:
+            logger.exception("唯讀生成來源失敗: %s", src.path)
+            box['error'] = True
+        finally:
+            q.put(_SENTINEL)
+
+    t = threading.Thread(target=_work, daemon=True)
+    t.start()
+    yield _sse_event({"type": "log", "level": "info", "message": f"唯讀生成: {src.path}"})
+    while True:
+        item = q.get()
+        if item is _SENTINEL:
+            break
+        yield _sse_event(_outcome_to_sse(item))
+    t.join()
+    if box.get('error'):
+        summary["source_errors"] += 1
+        yield _sse_event({
+            "type": "log", "level": "error",
+            "message": f"  {src.path}: 生成失敗（來源無法存取或設定錯誤）",
+        })
+        return
+    result = box.get('result')
+    if result is not None:
+        _accumulate_readonly(summary, result)
+        yield from _yield_source_summary(result)
+
+
 def generate_avlist() -> Generator[str, None, None]:
     """產生影片列表（SSE 串流）- 使用 SQLite 儲存"""
 
@@ -211,9 +317,21 @@ def generate_avlist() -> Generator[str, None, None]:
         session_added_paths = []  # 追蹤本次新增/變更的影片路徑
         long_paths: list[str] = []  # a5: Windows 長路徑收集（只在 win32 填充）
 
+        # TASK-88c-T2: readonly 來源生成摘要（跨來源累計，迴圈前初始化避免清零）
+        proxy_url = config.get('search', {}).get('proxy_url', '')
+        readonly_summary = {
+            "created": 0, "skipped": 0, "no_scrape": 0, "failed": 0,
+            "no_output": 0, "sources": 0, "source_errors": 0,
+        }
+
         for idx, src in enumerate(iter_gallery_sources(gallery_config), 1):
             directory = src.path
             logger.info(f"[Gallery] 掃描: {directory}")
+
+            # TASK-88c-T2: readonly 來源分流（早於 normalize，UNC 主場景不被擋）
+            if src.readonly:
+                yield from _run_readonly_source(src, config, repo, proxy_url, readonly_summary)
+                continue
 
             # 轉換路徑格式 (Windows -> WSL)
             try:
@@ -451,6 +569,17 @@ def generate_avlist() -> Generator[str, None, None]:
 
         logger.info(f"[Gallery] 完成，新增 {total_inserted}，更新 {total_updated}，刪除 {total_deleted}")
 
+        # TASK-88c-T2: readonly 生成摘要 log 行（僅有 readonly 活動時輸出）
+        if readonly_summary["sources"] > 0 or readonly_summary["no_output"] > 0 or readonly_summary["source_errors"] > 0:
+            logger.info(
+                "唯讀生成完成: 新增 %d／略過 %d／刮不到 %d／失敗 %d"
+                "（%d 個來源；%d 個未設輸出夾；%d 個來源錯誤）",
+                readonly_summary["created"], readonly_summary["skipped"],
+                readonly_summary["no_scrape"], readonly_summary["failed"],
+                readonly_summary["sources"], readonly_summary["no_output"],
+                readonly_summary["source_errors"],
+            )
+
         # a5: 寫長路徑清單到 debug.log（helper 內部判斷空 list）
         _emit_long_path_warnings(logger, long_paths)
 
@@ -483,7 +612,8 @@ def generate_avlist() -> Generator[str, None, None]:
                 "inserted": total_inserted,
                 "updated": total_updated,
                 "deleted": total_deleted
-            }
+            },
+            "readonly_stats": readonly_summary  # TASK-88c-T2: 加法式新欄位
         })
 
     except Exception as e:

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -588,11 +588,20 @@ def generate_avlist() -> Generator[str, None, None]:
         _jellyfin_cache_result = None
         _jellyfin_cache_time = 0
 
-        # 53b-T3: 掃描完成通知
-        if scan_error_count > 0:
+        # 53b-T3 / 88c-P2: 掃描完成通知
+        # scan_error_count（一般掃描逐檔失敗）與 readonly source_errors（唯讀來源
+        # 迴圈前整源拋錯）皆須讓完成通知走 warn，不可純 success（Codex P2：來源級
+        # 失敗原本只增 source_errors，完成通知沒納入 → 仍報成功，誤導）。
+        _source_errors = readonly_summary["source_errors"]
+        if scan_error_count > 0 or _source_errors > 0:
+            _err_parts = []
+            if scan_error_count > 0:
+                _err_parts.append(f"{scan_error_count} 部失敗")
+            if _source_errors > 0:
+                _err_parts.append(f"{_source_errors} 個來源失敗")
             _emit_notif(
                 "warn", "notif.scanner_done_with_errors",
-                message=f"完成 {len(all_videos)} 部，{scan_error_count} 部失敗",
+                message=f"完成 {len(all_videos)} 部，" + "、".join(_err_parts),
                 task_type="scanner_generate",
             )
         else:

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -592,13 +592,18 @@ def generate_avlist() -> Generator[str, None, None]:
         # scan_error_count（一般掃描逐檔失敗）與 readonly source_errors（唯讀來源
         # 迴圈前整源拋錯）皆須讓完成通知走 warn，不可純 success（Codex P2：來源級
         # 失敗原本只增 source_errors，完成通知沒納入 → 仍報成功，誤導）。
+        # 個別影片失敗（readonly failed，例如 NFO 寫入失敗）同樣須讓完成通知走
+        # warn（PR#91 ②）。no_scrape 是「線上查無 metadata」的正常情況，不計入。
         _source_errors = readonly_summary["source_errors"]
-        if scan_error_count > 0 or _source_errors > 0:
+        _readonly_failed = readonly_summary["failed"]
+        if scan_error_count > 0 or _source_errors > 0 or _readonly_failed > 0:
             _err_parts = []
             if scan_error_count > 0:
                 _err_parts.append(f"{scan_error_count} 部失敗")
             if _source_errors > 0:
                 _err_parts.append(f"{_source_errors} 個來源失敗")
+            if _readonly_failed > 0:
+                _err_parts.append(f"{_readonly_failed} 部失敗")
             _emit_notif(
                 "warn", "notif.scanner_done_with_errors",
                 message=f"完成 {len(all_videos)} 部，" + "、".join(_err_parts),

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -102,6 +102,24 @@ def _dir_candidate_forms(raw_dir: str, path_mappings: dict) -> tuple:
     return forms
 
 
+def _image_whitelist_dirs(gallery_config) -> List[str]:
+    """TASK-88c-T1: /api/gallery/image 白名單的候選 raw 目錄清單。
+
+    每個來源 emit `src.path`，並在 `src.output_path` 非空時一併 emit
+    （讓唯讀 + off 風味生成到 output_path 底下的封面/劇照能經 image proxy 服務）。
+
+    純函式、無 IO。`""` output_path 被過濾——不讓空字串進 `_dir_candidate_forms`
+    （避免 `to_file_uri('') = 'file:///'` 根路徑把整顆磁碟放進白名單，
+    CWE-allowlist bypass）。get_video 不共用此 helper（獨立 call site，spec P1a）。
+    """
+    dirs: List[str] = []
+    for src in iter_gallery_sources(gallery_config):
+        dirs.append(src.path)
+        if src.output_path:
+            dirs.append(src.output_path)
+    return dirs
+
+
 def _sse_event(data: dict) -> str:
     """將 dict 編碼為 SSE 格式的單條 message。"""
     return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
@@ -815,9 +833,11 @@ def get_image(path: str = Query(..., description="圖片路徑")):
     # TASK-73: 兩端對稱正規化 — request_uri 用 single-form（realpath已做）；
     # dir 端用 dual-form（normpath + realpath 候選），避免 SMB mapped drive 格式不同 403 誤殺
     request_uri = to_file_uri(local_path, path_mappings)
+    # TASK-88c-T1: 白名單納入各來源非空 output_path（唯讀 off 風味封面服務）；
+    # 複用 _dir_candidate_forms dual-form，不另寫 single-form 比對
     allowed = any(
         is_path_under_dir(request_uri, form)
-        for p in get_gallery_source_paths(gallery_config)
+        for p in _image_whitelist_dirs(gallery_config)
         for form in _dir_candidate_forms(p, path_mappings)
     )
     if not allowed:

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -40,7 +40,7 @@ from core.path_utils import normalize_path, to_file_uri, is_path_under_dir, uri_
 from core.nfo_updater import check_cache_needs_update, update_videos_generator
 from core.database import VideoRepository, Video, init_db, get_db_path, migrate_json_to_sqlite
 from core.organizer import generate_jellyfin_images, HEADERS as _EMBED_HEADERS
-from core.config import load_config
+from core.config import load_config, iter_gallery_sources, get_gallery_source_paths
 from core import thumbnail_cache
 from core.scraper import smart_search
 from core.source_settings import is_uncensored_mode_effective
@@ -136,7 +136,7 @@ def generate_avlist() -> Generator[str, None, None]:
         config = load_config()
         gallery_config = config.get('gallery', {})
 
-        directories = gallery_config.get('directories', [])
+        directories = get_gallery_source_paths(gallery_config)
         output_dir = gallery_config.get('output_dir', 'output')
         output_filename = gallery_config.get('output_filename', 'gallery_output.html')
         path_mappings = gallery_config.get('path_mappings', {})
@@ -193,7 +193,8 @@ def generate_avlist() -> Generator[str, None, None]:
         session_added_paths = []  # 追蹤本次新增/變更的影片路徑
         long_paths: list[str] = []  # a5: Windows 長路徑收集（只在 win32 填充）
 
-        for idx, directory in enumerate(directories, 1):
+        for idx, src in enumerate(iter_gallery_sources(gallery_config), 1):
+            directory = src.path
             logger.info(f"[Gallery] 掃描: {directory}")
 
             # 轉換路徑格式 (Windows -> WSL)
@@ -328,9 +329,9 @@ def generate_avlist() -> Generator[str, None, None]:
         # 建立「當前設定資料夾」URI 集合，用於過濾 DB 記錄
         # DB 保留所有歷史資料當 cache，但只輸出當前設定的資料夾
         configured_dir_uris = set()
-        for d in directories:
+        for p in get_gallery_source_paths(gallery_config):
             try:
-                configured_dir_uris.add(to_file_uri(d, path_mappings))
+                configured_dir_uris.add(to_file_uri(p, path_mappings))
             except ValueError:
                 continue
 
@@ -809,7 +810,6 @@ def get_image(path: str = Query(..., description="圖片路徑")):
     # 3. 目錄白名單：只允許 gallery.directories 底下的檔案
     config = load_config()
     gallery_config = config.get('gallery', {})
-    directories = gallery_config.get('directories', [])
     path_mappings = gallery_config.get('path_mappings', {})
 
     # TASK-73: 兩端對稱正規化 — request_uri 用 single-form（realpath已做）；
@@ -817,8 +817,8 @@ def get_image(path: str = Query(..., description="圖片路徑")):
     request_uri = to_file_uri(local_path, path_mappings)
     allowed = any(
         is_path_under_dir(request_uri, form)
-        for d in directories
-        for form in _dir_candidate_forms(d, path_mappings)
+        for p in get_gallery_source_paths(gallery_config)
+        for form in _dir_candidate_forms(p, path_mappings)
     )
     if not allowed:
         logger.warning("get_image: 拒絕白名單外路徑請求 uri=%s", request_uri)
@@ -1094,7 +1094,6 @@ def get_video(request: Request, path: str = Query(..., description="影片路徑
 
     # 4. 目錄白名單：只允許 gallery.directories 底下的檔案
     gallery_config = config.get('gallery', {})
-    directories = gallery_config.get('directories', [])
     path_mappings = gallery_config.get('path_mappings', {})
 
     # TASK-73: 兩端對稱正規化 — request_uri 用 single-form（realpath已做）；
@@ -1102,8 +1101,8 @@ def get_video(request: Request, path: str = Query(..., description="影片路徑
     request_uri = to_file_uri(local_path, path_mappings)
     allowed = any(
         is_path_under_dir(request_uri, form)
-        for d in directories
-        for form in _dir_candidate_forms(d, path_mappings)
+        for p in get_gallery_source_paths(gallery_config)
+        for form in _dir_candidate_forms(p, path_mappings)
     )
     if not allowed:
         logger.warning("get_video: 拒絕白名單外路徑請求 uri=%s", request_uri)

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -37,7 +37,7 @@ from fastapi.responses import StreamingResponse, HTMLResponse, Response, FileRes
 from core.gallery_scanner import VideoScanner, fast_scan_directory, VideoInfo, _run_sample_images_cleanup_pass
 from core.video_extensions import get_proxy_extensions, get_video_extensions
 from core.gallery_generator import HTMLGenerator
-from core.path_utils import normalize_path, to_file_uri, is_path_under_dir, uri_to_fs_path
+from core.path_utils import to_file_uri, is_path_under_dir, uri_to_fs_path, coerce_to_file_uri
 from core.nfo_updater import check_cache_needs_update, update_videos_generator
 from core.database import VideoRepository, Video, init_db, get_db_path, migrate_json_to_sqlite
 from core.organizer import generate_jellyfin_images, HEADERS as _EMBED_HEADERS
@@ -92,9 +92,16 @@ def _dir_candidate_forms(raw_dir: str, path_mappings: dict) -> tuple:
         if now < expire:
             return forms
 
-    normpath_form = to_file_uri(os.path.normpath(raw_dir), path_mappings)
+    # raw_dir 可能是 FS 路徑或 file:/// URI（DirectoryConfig.path schema：「FS 路徑或
+    # URI」）。先過 uri_to_fs_path 統一成 FS 路徑（URI→FS，FS→FS 冪等，path-contract
+    # 合規，不手刻 startswith('file:///')）。否則對 URI 直接 os.path.normpath/realpath
+    # 會把 file:/// 折成 file:/ 再被 to_file_uri 二次包成 file:///file:/…，image/video
+    # 兩條白名單同時誤殺（PR#91 P2-D 同源）。FS 輸入行為不變 → 保留 dual-form + TASK-73
+    # 跨格式 casefold。
+    fs_dir = uri_to_fs_path(raw_dir)
+    normpath_form = to_file_uri(os.path.normpath(fs_dir), path_mappings)
     try:
-        realpath_form = to_file_uri(os.path.realpath(raw_dir), path_mappings)
+        realpath_form = to_file_uri(os.path.realpath(fs_dir), path_mappings)
         forms = tuple(dict.fromkeys([normpath_form, realpath_form]))
         # cache-on-success-only
         _dir_forms_cache[cache_key] = (forms, now + _DIR_FORMS_TTL)
@@ -333,9 +340,12 @@ def generate_avlist() -> Generator[str, None, None]:
                 yield from _run_readonly_source(src, config, repo, proxy_url, readonly_summary)
                 continue
 
-            # 轉換路徑格式 (Windows -> WSL)
+            # 轉換路徑格式 (Windows -> WSL)。directory 可能是 FS 路徑或 file:/// URI
+            # （DirectoryConfig.path schema）。uri_to_fs_path 對 URI→FS、FS→FS 皆冪等，
+            # 取代裸 normalize_path（後者對 URI 原樣通過 → os.path.exists 失敗 → 誤報
+            # 「資料夾不存在」，非 readonly 的 URI 來源掃不到）。
             try:
-                normalized_dir = normalize_path(directory)
+                normalized_dir = uri_to_fs_path(directory)
             except ValueError:
                 logger.exception("路徑轉換失敗: %s", directory)
                 yield _sse_event({"type": "log", "level": "warn", "message": "路徑轉換失敗"})
@@ -467,7 +477,10 @@ def generate_avlist() -> Generator[str, None, None]:
         configured_dir_uris = set()
         for p in get_gallery_source_paths(gallery_config):
             try:
-                configured_dir_uris.add(to_file_uri(p, path_mappings))
+                # coerce_to_file_uri：來源 path 可能已是 file:/// URI（含 readonly 剛
+                # upsert 的列），已是 URI 就原樣回、FS 才轉，避免 to_file_uri 二次包成
+                # file:///file:/// 把 readonly 生成的列全數過濾掉（PR#91 P2-D）。
+                configured_dir_uris.add(coerce_to_file_uri(p, path_mappings))
             except ValueError:
                 continue
 

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -97,11 +97,14 @@ def scrape_single(request: ScrapeRequest) -> dict:
     # WSL/Linux 會拋 ValueError，而 UNC 正是 readonly 主場景）。
     _gallery_config = load_config().get('gallery', {})
     _path_mappings = _gallery_config.get('path_mappings', {})
-    _file_uri = to_file_uri(file_path, _path_mappings)
+    # coerce_to_file_uri：file_path 可能已是 DB canonical file:/// URI（鄰近寫入路徑
+    # 傳的就是 URI），直接 to_file_uri 會雙重包成 file:///file:/// 導致 guard 被繞過
+    # （Codex P1）。coerce 對「已是 URI」原樣回、對 FS path 才轉，兩端對稱處理。
+    _file_uri = coerce_to_file_uri(file_path, _path_mappings)
     for _s in iter_gallery_sources(_gallery_config):
         if not _s.readonly or not _s.path:
             continue
-        if is_path_under_dir(_file_uri, to_file_uri(_s.path, _path_mappings)):
+        if is_path_under_dir(_file_uri, coerce_to_file_uri(_s.path, _path_mappings)):
             return {
                 "success": False,
                 "error": "此來源路徑為唯讀（readonly），無法搬移或重新命名檔案。"

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -20,7 +20,7 @@ from core.database import VideoRepository
 from core.db_inflow import try_inflow_upsert
 from core.enricher import enrich_single, fetch_samples_only, resolve_nfo_cover_paths
 from core.organizer import organize_file
-from core.path_utils import to_file_uri, uri_to_fs_path, coerce_to_file_uri
+from core.path_utils import to_file_uri, uri_to_fs_path, coerce_to_file_uri, is_path_under_dir
 from core.scraper import (
     search_jav, search_jav_single_source, strip_internal_nfo_keys,
     search_javlib_versions, fetch_javlib_by_detail_url, internal_nfo_carriers,
@@ -29,7 +29,7 @@ from core.source_config import validate_source_id
 from core.cf_transport import get_cf_transport, CfChallengeRequired, CfTransportUnavailable
 from core.scrapers.javlibrary import JAVLIBRARY_ORIGIN
 from core.logger import get_logger
-from core.config import load_config
+from core.config import load_config, iter_gallery_sources
 from core import thumbnail_cache
 from web.routers.notifications import emit_notification as _emit_notif
 
@@ -89,6 +89,24 @@ def scrape_single(request: ScrapeRequest) -> dict:
     """
     file_path = request.file_path
     number = request.number
+
+    # U7 readonly guard：只依 file_path 判斷所屬來源是否唯讀（readonly）。
+    # 是 → 不搬檔、不刮削、不解析番號，回既有錯誤形狀 plain dict。
+    # 必須在 extract_number / search_jav / organize_file 之前（Codex P1）；
+    # 兩端一律用 UNC-tolerant to_file_uri，不做原生路徑正規化（Codex P2：對 UNC 在
+    # WSL/Linux 會拋 ValueError，而 UNC 正是 readonly 主場景）。
+    _gallery_config = load_config().get('gallery', {})
+    _path_mappings = _gallery_config.get('path_mappings', {})
+    _file_uri = to_file_uri(file_path, _path_mappings)
+    for _s in iter_gallery_sources(_gallery_config):
+        if not _s.readonly or not _s.path:
+            continue
+        if is_path_under_dir(_file_uri, to_file_uri(_s.path, _path_mappings)):
+            return {
+                "success": False,
+                "error": "此來源路徑為唯讀（readonly），無法搬移或重新命名檔案。"
+                         "請改用掃描頁『產生』生成本地媒體庫，或確認你對此路徑有寫入權限。",
+            }
 
     # 如果沒有提供番號，嘗試從檔名提取
     if not number:

--- a/web/routers/settings_link.py
+++ b/web/routers/settings_link.py
@@ -6,7 +6,7 @@ favorite 從 query param 取得（input 即時值），不讀 config 存檔的 f
 directories / path_mappings 仍從 config 讀（CD-58-B1-4）。
 """
 from fastapi import APIRouter, Query
-from core.config import load_config
+from core.config import load_config, get_gallery_source_paths
 from core.logger import get_logger
 from core.settings_link import find_matched_directory
 
@@ -32,17 +32,15 @@ def get_favorite_scanner_link(
     config = load_config()
     gallery_config = config.get("gallery", {}) if isinstance(config, dict) else getattr(config, "gallery", {})
 
-    # 從 config 讀 directories / path_mappings（不接受前端傳入）
+    # 從 config 讀 path_mappings（不接受前端傳入）
     if isinstance(gallery_config, dict):
-        directories = gallery_config.get("directories", [])
         path_mappings = gallery_config.get("path_mappings", {})
     else:
-        directories = getattr(gallery_config, "directories", [])
         path_mappings = getattr(gallery_config, "path_mappings", {})
 
     matched = find_matched_directory(
         favorite=favorite,
-        directories=directories,
+        directories=get_gallery_source_paths(gallery_config),
         path_mappings=path_mappings or None,
     )
 

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -14,7 +14,7 @@ from fastapi.responses import JSONResponse
 from core.database import VideoRepository, get_db_path, init_db
 from core.path_utils import to_file_uri, is_path_under_dir, uri_to_fs_path
 from core.logger import get_logger
-from core.config import load_config
+from core.config import load_config, get_gallery_source_paths
 from core import thumbnail_cache
 
 logger = get_logger(__name__)
@@ -72,13 +72,12 @@ def _serialize_video(v, path_mappings: dict, enabled: bool = False) -> dict:
 def _get_configured_dirs(config: dict) -> tuple[set, dict]:
     """從 config 取出 configured_dir_uris 與 path_mappings（列表與單筆端點共用）"""
     gallery_config = config.get('gallery', {})
-    directories = gallery_config.get('directories', [])
     path_mappings = gallery_config.get('path_mappings', {})
 
     configured_dir_uris: set = set()
-    for d in directories:
+    for p in get_gallery_source_paths(gallery_config):
         try:
-            configured_dir_uris.add(to_file_uri(d, path_mappings))
+            configured_dir_uris.add(to_file_uri(p, path_mappings))
         except ValueError:
             continue
 

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from core.database import VideoRepository, get_db_path, init_db
-from core.path_utils import to_file_uri, is_path_under_dir, uri_to_fs_path
+from core.path_utils import is_path_under_dir, uri_to_fs_path, coerce_to_file_uri
 from core.logger import get_logger
 from core.config import load_config, get_gallery_source_paths
 from core import thumbnail_cache
@@ -77,7 +77,10 @@ def _get_configured_dirs(config: dict) -> tuple[set, dict]:
     configured_dir_uris: set = set()
     for p in get_gallery_source_paths(gallery_config):
         try:
-            configured_dir_uris.add(to_file_uri(p, path_mappings))
+            # coerce_to_file_uri：來源 path 可能已是 file:/// URI（DirectoryConfig.path
+            # schema「FS 路徑或 URI」）。已是 URI 就原樣回，避免 to_file_uri 二次包成
+            # file:///file:/// 把 readonly 來源的列從 Showcase 過濾掉（PR#91 P2-D 同源）。
+            configured_dir_uris.add(coerce_to_file_uri(p, path_mappings))
         except ValueError:
             continue
 

--- a/web/static/js/pages/scanner/state-scan.js
+++ b/web/static/js/pages/scanner/state-scan.js
@@ -779,7 +779,17 @@ export function stateScan() {
                             this.nfoUpdateVisible = false;
                         }
 
-                        this.showToast(`成功產生 ${data.video_count} 部影片列表`, 'success');
+                        // 88c-P2: 唯讀來源整源失敗（source_errors）時完成 toast 走 warn，
+                        // 不可純 success（後端完成通知已同步納入 source_errors）。
+                        const srcErrors = (data.readonly_stats && data.readonly_stats.source_errors) || 0;
+                        if (srcErrors > 0) {
+                            this.showToast(
+                                `完成 ${data.video_count} 部，但 ${srcErrors} 個唯讀來源失敗，詳細見日誌`,
+                                'warn'
+                            );
+                        } else {
+                            this.showToast(`成功產生 ${data.video_count} 部影片列表`, 'success');
+                        }
 
                         // a5: Windows 長路徑警告
                         if (data.long_paths && data.long_paths.length > 0) {

--- a/web/static/js/pages/scanner/state-scan.js
+++ b/web/static/js/pages/scanner/state-scan.js
@@ -727,7 +727,10 @@ export function stateScan() {
             }
 
             // 自動儲存設定
-            if (this.configDirty) {
+            // configDirty：設定表單改動；isFolderDirty：資料夾清單改動（含 readonly 切換、
+            // output_path 編輯）。後者不會設 configDirty，若不納入 gate，readonly/輸出路徑的
+            // 編輯不會存檔，generate 會用舊的持久化設定 → readonly 路徑永遠不執行（PR#91 ①）。
+            if (this.configDirty || this.isFolderDirty) {
                 await this.saveConfig();
             }
 
@@ -779,12 +782,17 @@ export function stateScan() {
                             this.nfoUpdateVisible = false;
                         }
 
-                        // 88c-P2: 唯讀來源整源失敗（source_errors）時完成 toast 走 warn，
-                        // 不可純 success（後端完成通知已同步納入 source_errors）。
+                        // 88c-P2: 唯讀來源整源失敗（source_errors）或個別影片失敗（failed）時
+                        // 完成 toast 走 warn，不可純 success（後端完成通知已同步納入兩者）。
+                        // no_scrape 是「線上查無 metadata」的正常情況，不計為失敗（PR#91 ②）。
                         const srcErrors = (data.readonly_stats && data.readonly_stats.source_errors) || 0;
-                        if (srcErrors > 0) {
+                        const failedCount = (data.readonly_stats && data.readonly_stats.failed) || 0;
+                        if (srcErrors > 0 || failedCount > 0) {
+                            const parts = [];
+                            if (srcErrors > 0) parts.push(`${srcErrors} 個唯讀來源失敗`);
+                            if (failedCount > 0) parts.push(`${failedCount} 部失敗`);
                             this.showToast(
-                                `完成 ${data.video_count} 部，但 ${srcErrors} 個唯讀來源失敗，詳細見日誌`,
+                                `完成 ${data.video_count} 部，但 ${parts.join('、')}，詳細見日誌`,
                                 'warn'
                             );
                         } else {

--- a/web/static/js/pages/scanner/state-scan.js
+++ b/web/static/js/pages/scanner/state-scan.js
@@ -1,5 +1,8 @@
+import { dirPath } from '@/shared/dir-path.js';
+
 export function stateScan() {
     return {
+        dirPath,
         // ===== Data State =====
         directories: [],
         config: {},
@@ -435,7 +438,7 @@ export function stateScan() {
         },
 
         addFolderPath(folderPath) {
-            if (!this.directories.includes(folderPath)) {
+            if (!this.directories.some(d => dirPath(d) === folderPath)) {
                 this.directories.push(folderPath);
                 this.configDirty = true;
             } else {
@@ -456,7 +459,7 @@ export function stateScan() {
             const path = this.manualPath.trim();
             if (!path) return;
 
-            if (this.directories.includes(path)) {
+            if (this.directories.some(d => dirPath(d) === path)) {
                 this.showToast(window.t('scanner.toast.folder_already_added'), 'warning');
                 return;
             }

--- a/web/static/js/pages/scanner/state-scan.js
+++ b/web/static/js/pages/scanner/state-scan.js
@@ -1,5 +1,11 @@
 import { dirPath } from '@/shared/dir-path.js';
 
+function _detectReadonly(path) {
+    // UNC: \\server\share or //server/share → default readonly
+    // Use startsWith to avoid regex escaping pitfalls
+    return path.startsWith('\\\\') || path.startsWith('//');
+}
+
 export function stateScan() {
     return {
         dirPath,
@@ -439,7 +445,7 @@ export function stateScan() {
 
         addFolderPath(folderPath) {
             if (!this.directories.some(d => dirPath(d) === folderPath)) {
-                this.directories.push(folderPath);
+                this.directories.push({ path: folderPath, readonly: _detectReadonly(folderPath), output_path: '' });
                 this.configDirty = true;
             } else {
                 this.showToast(window.t('scanner.toast.folder_already_added'), 'warning');
@@ -464,7 +470,7 @@ export function stateScan() {
                 return;
             }
 
-            this.directories.push(path);
+            this.directories.push({ path: path, readonly: _detectReadonly(path), output_path: '' });
             this.configDirty = true;
             this.manualPath = '';
         },

--- a/web/static/js/pages/settings/state-ui.js
+++ b/web/static/js/pages/settings/state-ui.js
@@ -1,5 +1,8 @@
+import { dirPath } from '@/shared/dir-path.js';
+
 export function stateUI() {
     return {
+        dirPath,
         // ===== UI State =====
         newSuffixInput: '',
         showPathHelp: false,

--- a/web/static/js/shared/dir-path.js
+++ b/web/static/js/shared/dir-path.js
@@ -1,0 +1,20 @@
+/**
+ * dir-path.js — 共用目錄路徑萃取純函式（shared ESM）
+ *
+ * dirPath：從「字串」或「DirectoryConfig 物件（{path, ...}）」兩種形態
+ * 安全萃取路徑字串。T-2 資料仍純字串，T-3+ 型別翻轉後對物件同樣有效。
+ *
+ * 被 scanner / settings 兩頁 state 模組 import，template 經 state 屬性揭露。
+ * 純函式：無 DOM、無 Alpine、無 window、無副作用。
+ * 由 tests/unit/test_frontend_lint.py::TestDirPathHelperGuard 鎖死。
+ */
+
+/**
+ * 從 directory 元素（字串或物件）萃取路徑字串。
+ *
+ * @param {string|{path: string}|any} dir 目錄元素
+ * @returns {string} 路徑字串；無法解析時回空字串
+ */
+export function dirPath(dir) {
+  return typeof dir === 'string' ? dir : (dir?.path ?? '');
+}

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -69,13 +69,26 @@
 
                 <!-- Folder Items -->
                 <template x-for="(dir, idx) in directories" :key="idx">
-                    <div class="folder-item">
-                        <i class="bi bi-folder folder-icon"></i>
-                        <span class="folder-path" x-text="dirPath(dir)"></span>
-                        <button class="btn btn-sm btn-outline btn-error btn-remove"
-                                @click="removeDirectory(idx)" title="{{ t('scanner.folder.remove_title') }}">
-                            <i class="bi bi-x"></i>
-                        </button>
+                    <div>
+                        <div class="folder-item">
+                            <label class="flex items-center gap-1">
+                                <input type="checkbox" class="toggle toggle-primary toggle-sm"
+                                       x-model="dir.readonly">
+                                <span>{{ t('scanner.folder.readonly_label') }}</span>
+                            </label>
+                            <i class="bi bi-folder folder-icon"></i>
+                            <span class="folder-path" x-text="dirPath(dir)"></span>
+                            <button class="btn btn-sm btn-outline btn-error btn-remove"
+                                    @click="removeDirectory(idx)" title="{{ t('scanner.folder.remove_title') }}">
+                                <i class="bi bi-x"></i>
+                            </button>
+                        </div>
+                        <div class="folder-item-output" x-show="dir.readonly">
+                            <span>{{ t('scanner.folder.output_path_label') }}</span>
+                            <input type="text" class="input input-bordered input-sm flex-1"
+                                   x-model="dir.output_path"
+                                   placeholder="{{ t('scanner.folder.output_path_placeholder') }}">
+                        </div>
                     </div>
                 </template>
             </div>

--- a/web/templates/scanner.html
+++ b/web/templates/scanner.html
@@ -71,7 +71,7 @@
                 <template x-for="(dir, idx) in directories" :key="idx">
                     <div class="folder-item">
                         <i class="bi bi-folder folder-icon"></i>
-                        <span class="folder-path" x-text="dir"></span>
+                        <span class="folder-path" x-text="dirPath(dir)"></span>
                         <button class="btn btn-sm btn-outline btn-error btn-remove"
                                 @click="removeDirectory(idx)" title="{{ t('scanner.folder.remove_title') }}">
                             <i class="bi bi-x"></i>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -466,13 +466,13 @@
                                         <div style="padding:0.5rem 1rem;color:var(--text-muted);font-size:0.8rem;"
                                              x-text="t('settings.favorite_folder.no_directories')"></div>
                                     </template>
-                                    <template x-for="dir in scannerDirectories" :key="dir">
+                                    <template x-for="dir in scannerDirectories" :key="dirPath(dir)">
                                         <button type="button"
                                             class="btn btn-ghost btn-sm"
                                             style="width:100%;text-align:left;justify-content:flex-start;border-radius:0;font-size:0.8rem;padding:0.375rem 1rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
-                                            :title="dir"
-                                            @click="pickScannerDirectory(dir)"
-                                            x-text="dir">
+                                            :title="dirPath(dir)"
+                                            @click="pickScannerDirectory(dirPath(dir))"
+                                            x-text="dirPath(dir)">
                                         </button>
                                     </template>
                                 </div>


### PR DESCRIPTION
## 摘要

為 scanner 來源新增**「唯讀」模式**：勾了就不寫回來源夾，改在指定的本地輸出夾生成一個「每片一資料夾」的媒體庫（nfo + 封面 + extrafanart）並寫進 DB。適合影片放在唯讀網盤／NAS 共享／Alist 掛載（不能改名搬移）的人——OpenAver 讀來源、產出整理好的本地庫、來源零寫入，之後在 OpenAver 就能瀏覽、串流播放雲端原檔。對雲端足跡極輕（只列目錄 + 真的點播才讀那一部）。接停更的 MDCX 的棒，預設走純文字產物、零權限門檻。

> **範圍**：本 PR 只交付 **off 風味**（OpenAver 自瀏覽）。media-server 風味（多吐 `.strm` 給 Emby/Jellyfin/Kodi）＋一批 UI 調整延後至 `feature/89`。

## 變更（15 commits，分四階段）

- **88a — 基礎設施**：`GalleryConfig.directories` 由 `List[str]` 升級為 `DirectoryConfig`（`path`/`readonly`/`output_path`）＋ `load_config` 加法式向後相容遷移（舊純字串 config 照常載入）＋集中存取 helper（所有 call site 走 helper）＋ scanner UI 加 per-source 唯讀 checkbox 與輸出夾欄位。零生成行為。
- **88b — producer 純服務**：新建 `core/readonly_producer.py`（全新 code surface，不重用/不碰 `organize_file`/`enrich_single`/`scan_file`）；off 風味生成（nfo + 封面 + poster/fanart + extrafanart）＋寫 DB（`path`＝來源雲端 URI、`cover_path`＝本地 output URI）；同番號多版本防撞葉層（各獨立子夾、SHA-1 後綴、不覆蓋）；DB 加法式 `get_cover_index`。
- **88c — 接入（T-1…T-4）**：`/api/gallery/image` 白名單納入輸出夾（`get_video` 未動）；`generate_avlist` SSE 迴圈以 daemon thread + 無界 queue 橋接 producer（worker 例外顯式接手、來源級失敗不靜默吞）＋四數摘要；`/api/scrape-single` U7 organize guard（UNC-tolerant，唯讀來源回明確提示不搬檔）；off 風味端到端整合驗收。
- **Codex review 修正**：P1 U7 guard 對 canonical `file:///` 輸入改用 `coerce_to_file_uri` 兩端（原 `to_file_uri` 雙重包會繞過 guard）；P2 readonly 來源級失敗併入完成通知走 warn（不再誤報成功）。

## DB / API / capabilities

- **DB schema 零變更**（兩種資訊都用現有欄位）。
- **零新 API 端點**（生成沿用 `GET /api/gallery/generate`；guard 只收緊既有 `scrape_single`）。
- **capabilities 零改動**；唯讀生成不揭露給 AI agent。

## 測試

- 全套 pytest **5031 passed, 2 skipped**（unit + integration，排除 smoke/e2e，較 0.11.2 的 4848 **+183**）。
- `ruff check .`（全庫）綠 ＋ `npm run lint`（eslint + stylelint）綠。
- 來源金絲雀：**8 源全 PASS**（pre-merge live）。
- 每 task RED→GREEN + mutation 哨兵（`""` bypass / worker 例外契約 / deletion 安全 / file:/// guard bypass 皆修前 RED）；per-task Sonnet + fresh holistic cross-task Sonnet（APPROVE）+ Codex（P1/P2 已修）三重審查。

## 版號

`0.11.2 → 0.11.3`；CHANGELOG 已補 `[0.11.3]`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)