### PR TITLE
v0.11.6 — Cross-machine path mapping full-stack fix + DB-key namespace guards (feature/91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.6] - 2026-07-06
+
+本版主軸：**跨機器路徑映射（WSL2+UNC path_mappings）的讀寫全棧收斂 + DB-key 命名空間守衛**（feature/91，plan-91 axis-A ＋ plan-91b axis-B）——純 correctness 重構、零使用者可見功能變更、零 API/schema 變動。針對「OpenAver 在 WSL、影片放在網路磁碟（UNC `//NAS/share`）、DB 存映射後路徑」這條情境，把兩類長期潛伏的 silent bug 一次修乾淨並上守衛擋死回不去：一是**讀取端忘了在真正碰磁碟前把 `file:///` URI 反解回本機路徑**（縮圖／封面／劇照／串流／女優裁切一律 404 或讀不到）；二是**已反解的值又被餵回 DB key 建構**、落成沒映射過的命名空間，造成 silent DB miss（重複刮削、掉 user_tags、女優照 403）。
+
+### Fixed
+- **跨機器路徑（WSL+UNC）下讀圖／串流不再靜默失敗**：縮圖、封面＋劇照、影片串流（seek 206）、女優裁切、相似探索等所有「先讀 DB 路徑再碰磁碟」的入口，統一在磁碟 I/O 前經單一入口反解映射路徑；先前在 `path_mappings` 情境下這些入口會拿映射後的路徑直接碰磁碟而 404／讀不到圖。
+- **刮削不再掉使用者標籤（user_tags）live bug**：`web/routers/scraper.py` 對某片重刮時，DB key 由一個已反解的本機路徑裸建構、落成未映射命名空間，導致比對不到既有列、既有 `user_tags` 被當新片覆寫遺失。改為建 DB key 前先 forward-map 回 DB 命名空間，重刮後 user_tags 正確保留（WSL+UNC 回歸測試斷言單一 mapped row + tags union）。
+- **NFO 路徑推導反解**：`core/nfo_updater.py` 由影片路徑推導 NFO 檔位置時改用顯式反解入口，跨機器映射下定位到真實本機 NFO。
+
+### Internal
+- **axis-A（讀取端反解）**：新增單一顯式入口 `uri_to_local_fs_path()`，取代 22 個站台散落的裸 `uri_to_fs_path`／`coerce` 呼叫（router／scanner／core／enrich 全棧）；27 個純磁碟用途或已處理站台補 `# uri-no-reverse:` marker 標註安全；新增 pytest AST 結構守衛 `test_uri_to_fs_path_reverse_mapping_completeness.py`（sink 白名單＝`open`／`FileResponse`／`os.path.*`／`Path.*`／`shutil.*`），偵測「反解值未經處理直接碰磁碟」→ CI 擋死。含 Codex 兩輪 PR review 修正（enricher DB 命名空間、actress_crop 主流程 403 canonical、守衛 `Path()` 擴充）。
+- **axis-B（DB round-trip 命名空間）**：新增 sink-anchored AST 守衛 `test_db_key_namespace_completeness.py`（錨 DB-key 建構點 `to_file_uri`／`is_known_cover_path`／repo 寫入，非 source），偵測「反解值裸餵 DB round-trip 無 forward-map」→ CI 擋死；獨立 marker `# db-ns-ok:`（不 overload axis-A 的 `# uri-no-reverse:`）。含 Codex 二審修正（守衛 reaching-def marker 界限、keyword sink 抽取）。
+- **已接受殘留**：`core/enricher.py` `_write_nfo` 的 `user_tags is None` 分支裸 `to_file_uri` 為 dead path（所有 production 呼叫端恆傳 `user_tags != None`），marker + docstring 已註記，另開 follow-up；plan-91b D4 固化「寫入端命名空間統一（DB 一律存單一 canonical namespace）」暫緩為 feature/92+（守衛已達成 axis-B「不容易觸發」）。
+
+### 測試
+- 全套 pytest **5442 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.5 的 5365 +77：axis-A 22 站台 WSL+UNC 反解回歸〔縮圖／封面＋劇照／串流／女優裁切／相似〕+ axis-B 兩 bug 回歸〔刮削 user_tags union 單一 mapped row／enricher NFO DB 命名空間〕+ 兩支 AST 守衛自驗 21 案例〔含植入假違規 mutation 轉紅〕+ nfo_updater／path_utils／showcase／thumbnail_cache 補測）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live 健康檢查）。
+- 真機 E2E hard-gate（WSL2+UNC+path_mappings，CDP + DB SQL 檢查）：sign-off #1–12 全過——縮圖／封面劇照／串流 seek 206／女優裁切主線／similar／enrich NFO 落反解磁碟／fetch-samples 守衛觸發／真刮 MIDV-300 user_tags union 單一 mapped row／NFO 路徑反解／readonly `.strm` 純 marker 零回歸／DB 命名空間三查詢無分裂無重複。關鍵教訓：`D:\123`（`/mnt/` 短路成 drive-letter URI）無法觸發 bug，須非 `/mnt` 路徑 + UNC mapping 才是真觸發。
+
 ## [0.11.5] - 2026-07-05
 
 本版主軸：**唯讀來源生成媒體伺服器庫（media-server 風味）+ 跨機器路徑映射 + 唯讀寫入全面封鎖**（feature/90，spec-90 §90a/§90b/§90c）——承接 0.11.3/0.11.4 的唯讀產生庫，這版把「餵給 Emby／Jellyfin／Kodi」這條路走通：唯讀來源除了生成 OpenAver 自己瀏覽的本地庫，還多吐每片一個 `.strm` 捷徑檔給媒體伺服器掃描播放。針對「OpenAver 在這台、媒體伺服器在 NAS／別台」的跨機器情境，新增「播放端路徑替換」規則，把 `.strm` 裡的影片路徑翻成播放端看得懂的路徑；改了規則，既有 `.strm` 一鍵同步改寫。同時把唯讀來源的「零寫入」承諾補到滴水不漏：勾唯讀有破壞性確認、四個會寫回的入口在唯讀產生片上全部停用並導引、切換媒體伺服器模式時清乾淨舊唯讀來源的媒體卡（只清庫、不刪你輸出夾的檔）、產生中途斷線也乾淨收尾。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 - **axis-A（讀取端反解）**：新增單一顯式入口 `uri_to_local_fs_path()`，取代 22 個站台散落的裸 `uri_to_fs_path`／`coerce` 呼叫（router／scanner／core／enrich 全棧）；27 個純磁碟用途或已處理站台補 `# uri-no-reverse:` marker 標註安全；新增 pytest AST 結構守衛 `test_uri_to_fs_path_reverse_mapping_completeness.py`（sink 白名單＝`open`／`FileResponse`／`os.path.*`／`Path.*`／`shutil.*`），偵測「反解值未經處理直接碰磁碟」→ CI 擋死。含 Codex 兩輪 PR review 修正（enricher DB 命名空間、actress_crop 主流程 403 canonical、守衛 `Path()` 擴充）。
+- **axis-A drive-letter remote 反解對齊（Codex PR #94 review P2）**：`reverse_path_mapping` 補上 WSL-mount 候選前綴——當 `path_mappings` 的 remote 端是磁碟機代號（如 `Z:/share`）時，`uri_to_fs_path` 在 WSL 會把 `file:///Z:/share/...` 正規化成 `/mnt/z/share/...`，原本只比對 `Z:\share`／`Z:/share` 兩形式 → miss → fallback 回未反解的 `/mnt/z/...`（該磁碟未掛載時封面／影片／NFO 讀取失敗）。改為額外以 `to_wsl_path(win_prefix)` 產生 `/mnt` 形式候選（dedup，UNC 不受影響、零回歸）。
 - **axis-B（DB round-trip 命名空間）**：新增 sink-anchored AST 守衛 `test_db_key_namespace_completeness.py`（錨 DB-key 建構點 `to_file_uri`／`is_known_cover_path`／repo 寫入，非 source），偵測「反解值裸餵 DB round-trip 無 forward-map」→ CI 擋死；獨立 marker `# db-ns-ok:`（不 overload axis-A 的 `# uri-no-reverse:`）。含 Codex 二審修正（守衛 reaching-def marker 界限、keyword sink 抽取）。
 - **已接受殘留**：`core/enricher.py` `_write_nfo` 的 `user_tags is None` 分支裸 `to_file_uri` 為 dead path（所有 production 呼叫端恆傳 `user_tags != None`），marker + docstring 已註記，另開 follow-up；plan-91b D4 固化「寫入端命名空間統一（DB 一律存單一 canonical namespace）」暫緩為 feature/92+（守衛已達成 axis-B「不容易觸發」）。
 
 ### 測試
-- 全套 pytest **5442 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.5 的 5365 +77：axis-A 22 站台 WSL+UNC 反解回歸〔縮圖／封面＋劇照／串流／女優裁切／相似〕+ axis-B 兩 bug 回歸〔刮削 user_tags union 單一 mapped row／enricher NFO DB 命名空間〕+ 兩支 AST 守衛自驗 21 案例〔含植入假違規 mutation 轉紅〕+ nfo_updater／path_utils／showcase／thumbnail_cache 補測）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
+- 全套 pytest **5447 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.5 的 5365 +82：axis-A 22 站台 WSL+UNC 反解回歸〔縮圖／封面＋劇照／串流／女優裁切／相似〕+ axis-B 兩 bug 回歸〔刮削 user_tags union 單一 mapped row／enricher NFO DB 命名空間〕+ 兩支 AST 守衛自驗 21 案例〔含植入假違規 mutation 轉紅〕+ nfo_updater／path_utils／showcase／thumbnail_cache 補測 + Codex PR #94 drive-letter remote `/mnt` 候選反解回歸〔命中／backslash 形式／boundary share-vs-share2／UNC 零回歸／e2e〕）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
 - 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live 健康檢查）。
 - 真機 E2E hard-gate（WSL2+UNC+path_mappings，CDP + DB SQL 檢查）：sign-off #1–12 全過——縮圖／封面劇照／串流 seek 206／女優裁切主線／similar／enrich NFO 落反解磁碟／fetch-samples 守衛觸發／真刮 MIDV-300 user_tags union 單一 mapped row／NFO 路徑反解／readonly `.strm` 純 marker 零回歸／DB 命名空間三查詢無分裂無重複。關鍵教訓：`D:\123`（`/mnt/` 短路成 drive-letter URI）無法觸發 bug，須非 `/mnt` 路徑 + UNC mapping 才是真觸發。
 

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -15,7 +15,7 @@ from core.database import Video, VideoRepository, get_connection
 from core.logger import get_logger
 from core.nfo_updater import parse_nfo
 from core.organizer import crop_to_poster, download_image, find_subtitle_files, generate_nfo
-from core.path_utils import to_file_uri, uri_to_local_fs_path
+from core.path_utils import to_file_uri, uri_to_fs_path, uri_to_local_fs_path
 from core.scraper import search_jav
 
 logger = get_logger(__name__)
@@ -303,6 +303,7 @@ def _write_extrafanart(
     fs_path: str,
     sample_images: List[str],
     write_extrafanart: bool,
+    path_mappings: dict = None,
 ) -> List[str]:
     if not write_extrafanart or not sample_images:
         return []
@@ -316,7 +317,7 @@ def _write_extrafanart(
         dest = str(extrafanart_dir / f"fanart{i+1}.jpg")
         try:
             if download_image(url, dest):
-                written_uris.append(to_file_uri(dest))
+                written_uris.append(to_file_uri(dest, path_mappings))
         except Exception as e:
             logger.warning("extrafanart %d 下載失敗: %s", i + 1, e)
     return written_uris
@@ -359,6 +360,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         fs_path = uri_to_local_fs_path(file_path, path_mappings)
     except Exception:
         fs_path = file_path
+    fs_path_for_db = uri_to_fs_path(file_path)  # uri-no-reverse: DB key must stay in DB's stored namespace; disk I/O uses fs_path
 
     if not os.path.exists(fs_path):
         _empty.error = "檔案不存在"
@@ -374,7 +376,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
             scraper_data = search_jav(number, proxy_url=proxy_url,
                                       source=source or 'auto', javbus_lang=javbus_lang)
         if not scraper_data:
-            repo.update_scrape_attempted_at(to_file_uri(fs_path), time.time())
+            repo.update_scrape_attempted_at(to_file_uri(fs_path_for_db), time.time())
             _empty.error = f"找不到 {number} 的資料"
             return _empty
         meta = _scraper_to_meta(scraper_data)
@@ -410,7 +412,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
                 scraper_data = search_jav(number, proxy_url=proxy_url,
                                           source=source or 'auto', javbus_lang=javbus_lang)
             if not scraper_data:
-                repo.update_scrape_attempted_at(to_file_uri(fs_path), time.time())
+                repo.update_scrape_attempted_at(to_file_uri(fs_path_for_db), time.time())
                 _empty.error = f"找不到 {number} 的資料"
                 return _empty
             supplement = _scraper_to_meta(scraper_data)
@@ -420,7 +422,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
     has_subtitle = bool(find_subtitle_files(fs_path))
 
     # 讀取 DB 現有 user_tags，在 NFO 寫出和 DB upsert 時保留
-    path_uri = to_file_uri(fs_path)
+    path_uri = to_file_uri(fs_path_for_db)
     existing_record = repo.get_by_path(path_uri)
     preserved_user_tags = existing_record.user_tags if existing_record else []
 
@@ -487,6 +489,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         fs_path=fs_path,
         sample_images=meta.get("sample_images", []),
         write_extrafanart=write_extrafanart,
+        path_mappings=path_mappings,
     )
     extrafanart_written = len(written_uris)
 
@@ -496,8 +499,8 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         local_cover = str(Path(fs_path).with_suffix(".jpg")) if cover_written else ""
         nfo_path = Path(fs_path).with_suffix(".nfo")
         nfo_mtime = nfo_path.stat().st_mtime if nfo_path.exists() else 0.0
-        _db_upsert(repo, number, fs_path, meta, local_cover_path=local_cover,
-                   nfo_mtime=nfo_mtime, written_uris=written_uris)
+        _db_upsert(repo, number, fs_path_for_db, meta, local_cover_path=local_cover,
+                   nfo_mtime=nfo_mtime, written_uris=written_uris, path_mappings=path_mappings)
 
     # nfo_mtime 獨立更新：不論 mode/source，只要 NFO 存在就同步 DB
     # 避免 analysis 永遠視為 missing_nfo
@@ -505,7 +508,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
     if nfo_path.exists():
         conn = None
         try:
-            path_uri = to_file_uri(fs_path)
+            path_uri = to_file_uri(fs_path_for_db)
             nfo_mt = nfo_path.stat().st_mtime
             conn = get_connection(repo.db_path)
             conn.execute(
@@ -535,8 +538,9 @@ def _db_upsert(
     local_cover_path: str = "",
     nfo_mtime: float = 0.0,
     written_uris: List[str] = None,
+    path_mappings: dict = None,
 ) -> None:
-    """更新 DB 記錄。fs_path 必須是已解析的 FS 路徑（非 file:/// URI）。"""
+    """更新 DB 記錄。fs_path 為 DB key 專用（不做反解），必須是「DB 儲存命名空間」的 FS 路徑。"""
     try:
         path_uri = to_file_uri(fs_path)
 
@@ -547,7 +551,7 @@ def _db_upsert(
         # 若有本地封面路徑則轉 URI；否則保留 DB 既有值（透過傳空字串讓 upsert 不覆蓋）
         cover_uri = ""
         if local_cover_path and os.path.exists(local_cover_path):
-            cover_uri = to_file_uri(local_cover_path)
+            cover_uri = to_file_uri(local_cover_path, path_mappings)
         elif existing and existing.cover_path:
             cover_uri = existing.cover_path
 
@@ -592,7 +596,7 @@ def _db_upsert(
 
 
 def _db_upsert_samples_only(repo: VideoRepository, fs_path: str, sample_images: list) -> None:
-    """只更新 DB 的 sample_images 欄位（不觸碰其他欄位）。"""
+    """只更新 DB 的 sample_images 欄位（不觸碰其他欄位）。fs_path 為 DB key 專用（不做反解）。"""
     path_uri = to_file_uri(fs_path)
     repo.update_sample_images(path_uri, sample_images)
 
@@ -620,6 +624,7 @@ def fetch_samples_only(
         fs_path = uri_to_local_fs_path(file_path, path_mappings)
     except Exception:
         fs_path = file_path
+    fs_path_for_db = uri_to_fs_path(file_path)  # uri-no-reverse: DB key must stay in DB's stored namespace; disk I/O uses fs_path
 
     if not os.path.exists(fs_path):
         logger.warning("[fetch_samples_only] 檔案不存在: %s", fs_path)
@@ -634,11 +639,11 @@ def fetch_samples_only(
         return _empty
 
     sample_images = meta.get("sample_images", [])
-    written_uris = _write_extrafanart(fs_path, sample_images, write_extrafanart=True)
+    written_uris = _write_extrafanart(fs_path, sample_images, write_extrafanart=True, path_mappings=path_mappings)
 
     if written_uris:
         repo = VideoRepository()
-        _db_upsert_samples_only(repo, fs_path, written_uris)
+        _db_upsert_samples_only(repo, fs_path_for_db, written_uris)
 
     logger.info("[fetch_samples_only] %s: %d samples downloaded", number, len(written_uris))
     return EnrichResult(

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -15,7 +15,7 @@ from core.database import Video, VideoRepository, get_connection
 from core.logger import get_logger
 from core.nfo_updater import parse_nfo
 from core.organizer import crop_to_poster, download_image, find_subtitle_files, generate_nfo
-from core.path_utils import to_file_uri, uri_to_fs_path
+from core.path_utils import to_file_uri, uri_to_local_fs_path
 from core.scraper import search_jav
 
 logger = get_logger(__name__)
@@ -335,6 +335,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
     source: Optional[str] = None,
     javbus_lang: Optional[str] = None,
     scraper_data: Optional[dict] = None,
+    path_mappings: dict = None,
 ) -> EnrichResult:
     _empty = EnrichResult(
         success=False,
@@ -355,7 +356,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         return _empty
 
     try:
-        fs_path = uri_to_fs_path(file_path)
+        fs_path = uri_to_local_fs_path(file_path, path_mappings)
     except Exception:
         fs_path = file_path
 
@@ -600,6 +601,7 @@ def fetch_samples_only(
     file_path: str,
     number: str,
     proxy_url: str = "",
+    path_mappings: dict = None,
 ) -> EnrichResult:
     """只補抓劇照：呼叫 scraper → 下載 extrafanart → 更新 DB sample_images。
     不寫 NFO / cover / 其他欄位。
@@ -615,7 +617,7 @@ def fetch_samples_only(
     )
 
     try:
-        fs_path = uri_to_fs_path(file_path)
+        fs_path = uri_to_local_fs_path(file_path, path_mappings)
     except Exception:
         fs_path = file_path
 
@@ -650,11 +652,11 @@ def fetch_samples_only(
     )
 
 
-def resolve_nfo_cover_paths(file_path: str) -> tuple:
+def resolve_nfo_cover_paths(file_path: str, path_mappings: dict = None) -> tuple:
     """由影片 file_path 推導目標 NFO / cover 的 FS 路徑。
 
     復用 enrich_single / _write_nfo / _write_cover 的同一套路徑邏輯：
-    先以 uri_to_fs_path() 解析（fallback 原值），再 with_suffix。
+    先以 uri_to_local_fs_path() 解析（fallback 原值），再 with_suffix。
     回傳 (nfo_path, cover_path)，兩者皆為當前環境 FS 字串路徑。
 
     ⚠️ 路徑邏輯必須與 `_write_nfo`（with_suffix(".nfo")）/ `_write_cover`
@@ -664,7 +666,7 @@ def resolve_nfo_cover_paths(file_path: str) -> tuple:
     本函數要一起改，否則守衛會悄悄檢查錯路徑（false-allow 重現分裂 / false-block 打爆缺封面 quick-enrich）。
     """
     try:
-        fs_path = uri_to_fs_path(file_path)
+        fs_path = uri_to_local_fs_path(file_path, path_mappings)
     except Exception:
         fs_path = file_path
     nfo_path = str(Path(fs_path).with_suffix(".nfo"))

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -169,6 +169,7 @@ def _write_nfo(
     external_manager: str = "off",
     has_poster: bool = False,
     has_fanart: bool = False,
+    fs_path_for_db: str = None,
 ) -> bool:
     if not write_nfo:
         return False
@@ -181,7 +182,10 @@ def _write_nfo(
     # 若未傳入 user_tags，從 DB 讀取現有值（確保不被覆蓋）
     if user_tags is None:
         repo = VideoRepository()
-        path_uri = to_file_uri(fs_path)
+        # db-ns-ok: TASK-91b-T1 `_for_db` 式 — fs_path_for_db 來自 caller
+        # （enrich_single 已在其內算好、DB 命名空間值）；None-fallback 用 fs_path
+        # 僅供 legacy 直呼（未傳 fs_path_for_db）相容，production 恆傳，accepted residual。
+        path_uri = to_file_uri(fs_path_for_db if fs_path_for_db is not None else fs_path)
         existing = repo.get_by_path(path_uri)
         user_tags = existing.user_tags if existing else []
 
@@ -376,7 +380,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
             scraper_data = search_jav(number, proxy_url=proxy_url,
                                       source=source or 'auto', javbus_lang=javbus_lang)
         if not scraper_data:
-            repo.update_scrape_attempted_at(to_file_uri(fs_path_for_db), time.time())
+            repo.update_scrape_attempted_at(to_file_uri(fs_path_for_db), time.time())  # db-ns-ok: fs_path_for_db, DB round-trip value, no reverse mapping applied
             _empty.error = f"找不到 {number} 的資料"
             return _empty
         meta = _scraper_to_meta(scraper_data)
@@ -412,7 +416,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
                 scraper_data = search_jav(number, proxy_url=proxy_url,
                                           source=source or 'auto', javbus_lang=javbus_lang)
             if not scraper_data:
-                repo.update_scrape_attempted_at(to_file_uri(fs_path_for_db), time.time())
+                repo.update_scrape_attempted_at(to_file_uri(fs_path_for_db), time.time())  # db-ns-ok: fs_path_for_db, DB round-trip value, no reverse mapping applied
                 _empty.error = f"找不到 {number} 的資料"
                 return _empty
             supplement = _scraper_to_meta(scraper_data)
@@ -422,7 +426,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
     has_subtitle = bool(find_subtitle_files(fs_path))
 
     # 讀取 DB 現有 user_tags，在 NFO 寫出和 DB upsert 時保留
-    path_uri = to_file_uri(fs_path_for_db)
+    path_uri = to_file_uri(fs_path_for_db)  # db-ns-ok: fs_path_for_db, DB round-trip value, no reverse mapping applied
     existing_record = repo.get_by_path(path_uri)
     preserved_user_tags = existing_record.user_tags if existing_record else []
 
@@ -458,6 +462,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
                 external_manager=external_manager,
                 has_poster=imgs["poster"],
                 has_fanart=imgs["fanart"],
+                fs_path_for_db=fs_path_for_db,
             )
         except PermissionError:
             _empty.error = "NFO 寫入失敗，請確認目錄寫入權限"
@@ -473,6 +478,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
                 overwrite_existing=overwrite_existing,
                 has_subtitle=has_subtitle,
                 user_tags=preserved_user_tags,
+                fs_path_for_db=fs_path_for_db,
             )
         except PermissionError:
             _empty.error = "NFO 寫入失敗，請確認目錄寫入權限"
@@ -499,6 +505,8 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         local_cover = str(Path(fs_path).with_suffix(".jpg")) if cover_written else ""
         nfo_path = Path(fs_path).with_suffix(".nfo")
         nfo_mtime = nfo_path.stat().st_mtime if nfo_path.exists() else 0.0
+        # db-ns-ok: fs_path_for_db passed through to _db_upsert's internal primitive
+        # sink（wrapper callsite decision point; helper itself: enforced at callsites）
         _db_upsert(repo, number, fs_path_for_db, meta, local_cover_path=local_cover,
                    nfo_mtime=nfo_mtime, written_uris=written_uris, path_mappings=path_mappings)
 
@@ -508,7 +516,7 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
     if nfo_path.exists():
         conn = None
         try:
-            path_uri = to_file_uri(fs_path_for_db)
+            path_uri = to_file_uri(fs_path_for_db)  # db-ns-ok: fs_path_for_db, DB round-trip value, no reverse mapping applied
             nfo_mt = nfo_path.stat().st_mtime
             conn = get_connection(repo.db_path)
             conn.execute(
@@ -540,7 +548,11 @@ def _db_upsert(
     written_uris: List[str] = None,
     path_mappings: dict = None,
 ) -> None:
-    """更新 DB 記錄。fs_path 為 DB key 專用（不做反解），必須是「DB 儲存命名空間」的 FS 路徑。"""
+    """更新 DB 記錄。fs_path 為 DB key 專用（不做反解），必須是「DB 儲存命名空間」的 FS 路徑。
+
+    db-ns-ok: enforced at callsites — 本體內 to_file_uri(fs_path) primitive sink 命名空間
+    正確性委派給呼叫端保證（TASK-91b-T1 wrapper sink 登記，callsite 各自標記）。
+    """
     try:
         path_uri = to_file_uri(fs_path)
 
@@ -596,7 +608,11 @@ def _db_upsert(
 
 
 def _db_upsert_samples_only(repo: VideoRepository, fs_path: str, sample_images: list) -> None:
-    """只更新 DB 的 sample_images 欄位（不觸碰其他欄位）。fs_path 為 DB key 專用（不做反解）。"""
+    """只更新 DB 的 sample_images 欄位（不觸碰其他欄位）。fs_path 為 DB key 專用（不做反解）。
+
+    db-ns-ok: enforced at callsites — 本體內 to_file_uri(fs_path) primitive sink 命名空間
+    正確性委派給呼叫端保證（TASK-91b-T1 wrapper sink 登記，callsite 各自標記）。
+    """
     path_uri = to_file_uri(fs_path)
     repo.update_sample_images(path_uri, sample_images)
 
@@ -643,6 +659,7 @@ def fetch_samples_only(
 
     if written_uris:
         repo = VideoRepository()
+        # db-ns-ok: fs_path_for_db, DB round-trip value passed to wrapper sink
         _db_upsert_samples_only(repo, fs_path_for_db, written_uris)
 
     logger.info("[fetch_samples_only] %s: %d samples downloaded", number, len(written_uris))

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -182,9 +182,10 @@ def _write_nfo(
     # 若未傳入 user_tags，從 DB 讀取現有值（確保不被覆蓋）
     if user_tags is None:
         repo = VideoRepository()
-        # db-ns-ok: TASK-91b-T1 `_for_db` 式 — fs_path_for_db 來自 caller
-        # （enrich_single 已在其內算好、DB 命名空間值）；None-fallback 用 fs_path
-        # 僅供 legacy 直呼（未傳 fs_path_for_db）相容，production 恆傳，accepted residual。
+        # TASK-91b-T1 `_for_db` 式 — fs_path_for_db 來自 caller（enrich_single 已在其內
+        # 算好、DB 命名空間值）；None-fallback 用 fs_path 僅供 legacy 直呼（未傳
+        # fs_path_for_db）相容，production 恆傳，accepted residual。
+        # db-ns-ok: fs_path_for_db is DB round-trip value, no reverse mapping applied
         path_uri = to_file_uri(fs_path_for_db if fs_path_for_db is not None else fs_path)
         existing = repo.get_by_path(path_uri)
         user_tags = existing.user_tags if existing else []
@@ -505,8 +506,8 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         local_cover = str(Path(fs_path).with_suffix(".jpg")) if cover_written else ""
         nfo_path = Path(fs_path).with_suffix(".nfo")
         nfo_mtime = nfo_path.stat().st_mtime if nfo_path.exists() else 0.0
-        # db-ns-ok: fs_path_for_db passed through to _db_upsert's internal primitive
-        # sink（wrapper callsite decision point; helper itself: enforced at callsites）
+        # wrapper callsite decision point; helper itself: enforced at callsites
+        # db-ns-ok: fs_path_for_db passed through to _db_upsert's internal primitive sink
         _db_upsert(repo, number, fs_path_for_db, meta, local_cover_path=local_cover,
                    nfo_mtime=nfo_mtime, written_uris=written_uris, path_mappings=path_mappings)
 

--- a/core/gallery_scanner.py
+++ b/core/gallery_scanner.py
@@ -19,7 +19,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from core.logger import get_logger
 from core.maker_mapping import load_name_mapping, load_prefix_mapping
 from core.nfo_utils import sanitize_nfo_bytes
-from core.path_utils import normalize_path, to_file_uri, uri_to_fs_path
+from core.path_utils import normalize_path, to_file_uri, uri_to_fs_path, uri_to_local_fs_path
 from core.video_extensions import DEFAULT_VIDEO_EXTENSIONS, ZERO_SIZE_EXTENSIONS
 
 logger = get_logger(__name__)
@@ -728,7 +728,7 @@ class VideoScanner:
         logger.info(f"[*] 完成: 新增 {inserted}, 更新 {updated}, 刪除 {deleted_count}")
 
         # §b1 AC#2: sample_images 孤兒清理 pass（CLI / 直接呼叫路徑覆蓋）
-        _run_sample_images_cleanup_pass(repo)
+        _run_sample_images_cleanup_pass(repo, self.path_mappings)
 
         return {
             'inserted': inserted,
@@ -843,12 +843,15 @@ class VideoScanner:
         return videos, stats
 
 
-def _validate_sample_images(sample_images: list, video_path: str = "") -> list:
+def _validate_sample_images(sample_images: list, video_path: str = "", path_mappings: dict = None) -> list:
     """驗證 sample_images 中的 file:/// URI 對應磁碟檔案存在性。
     不存在的項目剔除；uri_to_fs_path 轉換失敗也視為不存在（但 log warning）。
     非 file:/// 且非 http:// / https:// 格式（相對路徑、絕對 FS 路徑等）原樣保留 —
     cleanup pass 只管 file:/// URI 的磁碟失效情境。
     http:// / https:// 遠端 URL 為 Codex P1 修前 scraper URL 污染，一律清除。
+
+    TASK-91-T2b #16：path_mappings 預設 None，WSL+UNC mapping 環境下反解成真正
+    能 open() 的本機路徑再判斷存在性（減少誤刪合法映射端 sample_images）。
     """
     valid = []
     non_file_purged = 0
@@ -863,7 +866,7 @@ def _validate_sample_images(sample_images: list, video_path: str = "") -> list:
             valid.append(uri)
             continue
         try:
-            fs = uri_to_fs_path(uri)
+            fs = uri_to_local_fs_path(uri, path_mappings)
         except Exception as e:
             logger.warning(
                 "uri_to_fs_path failed for sample_image; treating as missing. "
@@ -886,7 +889,7 @@ def _validate_sample_images(sample_images: list, video_path: str = "") -> list:
     return valid
 
 
-def _run_sample_images_cleanup_pass(repo) -> int:
+def _run_sample_images_cleanup_pass(repo, path_mappings: dict = None) -> int:
     """一次性孤兒清理 pass：驗證所有 Video row 的 sample_images URI，
     不存在的剔除，寫回 DB。回傳清理的 row 數。
     共用於 scan_to_sqlite() + generate_avlist() 兩個流程（Canonical Decision #4）。
@@ -896,7 +899,7 @@ def _run_sample_images_cleanup_pass(repo) -> int:
     for video in all_videos:
         if not video.sample_images:
             continue
-        validated = _validate_sample_images(video.sample_images, video_path=video.path)
+        validated = _validate_sample_images(video.sample_images, video_path=video.path, path_mappings=path_mappings)
         if validated != video.sample_images:
             removed = len(video.sample_images) - len(validated)
             logger.info(

--- a/core/gallery_scanner.py
+++ b/core/gallery_scanner.py
@@ -466,7 +466,7 @@ class VideoScanner:
         try:
             # Case 2: file:/// URI
             if thumb_val.startswith('file://'):
-                fs = uri_to_fs_path(thumb_val)
+                fs = uri_to_fs_path(thumb_val)  # uri-no-reverse: third-party NFO <thumb> value, unrelated to path_mappings namespace
             # Case 3: Windows drive letter
             elif len(thumb_val) >= 2 and thumb_val[1] == ':':
                 fs = normalize_path(thumb_val)

--- a/core/nfo_updater.py
+++ b/core/nfo_updater.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Tuple, Generator
 
 from core.logger import get_logger
 from core.nfo_utils import sanitize_nfo_bytes
-from core.path_utils import uri_to_fs_path
+from core.path_utils import uri_to_local_fs_path
 from core.scraper import search_jav
 
 logger = get_logger(__name__)
@@ -137,16 +137,17 @@ def check_cache_needs_update(cache: Dict[str, dict]) -> Dict:
     return stats
 
 
-def get_nfo_path_from_video(video_path: str) -> Optional[str]:
+def get_nfo_path_from_video(video_path: str, path_mappings: dict = None) -> Optional[str]:
     """從影片路徑取得對應的 NFO 檔案路徑
 
     Args:
         video_path: 影片檔案路徑（可能是 file:/// URL 或任意格式路徑）
+        path_mappings: 路徑映射表（WSL 環境用，讓 UNC URI 反解回真實可 exists() 的本機路徑）
 
     Returns:
         NFO 檔案的路徑，不存在則返回 None
     """
-    video_path = uri_to_fs_path(video_path)
+    video_path = uri_to_local_fs_path(video_path, path_mappings)
 
     # 取得 NFO 路徑
     video_p = Path(video_path)
@@ -377,13 +378,15 @@ def update_nfo_file(nfo_path: str, metadata: dict, info: dict) -> Tuple[bool, st
 
 def update_videos_generator(
     cache: Dict[str, dict],
-    paths: List[str]
+    paths: List[str],
+    path_mappings: dict = None
 ) -> Generator[dict, None, dict]:
     """更新影片的生成器（用於 SSE 串流）
 
     Args:
         cache: gallery_output_cache.json 的內容
         paths: 需要更新的影片路徑列表
+        path_mappings: 路徑映射表（WSL 環境用，透傳給 get_nfo_path_from_video）
 
     Yields:
         進度訊息 dict
@@ -414,7 +417,7 @@ def update_videos_generator(
         }
 
         # 取得 NFO 路徑
-        nfo_path = get_nfo_path_from_video(path)
+        nfo_path = get_nfo_path_from_video(path, path_mappings)
         if not nfo_path:
             yield {
                 'type': 'log',

--- a/core/path_utils.py
+++ b/core/path_utils.py
@@ -433,6 +433,20 @@ def reverse_path_mapping(fs_path: str, path_mappings: dict) -> Optional[str]:
     return None
 
 
+def uri_to_local_fs_path(uri: str, path_mappings: dict) -> str:
+    """file:/// URI → 本機『實際可存取』FS 路徑（含 WSL+mapping 反解）。
+
+    專供「即將對回傳值做真實磁碟 I/O」的呼叫端使用。
+    非 WSL 或無 mappings → 與 uri_to_fs_path(uri) 字面等價（reverse 分支不觸發）。
+
+    與 coerce_to_file_uri（正向建 URI）方向相反、互補：各自呼叫，不要疊加（D2）。
+    """
+    fs = uri_to_fs_path(uri)
+    if CURRENT_ENV == 'wsl' and path_mappings:
+        fs = reverse_path_mapping(fs, path_mappings) or fs
+    return fs
+
+
 def uri_to_fs_path(uri: str) -> str:
     """file:/// URI → 當前環境檔案系統路徑。
 

--- a/core/path_utils.py
+++ b/core/path_utils.py
@@ -403,6 +403,13 @@ def reverse_path_mapping(fs_path: str, path_mappings: dict) -> Optional[str]:
           separator 開頭，避免 //NAS/share 誤命中 //NAS/share2。
         - trailing separator normalize（T6 P2 fix）：win_prefix 與 local_prefix 結尾
           的 / 或 \\ 會被 rstrip('/\\\\') 清掉，避免拼接時缺斜線或雙斜線。
+        - WSL-mount candidate（91b P2 fix）：drive-letter remote（如 ``Z:/share``）經
+          uri_to_fs_path() 在 WSL 環境會被 to_wsl_path() 正規化成 ``/mnt/z/share``
+          （非 win_bs/win_fwd 任一形式），若不額外加入這個候選前綴，
+          reverse_path_mapping 永遠 miss、fallback 回未反解的 /mnt/z/... 路徑。
+          此候選以 to_wsl_path(win_prefix) 產生，try/except 包裹
+          （SMB backslash UNC 會讓 to_wsl_path 拋 ValueError，略過即可，
+          UNC 本身已由 win_fwd 命中，不受影響）。
     """
     if not fs_path or not path_mappings:
         return None
@@ -420,7 +427,18 @@ def reverse_path_mapping(fs_path: str, path_mappings: dict) -> Optional[str]:
         win_bs = win_bs_raw.rstrip('/\\')
         win_fwd = win_bs.replace('\\', '/')
 
-        for prefix in (win_bs, win_fwd):
+        # 91b P2 fix: 額外加入 WSL-mount 形式候選（/mnt/<drive>/...），
+        # 與 uri_to_fs_path() 對 drive-letter URI 的正規化結果對齊。
+        # to_wsl_path 對 UNC 直接原樣回傳（等同 win_fwd），dedup 後不重複比對。
+        candidates = [win_bs, win_fwd]
+        try:
+            win_mnt = to_wsl_path(win_prefix).rstrip('/\\')
+            if win_mnt not in candidates:
+                candidates.append(win_mnt)
+        except ValueError:
+            pass
+
+        for prefix in candidates:
             if not fs_path.startswith(prefix):
                 continue
             tail = fs_path[len(prefix):]

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -107,7 +107,7 @@ def _list_source_videos(
     on_skip (TASK-89b-T5): forwarded verbatim to fast_scan_directory — invoked
     (path, exception) for entries/subdirectories dropped due to OSError/PermissionError.
     """
-    fs_dir = uri_to_fs_path(source_path)
+    fs_dir = uri_to_fs_path(source_path)  # uri-no-reverse: native config path (DirectoryConfig.path), no DB-mapped namespace
     return fast_scan_directory(fs_dir, extensions, min_size_bytes, on_skip=on_skip)
 
 
@@ -162,7 +162,7 @@ def _derive_source_name(source_path: str) -> str:
     # standalone normalize_path() raises ValueError on foreign-platform path
     # strings (e.g. a Windows path fed to a Linux CI run), which uri_to_fs_path
     # already guards against via its own try/except.
-    fs_path = uri_to_fs_path(source_path)
+    fs_path = uri_to_fs_path(source_path)  # uri-no-reverse: native config path (DirectoryConfig.path), no DB-mapped namespace
     canonical = to_file_uri(fs_path)
     shortcode = hashlib.sha1(canonical.encode()).hexdigest()[:6]
     basename = sanitize_filename(Path(fs_path).name)
@@ -327,7 +327,7 @@ def _resolve_movie_dir(
         # targeted 反解。只反解回傳給呼叫端的 fs Path，不反解存回 DB 的 URI
         # （movie_dir_uri 維持 existing.output_dir 原值），否則下一輪
         # is_path_under_dir(existing.output_dir, output_uri) 比對會失準。
-        movie_dir_fs = uri_to_fs_path(movie_dir_uri)
+        movie_dir_fs = uri_to_fs_path(movie_dir_uri)  # uri-no-reverse: already paired with reverse_path_mapping on next line
         if CURRENT_ENV == 'wsl' and path_mappings:
             movie_dir_fs = reverse_path_mapping(movie_dir_fs, path_mappings) or movie_dir_fs
         return Path(movie_dir_fs), movie_dir_uri
@@ -897,7 +897,7 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
     # the "unreachable" guard above already returned before this point, so any
     # execution path reaching here has aborted_reason == "" (empty).
     if files and not result.skipped_paths:
-        source_root_fs = uri_to_fs_path(source.path)
+        source_root_fs = uri_to_fs_path(source.path)  # uri-no-reverse: native config path (SourceConfig.path), comparison-only
         source_root_uri = to_file_uri(source_root_fs, path_mappings)
         this_run_uris = {to_file_uri(fi["path"], path_mappings) for fi in files}
         candidates = [

--- a/core/readonly_source.py
+++ b/core/readonly_source.py
@@ -25,7 +25,7 @@ def _canonical_source_prefix(path: str, path_mappings) -> str:
     - FS-path 型：uri_to_fs_path 近似 pass-through（normalize），等價原 coerce（無回歸）。
     - 非 WSL / 無 mapping：to_file_uri 的 mapping 分支不觸發，round-trip 回同一 URI 形。
     """
-    return to_file_uri(uri_to_fs_path(path), path_mappings)
+    return to_file_uri(uri_to_fs_path(path), path_mappings)  # uri-no-reverse: native config source path, no DB-mapped namespace
 
 
 def is_path_readonly(file_uri: str, readonly_prefixes, writable_prefixes=None) -> bool:

--- a/core/settings_link.py
+++ b/core/settings_link.py
@@ -55,7 +55,7 @@ def find_matched_directory(
     # URI 原樣通過 → to_file_uri 二次包成 file:///file:/// → 永不命中）(PR#91 同源)。
     for directory in directories:
         try:
-            d_normalized = uri_to_fs_path(directory)
+            d_normalized = uri_to_fs_path(directory)  # uri-no-reverse: native config path (DirectoryConfig.path), no DB-mapped namespace
             d_uri = to_file_uri(d_normalized, path_mappings)
         except (ValueError, Exception) as e:
             logger.warning("跳過無效 directory=%r: %s", directory, e)

--- a/core/thumbnail_cache.py
+++ b/core/thumbnail_cache.py
@@ -21,7 +21,7 @@ from PIL import Image
 
 from core.database import get_db_path
 from core.logger import get_logger
-from core.path_utils import uri_to_fs_path
+from core.path_utils import uri_to_local_fs_path
 
 logger = get_logger(__name__)
 
@@ -131,11 +131,14 @@ def clear_all() -> None:
     shutil.rmtree(_thumb_dir(), ignore_errors=True)
 
 
-def iter_missing(videos) -> Iterator[Tuple[str, str]]:
+def iter_missing(videos, path_mappings: dict = None) -> Iterator[Tuple[str, str]]:
     """prewarm 用：yield 出「缺 thumb 且 cover 有效」者（CD-8）。
 
     產出 (video_path_uri, cover_fs_path)。已有 thumb 或 cover 無效者跳過
     （冪等、只補缺，spec 2.A.2/D3）。用 getattr 容忍物件/屬性缺漏。
+
+    TASK-91-T2b #15：path_mappings 預設 None（等價於裸 uri_to_fs_path），
+    不動既有呼叫端測試。
     """
     for v in videos:
         video_path_uri = getattr(v, "path", None)
@@ -146,7 +149,7 @@ def iter_missing(videos) -> Iterator[Tuple[str, str]]:
         cover_path = getattr(v, "cover_path", None)
         if not cover_path:
             continue
-        cover_fs = uri_to_fs_path(cover_path)
+        cover_fs = uri_to_local_fs_path(cover_path, path_mappings)
         if not os.path.exists(cover_fs):
             continue
         yield (video_path_uri, cover_fs)

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/integration/test_actress_photo.py
+++ b/tests/integration/test_actress_photo.py
@@ -209,3 +209,112 @@ def test_cloud_sources_use_primary_name_only(client):
         assert name_arg == "alice", (
             f"雲端 scraper '{src_arg}' 收到 '{name_arg}'，應只收到 'alice'（primary/URL param）"
         )
+
+
+# ---------------------------------------------------------------------------
+# TASK-91-T2a #6,#7,#8: WSL + UNC path_mappings 反解回歸測試
+# ---------------------------------------------------------------------------
+
+class TestActressPathMappingsReverse:
+    """list_photo_candidates / actress_crop / set_actress_photo(local_crop) 三站台
+    在 WSL + UNC path_mappings 環境下必須反解成真正能 open() 的本機路徑，而不是
+    留下裸 uri_to_fs_path() 產生的映射端 UNC 字串。
+    """
+
+    _MAPPINGS = {"/home/user/nas": "//NAS/share"}
+
+    def test_list_photo_candidates_crop_url_reverse_maps_wsl_unc(self, client, monkeypatch):
+        import core.path_utils as path_utils
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        monkeypatch.setattr(
+            "web.routers.actress.load_config",
+            lambda: {"gallery": {"path_mappings": self._MAPPINGS}},
+        )
+
+        mock_actress = _make_mock_actress("alice")
+        mock_video = _make_mock_video(
+            path="file:///home/user/media/video.mp4",
+            cover_path="file://///NAS/share/cover.jpg",
+        )
+
+        with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+             patch('web.routers.actress.init_db'), \
+             patch('web.routers.actress._fetch_single_source', return_value=None), \
+             patch('web.routers.actress._get_random_videos_with_covers', return_value=[mock_video]):
+            mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+
+            response = client.get("/api/actresses/alice/photo-candidates")
+            assert response.status_code == 200
+
+        events = _parse_sse(response.text)
+        candidate = next(
+            data for (event, data) in events
+            if event == "candidate" and data.get("source") == "local_crop"
+        )
+        assert "/home/user/nas/cover.jpg" in candidate["thumb_url"], (
+            f"crop_url 應反解為本機路徑，實際: {candidate['thumb_url']}"
+        )
+        assert "//NAS/share/cover.jpg" not in candidate["thumb_url"], (
+            f"crop_url 不應殘留裸 UNC 映射端字串，實際: {candidate['thumb_url']}"
+        )
+
+    def test_actress_crop_reverse_maps_wsl_unc(self, client, monkeypatch):
+        import core.path_utils as path_utils
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        monkeypatch.setattr(
+            "web.routers.actress.load_config",
+            lambda: {"gallery": {"path_mappings": self._MAPPINGS}},
+        )
+
+        with patch('web.routers.actress.init_db'), \
+             patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+             patch('web.routers.actress.crop_video_cover', return_value=b"fakejpeg") as mock_crop:
+            mock_video_repo_cls.return_value.is_known_cover_path.return_value = True
+
+            response = client.get(
+                "/api/actresses/actress-crop",
+                params={"path": "//NAS/share/cover.jpg", "spec": "v1"},
+            )
+            assert response.status_code == 200
+
+        called_check_path = mock_video_repo_cls.return_value.is_known_cover_path.call_args[0][0]
+        assert called_check_path == "/home/user/nas/cover.jpg", (
+            f"is_known_cover_path 應以反解後的本機路徑呼叫，實際: {called_check_path}"
+        )
+        mock_crop.assert_called_once_with("/home/user/nas/cover.jpg", "v1")
+
+    def test_set_actress_photo_local_crop_reverse_maps_wsl_unc(self, client, monkeypatch):
+        import core.path_utils as path_utils
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        monkeypatch.setattr(
+            "web.routers.actress.load_config",
+            lambda: {"gallery": {"path_mappings": self._MAPPINGS}},
+        )
+
+        mock_actress = _make_mock_actress("alice")
+        video_uri = "file:///home/user/media/video.mp4"
+        mock_video = _make_mock_video(path=video_uri, cover_path="file://///NAS/share/cover.jpg")
+
+        with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+             patch('web.routers.actress.init_db'), \
+             patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+             patch('web.routers.actress.crop_video_cover', return_value=b"fakejpeg") as mock_crop, \
+             patch('web.routers.actress._write_actress_photo'):
+            mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+            mock_actress_repo_cls.return_value.save = MagicMock()
+            mock_video_repo_cls.return_value.get_videos_by_actress.return_value = [mock_video]
+
+            response = client.post(
+                "/api/actresses/alice/photo",
+                json={"source": "local_crop", "video_path": video_uri, "crop_spec": "v1"},
+            )
+            assert response.status_code == 200
+
+        mock_crop.assert_called_once()
+        called_cover_path = mock_crop.call_args[0][0]
+        assert called_cover_path == "/home/user/nas/cover.jpg", (
+            f"crop_video_cover 應以反解後的本機路徑呼叫，實際: {called_cover_path}"
+        )

--- a/tests/integration/test_actress_photo.py
+++ b/tests/integration/test_actress_photo.py
@@ -223,7 +223,13 @@ class TestActressPathMappingsReverse:
 
     _MAPPINGS = {"/home/user/nas": "//NAS/share"}
 
-    def test_list_photo_candidates_crop_url_reverse_maps_wsl_unc(self, client, monkeypatch):
+    def test_list_photo_candidates_crop_url_stays_canonical_wsl_unc(self, client, monkeypatch):
+        """TASK-91 Codex round-2 P1：list_photo_candidates 不做磁碟 I/O，crop_url 的
+        path 參數必須是 DB/URL 命名空間下的「正規」路徑（uri_to_fs_path，此處即映射端
+        UNC 字串），不可反解成本機路徑 —— 否則 actress_crop 收到本機路徑後，
+        is_known_cover_path 用裸 to_file_uri() 比對 DB（DB 存的是映射端 UNC URI）
+        永遠對不上，造成誤 403（bug 重現）。反解只能發生在 actress_crop 真正碰磁碟的那一刻。
+        """
         import core.path_utils as path_utils
 
         monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
@@ -252,11 +258,12 @@ class TestActressPathMappingsReverse:
             data for (event, data) in events
             if event == "candidate" and data.get("source") == "local_crop"
         )
-        assert "/home/user/nas/cover.jpg" in candidate["thumb_url"], (
-            f"crop_url 應反解為本機路徑，實際: {candidate['thumb_url']}"
+        assert "//NAS/share/cover.jpg" in candidate["thumb_url"], (
+            "crop_url 應保持 DB/URL 命名空間的正規路徑（uri_to_fs_path，映射端 UNC），"
+            f"反解須留給 actress_crop 磁碟 I/O 那一刻，實際: {candidate['thumb_url']}"
         )
-        assert "//NAS/share/cover.jpg" not in candidate["thumb_url"], (
-            f"crop_url 不應殘留裸 UNC 映射端字串，實際: {candidate['thumb_url']}"
+        assert "/home/user/nas/cover.jpg" not in candidate["thumb_url"], (
+            f"crop_url 不應提前反解為本機路徑，實際: {candidate['thumb_url']}"
         )
 
     def test_actress_crop_reverse_maps_wsl_unc(self, client, monkeypatch):
@@ -280,10 +287,136 @@ class TestActressPathMappingsReverse:
             assert response.status_code == 200
 
         called_check_path = mock_video_repo_cls.return_value.is_known_cover_path.call_args[0][0]
-        assert called_check_path == "/home/user/nas/cover.jpg", (
-            f"is_known_cover_path 應以反解後的本機路徑呼叫，實際: {called_check_path}"
+        assert called_check_path == "//NAS/share/cover.jpg", (
+            "is_known_cover_path 是 DB round-trip 比對，DB 存的是映射端命名空間（如 cover_path），"
+            f"不應被反解成本機路徑（否則永遠比對不上 DB 現存值），實際: {called_check_path}"
         )
         mock_crop.assert_called_once_with("/home/user/nas/cover.jpg", "v1")
+
+    def test_actress_crop_real_db_not_403(self, tmp_path, monkeypatch):
+        """TASK-91 Finding 2 real test（無 is_known_cover_path mock）：
+        真實 DB 存一筆 mapped cover_path（file://///NAS/share/cover.jpg），真實磁碟檔案
+        放在反解後的本機路徑；GET actress-crop?path=//NAS/share/cover.jpg 必須通過
+        DB round-trip 檢查（不應 403）。若 cover_fs_for_db 誤用反解後路徑比對，
+        DB round-trip 永遠 miss → 錯誤 403（bug 重現）。
+        """
+        import core.path_utils as path_utils
+        from core.database import init_db, VideoRepository, Video
+        from core.path_utils import to_file_uri
+        from fastapi.testclient import TestClient
+
+        db_path = tmp_path / "test_actress_crop_real.db"
+        init_db(db_path)
+        monkeypatch.setattr("core.database.connection.get_db_path", lambda: db_path)
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        local_nas_dir = tmp_path / "nas"
+        local_nas_dir.mkdir()
+        local_cover_path = local_nas_dir / "cover.jpg"
+        local_cover_path.write_bytes(b"\xff\xd8\xff\xe0fake_cover")
+        mappings = {str(local_nas_dir): "//NAS/share"}
+
+        monkeypatch.setattr(
+            "web.routers.actress.load_config",
+            lambda: {"gallery": {"path_mappings": mappings}},
+        )
+
+        cover_uri = to_file_uri(str(local_cover_path), mappings)
+        repo = VideoRepository()
+        repo.upsert(Video(
+            path=to_file_uri(str(tmp_path / "video.mp4")),
+            title="Test Video",
+            cover_path=cover_uri,
+        ))
+
+        from web.app import app
+        test_client = TestClient(app)
+
+        with patch('web.routers.actress.crop_video_cover', return_value=b"fakejpeg"):
+            response = test_client.get(
+                "/api/actresses/actress-crop",
+                params={"path": "//NAS/share/cover.jpg", "spec": "v1"},
+            )
+
+        assert response.status_code != 403, (
+            "真實 DB round-trip（is_known_cover_path）應通過，不應誤 403，"
+            f"實際 status={response.status_code}, body={response.text!r}"
+        )
+
+    def test_list_photo_candidates_main_flow_no_403_real_db(self, tmp_path, monkeypatch):
+        """TASK-91 Codex round-2 P1 主流程 e2e：不 mock is_known_cover_path / VideoRepository。
+
+        真實 DB 播一筆 Actress + Video（cover_path 為 mapped URI file://///NAS/share/cover.jpg），
+        真實磁碟檔案放在反解後的本機路徑。驅動 GET .../photo-candidates（SSE）取得
+        local_crop candidate 的 crop_url，斷言其 path 參數是正規（uri_to_fs_path）形式
+        而非反解後的本機路徑；再把那個 path 原封不動餵給 GET actress-crop，斷言不 403 —
+        這正是 Codex 指出缺失的「local path 主流程」端對端測試。
+        """
+        import core.path_utils as path_utils
+        from core.database import init_db, VideoRepository, Video, ActressRepository, Actress
+        from core.path_utils import to_file_uri
+        from urllib.parse import urlparse, parse_qs
+        from fastapi.testclient import TestClient
+
+        db_path = tmp_path / "test_photo_candidates_main_flow.db"
+        init_db(db_path)
+        monkeypatch.setattr("core.database.connection.get_db_path", lambda: db_path)
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        local_nas_dir = tmp_path / "nas"
+        local_nas_dir.mkdir()
+        local_cover_path = local_nas_dir / "cover.jpg"
+        local_cover_path.write_bytes(b"\xff\xd8\xff\xe0fake_cover")
+        mappings = {str(local_nas_dir): "//NAS/share"}
+
+        monkeypatch.setattr(
+            "web.routers.actress.load_config",
+            lambda: {"gallery": {"path_mappings": mappings}},
+        )
+
+        cover_uri = to_file_uri(str(local_cover_path), mappings)
+
+        actress_repo = ActressRepository()
+        actress_repo.save(Actress(name="carol", photo_source="graphis"))
+
+        video_repo = VideoRepository()
+        video_repo.upsert(Video(
+            path=to_file_uri(str(tmp_path / "video.mp4")),
+            title="Test Video",
+            actresses=["carol"],
+            cover_path=cover_uri,
+        ))
+
+        from web.app import app
+        test_client = TestClient(app)
+
+        with patch('web.routers.actress._fetch_single_source', return_value=None):
+            response = test_client.get("/api/actresses/carol/photo-candidates")
+        assert response.status_code == 200
+
+        events = _parse_sse(response.text)
+        candidate = next(
+            data for (event, data) in events
+            if event == "candidate" and data.get("source") == "local_crop"
+        )
+        crop_url = candidate["thumb_url"]
+        query = parse_qs(urlparse(crop_url).query)
+        candidate_path = query["path"][0]
+
+        assert candidate_path == "//NAS/share/cover.jpg", (
+            "crop_url 應保持正規（uri_to_fs_path）路徑，不應提前反解為本機路徑，"
+            f"實際: {candidate_path}"
+        )
+
+        with patch('web.routers.actress.crop_video_cover', return_value=b"fakejpeg"):
+            crop_response = test_client.get(
+                "/api/actresses/actress-crop",
+                params={"path": candidate_path, "spec": "v1"},
+            )
+        assert crop_response.status_code != 403, (
+            "list_photo_candidates 產生的 crop_url 餵回 actress_crop 真實 DB round-trip "
+            f"不應誤 403，實際 status={crop_response.status_code}, body={crop_response.text!r}"
+        )
 
     def test_set_actress_photo_local_crop_reverse_maps_wsl_unc(self, client, monkeypatch):
         import core.path_utils as path_utils

--- a/tests/integration/test_api_enrich.py
+++ b/tests/integration/test_api_enrich.py
@@ -1016,3 +1016,166 @@ class TestEnrichEndpointExternalManagerThreading:
         })
 
         assert captured_calls[0].get("external_manager") == "kodi"
+
+
+# ── TASK-91-T3 站台4：enrich_single_endpoint external_manager 分支 WSL+UNC path_mappings ──
+
+_WSL_UNC_MAPPINGS = {"/home/user/nas": "//NAS/share"}
+_WSL_UNC_URI = "file://///NAS/share/dir/movie.mp4"
+_WSL_UNC_REVERSED_DIR = "/home/user/nas/dir"
+
+
+class TestEnrichSingleExternalManagerPathMappingReverse:
+    """站台4（:322 stem = os.path.splitext(uri_to_fs_path(...))[0]）改用
+    uri_to_local_fs_path 後，poster/fanart_path 存在性檢查必須落在反解後的本機目錄
+    （mutation-sensitive）；並確認與站台3 cover_path 的 dirname 一致（邊界5）。"""
+
+    def _patch_common(self, mocker):
+        mocker.patch(
+            "web.routers.scraper.resolve_nfo_cover_paths",
+            return_value=(
+                f"{_WSL_UNC_REVERSED_DIR}/movie.nfo",
+                f"{_WSL_UNC_REVERSED_DIR}/movie.jpg",
+            ),
+        )
+        mocker.patch("web.routers.scraper.load_config", return_value={
+            "search": {},
+            "scraper": {"external_manager": "jellyfin"},
+            "gallery": {"path_mappings": _WSL_UNC_MAPPINGS},
+        })
+        mocker.patch("web.routers.scraper.enrich_single", return_value=_ok_result())
+
+    def test_wsl_unc_mapping_reverses_stem_for_poster_fanart(self, client, mocker, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        self._patch_common(mocker)
+
+        captured_exists = []
+
+        def fake_exists(p):
+            captured_exists.append(p)
+            return True
+
+        mocker.patch("web.routers.scraper.os.path.exists", side_effect=fake_exists)
+
+        client.post("/api/enrich-single", json={
+            "file_path": _WSL_UNC_URI,
+            "number": "SONE-205",
+            "mode": "refresh_full",
+            "overwrite_existing": False,
+        })
+
+        poster_calls = [p for p in captured_exists if p.endswith("-poster.jpg")]
+        fanart_calls = [p for p in captured_exists if p.endswith("-fanart.jpg")]
+        assert poster_calls, "poster_path 存在性應被檢查"
+        assert fanart_calls, "fanart_path 存在性應被檢查"
+        assert poster_calls[0] == f"{_WSL_UNC_REVERSED_DIR}/movie-poster.jpg", (
+            f"poster_path 應反解為本機路徑，實際: {poster_calls[0]!r}"
+        )
+        assert fanart_calls[0] == f"{_WSL_UNC_REVERSED_DIR}/movie-fanart.jpg", (
+            f"fanart_path 應反解為本機路徑，實際: {fanart_calls[0]!r}"
+        )
+
+    def test_stem_dirname_matches_resolve_nfo_cover_paths_dirname(self, client, mocker, monkeypatch):
+        """邊界5：cover_path（站台3）與 poster/fanart_path（站台4）dirname 須一致，
+        否則 will_write_external 判斷會因命名空間不一致誤判。"""
+        import os as _os
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        self._patch_common(mocker)
+
+        captured_exists = []
+
+        def fake_exists(p):
+            captured_exists.append(p)
+            return True
+
+        mocker.patch("web.routers.scraper.os.path.exists", side_effect=fake_exists)
+
+        client.post("/api/enrich-single", json={
+            "file_path": _WSL_UNC_URI,
+            "number": "SONE-205",
+            "mode": "refresh_full",
+            "overwrite_existing": False,
+        })
+
+        poster_calls = [p for p in captured_exists if p.endswith("-poster.jpg")]
+        assert poster_calls
+        cover_dirname = _os.path.dirname(f"{_WSL_UNC_REVERSED_DIR}/movie.jpg")
+        poster_dirname = _os.path.dirname(poster_calls[0])
+        assert cover_dirname == poster_dirname == _WSL_UNC_REVERSED_DIR
+
+
+# ── TASK-91-T3 站台5：fetch_samples_endpoint outer to_file_uri 補傳 path_mappings ──
+
+class TestFetchSamplesFolderPrefixPathMappingReverse:
+    """站台5（:409 folder_uri_prefix = to_file_uri(os.path.dirname(uri_to_fs_path(...))) + '/'）：
+    外層 to_file_uri 補傳 path_mappings 後，folder_uri_prefix 須落在映射命名空間，
+    DB LIKE 比對才能命中 scanner 以映射端 URI 寫入的 path（mutation-sensitive）。"""
+
+    def _ok_samples(self, **kwargs):
+        from core.enricher import EnrichResult
+        defaults = dict(
+            success=True, nfo_written=False, cover_written=False,
+            extrafanart_written=3, fields_filled=[], source_used="javbus", error=None,
+        )
+        defaults.update(kwargs)
+        return EnrichResult(**defaults)
+
+    def test_case2_native_input_prefix_mapped_to_unc_namespace(self, client, mocker, monkeypatch):
+        """Case 2（本機原生輸入）：加了 path_mappings 後 prefix 落在映射命名空間
+        （沒傳 path_mappings 現況 bug 會落在原生命名空間，永遠比對不到 DB）。"""
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        mocker.patch("web.routers.scraper.load_config", return_value={
+            "search": {}, "scraper": {},
+            "gallery": {"path_mappings": _WSL_UNC_MAPPINGS},
+        })
+        mock_repo = mocker.patch("web.routers.scraper.VideoRepository")
+        mock_repo.return_value.count_videos_in_folder.return_value = 1
+        mocker.patch(
+            "web.routers.scraper.fetch_samples_only", return_value=self._ok_samples()
+        )
+
+        response = client.post("/api/scraper/fetch-samples", json={
+            "file_path": "file:///home/user/nas/dir/movie.mp4",
+            "number": "SONE-205",
+        })
+
+        assert response.status_code == 200
+        mock_repo.return_value.count_videos_in_folder.assert_called_once()
+        prefix = mock_repo.return_value.count_videos_in_folder.call_args[0][0]
+        assert prefix == "file://///NAS/share/dir/", (
+            f"folder_uri_prefix 應落在映射命名空間，實際: {prefix!r}"
+        )
+
+    def test_case1_unc_input_prefix_unaffected_by_mappings(self, client, mocker, monkeypatch):
+        """Case 1（UNC 輸入）零回歸：加不加 path_mappings 對 folder_uri_prefix 結果相同
+        （UNC branch 在 to_file_uri 內提早 return，不受 path_mappings 影響）。"""
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        captured_prefixes = {}
+        for label, pm in (("with_mapping", _WSL_UNC_MAPPINGS), ("without_mapping", {})):
+            mocker.patch("web.routers.scraper.load_config", return_value={
+                "search": {}, "scraper": {},
+                "gallery": {"path_mappings": pm},
+            })
+            mock_repo = mocker.patch("web.routers.scraper.VideoRepository")
+            mock_repo.return_value.count_videos_in_folder.return_value = 1
+            mocker.patch(
+                "web.routers.scraper.fetch_samples_only", return_value=self._ok_samples()
+            )
+
+            client.post("/api/scraper/fetch-samples", json={
+                "file_path": _WSL_UNC_URI,
+                "number": "SONE-205",
+            })
+
+            call_args = mock_repo.return_value.count_videos_in_folder.call_args
+            captured_prefixes[label] = call_args[0][0]
+
+        assert captured_prefixes["with_mapping"] == captured_prefixes["without_mapping"], (
+            f"UNC 輸入下 path_mappings 不應影響結果: {captured_prefixes!r}"
+        )
+        assert captured_prefixes["with_mapping"] == "file://///NAS/share/dir/"

--- a/tests/integration/test_api_gallery.py
+++ b/tests/integration/test_api_gallery.py
@@ -530,9 +530,45 @@ class TestGenerateFromIds:
 
         fake_bytes = b'\xff\xd8\xff\xe0' + b'\x00' * 2000
         mocker.patch('web.routers.scanner.Path.read_bytes', return_value=fake_bytes)
-        mocker.patch('web.routers.scanner.uri_to_fs_path', return_value='/fake/cover.jpg')
+        mocker.patch('web.routers.scanner.uri_to_local_fs_path', return_value='/fake/cover.jpg')
 
         result = _embed_cover(to_file_uri('/fake/cover.jpg'))
+
+        expected_b64 = base64.b64encode(fake_bytes).decode('ascii')
+        assert result == f'data:image/jpeg;base64,{expected_b64}'
+
+    def test_embed_cover_reverse_maps_wsl_unc_path_mappings(self, mocker, tmp_path, monkeypatch):
+        """TASK-91-T2b #14：_embed_cover(img_ref, path_mappings) 在 WSL+UNC mapping
+        環境下，Path.read_bytes 讀的必須是反解後的本機路徑（可真的 open()），非裸
+        uri_to_fs_path() 產生的映射端 UNC 字串。"""
+        import core.path_utils as path_utils
+        from web.routers.scanner import _embed_cover
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        cover = nas_dir / "cover.jpg"
+        fake_bytes = b'\xff\xd8\xff\xe0' + b'\x00' * 2000
+        cover.write_bytes(fake_bytes)
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        result = _embed_cover("file://///NAS/share/cover.jpg", mappings)
+
+        expected_b64 = base64.b64encode(fake_bytes).decode('ascii')
+        assert result == f'data:image/jpeg;base64,{expected_b64}', (
+            f"應反解成本機路徑真的讀到檔案，實際: {result[:80]}"
+        )
+
+    def test_embed_cover_no_mappings_default_none_equivalent_to_before(self, mocker):
+        """#14 邊界：path_mappings 預設 None → 與改動前裸 uri_to_fs_path 呼叫等價
+        （保護既有呼叫端 generate_from_ids 舊行為不回歸）。"""
+        from web.routers.scanner import _embed_cover as _ec
+
+        fake_bytes = b'\xff\xd8\xff\xe0' + b'\x00' * 2000
+        mocker.patch('web.routers.scanner.Path.read_bytes', return_value=fake_bytes)
+
+        result = _ec(to_file_uri('/fake/cover2.jpg'))  # 不傳 path_mappings
 
         expected_b64 = base64.b64encode(fake_bytes).decode('ascii')
         assert result == f'data:image/jpeg;base64,{expected_b64}'

--- a/tests/integration/test_api_scanner.py
+++ b/tests/integration/test_api_scanner.py
@@ -442,6 +442,44 @@ class TestJellyfinCheck:
         assert 'error' in data
         assert data['error'] == '檢查圖片狀態失敗'
 
+    def test_jellyfin_check_reverse_maps_wsl_unc_path_mappings(self, tmp_path, monkeypatch):
+        """TASK-91-T2b #13：check_jellyfin_images_needed(repo, path_mappings) 在 WSL+UNC
+        mapping 環境下，os.path.exists 檢查的 cover_fs 必須是反解後的本機路徑（可真的
+        open()），而非裸 uri_to_fs_path() 產生的映射端 UNC 字串（該路徑在磁碟上不存在，
+        會讓合法影片被誤判成 need_update）。
+        """
+        import core.path_utils as path_utils
+        from core.database import init_db, VideoRepository, Video
+        from web.routers.scanner import check_jellyfin_images_needed
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        cover = nas_dir / "cover.jpg"
+        cover.write_bytes(b'\xff\xd8\xff' + b'\x00' * 50)
+        # poster/fanart 也建好，讓這部片不需要補圖（純測反解，不測補圖判定）
+        (nas_dir / "cover-poster.jpg").write_bytes(b'\x00')
+        (nas_dir / "cover-fanart.jpg").write_bytes(b'\x00')
+
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        db_path = tmp_path / "t.db"
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+        repo.upsert_batch([
+            Video(path="file:///movies/v1.mp4", mtime=1.0,
+                  cover_path="file://///NAS/share/cover.jpg"),
+        ])
+
+        result = check_jellyfin_images_needed(repo, mappings)
+
+        assert result['need_update'] == 0, (
+            f"cover/poster/fanart 皆存在（反解後本機路徑）應判定不需補圖，"
+            f"實際: {result}"
+        )
+        assert result['items'] == []
+
     def test_jellyfin_check_uses_to_thread(self):
         """靜態掃描確認 scanner.py 使用 asyncio.to_thread 包裝 _check_jellyfin_needed helper，
         且 helper 內含 db_path.exists、VideoRepository、check_jellyfin_images_needed"""
@@ -453,7 +491,7 @@ class TestJellyfinCheck:
         assert 'def _check_jellyfin_needed(' in scanner_src
         assert 'db_path.exists()' in scanner_src
         assert 'VideoRepository(db_path)' in scanner_src
-        assert 'check_jellyfin_images_needed(repo)' in scanner_src
+        assert 'check_jellyfin_images_needed(repo, path_mappings)' in scanner_src
 
     # ---- T3(40c): TTL 快取相關測試 ----
 

--- a/tests/integration/test_api_thumb.py
+++ b/tests/integration/test_api_thumb.py
@@ -636,6 +636,7 @@ class TestPrewarmClearRace:
             mocker, items,
             get_by_path_side=[video_a, video_a],
             load_config_side=[
+                {"thumbnail_cache_enabled": True},   # TASK-91-T2b #11: 迴圈外 path_mappings 讀取
                 {"thumbnail_cache_enabled": True},   # A before-check
                 {"thumbnail_cache_enabled": False},  # A after-check（generate 期間關閉）
             ],
@@ -698,6 +699,7 @@ class TestPrewarmClearRace:
             mocker, items,
             get_by_path_side=[video_a, video_a],
             load_config_side=[
+                {"thumbnail_cache_enabled": True},   # TASK-91-T2b #11: 迴圈外 path_mappings 讀取
                 {"thumbnail_cache_enabled": True},   # A before-check
                 {"thumbnail_cache_enabled": False},  # A after-check（generate 期間關閉）
             ],
@@ -843,4 +845,174 @@ class TestGetThumbMissDisabledGateP2B:
         )
         assert resp.headers["content-type"] == "image/jpeg", (
             f"fallback 應是原圖 jpeg，實際 {resp.headers['content-type']}"
+        )
+
+
+# ============ TASK-91-T2b #9/#10/#11: WSL+UNC path_mappings 反解 ============
+
+class TestUriToLocalFsPathReverseMappingThumb:
+    """get_thumb miss 分支（#9 首次 generate 用的 cover_fs / #10 generate 後
+    re-read 的 fresh_fs）與 _prewarm_worker（#11）在 WSL + UNC path_mappings
+    環境下，餵給磁碟 I/O（thumbnail_cache.generate/os.path.exists）的路徑必須是
+    反解後的本機路徑，而不是裸 uri_to_fs_path() 產生的映射端 UNC 字串。
+    """
+
+    def test_get_thumb_miss_generate_uses_reverse_mapped_path(
+        self, client, thumb_dir, temp_db, tmp_path, mocker, monkeypatch
+    ):
+        """#9：miss→generate，DB cover_path 為 mapped UNC URI，config 帶 WSL+mapping
+        → thumbnail_cache.generate 收到的 cover_fs 是反解後的本機路徑（可 open()），
+        而非裸 UNC 字串 //NAS/share/...（該路徑在測試環境不存在，會讓 generate 失敗）。
+        """
+        import core.path_utils as path_utils
+        from core.database import Video
+
+        _, repo = temp_db
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        cover = _make_small_jpg(nas_dir / "cover.jpg")
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        mocker.patch(
+            "web.routers.scanner.load_config",
+            return_value={
+                "thumbnail_cache_enabled": True,
+                "gallery": {"path_mappings": mappings},
+            },
+        )
+
+        uri = to_file_uri("/movies/wsl_unc.mp4")
+        cover_uri = "file://///NAS/share/cover.jpg"
+        repo.upsert_batch([Video(path=uri, mtime=100.0, cover_path=cover_uri)])
+
+        gen_spy = mocker.spy(thumbnail_cache, "generate")
+
+        resp = client.get("/api/gallery/thumb", params={"path": uri})
+
+        assert resp.status_code == 200, (
+            f"反解後應能真的 open() 本機檔案生成 webp，實際 {resp.status_code}"
+        )
+        assert resp.headers["content-type"] == "image/webp"
+        gen_spy.assert_called_once()
+        called_cover_fs = gen_spy.call_args[0][0]
+        assert called_cover_fs == str(cover), (
+            f"generate 應收到反解後的本機路徑 {cover}，實際 {called_cover_fs}"
+        )
+        assert "//NAS/share" not in called_cover_fs, (
+            f"generate 不應收到裸 UNC 映射端字串，實際 {called_cover_fs}"
+        )
+
+    def test_get_thumb_miss_reread_uses_reverse_mapped_path(
+        self, client, thumb_dir, temp_db, tmp_path, mocker, monkeypatch
+    ):
+        """#10：generate 成功後 re-read DB 拿到「換過的」cover_path（也是 mapped UNC URI），
+        fresh_fs 反解比對也必須是本機路徑，換封面判定（fresh_fs != cover_fs）才正確。
+        """
+        import core.path_utils as path_utils
+        from core.database import Video
+
+        _, repo = temp_db
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        _make_small_jpg(nas_dir / "cover_a.jpg")  # 只需存在於磁碟，供 generate() 讀
+        _make_small_jpg(nas_dir / "cover_b.jpg")
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        mocker.patch(
+            "web.routers.scanner.load_config",
+            return_value={
+                "thumbnail_cache_enabled": True,
+                "gallery": {"path_mappings": mappings},
+            },
+        )
+
+        uri = to_file_uri("/movies/wsl_unc_reread.mp4")
+        repo.upsert_batch([
+            Video(path=uri, mtime=100.0, cover_path="file://///NAS/share/cover_a.jpg"),
+        ])
+
+        # generate() 由第一個 cover_a 觸發後，模擬並發換封面：re-read 拿到 cover_b
+        real_get_by_path = repo.get_by_path
+        calls = {"n": 0}
+
+        def fake_get_by_path(p):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return real_get_by_path(p)
+            # 第二次呼叫（re-read）：換成 cover_b
+            v = real_get_by_path(p)
+            v.cover_path = "file://///NAS/share/cover_b.jpg"
+            return v
+
+        mocker.patch.object(repo, "get_by_path", side_effect=fake_get_by_path)
+        mocker.patch("web.routers.scanner.VideoRepository", return_value=repo)
+        invalidate_spy = mocker.patch("web.routers.scanner.thumbnail_cache.invalidate")
+
+        resp = client.get("/api/gallery/thumb", params={"path": uri})
+
+        # cover 換了 → invalidate 被呼叫，fallback serve 當前（cover_b）封面
+        invalidate_spy.assert_called_once_with(uri)
+        assert resp.status_code == 200
+        # fallback 應是本機反解後的 cover_b（可真的 open()），非 404/500
+        assert resp.headers["content-type"] == "image/jpeg"
+
+    def test_prewarm_worker_generate_uses_reverse_mapped_path(
+        self, mocker, tmp_path, monkeypatch, thumb_dir
+    ):
+        """#11：_prewarm_worker 迴圈內 cover_fs 反解後才傳入 thumbnail_cache.generate。"""
+        import core.path_utils as path_utils
+        import web.routers.scanner as scanner_mod
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        cover = _make_small_jpg(nas_dir / "cover.jpg")
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        uri_a = "file:///movies/wsl_prewarm.mp4"
+        cover_uri = "file://///NAS/share/cover.jpg"
+
+        db_path = mocker.MagicMock()
+        db_path.exists.return_value = True
+        mocker.patch("web.routers.scanner.get_db_path", return_value=db_path)
+
+        video_a = mocker.MagicMock(cover_path=cover_uri)
+        repo_mock = mocker.MagicMock()
+        repo_mock.get_all.return_value = []  # iter_missing 被 mock，回值不重要
+        repo_mock.get_by_path.side_effect = [video_a, video_a]
+        mocker.patch("web.routers.scanner.VideoRepository", return_value=repo_mock)
+
+        mocker.patch(
+            "web.routers.scanner.load_config",
+            return_value={
+                "thumbnail_cache_enabled": True,
+                "gallery": {"path_mappings": mappings},
+            },
+        )
+        mocker.patch(
+            "web.routers.scanner.thumbnail_cache.iter_missing",
+            return_value=[(uri_a, "/stale/cover.jpg")],
+        )
+        gen_spy = mocker.patch("web.routers.scanner.thumbnail_cache.generate", return_value=True)
+        mocker.patch("web.routers.scanner.thumbnail_cache.invalidate")
+        mocker.patch("web.routers.scanner._emit_notif")
+
+        scanner_mod._prewarming = True
+        try:
+            scanner_mod._prewarm_worker()
+        finally:
+            scanner_mod._prewarming = False
+
+        gen_spy.assert_called_once()
+        called_cover_fs = gen_spy.call_args[0][0]
+        assert called_cover_fs == str(cover), (
+            f"generate 應收到反解後的本機路徑 {cover}，實際 {called_cover_fs}"
+        )
+        assert "//NAS/share" not in called_cover_fs, (
+            f"generate 不應收到裸 UNC 映射端字串，實際 {called_cover_fs}"
         )

--- a/tests/integration/test_async_offload_guard.py
+++ b/tests/integration/test_async_offload_guard.py
@@ -338,7 +338,7 @@ class TestT4OffloadHousePattern:
         assert "def _check_jellyfin_needed(" in src
         assert "db_path.exists()" in src
         assert "VideoRepository(db_path)" in src
-        assert "check_jellyfin_images_needed(repo)" in src
+        assert "check_jellyfin_images_needed(repo, path_mappings)" in src
 
     def test_connect_uses_to_thread_helper(self):
         src = self._src("settings_metatube.py")

--- a/tests/integration/test_similar_api.py
+++ b/tests/integration/test_similar_api.py
@@ -506,6 +506,89 @@ class TestSimilarThumbnailCacheCoverUrl:
             SimilarRankerCache._instance = None
 
 
+class TestSimilarCoverUrlPathMappingsReverse:
+    """TASK-91-T2a #3,#4: `_build_cover_url`/`_build_cover_full_url` 在 WSL +
+    UNC path_mappings 環境下必須反解成真正能 open() 的本機路徑，而不是留下裸
+    uri_to_fs_path() 產生的映射端 UNC 字串（get_image 端沒有第二次反解機會）。
+    """
+
+    @pytest.fixture
+    def client_with_wsl_unc_cover(self, tmp_path, monkeypatch):
+        import core.path_utils as path_utils
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        db_path = tmp_path / "wsl_unc.db"
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+
+        unc_cover = "file://///NAS/share/cover_001.jpg"
+        target = _make_video(idx=1, number="TEST-001",
+                              tags=["高畫質", "單體作品", "美乳"], cover_path=unc_cover)
+        target_id = repo.upsert(target)
+        candidates = [
+            _make_video(idx=i, number=f"TEST-{i:03d}",
+                        tags=["高畫質", "單體作品", "美乳"],
+                        cover_path=("file://///NAS/share/cover_%03d.jpg" % i))
+            for i in range(2, 14)
+        ]
+        repo.upsert_batch(candidates)
+
+        real_repo_cls = VideoRepository
+
+        class _PatchedRepo(real_repo_cls):
+            def __init__(self, _=None):
+                super().__init__(db_path)
+
+        monkeypatch.setattr("web.routers.similar.VideoRepository", _PatchedRepo)
+        corpus = repo.get_all()
+        ranker = SimilarRanker(corpus)
+        monkeypatch.setattr(SimilarRankerCache, "_instance", ranker)
+        monkeypatch.setattr(
+            "web.routers.similar.load_config",
+            lambda: {
+                "thumbnail_cache_enabled": False,
+                "gallery": {"path_mappings": {"/home/user/nas": "//NAS/share"}},
+            },
+        )
+
+        yield TestClient(_make_test_app()), target_id
+        SimilarRankerCache._instance = None
+
+    def test_cover_url_reverse_maps_wsl_unc(self, client_with_wsl_unc_cover):
+        from urllib.parse import unquote
+
+        client, target_id = client_with_wsl_unc_cover
+        resp = client.get(f"/api/similar-covers/{target_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        qv_url = unquote(data["query_video"]["cover_url"])
+        assert "/home/user/nas/cover_001.jpg" in qv_url, (
+            f"cover_url 應反解為本機路徑，實際: {qv_url}"
+        )
+        assert "//NAS/share/cover_001.jpg" not in qv_url, (
+            f"cover_url 不應殘留裸 UNC 映射端字串，實際: {qv_url}"
+        )
+
+    def test_cover_full_url_reverse_maps_wsl_unc(self, client_with_wsl_unc_cover):
+        from urllib.parse import unquote
+
+        client, target_id = client_with_wsl_unc_cover
+        resp = client.get(f"/api/similar-covers/{target_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        for r in data["results"]:
+            full_url = unquote(r["cover_full_url"])
+            assert "/home/user/nas/" in full_url, (
+                f"cover_full_url 應反解為本機路徑，實際: {full_url}"
+            )
+            assert "//NAS/share/" not in full_url, (
+                f"cover_full_url 不應殘留裸 UNC 映射端字串，實際: {full_url}"
+            )
+
+
 # ---------------------------------------------------------------------------
 # Codex P1 — legacy DB startup path regression test
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_db_key_namespace_completeness.py
+++ b/tests/unit/test_db_key_namespace_completeness.py
@@ -67,11 +67,25 @@ _DB_KEY_SINK_METHODS = {
 # 0-based 位置索引（direct-call 情形；asyncio.to_thread 間接呼叫時，真正引數位置整體
 # 往後位移 1，因 to_thread(fn, *args) 的 args[0] 是 fn 本身）
 WRAPPER_SINK_NAMES = {"_db_upsert", "_db_upsert_samples_only", "_check_cover_path"}
-_WRAPPER_PATH_ARG_INDEX = {
-    "_db_upsert": 2,                 # _db_upsert(repo, number, fs_path, meta, ...)
-    "_db_upsert_samples_only": 1,    # _db_upsert_samples_only(repo, fs_path, sample_images)
-    "_check_cover_path": 0,          # _check_cover_path(fs_path)
+# 各 wrapper「路徑實參」在其呼叫式中的 0-based 位置索引 + 參數名（direct-call 情形；
+# asyncio.to_thread 間接呼叫時，真正引數位置整體往後位移 1，因 to_thread(fn, *args) 的
+# args[0] 是 fn 本身）。參數名用於支援 keyword 傳參 callsite（`_db_upsert(..., fs_path=x)`）。
+_WRAPPER_PATH_ARG = {
+    "_db_upsert": (2, "fs_path"),                # _db_upsert(repo, number, fs_path, meta, ...)
+    "_db_upsert_samples_only": (1, "fs_path"),   # _db_upsert_samples_only(repo, fs_path, sample_images)
+    "_check_cover_path": (0, "fs_path"),         # _check_cover_path(fs_path)
 }
+
+
+def _extract_wrapper_arg(node_args, node_keywords, idx, param_name, offset=0):
+    """依位置（含 offset）或 keyword 名稱取出 wrapper 呼叫式中的路徑實參節點；
+    兩者皆未命中回傳 None（呼叫端視為無法判定，跳過該 callsite）。"""
+    if idx is not None and (offset + idx) < len(node_args):
+        return node_args[offset + idx]
+    for kw in node_keywords:
+        if kw.arg == param_name:
+            return kw.value
+    return None
 
 
 def _is_primitive_sink_call(node: ast.AST) -> bool:
@@ -153,9 +167,10 @@ def _find_assign_target_name(funcdef: ast.AST, call_node: ast.Call):
     return None
 
 
-def _find_assign_lineno_for_name(funcdef: ast.AST, name: str):
-    """在 funcdef 內找出 `name = ...`（單一 Name target）的賦值語句 lineno（保守取最後一次
-    賦值，貼近『就近』語意；非真正資料流分析，單函式內不跨跳）。"""
+def _find_assign_lineno_for_name(funcdef: ast.AST, name: str, before_lineno: int):
+    """在 funcdef 內找出 lineno < before_lineno 的最近一次 `name = ...`（單一 Name target）
+    賦值語句 lineno（reaching-definition 近似：只取 sink 之前的賦值，避免 sink 之後的同名
+    重賦值遮蔽/誤扯 marker 判斷；非真正資料流分析，單函式內不跨跳）。"""
     lineno = None
     for node in ast.walk(funcdef):
         if (
@@ -163,6 +178,8 @@ def _find_assign_lineno_for_name(funcdef: ast.AST, name: str):
             and len(node.targets) == 1
             and isinstance(node.targets[0], ast.Name)
             and node.targets[0].id == name
+            and node.lineno < before_lineno
+            and (lineno is None or node.lineno > lineno)
         ):
             lineno = node.lineno
     return lineno
@@ -170,11 +187,11 @@ def _find_assign_lineno_for_name(funcdef: ast.AST, name: str):
 
 def _has_marker_two_layer(source_lines: list[str], sink_lineno: int, arg_node, funcdef: ast.AST) -> bool:
     """⭐ Opus 裁決兩層 OR：① sink 命中行/上一行；② 若路徑實參是同函式區域變數 →
-    該變數賦值行/上一行。任一層命中即豁免。"""
+    該變數「sink 之前最近一次」賦值行/上一行。任一層命中即豁免。"""
     if _has_marker(source_lines, sink_lineno):
         return True
     if isinstance(arg_node, ast.Name):
-        assign_lineno = _find_assign_lineno_for_name(funcdef, arg_node.id)
+        assign_lineno = _find_assign_lineno_for_name(funcdef, arg_node.id, sink_lineno)
         if assign_lineno is not None and _has_marker(source_lines, assign_lineno):
             return True
     return False
@@ -276,14 +293,14 @@ def _scan_source(source: str, filename: str = "<test>") -> list[str]:
 
             if _is_wrapper_direct_call(node):
                 wrapper_name = node.func.id
-                idx = _WRAPPER_PATH_ARG_INDEX.get(wrapper_name)
-                if idx is not None and idx < len(node.args):
-                    arg_node = node.args[idx]
+                idx, param_name = _WRAPPER_PATH_ARG.get(wrapper_name, (None, None))
+                arg_node = _extract_wrapper_arg(node.args, node.keywords, idx, param_name)
             elif _is_asyncio_to_thread_wrapper_call(node):
                 wrapper_name = node.args[0].id
-                idx = _WRAPPER_PATH_ARG_INDEX.get(wrapper_name)
-                if idx is not None and (1 + idx) < len(node.args):
-                    arg_node = node.args[1 + idx]
+                idx, param_name = _WRAPPER_PATH_ARG.get(wrapper_name, (None, None))
+                # to_thread(fn, *args, **kwargs) 的 keywords 直接 forward 給 fn，
+                # 故 keyword 查找用 node.keywords（不需 offset）；位置引數需 offset=1。
+                arg_node = _extract_wrapper_arg(node.args, node.keywords, idx, param_name, offset=1)
 
             if arg_node is None:
                 continue
@@ -479,5 +496,73 @@ def test_guard_ignores_non_sink_use():
         "    path_uri = to_file_uri(fs_path)\n"
         "    if path_uri == other:\n"
         "        return path_uri\n"
+    )
+    assert _scan_source(source) == []
+
+
+# --- reaching-definition 近似（Fix 1）：sink 之前/之後同名重賦值不應互相干擾 ---
+
+
+def test_guard_reaching_def_earlier_unmarked_sink_not_hidden_by_later_marked_reassign():
+    """較早的真 violation（unmarked sink）不應被較晚同名變數的 marked 重賦值遮蔽
+    （false negative 回歸鎖：修前 `_find_assign_lineno_for_name` 取『全函式最後一次賦值』，
+    會誤把此處 sink 的賦值行判定成後面那個 marked 重賦值行）。"""
+    source = (
+        "def bad():\n"
+        "    fs_path_for_db = uri_to_local_fs_path(uri, path_mappings)\n"
+        "    _db_upsert(repo, number, fs_path_for_db, meta)\n"
+        "    fs_path_for_db = other()  # db-ns-ok: unrelated later reassign\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_reaching_def_earlier_marked_assign_not_falsely_flagged_by_later_unmarked_reassign():
+    """較早的合法賦值（marked）供較早的 sink 使用，不應被較晚同名變數的 unmarked 重賦值
+    拖累而誤報（false positive 回歸鎖：修前取『全函式最後一次賦值』會誤把 sink 對應到
+    後面那個沒有 marker 的重賦值行）。"""
+    source = (
+        "def ok():\n"
+        "    fs_path_for_db = uri_to_local_fs_path(uri, path_mappings)  # db-ns-ok: mapped\n"
+        "    _db_upsert(repo, number, fs_path_for_db, meta)\n"
+        "    fs_path_for_db = other()\n"
+    )
+    assert _scan_source(source) == []
+
+
+# --- wrapper callsite keyword 傳參（Fix 2）：位置引數之外也要支援 keyword ---
+
+
+def test_guard_catches_planted_violation_wrapper_direct_call_keyword_arg():
+    source = (
+        "def bad():\n"
+        "    bad_var = uri_to_local_fs_path(uri, path_mappings)\n"
+        "    _db_upsert(repo, number, fs_path=bad_var, meta=meta)\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_catches_planted_violation_asyncio_to_thread_keyword_arg():
+    source = (
+        "async def bad():\n"
+        "    bad_var = uri_to_local_fs_path(uri, path_mappings)\n"
+        "    allowed = await asyncio.to_thread(_check_cover_path, fs_path=bad_var)\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_wrapper_direct_call_keyword_arg_marker_exempts():
+    source = (
+        "def ok():\n"
+        "    # db-ns-ok: reason\n"
+        "    _db_upsert(repo, number, fs_path=fs_path_for_db, meta=meta)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_asyncio_to_thread_keyword_arg_marker_exempts():
+    source = (
+        "async def ok():\n"
+        "    # db-ns-ok: reason\n"
+        "    allowed = await asyncio.to_thread(_check_cover_path, fs_path=fs_path_for_db)\n"
     )
     assert _scan_source(source) == []

--- a/tests/unit/test_db_key_namespace_completeness.py
+++ b/tests/unit/test_db_key_namespace_completeness.py
@@ -1,0 +1,483 @@
+"""
+tests/unit/test_db_key_namespace_completeness.py
+AST 結構守衛 — 防「DB-key 建構 sink」在無 marker 情況下吃進命名空間錯誤的路徑值
+（axis-B：污染值 / 裸本機路徑 → DB round-trip 命名空間）。
+plan-91b.md §5 D3 / TASK-91b-T2.md
+
+守衛骨架複用 T6（`test_uri_to_fs_path_reverse_mapping_completeness.py`），
+換掉「危險呼叫」與「sink」判斷；獨立 marker、獨立檔案，不混進 T6（D2）。
+
+## 偵測範圍（sink-anchored，見 plan-91b §5 D3）
+
+1. **primitive sink**：`to_file_uri(X)` 只有 1 個引數（無 `path_mappings`）→ 其回傳值同函式內
+   直接嵌套（Shape 1）或賦值後使用（Shape 2）流向 `_DB_KEY_SINK_METHODS` 集合的 repo 方法呼叫，
+   或流向 `is_known_cover_path(...)`。`to_file_uri(X, path_mappings)`（帶第二引數）視為已
+   forward-map，**自動放行、不查 marker**。
+2. **`is_known_cover_path(X)` 直接命中**：本身即 sink（非需再流向下一層）。若引數本身是巢狀
+   `to_file_uri(X)` 呼叫，已由上述 Shape 1 涵蓋；若引數是裸變數/其他運算式，此呼叫本身即為
+   命中點，查其呼叫行的 marker（含兩層搜尋，見下）。
+3. **wrapper sink callsite**（`WRAPPER_SINK_NAMES`）：已登記 helper（`_db_upsert` /
+   `_db_upsert_samples_only` / `_check_cover_path`）内部已用 primitive sink 建 DB key，
+   命名空間正確性委派給呼叫端（callsite）保證。守衛偵測其 **callsite**（不查 helper 本體，
+   本體已用一次性 docstring `db-ns-ok: enforced at callsites` 說明委派），含兩種語法形狀：
+   - 直接呼叫：`_db_upsert(...)` / `_db_upsert_samples_only(...)` / `_check_cover_path(...)`。
+   - 間接呼叫：`asyncio.to_thread(_check_cover_path, cover_fs_for_db)`（wrapper 名稱是
+     `to_thread` 的第一個引數，真正路徑實參往後位移一格）。
+
+## Marker 豁免（⭐ Opus 裁決：canonical 兩層 marker 規則，不放寬「上 N 行」）
+
+固定兩層 OR：
+① sink 命中行（該 `ast.Call` 節點的 `lineno`）或其正上一行含 `# db-ns-ok:`；
+② 若 sink 的「路徑實參」是同函式內的區域變數（`ast.Name`）→ 該變數賦值語句所在行
+   或其正上一行含 `# db-ns-ok:`（複用 T6 `_find_assign_target_name` 風格，單變數同函式不跨跳）。
+
+任一層命中即豁免。**嚴禁**放寬成「上 N 行」——這是精確度與 per-site hackery 的分界。
+
+wrapper helper **本體**內部的 primitive sink（如 `_db_upsert` 內 `to_file_uri(fs_path)`）
+因命名空間正確性已委派給 callsite（D3 設計），**不在此守衛的 primitive-sink 掃描範圍內**
+（守衛跳過 `funcdef.name in WRAPPER_SINK_NAMES` 的函式本體做 primitive/`is_known_cover_path`
+掃描；wrapper callsite 掃描則不受此排除，正常掃描所有函式）。
+
+## 已知射程外（不抓，靠 code review 補，見 plan-91b §3）
+
+- 手工拼接的 raw SQL 字串（`f"UPDATE videos SET ... WHERE path='{x}'"`）/ `conn.execute(...)`
+  裸呼叫——字串拼接非 `ast.Call`，且 `conn.execute` 不在 `_DB_KEY_SINK_METHODS`，屬已知射程外
+  （即使剛好因既有 marker 而不誤報，也非本守衛刻意涵蓋，勿誤以為涵蓋）。
+- 跨函式/跨模組傳遞後才建 key（值先 `return`，在 caller 端才 `to_file_uri`）——不抓，
+  T6 的 Shape 1/2 皆限定同函式內，T2 沿用相同限制。
+- 未登記的新 wrapper helper（未來新增類似 `_db_upsert` 但未加進 `WRAPPER_SINK_NAMES`）——
+  不抓，守衛詞彙表需人工維護，比照 T6 磁碟 I/O 白名單也是硬編碼集合、非動態推導。
+- 經多層別名的 sink（`f = repo.get_by_path; f(to_file_uri(x))`）——不抓。
+"""
+import ast
+from pathlib import Path
+
+EXCLUDE_PREFIXES = ("tests/", "archive/", "venv/", ".venv/", "build/", "node_modules/")
+EXCLUDE_FILES = ("core/path_utils.py",)
+
+MARKER = "# db-ns-ok:"
+
+# repo path 方法（DB-key sink）窮舉集合（T1 窮舉，plan-91b §6.2）
+_DB_KEY_SINK_METHODS = {
+    "get_by_path", "update_user_tags", "update_scrape_attempted_at",
+    "update_sample_images", "repath", "repath_path_only",
+}
+
+# 已登記 wrapper sink helper（T1 窮舉，plan-91b §6.2）+ 各自「路徑實參」在其呼叫式中的
+# 0-based 位置索引（direct-call 情形；asyncio.to_thread 間接呼叫時，真正引數位置整體
+# 往後位移 1，因 to_thread(fn, *args) 的 args[0] 是 fn 本身）
+WRAPPER_SINK_NAMES = {"_db_upsert", "_db_upsert_samples_only", "_check_cover_path"}
+_WRAPPER_PATH_ARG_INDEX = {
+    "_db_upsert": 2,                 # _db_upsert(repo, number, fs_path, meta, ...)
+    "_db_upsert_samples_only": 1,    # _db_upsert_samples_only(repo, fs_path, sample_images)
+    "_check_cover_path": 0,          # _check_cover_path(fs_path)
+}
+
+
+def _is_primitive_sink_call(node: ast.AST) -> bool:
+    """`to_file_uri(X)` 且僅有 1 個引數（無 path_mappings，未 forward-map）。"""
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "to_file_uri"
+    ):
+        return False
+    return (len(node.args) + len(node.keywords)) == 1
+
+
+def _is_db_key_sink_call(node: ast.AST) -> bool:
+    """`repo.<method>(...)` / `VideoRepository().<method>(...)`，method 屬於
+    `_DB_KEY_SINK_METHODS`。不強求 receiver 變數名（比照 T6 對 os.path.<attr> 的寬鬆比對）。"""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _DB_KEY_SINK_METHODS
+    )
+
+
+def _is_known_cover_path_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "is_known_cover_path"
+    )
+
+
+def _is_sink_call(node: ast.AST) -> bool:
+    """Shape 1/2 nesting/assign 判斷用的統一 sink 集合：repo path 方法 或 is_known_cover_path。"""
+    return _is_db_key_sink_call(node) or _is_known_cover_path_call(node)
+
+
+def _is_wrapper_direct_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in WRAPPER_SINK_NAMES
+    )
+
+
+def _is_asyncio_to_thread_wrapper_call(node: ast.AST) -> bool:
+    """`asyncio.to_thread(<wrapper_name>, ...)` 間接呼叫形狀。"""
+    if not (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "to_thread"
+    ):
+        return False
+    if not node.args:
+        return False
+    first = node.args[0]
+    return isinstance(first, ast.Name) and first.id in WRAPPER_SINK_NAMES
+
+
+def _has_marker(source_lines: list[str], lineno: int) -> bool:
+    """呼叫所在行（1-based lineno）或緊鄰上一行是否含 marker。"""
+    idx = lineno - 1
+    if 0 <= idx < len(source_lines) and MARKER in source_lines[idx]:
+        return True
+    if 0 <= idx - 1 < len(source_lines) and MARKER in source_lines[idx - 1]:
+        return True
+    return False
+
+
+def _find_assign_target_name(funcdef: ast.AST, call_node: ast.Call):
+    """在 funcdef 內找出 `var = ...call_node...`（單一 Name target）的 var 名稱，
+    僅當 call_node 出現在該 Assign 的 value 運算式中（walk 整個 value 子樹）。"""
+    for node in ast.walk(funcdef):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if call_node is node.value or call_node in ast.walk(node.value):
+            return node.targets[0].id
+    return None
+
+
+def _find_assign_lineno_for_name(funcdef: ast.AST, name: str):
+    """在 funcdef 內找出 `name = ...`（單一 Name target）的賦值語句 lineno（保守取最後一次
+    賦值，貼近『就近』語意；非真正資料流分析，單函式內不跨跳）。"""
+    lineno = None
+    for node in ast.walk(funcdef):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == name
+        ):
+            lineno = node.lineno
+    return lineno
+
+
+def _has_marker_two_layer(source_lines: list[str], sink_lineno: int, arg_node, funcdef: ast.AST) -> bool:
+    """⭐ Opus 裁決兩層 OR：① sink 命中行/上一行；② 若路徑實參是同函式區域變數 →
+    該變數賦值行/上一行。任一層命中即豁免。"""
+    if _has_marker(source_lines, sink_lineno):
+        return True
+    if isinstance(arg_node, ast.Name):
+        assign_lineno = _find_assign_lineno_for_name(funcdef, arg_node.id)
+        if assign_lineno is not None and _has_marker(source_lines, assign_lineno):
+            return True
+    return False
+
+
+def _direct_nesting_hits_sink(call_node: ast.Call, funcdef: ast.AST) -> bool:
+    """Shape 1：`repo.get_by_path(to_file_uri(x))` / `repo.is_known_cover_path(to_file_uri(x))`
+    同語句嵌套。"""
+    for node in ast.walk(funcdef):
+        if not isinstance(node, ast.Call):
+            continue
+        args = list(node.args) + [kw.value for kw in node.keywords]
+        if call_node in args and _is_sink_call(node):
+            return True
+    return False
+
+
+def _assign_then_use_hits_sink(assign_target_name: str, funcdef: ast.AST) -> bool:
+    """Shape 2：`path_uri = to_file_uri(x); repo.get_by_path(path_uri)` 同函式內
+    賦值後使用。"""
+    for node in ast.walk(funcdef):
+        if not _is_sink_call(node):
+            continue
+        args = list(node.args) + [kw.value for kw in node.keywords]
+        for a in args:
+            if isinstance(a, ast.Name) and a.id == assign_target_name:
+                return True
+    return False
+
+
+def _scan_source(source: str, filename: str = "<test>") -> list[str]:
+    """AST-parse source，回傳未豁免的 DB-key 命名空間 sink violation list。"""
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[str] = []
+
+    for funcdef in ast.walk(tree):
+        if not isinstance(funcdef, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        is_wrapper_body = funcdef.name in WRAPPER_SINK_NAMES
+
+        if not is_wrapper_body:
+            # --- primitive sink：Shape 1 / Shape 2 ---
+            for node in ast.walk(funcdef):
+                if not _is_primitive_sink_call(node):
+                    continue
+
+                if _has_marker(source_lines, node.lineno):
+                    continue
+
+                if _direct_nesting_hits_sink(node, funcdef):
+                    violations.append(
+                        f"{filename}:{node.lineno}: unmarked to_file_uri() call nested directly "
+                        f"into a DB-key sink within function `{funcdef.name}`. "
+                        f"Fix: pass path_mappings, use _for_db pattern, or add '# db-ns-ok: <reason>'."
+                    )
+                    continue
+
+                target_name = _find_assign_target_name(funcdef, node)
+                if target_name and _assign_then_use_hits_sink(target_name, funcdef):
+                    violations.append(
+                        f"{filename}:{node.lineno}: unmarked to_file_uri() call assigned to "
+                        f"`{target_name}` which later reaches a DB-key sink within function "
+                        f"`{funcdef.name}`. Fix: pass path_mappings, use _for_db pattern, "
+                        f"or add '# db-ns-ok: <reason>'."
+                    )
+
+            # --- is_known_cover_path 直接命中（引數非巢狀 to_file_uri，已由上方 Shape 1 涵蓋） ---
+            for node in ast.walk(funcdef):
+                if not _is_known_cover_path_call(node):
+                    continue
+                if not node.args:
+                    continue
+                arg = node.args[0]
+                if (
+                    isinstance(arg, ast.Call)
+                    and isinstance(arg.func, ast.Name)
+                    and arg.func.id == "to_file_uri"
+                ):
+                    continue  # 已由 Shape 1（direct-nesting）涵蓋，避免重複列舉
+                if _has_marker_two_layer(source_lines, node.lineno, arg, funcdef):
+                    continue
+                violations.append(
+                    f"{filename}:{node.lineno}: unmarked is_known_cover_path() call within "
+                    f"function `{funcdef.name}` — DB-key namespace not verified. "
+                    f"Fix: ensure argument round-trips to mapped namespace or add "
+                    f"'# db-ns-ok: <reason>'."
+                )
+
+        # --- wrapper sink callsite（直接呼叫 + asyncio.to_thread 間接呼叫），不受 wrapper 本體排除 ---
+        for node in ast.walk(funcdef):
+            arg_node = None
+            wrapper_name = None
+
+            if _is_wrapper_direct_call(node):
+                wrapper_name = node.func.id
+                idx = _WRAPPER_PATH_ARG_INDEX.get(wrapper_name)
+                if idx is not None and idx < len(node.args):
+                    arg_node = node.args[idx]
+            elif _is_asyncio_to_thread_wrapper_call(node):
+                wrapper_name = node.args[0].id
+                idx = _WRAPPER_PATH_ARG_INDEX.get(wrapper_name)
+                if idx is not None and (1 + idx) < len(node.args):
+                    arg_node = node.args[1 + idx]
+
+            if arg_node is None:
+                continue
+
+            if _has_marker_two_layer(source_lines, node.lineno, arg_node, funcdef):
+                continue
+
+            violations.append(
+                f"{filename}:{node.lineno}: unmarked callsite of wrapper sink `{wrapper_name}` "
+                f"within function `{funcdef.name}` — DB-key namespace not verified. "
+                f"Fix: ensure argument round-trips to mapped namespace or add "
+                f"'# db-ns-ok: <reason>'."
+            )
+
+    return violations
+
+
+def _scan_repo() -> list[str]:
+    root = Path(".")
+    violations: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.as_posix()
+        if any(rel.startswith(p) for p in EXCLUDE_PREFIXES):
+            continue
+        if rel in EXCLUDE_FILES:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if (
+            "to_file_uri(" not in source
+            and "is_known_cover_path(" not in source
+            and not any(name in source for name in WRAPPER_SINK_NAMES)
+        ):
+            continue
+        violations.extend(_scan_source(source, filename=rel))
+    return violations
+
+
+def test_no_unmarked_db_key_namespace_violations():
+    """全 repo 掃描：DB-key 建構 sink（primitive / is_known_cover_path / wrapper callsite）
+    必須有 '# db-ns-ok:' marker（兩層 OR）或已 forward-map（帶 path_mappings）。
+    T1 已補齊現況 marker，故現況應為 0。
+    """
+    violations = _scan_repo()
+    assert violations == [], (
+        f"Found {len(violations)} unmarked DB-key namespace sink(s):\n"
+        + "\n".join(violations)
+    )
+
+
+# --- (i) 反解值裸餵 primitive sink 無 marker → 應紅 ---
+
+
+def test_guard_catches_planted_violation_reversed_value_to_primitive_sink():
+    source = (
+        "def bad():\n"
+        "    fs_path = uri_to_local_fs_path(uri, path_mappings)\n"
+        "    path_uri = to_file_uri(fs_path)\n"
+        "    repo.get_by_path(path_uri)\n"
+    )
+    assert _scan_source(source) != []
+
+
+# --- (ii) 裸本機路徑餵 primitive sink 無 marker → 應紅（對應 scraper.py:180 修前形狀） ---
+
+
+def test_guard_catches_planted_violation_bare_local_path_to_primitive_sink():
+    source = (
+        "def bad():\n"
+        "    new_filename = organize_file(path)['new_filename']\n"
+        "    path_uri = to_file_uri(new_filename)\n"
+        "    repo.update_user_tags(path_uri, tags)\n"
+    )
+    assert _scan_source(source) != []
+
+
+# --- (iii) 錯命名空間值傳進已登記 wrapper callsite 無 marker → 應紅 ---
+
+
+def test_guard_catches_planted_violation_wrapper_callsite_wrong_namespace():
+    source = (
+        "def bad():\n"
+        "    fs_path = uri_to_local_fs_path(uri, path_mappings)\n"
+        "    _db_upsert(repo, number, fs_path, meta)\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_catches_planted_violation_direct_nesting_primitive_sink():
+    source = (
+        "def bad():\n"
+        "    repo.get_by_path(to_file_uri(fs_path))\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_catches_planted_violation_is_known_cover_path_bare_variable():
+    source = (
+        "def bad():\n"
+        "    repo.is_known_cover_path(cover_fs)\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_catches_planted_violation_asyncio_to_thread_indirect_callsite():
+    source = (
+        "async def bad():\n"
+        "    cover_fs_for_db = compute_something(path)\n"
+        "    allowed = await asyncio.to_thread(_check_cover_path, cover_fs_for_db)\n"
+    )
+    assert _scan_source(source) != []
+
+
+# --- negative：forward-mapped（帶第二引數）不誤報 ---
+
+
+def test_guard_forward_mapped_second_arg_not_flagged():
+    source = (
+        "def ok():\n"
+        "    path_uri = to_file_uri(fs_path, path_mappings)\n"
+        "    repo.get_by_path(path_uri)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_forward_mapped_keyword_arg_not_flagged():
+    source = (
+        "def ok():\n"
+        "    path_uri = to_file_uri(fs_path, path_mappings=path_mappings)\n"
+        "    repo.get_by_path(path_uri)\n"
+    )
+    assert _scan_source(source) == []
+
+
+# --- negative：marker 豁免（呼叫行 / 賦值行兩種慣例） ---
+
+
+def test_guard_marker_exempts_primitive_sink_same_line():
+    source = (
+        "def ok():\n"
+        "    path_uri = to_file_uri(fs_path_for_db)  # db-ns-ok: reason\n"
+        "    repo.get_by_path(path_uri)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_marker_exempts_primitive_sink_prev_line():
+    source = (
+        "def ok():\n"
+        "    # db-ns-ok: reason\n"
+        "    path_uri = to_file_uri(fs_path_for_db)\n"
+        "    repo.get_by_path(path_uri)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_marker_on_assignment_line_exempts_wrapper_callsite():
+    """比照 actress.py:525/528 慣例：marker 貼在賦值行，wrapper callsite 在後面幾行。"""
+    source = (
+        "def ok():\n"
+        "    cover_fs_for_db = uri_to_fs_path(path)  # db-ns-ok: reason\n"
+        "    asyncio.to_thread(_check_cover_path, cover_fs_for_db)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_marker_on_callsite_line_exempts_wrapper_direct_call():
+    """比照 enricher.py _db_upsert callsite 慣例：marker 貼在呼叫行正上一行。"""
+    source = (
+        "def ok():\n"
+        "    # db-ns-ok: reason\n"
+        "    _db_upsert(repo, number, fs_path_for_db, meta)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_wrapper_body_internal_primitive_sink_not_flagged():
+    """wrapper helper 本體內部的 primitive sink 已委派給 callsite（D3），
+    不應被獨立當成 primitive-sink violation 列舉（callsite 掃描仍正常運作）。"""
+    source = (
+        "def _db_upsert(repo, number, fs_path, meta):\n"
+        "    path_uri = to_file_uri(fs_path)\n"
+        "    repo.get_by_path(path_uri)\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_ignores_non_sink_use():
+    source = (
+        "def ok():\n"
+        "    path_uri = to_file_uri(fs_path)\n"
+        "    if path_uri == other:\n"
+        "        return path_uri\n"
+    )
+    assert _scan_source(source) == []

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -2063,3 +2063,153 @@ class TestKodiStemNaming:
         assert fanart_text.strip() != "fanart.jpg", (
             "NFO <fanart> 不應是 bare 'fanart.jpg'"
         )
+
+
+# ── TASK-91-T3: 站台 1/2/3 — uri_to_local_fs_path WSL+UNC path_mappings 反解 ──
+
+_WSL_UNC_MAPPINGS = {"/home/user/nas": "//NAS/share"}
+_WSL_UNC_URI = "file://///NAS/share/dir/movie.mp4"
+_WSL_UNC_REVERSED = "/home/user/nas/dir/movie.mp4"
+
+
+class TestEnrichSinglePathMappingReverse:
+    """站台1（enrich_single :358）：fs_path 必須是 path_mappings 反解後的本機路徑，
+    不是裸 uri_to_fs_path 產出的 UNC 字面值（mutation-sensitive）。"""
+
+    def test_wsl_unc_mapping_reverses_fs_path(self, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        captured = []
+
+        def fake_exists(p):
+            captured.append(p)
+            return False  # 提早以「檔案不存在」return，不需 mock 整條 pipeline
+
+        with patch("os.path.exists", side_effect=fake_exists):
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=_WSL_UNC_URI,
+                number="SONE-205",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.error == "檔案不存在"
+        assert captured, "os.path.exists 應被呼叫"
+        assert captured[0] == _WSL_UNC_REVERSED, (
+            f"fs_path 應反解為本機路徑 {_WSL_UNC_REVERSED}，實際: {captured[0]!r}"
+        )
+
+    def test_non_file_uri_fallback_passthrough_unchanged(self, monkeypatch):
+        """邊界4：非 file:/// 輸入的 try/except passthrough 不可回歸。"""
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        bare_path = "just-a-bare-local-string-not-a-uri"
+        captured = []
+
+        def fake_exists(p):
+            captured.append(p)
+            return False
+
+        with patch("os.path.exists", side_effect=fake_exists):
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=bare_path,
+                number="SONE-205",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.error == "檔案不存在"
+        assert captured[0] == bare_path, (
+            f"非 URI 輸入應原樣 passthrough，實際: {captured[0]!r}"
+        )
+
+
+class TestFetchSamplesOnlyPathMappingReverse:
+    """站台2（fetch_samples_only :618）：同站台1的反解行為。"""
+
+    def test_wsl_unc_mapping_reverses_fs_path(self, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        captured = []
+
+        def fake_exists(p):
+            captured.append(p)
+            return False
+
+        with patch("os.path.exists", side_effect=fake_exists):
+            from core.enricher import fetch_samples_only
+            result = fetch_samples_only(
+                file_path=_WSL_UNC_URI,
+                number="SONE-205",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.error == "檔案不存在"
+        assert captured, "os.path.exists 應被呼叫"
+        assert captured[0] == _WSL_UNC_REVERSED, (
+            f"fs_path 應反解為本機路徑 {_WSL_UNC_REVERSED}，實際: {captured[0]!r}"
+        )
+
+    def test_non_file_uri_fallback_passthrough_unchanged(self, monkeypatch):
+        """邊界4：非 file:/// 輸入的 try/except passthrough 不可回歸。"""
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        bare_path = "just-a-bare-local-string-not-a-uri"
+        captured = []
+
+        def fake_exists(p):
+            captured.append(p)
+            return False
+
+        with patch("os.path.exists", side_effect=fake_exists):
+            from core.enricher import fetch_samples_only
+            result = fetch_samples_only(
+                file_path=bare_path,
+                number="SONE-205",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.error == "檔案不存在"
+        assert captured[0] == bare_path, (
+            f"非 URI 輸入應原樣 passthrough，實際: {captured[0]!r}"
+        )
+
+
+class TestResolveNfoCoverPathsMappingReverse:
+    """站台3（resolve_nfo_cover_paths :667）：純函式，直接測反解後的 nfo/cover 路徑。"""
+
+    def test_wsl_unc_mapping_reverses_paths(self, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        from core.enricher import resolve_nfo_cover_paths
+        nfo_path, cover_path = resolve_nfo_cover_paths(
+            _WSL_UNC_URI,
+            path_mappings=_WSL_UNC_MAPPINGS,
+        )
+
+        assert nfo_path == "/home/user/nas/dir/movie.nfo", (
+            f"nfo_path 應反解為本機路徑，實際: {nfo_path!r}"
+        )
+        assert cover_path == "/home/user/nas/dir/movie.jpg", (
+            f"cover_path 應反解為本機路徑，實際: {cover_path!r}"
+        )
+
+    def test_non_file_uri_fallback_passthrough_unchanged(self, monkeypatch):
+        """邊界4：非 file:/// 輸入的 try/except passthrough 不可回歸。"""
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        bare_path = "just-a-bare-local-string-not-a-uri"
+        from core.enricher import resolve_nfo_cover_paths
+        nfo_path, cover_path = resolve_nfo_cover_paths(
+            bare_path,
+            path_mappings=_WSL_UNC_MAPPINGS,
+        )
+
+        assert nfo_path == bare_path + ".nfo"
+        assert cover_path == bare_path + ".jpg"

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -2213,3 +2213,160 @@ class TestResolveNfoCoverPathsMappingReverse:
 
         assert nfo_path == bare_path + ".nfo"
         assert cover_path == bare_path + ".jpg"
+
+
+# ── TASK-91 Codex Finding 1: DB key 必須維持映射命名空間，不可用反解後本機路徑 ──
+# 反例：若 fs_path_for_db 被誤還原為 fs_path（反解後本機路徑），DB round-trip
+# （get_by_path / update_scrape_attempted_at / nfo_mtime WHERE path=?）永遠對不上
+# DB 既有 row（DB 存的是映射端 UNC URI）。Mutation-sensitive：revert 該行 → 下列全 RED。
+
+class TestEnrichSingleDbKeyMappingPreserved:
+    """站台1 DB key（enrich_single）：get_by_path / update_scrape_attempted_at 必須用
+    fs_path_for_db（裸 uri_to_fs_path，維持 DB 映射命名空間），不是反解後 fs_path。"""
+
+    def test_not_found_branch_marks_scrape_attempted_at_with_mapped_key(self, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.search_jav", return_value=None),
+        ):
+            mock_repo = MagicMock()
+            mock_repo_cls.return_value = mock_repo
+
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=_WSL_UNC_URI,
+                number="SONE-205",
+                mode="refresh_full",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.success is False
+        mock_repo.update_scrape_attempted_at.assert_called_once()
+        call_args = mock_repo.update_scrape_attempted_at.call_args[0]
+        assert call_args[0] == _WSL_UNC_URI, (
+            f"DB key 必須維持映射命名空間（{_WSL_UNC_URI!r}），"
+            f"不可用反解後本機路徑組出的 URI，實際: {call_args[0]!r}"
+        )
+
+    def test_get_by_path_uses_mapped_db_key(self, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        video = _make_video()
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.download_image", return_value=True),
+        ):
+            mock_repo = MagicMock()
+            mock_repo_cls.return_value = mock_repo
+            mock_repo.get_by_numbers.return_value = {"SONE-205": [video]}
+            mock_repo.get_by_path.return_value = None
+
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=_WSL_UNC_URI,
+                number="SONE-205",
+                mode="fill_missing",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.success is True
+        mock_repo.get_by_path.assert_called_once()
+        called_uri = mock_repo.get_by_path.call_args[0][0]
+        assert called_uri == _WSL_UNC_URI, (
+            f"get_by_path 必須用映射命名空間查 DB（{_WSL_UNC_URI!r}），實際: {called_uri!r}"
+        )
+
+
+class TestDbUpsertCoverAndSampleUrisForwardMapped:
+    """TASK-91 Finding 1 extension：新產生的 cover / extrafanart 磁碟路徑寫回 DB 前，
+    必須 forward-map 回映射命名空間（cover/sample 是新產生的磁碟路徑，不是自描述輸入，
+    走 to_file_uri(local_path, path_mappings) 正向 pattern，非 uri-no-reverse pattern）。"""
+
+    def test_full_flow_cover_and_sample_uris_are_mapped(self, monkeypatch):
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        scraper_data = _make_scraper_result()
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.search_jav", return_value=scraper_data),
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.download_image", return_value=True),
+            patch("os.makedirs"),
+        ):
+            mock_repo = MagicMock()
+            mock_repo_cls.return_value = mock_repo
+            mock_repo.get_by_numbers.return_value = {}
+            mock_repo.get_by_path.return_value = None
+            captured = []
+            mock_repo.upsert.side_effect = lambda v: captured.append(v)
+
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=_WSL_UNC_URI,
+                number="SONE-205",
+                mode="refresh_full",
+                write_extrafanart=True,
+                overwrite_existing=True,
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.success is True
+        assert len(captured) == 1
+        video = captured[0]
+        assert video.path == _WSL_UNC_URI, (
+            f"DB row path 必須是映射命名空間，實際: {video.path!r}"
+        )
+        assert video.cover_path.startswith("file://///NAS/share/dir/"), (
+            f"cover_path 應 forward-map 回映射命名空間，不應殘留反解後本機路徑，實際: {video.cover_path!r}"
+        )
+        assert video.sample_images, "extrafanart 應有實際寫入"
+        for uri in video.sample_images:
+            assert uri.startswith("file://///NAS/share/dir/extrafanart/"), (
+                f"sample_images 應 forward-map 回映射命名空間，實際: {uri!r}"
+            )
+
+    def test_fetch_samples_only_sample_uris_are_mapped(self, monkeypatch):
+        """站台2（fetch_samples_only）：_db_upsert_samples_only 用 fs_path_for_db 當 key，
+        _write_extrafanart 產生的 sample uri 亦需 forward-map。"""
+        from core import path_utils
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        meta = {"sample_images": ["https://example.com/s1.jpg"], "source": "javbus"}
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.search_jav", return_value=meta),
+            patch("core.enricher.download_image", return_value=True),
+            patch("os.makedirs"),
+        ):
+            mock_repo = MagicMock()
+            mock_repo_cls.return_value = mock_repo
+
+            from core.enricher import fetch_samples_only
+            result = fetch_samples_only(
+                file_path=_WSL_UNC_URI,
+                number="SONE-205",
+                path_mappings=_WSL_UNC_MAPPINGS,
+            )
+
+        assert result.success is True
+        mock_repo.update_sample_images.assert_called_once()
+        call_args = mock_repo.update_sample_images.call_args[0]
+        assert call_args[0] == _WSL_UNC_URI, (
+            f"update_sample_images DB key 必須維持映射命名空間，實際: {call_args[0]!r}"
+        )
+        for uri in call_args[1]:
+            assert uri.startswith("file://///NAS/share/dir/extrafanart/"), (
+                f"sample uri 應 forward-map 回映射命名空間，實際: {uri!r}"
+            )

--- a/tests/unit/test_enricher_nfo.py
+++ b/tests/unit/test_enricher_nfo.py
@@ -1,7 +1,8 @@
 """63c-5: enricher summary/rating crossing — _scraper_to_meta / _merge_meta / _write_nfo（CD-63c-5）。"""
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from core.enricher import _scraper_to_meta, _merge_meta, _write_nfo
+from core.path_utils import to_file_uri, uri_to_fs_path
 
 
 # ─── _scraper_to_meta crossing point（_ 前綴 → canonical）───
@@ -115,3 +116,69 @@ def test_write_nfo_off_mode_default_has_poster_fanart_false(tmp_path):
     assert kwargs.get("external_manager", "off") == "off"
     assert kwargs.get("has_poster", False) is False
     assert kwargs.get("has_fanart", False) is False
+
+
+# ─── TASK-91b-T1：_write_nfo user_tags is None 分支 WSL+UNC 回歸（axis-B 子形狀 i）───
+
+def test_write_nfo_user_tags_none_wsl_mapped_uses_mapped_namespace(tmp_path, monkeypatch):
+    """`_write_nfo` 的 `user_tags is None` fallback 分支（enricher.py 原 :184）若用反解後
+    的本機路徑 `fs_path` 建 DB key，在 WSL+path_mappings 下會落非 mapped 命名空間 →
+    `get_by_path` miss → 既有 user_tags 讀回 []（清空語意）。修法：新增
+    `fs_path_for_db` 參數，DB key 改用它建（未傳時 fallback `fs_path`，向後相容）。
+
+    修前 RED：get_by_path 收到用 `fs_path`（反解後的本機磁碟路徑）建的 unmapped key，
+    miss，generate_nfo 收到 user_tags=[]（既有 '評5' 被清空）。
+    修後 GREEN：get_by_path 收到用 `fs_path_for_db`（未反解、round-trip 回原 DB URI）
+    建的 mapped key，命中既有 record，generate_nfo 收到 user_tags=['評5']。
+
+    `fs_path_for_db` 語意比照 `enrich_single`（enricher.py:363）：
+    `uri_to_fs_path(file_path)`（file_path 是既有 DB URI，只 strip prefix、不反解 mapping）
+    —— 與 `fs_path = uri_to_local_fs_path(file_path, path_mappings)`（反解到本機磁碟路徑）
+    是同一來源、兩種分流用途；DB round-trip 不需第二引數 `path_mappings`
+    （round-trip 本身即回到原 mapped URI）。
+    """
+    import core.path_utils as path_utils_module
+    # gotcha：CURRENT_ENV 是 core.path_utils 的 module-global，_write_nfo 內
+    # `to_file_uri` 在同模組查找，patch 該模組單一 binding 即可。
+    monkeypatch.setattr(path_utils_module, 'CURRENT_ENV', 'wsl')
+
+    path_mappings = {"/home/user/nas/share": "//NAS/share"}
+    local_path = "/home/user/nas/share/ABC-003/ABC-003.mp4"
+    mapped_uri = to_file_uri(local_path, path_mappings)  # 既有 DB row 的 canonical URI
+    fs_path_for_db = uri_to_fs_path(mapped_uri)  # DB round-trip 用值（不反解 mapping）
+    # sanity：round-trip 回同一 mapped URI（不需 path_mappings 第二引數）
+    assert to_file_uri(fs_path_for_db) == mapped_uri
+
+    fs_path = str(tmp_path / "ABC-003.mp4")  # 磁碟 I/O 用值：反解後的本機路徑（與 DB 值不同）
+
+    existing_video = MagicMock()
+    existing_video.user_tags = ["評5"]
+
+    def _get_by_path(path_uri):
+        if path_uri == mapped_uri:
+            return existing_video
+        return None
+
+    mock_repo = MagicMock()
+    mock_repo.get_by_path.side_effect = _get_by_path
+
+    meta = {"title": "T"}
+    with patch("core.enricher.VideoRepository", return_value=mock_repo), \
+         patch("core.enricher.generate_nfo") as mock_gen:
+        mock_gen.return_value = True
+        _write_nfo(
+            fs_path=fs_path,
+            number="ABC-003",
+            meta=meta,
+            write_nfo=True,
+            overwrite_existing=True,
+            has_subtitle=False,
+            user_tags=None,
+            fs_path_for_db=fs_path_for_db,
+        )
+
+    mock_repo.get_by_path.assert_called_once_with(mapped_uri)
+    _, kwargs = mock_gen.call_args
+    assert kwargs["user_tags"] == ["評5"], (
+        f"既有 user_tags 不應被 WSL+mapped 命名空間 miss 清空，實際: {kwargs['user_tags']}"
+    )

--- a/tests/unit/test_gallery_scanner.py
+++ b/tests/unit/test_gallery_scanner.py
@@ -567,7 +567,7 @@ class TestScannerSampleImagesValidationPass:
         from core.gallery_scanner import _validate_sample_images
 
         # uri_to_fs_path 正常回傳路徑，os.path.exists 回傳 True
-        with patch("core.gallery_scanner.uri_to_fs_path", return_value="/fake/path/s1.jpg"), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", return_value="/fake/path/s1.jpg"), \
              patch("os.path.exists", return_value=True):
             result = _validate_sample_images(
                 [to_file_uri("/fake/path/s1.jpg")],
@@ -581,7 +581,7 @@ class TestScannerSampleImagesValidationPass:
         from unittest.mock import patch
         from core.gallery_scanner import _validate_sample_images
 
-        with patch("core.gallery_scanner.uri_to_fs_path", return_value="/fake/path/missing.jpg"), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", return_value="/fake/path/missing.jpg"), \
              patch("os.path.exists", return_value=False):
             result = _validate_sample_images(
                 [to_file_uri("/fake/path/missing.jpg")],
@@ -595,7 +595,7 @@ class TestScannerSampleImagesValidationPass:
         from unittest.mock import patch
         from core.gallery_scanner import _validate_sample_images
 
-        with patch("core.gallery_scanner.uri_to_fs_path", side_effect=ValueError("環境不支援")), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", side_effect=ValueError("環境不支援")), \
              patch("core.gallery_scanner.logger") as mock_logger:
             result = _validate_sample_images(
                 [to_file_uri("/bad/path.jpg")],
@@ -628,14 +628,14 @@ class TestScannerSampleImagesValidationPass:
 
         mock_repo.get_all.return_value = [video_with_orphan_1, video_with_orphan_2, video_clean]
 
-        def fake_uri_to_fs_path(uri):
+        def fake_uri_to_fs_path(uri, path_mappings=None):
             return uri.replace("file:///", "/")
 
         # v1/v2 的 sample 不存在磁碟，v3 的存在
         def fake_exists(path):
             return "s3.jpg" in path  # 只有 s3.jpg 存在
 
-        with patch("core.gallery_scanner.uri_to_fs_path", side_effect=fake_uri_to_fs_path), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", side_effect=fake_uri_to_fs_path), \
              patch("os.path.exists", side_effect=fake_exists):
             count = _run_sample_images_cleanup_pass(mock_repo)
 
@@ -653,7 +653,7 @@ class TestScannerSampleImagesValidationPass:
 
         mock_repo.get_all.return_value = [video_no_samples]
 
-        with patch("core.gallery_scanner.uri_to_fs_path"), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path"), \
              patch("os.path.exists"):
             count = _run_sample_images_cleanup_pass(mock_repo)
 
@@ -672,13 +672,13 @@ class TestScannerSampleImagesValidationPass:
         video.sample_images = [to_file_uri("/A/ext/exist.jpg"), to_file_uri("/A/ext/missing.jpg")]
         mock_repo.get_all.return_value = [video]
 
-        def fake_uri_to_fs_path(uri):
+        def fake_uri_to_fs_path(uri, path_mappings=None):
             return uri.replace("file:///", "/")
 
         def fake_exists(path):
             return "exist.jpg" in path  # 只有 exist.jpg 存在
 
-        with patch("core.gallery_scanner.uri_to_fs_path", side_effect=fake_uri_to_fs_path), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", side_effect=fake_uri_to_fs_path), \
              patch("os.path.exists", side_effect=fake_exists):
             _run_sample_images_cleanup_pass(mock_repo)
 
@@ -738,13 +738,13 @@ class TestScannerSampleImagesValidationPass:
             "https://cdn.example.com/s2.jpg",          # scraper URL 污染 → 清除
         ]
 
-        def fake_uri_to_fs_path(uri):
+        def fake_uri_to_fs_path(uri, path_mappings=None):
             return uri.replace("file:///", "/")
 
         def fake_exists(path):
             return "valid" in path  # only /valid/... exists
 
-        with patch("core.gallery_scanner.uri_to_fs_path", side_effect=fake_uri_to_fs_path), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", side_effect=fake_uri_to_fs_path), \
              patch("os.path.exists", side_effect=fake_exists):
             result = _validate_sample_images(mixed_samples, video_path=to_file_uri("/v1.mp4"))
 
@@ -785,13 +785,13 @@ class TestScannerSampleImagesValidationPass:
         ]
         mock_repo.get_all.return_value = [video]
 
-        def fake_uri_to_fs_path(uri):
+        def fake_uri_to_fs_path(uri, path_mappings=None):
             return uri.replace("file:///", "/")
 
         def fake_exists(path):
             return "fanart1.jpg" in path  # only fanart1.jpg exists on disk
 
-        with patch("core.gallery_scanner.uri_to_fs_path", side_effect=fake_uri_to_fs_path), \
+        with patch("core.gallery_scanner.uri_to_local_fs_path", side_effect=fake_uri_to_fs_path), \
              patch("os.path.exists", side_effect=fake_exists):
             count = _run_sample_images_cleanup_pass(mock_repo)
 
@@ -800,3 +800,70 @@ class TestScannerSampleImagesValidationPass:
             to_file_uri("/A/v1.mp4"),
             [to_file_uri("/A/extrafanart/fanart1.jpg")],
         )
+
+    def test_validate_reverse_maps_wsl_unc_path_mappings(self, tmp_path, monkeypatch):
+        """TASK-91-T2b #16：_validate_sample_images(sample_images, video_path, path_mappings)
+        在 WSL+UNC mapping 環境下，os.path.exists 檢查的路徑必須是反解後的本機路徑
+        （可真的 open()），非裸 uri_to_fs_path() 產生的映射端 UNC 字串（磁碟上不存在）。
+        """
+        import core.path_utils as path_utils
+        from core.gallery_scanner import _validate_sample_images
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        (nas_dir / "s1.jpg").write_bytes(b'\x00')
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        mapped_uri = "file://///NAS/share/s1.jpg"
+        result = _validate_sample_images(
+            [mapped_uri], video_path=to_file_uri("/fake/v1.mp4"), path_mappings=mappings,
+        )
+
+        assert result == [mapped_uri], (
+            f"反解後應能確認磁碟真的存在該檔案，不應誤判剔除。got: {result}"
+        )
+
+    def test_cleanup_pass_threads_path_mappings_to_validate(self, tmp_path, monkeypatch):
+        """TASK-91-T2b #16：_run_sample_images_cleanup_pass(repo, path_mappings) 把
+        path_mappings 透傳給 _validate_sample_images，WSL+UNC mapping 命中的合法
+        sample_image 不應被誤判孤兒而清除。"""
+        import core.path_utils as path_utils
+        from unittest.mock import MagicMock
+        from core.gallery_scanner import _run_sample_images_cleanup_pass
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        (nas_dir / "s1.jpg").write_bytes(b'\x00')
+        mappings = {str(nas_dir): "//NAS/share"}
+
+        mock_repo = MagicMock()
+        video = MagicMock()
+        video.path = to_file_uri("/A/v1.mp4")
+        video.sample_images = ["file://///NAS/share/s1.jpg"]
+        mock_repo.get_all.return_value = [video]
+
+        count = _run_sample_images_cleanup_pass(mock_repo, mappings)
+
+        assert count == 0, (
+            f"WSL+mapping 命中的合法 sample_image 反解後存在，不應被清除，got count={count}"
+        )
+        mock_repo.update_sample_images.assert_not_called()
+
+    def test_validate_default_none_path_mappings_equivalent_to_before(self, tmp_path):
+        """#16 邊界：path_mappings 預設 None → 與改動前裸 uri_to_fs_path 呼叫等價
+        （保護既有呼叫端測試不用改就能繼續 GREEN，見上方本 class 其餘測試）。"""
+        from unittest.mock import patch
+        from core.gallery_scanner import _validate_sample_images
+
+        with patch("core.gallery_scanner.uri_to_local_fs_path", return_value="/fake/path/s1.jpg"), \
+             patch("os.path.exists", return_value=True):
+            result = _validate_sample_images(
+                [to_file_uri("/fake/path/s1.jpg")],
+                video_path=to_file_uri("/fake/v1.mp4"),
+            )
+
+        assert result == [to_file_uri("/fake/path/s1.jpg")]

--- a/tests/unit/test_motion_lab_router.py
+++ b/tests/unit/test_motion_lab_router.py
@@ -111,6 +111,50 @@ class TestMotionLabDataAPI:
                 assert video["cover_url"].startswith("/api/gallery/image?path="), \
                     f"cover_url 格式錯誤: {video['cover_url']}"
 
+    def test_motion_lab_data_cover_url_reverse_maps_wsl_unc(self, tmp_path, monkeypatch):
+        """TASK-91-T2a #5: cover_url 在 WSL + UNC path_mappings 下必須反解為
+        本機路徑，而不是留下裸 uri_to_fs_path() 產生的映射端 UNC 字串
+        （get_image 端沒有第二次反解機會）。"""
+        import core.path_utils as path_utils
+        from core.database import Video
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        db_path = tmp_path / "wsl_unc.db"
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+        video = Video(
+            path="file://///NAS/share/video.mp4",
+            number="TEST-001",
+            title="WSL UNC Video",
+            cover_path="file://///NAS/share/cover.jpg",
+        )
+        repo.upsert(video)
+
+        monkeypatch.setattr("web.routers.motion_lab.get_db_path", lambda: db_path)
+        monkeypatch.setattr(
+            "web.routers.motion_lab.load_config",
+            lambda: {"gallery": {"path_mappings": {"/home/user/nas": "//NAS/share"}}},
+        )
+
+        from web.routers.motion_lab import router
+        from fastapi import FastAPI
+        test_app = FastAPI()
+        test_app.include_router(router)
+        client = TestClient(test_app)
+
+        response = client.get("/api/motion-lab/data")
+        assert response.status_code == 200
+        data = response.json()
+        from urllib.parse import unquote
+        cover_url = unquote(data["videos"][0]["cover_url"])
+        assert "/home/user/nas/cover.jpg" in cover_url, (
+            f"cover_url 應反解為本機路徑，實際: {cover_url}"
+        )
+        assert "//NAS/share/cover.jpg" not in cover_url, (
+            f"cover_url 不應殘留裸 UNC 映射端字串，實際: {cover_url}"
+        )
+
     def test_motion_lab_data_db_not_exists(self, tmp_path, monkeypatch):
         """DB 不存在時回傳空結果，不拋例外"""
         nonexistent_db = tmp_path / "nonexistent.db"

--- a/tests/unit/test_nfo_updater.py
+++ b/tests/unit/test_nfo_updater.py
@@ -10,9 +10,11 @@ from pathlib import Path
 
 import pytest
 
+import core.path_utils as path_utils
 from core.nfo_updater import (
     add_actor,
     add_tags_and_genres,
+    get_nfo_path_from_video,
     needs_update,
     update_nfo_file,
     update_nfo_user_tags,
@@ -757,3 +759,81 @@ class TestUpdateNfoFileFillBranches:
         names = [e.text for e in root.findall('.//actor/name')]
         # Only the original actor should be present — the fill branch was skipped
         assert names == ["女優A"]
+
+
+# ============================================================
+# TASK-91-T4: get_nfo_path_from_video path_mappings 反解測試
+# ============================================================
+
+class TestGetNfoPathPathMappingReverse:
+    """get_nfo_path_from_video 改用 uri_to_local_fs_path 後的行為驗證。
+
+    場景 C：WSL + UNC path_mappings 下，NFO 存在性判斷需拿到真正可 exists() 的
+    本機路徑，而非裸 uri_to_fs_path 產生的非法 WSL 路徑（恆 False）。
+    """
+
+    def test_wsl_mapping_hit(self, tmp_path, monkeypatch):
+        """WSL + mapping 命中：video_path 經反解對應到真實存在的 NFO。"""
+        nas_dir = tmp_path / "nas"
+        nas_dir.mkdir()
+        nfo_file = nas_dir / "movie.nfo"
+        nfo_file.write_text("<movie></movie>", encoding="utf-8")
+
+        mappings = {str(nas_dir): "//NAS/share"}
+        video_path = "file://///NAS/share/movie.mp4"
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        result = get_nfo_path_from_video(video_path, mappings)
+        assert result == str(nfo_file)
+
+        # 裸呼叫（無 mapping）在同一 WSL 環境下應回 None：
+        # 證明是 mapping 讓它解得到，而非其他因素（mutation-sensitive）
+        result_no_mapping = get_nfo_path_from_video(video_path)
+        assert result_no_mapping is None
+
+    def test_non_wsl_equivalent(self, tmp_path, monkeypatch):
+        """非 WSL 環境：mapping 存在也不生效，行為與改動前字面等價。"""
+        video_dir = tmp_path / "videos"
+        video_dir.mkdir()
+        video_path_str = str(video_dir / "movie.mp4")
+        nfo_file = video_dir / "movie.nfo"
+        nfo_file.write_text("<movie></movie>", encoding="utf-8")
+
+        mappings = {str(video_dir): "//NAS/share"}
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "linux")
+
+        result = get_nfo_path_from_video(video_path_str, mappings)
+        assert result == str(nfo_file)
+
+        # NFO 不存在 → None
+        missing_path = str(video_dir / "missing.mp4")
+        assert get_nfo_path_from_video(missing_path, mappings) is None
+
+    def test_no_mapping_equivalent(self, tmp_path):
+        """無 mapping（None）：行為與改動前字面等價。"""
+        video_dir = tmp_path / "videos2"
+        video_dir.mkdir()
+        video_path_str = str(video_dir / "movie.mp4")
+        nfo_file = video_dir / "movie.nfo"
+        nfo_file.write_text("<movie></movie>", encoding="utf-8")
+
+        result = get_nfo_path_from_video(video_path_str, None)
+        assert result == str(nfo_file)
+
+        missing_path = str(video_dir / "missing.mp4")
+        assert get_nfo_path_from_video(missing_path, None) is None
+
+    def test_default_none_caller_unchanged(self, tmp_path):
+        """既有呼叫端形狀（不傳 path_mappings）維持零回歸。"""
+        video_dir = tmp_path / "videos3"
+        video_dir.mkdir()
+        video_path_str = str(video_dir / "movie.mp4")
+        nfo_file = video_dir / "movie.nfo"
+        nfo_file.write_text("<movie></movie>", encoding="utf-8")
+
+        result = get_nfo_path_from_video(video_path_str)
+        assert result == str(nfo_file)
+
+        missing_path = str(video_dir / "missing.mp4")
+        assert get_nfo_path_from_video(missing_path) is None

--- a/tests/unit/test_path_utils.py
+++ b/tests/unit/test_path_utils.py
@@ -1260,3 +1260,42 @@ class TestIsPathUnderDirNFC:
         dir_uri  = to_file_uri(f'/media/{nfc}')
         path_uri = to_file_uri(f'/media2/{nfc}/video.mp4')
         assert is_path_under_dir(path_uri, dir_uri) is False
+
+
+# ============ TestUriToLocalFsPath ============
+
+class TestUriToLocalFsPath:
+    """測試 uri_to_local_fs_path()：file:/// URI → 本機實際可存取 FS 路徑（含 WSL+mapping 反解）"""
+
+    def test_wsl_mapping_hit(self, monkeypatch):
+        """WSL + mapping 命中 → 回本機 local FS 路徑，且不等於裸 uri_to_fs_path"""
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {'/home/user/nas': '//NAS/share'}
+        uri = 'file://///NAS/share/video.mp4'
+        result = path_utils.uri_to_local_fs_path(uri, mappings)
+        assert result == '/home/user/nas/video.mp4'
+        assert result != path_utils.uri_to_fs_path(uri)
+
+    def test_wsl_mapping_miss(self, monkeypatch):
+        """WSL + mapping 未命中 → reverse 回 None → or fs 退回 uri_to_fs_path"""
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {'/home/user/nas': '//NAS/share'}
+        uri = 'file:///D:/other/video.mp4'
+        result = path_utils.uri_to_local_fs_path(uri, mappings)
+        assert result == path_utils.uri_to_fs_path(uri)
+
+    def test_non_wsl_equivalent(self, monkeypatch):
+        """非 WSL（即使傳 mappings）→ reverse 分支不觸發，字面等價於 uri_to_fs_path"""
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'windows')
+        mappings = {'/home/user/nas': '//NAS/share'}
+        uri = 'file://///NAS/share/video.mp4'
+        result = path_utils.uri_to_local_fs_path(uri, mappings)
+        assert result == path_utils.uri_to_fs_path(uri)
+
+    def test_no_mapping_equivalent(self, monkeypatch):
+        """WSL + 空 mappings → 字面等價於 uri_to_fs_path"""
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {}
+        uri = 'file://///NAS/share/video.mp4'
+        result = path_utils.uri_to_local_fs_path(uri, mappings)
+        assert result == path_utils.uri_to_fs_path(uri)

--- a/tests/unit/test_path_utils.py
+++ b/tests/unit/test_path_utils.py
@@ -1060,6 +1060,40 @@ class TestReversePathMapping:
         result = reverse_path_mapping("//NAS/share/", mappings)
         assert result == "/local/"
 
+    # -------- 91b P2 fix：drive-letter remote WSL-mount 候選 --------
+
+    def test_drive_letter_remote_mnt_form_hits(self, monkeypatch):
+        """91b P2：drive-letter remote 經 uri_to_fs_path 正規化成 /mnt/z/share 形式仍應命中"""
+        from core.path_utils import reverse_path_mapping
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {"/nas": "Z:/share"}
+        result = reverse_path_mapping("/mnt/z/share/movie.mp4", mappings)
+        assert result == "/nas/movie.mp4"
+
+    def test_drive_letter_remote_backslash_form_mnt_hits(self, monkeypatch):
+        """91b P2：drive-letter remote 以 backslash 形式給出（Z:\\share）仍能算出 /mnt 候選並命中"""
+        from core.path_utils import reverse_path_mapping
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {"/nas": "Z:\\share"}
+        result = reverse_path_mapping("/mnt/z/share/movie.mp4", mappings)
+        assert result == "/nas/movie.mp4"
+
+    def test_drive_letter_remote_mnt_form_boundary_share_vs_share2(self, monkeypatch):
+        """91b P2 boundary：/mnt/z/share2/x 不應命中 Z:/share mapping（share vs share2）"""
+        from core.path_utils import reverse_path_mapping
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {"/nas": "Z:/share"}
+        result = reverse_path_mapping("/mnt/z/share2/x", mappings)
+        assert result is None
+
+    def test_unc_remote_no_regression_with_mnt_candidate(self, monkeypatch):
+        """91b P2 no-regression：UNC remote 加入 /mnt 候選後行為不變（dedup，仍走 win_fwd 命中）"""
+        from core.path_utils import reverse_path_mapping
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {"/nas": "//NAS/share"}
+        result = reverse_path_mapping("//NAS/share/movie.mp4", mappings)
+        assert result == "/nas/movie.mp4"
+
 
 # ============ TestIsPathUnderDirNFC ============
 
@@ -1299,3 +1333,13 @@ class TestUriToLocalFsPath:
         uri = 'file://///NAS/share/video.mp4'
         result = path_utils.uri_to_local_fs_path(uri, mappings)
         assert result == path_utils.uri_to_fs_path(uri)
+
+    def test_drive_letter_remote_reverse_maps_correctly(self, monkeypatch):
+        """91b P2：drive-letter remote（Z:/share）經 to_wsl_path 正規化為 /mnt/z/share 後，
+        reverse_path_mapping 須能反解回 local_prefix，不可 fallback 回未反解的 /mnt/z/... 路徑"""
+        monkeypatch.setattr(path_utils, 'CURRENT_ENV', 'wsl')
+        mappings = {'/nas': 'Z:/share'}
+        uri = 'file:///Z:/share/movie.mp4'
+        result = path_utils.uri_to_local_fs_path(uri, mappings)
+        assert result == '/nas/movie.mp4'
+        assert result != path_utils.uri_to_fs_path(uri)

--- a/tests/unit/test_showcase_api.py
+++ b/tests/unit/test_showcase_api.py
@@ -1440,6 +1440,105 @@ class TestMappedDriveWhitelist:
         )
 
 
+class TestMappedDriveWhitelistWslUncSymmetry:
+    """TASK-91-T2b（Opus 加測）：WSL + UNC path_mappings 環境下白名單對稱性
+    end-to-end 驗證。
+
+    - get_image：T2a 呼叫端（showcase/similar/motion_lab）反解後會產生
+      `?path=<反解後本機路徑>` 這種請求，config directories 存的是同一份本機路徑
+      （native `/home/user/nas` 形式）——這條路徑本來就該直接命中白名單，證明
+      T2a 的反解不會製造白名單誤殺。
+    - get_video：T2b #12 修正後，`local_path = uri_to_local_fs_path(path, ...)`
+      反解成本機路徑，`to_file_uri(local_path, path_mappings)` 再正向重新映射回
+      mapped-namespace request_uri，跟 `_dir_candidate_forms` 比對仍需命中 → 200/206。
+    """
+
+    @pytest.fixture
+    def image_client(self):
+        from web.app import app
+        from fastapi.testclient import TestClient
+        return TestClient(app)
+
+    @pytest.fixture
+    def video_client(self):
+        from web.app import app
+        from fastapi.testclient import TestClient
+        return TestClient(app)
+
+    def _clear_cache(self):
+        import web.routers.scanner as _scanner
+        _scanner._dir_forms_cache.clear()
+
+    def test_get_image_reverse_mapped_native_path_passes_whitelist(
+        self, image_client, tmp_path, monkeypatch
+    ):
+        """get_image：請求 `?path=<反解後本機路徑>`（T2a 呼叫端 WSL+UNC 反解後產生的
+        形式），config directories 也是同一份本機路徑 → 200（非 403）。"""
+        import core.path_utils as path_utils
+        self._clear_cache()
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        local_dir = tmp_path / "home_user_nas"
+        local_dir.mkdir(parents=True, exist_ok=True)
+        cover = local_dir / "x.jpg"
+        cover.write_bytes(b'\xff\xd8\xff' + b'\x00' * 100)
+
+        mappings = {str(local_dir): "//NAS/share"}
+
+        def mock_load_config():
+            return {
+                "gallery": {
+                    "directories": [str(local_dir)],
+                    "path_mappings": mappings,
+                }
+            }
+        monkeypatch.setattr("web.routers.scanner.load_config", mock_load_config)
+
+        response = image_client.get(f"/api/gallery/image?path={str(cover)}")
+        assert response.status_code == 200, (
+            "反解後的本機路徑（跟 config directories 同一份格式）應直接命中白名單，"
+            f"實際: {response.status_code}"
+        )
+
+    def test_get_video_mapped_unc_uri_reverse_maps_and_passes_whitelist(
+        self, video_client, tmp_path, monkeypatch
+    ):
+        """get_video：請求 `?path=file://///NAS/share/x.mp4`（mapped-namespace URI）。
+        TASK-91-T2b #12 修正後：local_path 反解成本機路徑（真實檔案在此），
+        request_uri 用同一份 path_mappings 正向重新映射回 mapped-namespace，
+        跟 `_dir_candidate_forms`（也用同一份 path_mappings 產生）比對仍命中 → 200/206。
+        """
+        import core.path_utils as path_utils
+        self._clear_cache()
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+        local_dir = tmp_path / "home_user_nas"
+        local_dir.mkdir(parents=True, exist_ok=True)
+        video = local_dir / "x.mp4"
+        video.write_bytes(b'\x00' * 1000)
+
+        mappings = {str(local_dir): "//NAS/share"}
+
+        def mock_load_config():
+            return {
+                "scraper": {"video_extensions": [".mp4"]},
+                "gallery": {
+                    "directories": [str(local_dir)],
+                    "path_mappings": mappings,
+                },
+            }
+        monkeypatch.setattr("web.routers.scanner.load_config", mock_load_config)
+        monkeypatch.setattr("web.routers.scanner.os.path.getsize", lambda p: 1000)
+
+        response = video_client.get("/api/gallery/video?path=file://///NAS/share/x.mp4")
+        assert response.status_code in (200, 206), (
+            "反解 → 正向重新映射對稱性應保住白名單比對，不應 403/404，"
+            f"實際: {response.status_code}"
+        )
+
+
 class TestSampleImagesAPI:
     """sample_images 欄位 — Showcase API integration 測試"""
 

--- a/tests/unit/test_showcase_api.py
+++ b/tests/unit/test_showcase_api.py
@@ -1536,3 +1536,58 @@ class TestSampleImagesAPI:
         for url in video1["sample_images"]:
             assert url.startswith("/api/gallery/image?path="), f"期望 /api/gallery/image?path=... 格式，實際: {url}"
             assert "fanart" in url
+
+
+class TestSerializeVideoPathMappingsReverse:
+    """TASK-91-T2a #1,#2: `_serialize_video` 的 cover_full_url / sample_images URL
+    在 WSL + UNC path_mappings 環境下必須反解成真正能 open() 的本機路徑，
+    而不是留下裸 uri_to_fs_path() 產生的映射端 UNC 字串（get_image 端沒有第二次反解機會）。
+    """
+
+    @pytest.fixture
+    def wsl_video(self):
+        from core.database import Video
+        return Video(
+            path="file://///NAS/share/video.mp4",
+            number="TEST-001",
+            title="WSL UNC Video",
+            cover_path="file://///NAS/share/cover.jpg",
+            sample_images=["file://///NAS/share/sample1.jpg"],
+        )
+
+    def test_cover_full_url_reverse_maps_wsl_unc(self, wsl_video, monkeypatch):
+        import core.path_utils as path_utils
+        from urllib.parse import unquote
+        from web.routers.showcase import _serialize_video
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        mappings = {"/home/user/nas": "//NAS/share"}
+
+        result = _serialize_video(wsl_video, mappings, enabled=False)
+        decoded = unquote(result["cover_full_url"])
+
+        assert "/home/user/nas/cover.jpg" in decoded, (
+            f"cover_full_url 應反解為本機路徑，實際: {decoded}"
+        )
+        assert "//NAS/share/cover.jpg" not in decoded, (
+            f"cover_full_url 不應殘留裸 UNC 映射端字串，實際: {decoded}"
+        )
+
+    def test_sample_images_url_reverse_maps_wsl_unc(self, wsl_video, monkeypatch):
+        import core.path_utils as path_utils
+        from urllib.parse import unquote
+        from web.routers.showcase import _serialize_video
+
+        monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+        mappings = {"/home/user/nas": "//NAS/share"}
+
+        result = _serialize_video(wsl_video, mappings, enabled=False)
+
+        assert len(result["sample_images"]) == 1
+        sample_url = unquote(result["sample_images"][0])
+        assert "/home/user/nas/sample1.jpg" in sample_url, (
+            f"sample_images URL 應反解為本機路徑，實際: {sample_url}"
+        )
+        assert "//NAS/share/sample1.jpg" not in sample_url, (
+            f"sample_images URL 不應殘留裸 UNC 映射端字串，實際: {sample_url}"
+        )

--- a/tests/unit/test_thumbnail_cache.py
+++ b/tests/unit/test_thumbnail_cache.py
@@ -198,6 +198,48 @@ def test_iter_missing_skips_no_cover(thumb_dir):
     assert list(tc.iter_missing(videos)) == []
 
 
+# ── TASK-91-T2b #15: iter_missing WSL+UNC path_mappings 反解 ──────
+def test_iter_missing_reverse_maps_wsl_unc_path_mappings(thumb_dir, tmp_path, monkeypatch):
+    """cover_path 為 mapped UNC URI，path_mappings 命中時 yield 出的
+    cover_fs_path 應為反解後的本機路徑（真的存在、可 open()），而非裸
+    uri_to_fs_path() 產生的映射端 UNC 字串（該路徑在磁碟上不存在）。"""
+    import core.path_utils as path_utils
+
+    monkeypatch.setattr(path_utils, "CURRENT_ENV", "wsl")
+
+    nas_dir = tmp_path / "nas"
+    nas_dir.mkdir()
+    cover = _make_jpg(nas_dir / "cover.jpg")
+    mappings = {str(nas_dir): "//NAS/share"}
+
+    uri = "file:///x/wsl_unc.mp4"
+    videos = [
+        types.SimpleNamespace(path=uri, cover_path="file://///NAS/share/cover.jpg"),
+    ]
+
+    result = list(tc.iter_missing(videos, mappings))
+    assert len(result) == 1
+    yielded_uri, yielded_cover = result[0]
+    assert yielded_uri == uri
+    assert yielded_cover == str(cover), (
+        f"應反解為本機路徑 {cover}，實際 {yielded_cover}"
+    )
+    assert "//NAS/share" not in yielded_cover
+
+
+def test_iter_missing_default_none_path_mappings_equivalent_to_before(thumb_dir, tmp_path):
+    """#15 邊界：path_mappings 預設 None → 與改動前裸 uri_to_fs_path 呼叫等價
+    （保護既有兩個呼叫點 tc.iter_missing(videos) 不用改就能繼續 GREEN）。"""
+    cover = _make_jpg(tmp_path / "plain.jpg")
+    uri = "file:///x/plain.mp4"
+    videos = [types.SimpleNamespace(path=uri, cover_path="file://" + str(cover))]
+
+    result = list(tc.iter_missing(videos))  # 不傳 path_mappings
+    assert len(result) == 1
+    assert result[0][0] == uri
+    assert os.path.exists(result[0][1])
+
+
 # ── 11. per-thumb 鎖 key 一致性（Codex round-2 P1 修法 A）────────
 def test_lock_for_thumb_same_path_same_lock(thumb_dir):
     """同一 video_path_uri → thumb_file_for 回同 Path → str 相同 → 同一把鎖。

--- a/tests/unit/test_uri_to_fs_path_reverse_mapping_completeness.py
+++ b/tests/unit/test_uri_to_fs_path_reverse_mapping_completeness.py
@@ -108,6 +108,29 @@ def _has_marker(source_lines: list[str], lineno: int) -> bool:
     return False
 
 
+def _is_path_constructor_call(node: ast.AST) -> bool:
+    """`Path(...)` 呼叫本身（尚未接 disk-method attribute）。"""
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "Path"
+
+
+def _path_call_feeds_disk_method(path_call: ast.Call, funcdef: ast.AST) -> bool:
+    """`path_call`（一個 Path(...) 呼叫）是否被同函式內某 `.<disk-method>(...)` 直接接住。
+
+    對應 `Path(uri_to_fs_path(x)).exists()` 這種同語句寫法：uri_to_fs_path(x) 是
+    Path(...) 呼叫的引數，而 Path(...) 呼叫又是 .exists() 的 value（非引數），
+    原本的「call_node in args」判斷抓不到這層，需另外比對 attribute call 的 func.value。
+    """
+    for node in ast.walk(funcdef):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _PATH_DISK_ATTRS
+            and node.func.value is path_call
+        ):
+            return True
+    return False
+
+
 def _direct_nesting_hits_disk_io(call_node: ast.Call, funcdef: ast.AST) -> bool:
     """從 call_node 往外找最近的 Call 祖先鏈（含穿過純字串 helper），判斷是否嵌套進磁碟 I/O 呼叫。
 
@@ -126,6 +149,8 @@ def _direct_nesting_hits_disk_io(call_node: ast.Call, funcdef: ast.AST) -> bool:
                 # 純字串 helper 消費了 call_node，再往外找是否被磁碟 I/O 呼叫吃下
                 if _direct_nesting_hits_disk_io(node, funcdef):
                     return True
+            if _is_path_constructor_call(node) and _path_call_feeds_disk_method(node, funcdef):
+                return True
     return False
 
 
@@ -282,6 +307,24 @@ def test_guard_respects_marker_prev_line():
         "    p = uri_to_fs_path(v.cover_path)\n"
         "    if os.path.exists(p):\n"
         "        return p\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_catches_path_constructor_direct_nesting():
+    source = (
+        "def bad():\n"
+        "    if Path(uri_to_fs_path(x)).exists():\n"
+        "        pass\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_respects_marker_on_path_constructor_direct_nesting():
+    source = (
+        "def bad():\n"
+        "    if Path(uri_to_fs_path(x)).exists():  # uri-no-reverse: reason\n"
+        "        pass\n"
     )
     assert _scan_source(source) == []
 

--- a/tests/unit/test_uri_to_fs_path_reverse_mapping_completeness.py
+++ b/tests/unit/test_uri_to_fs_path_reverse_mapping_completeness.py
@@ -1,0 +1,296 @@
+"""
+tests/unit/test_uri_to_fs_path_reverse_mapping_completeness.py
+AST 結構守衛 — 防 uri_to_fs_path() 回傳值未經 marker 豁免就流向磁碟 I/O 的漏網回歸。
+spec-91 / plan-91.md §5 D3 / TASK-91-T6.md
+
+守衛範圍（保守，見 plan-91 §7 ⚠️ T6 邊界紀律）：
+- 只抓兩種形狀：direct-nesting（同語句嵌套）、assign-then-use（同函式內賦值後使用）。
+- 不做跨函式資料流、不做別名追蹤、不做 return-then-caller-uses。漏抓靠 code review 補。
+- 唯一豁免 = `# uri-no-reverse:` marker（貼在呼叫所在行或緊鄰上一行）。
+"""
+import ast
+from pathlib import Path
+
+EXCLUDE_PREFIXES = ("tests/", "archive/", "venv/", ".venv/", "build/", "node_modules/")
+EXCLUDE_FILES = ("core/path_utils.py",)
+
+MARKER = "# uri-no-reverse:"
+
+# os.path.<attr> 磁碟 I/O 集合
+_OS_PATH_DISK_ATTRS = {"exists", "isfile", "isdir", "getsize", "getmtime", "realpath", "stat"}
+# os.<attr> 磁碟 I/O 集合
+_OS_DISK_ATTRS = {"scandir", "listdir", "remove", "stat", "makedirs", "startfile"}
+# Path(...).<attr> 磁碟 I/O 集合
+_PATH_DISK_ATTRS = {
+    "read_bytes", "read_text", "exists", "is_file", "is_dir",
+    "glob", "iterdir", "stat", "write_bytes", "write_text",
+}
+# 純字串 helper（direct-nesting 時允許中間巢狀，不視為「已消費」uri_to_fs_path 回傳值）
+_PURE_STRING_HELPERS = {"dirname", "splitext", "join"}
+
+
+def _is_uri_to_fs_path_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "uri_to_fs_path"
+    )
+
+
+def _is_disk_io_call(node: ast.Call) -> bool:
+    """判斷此 Call node 本身是否為磁碟 I/O 呼叫（依函式/屬性名比對）。"""
+    func = node.func
+
+    # builtin open(...)
+    if isinstance(func, ast.Name) and func.id == "open":
+        return True
+
+    # FileResponse(...)
+    if isinstance(func, ast.Name) and func.id == "FileResponse":
+        return True
+
+    if isinstance(func, ast.Attribute):
+        attr = func.attr
+        value = func.value
+
+        # os.path.<attr>(...)
+        if (
+            isinstance(value, ast.Attribute)
+            and value.attr == "path"
+            and isinstance(value.value, ast.Name)
+            and value.value.id == "os"
+            and attr in _OS_PATH_DISK_ATTRS
+        ):
+            return True
+
+        # os.<attr>(...)
+        if isinstance(value, ast.Name) and value.id == "os" and attr in _OS_DISK_ATTRS:
+            return True
+
+        # shutil.<attr>(...) — 任何 shutil 屬性都算
+        if isinstance(value, ast.Name) and value.id == "shutil":
+            return True
+
+        # Path(...).<attr>(...)  — value 本身是 Path(...) 呼叫
+        if (
+            attr in _PATH_DISK_ATTRS
+            and isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "Path"
+        ):
+            return True
+
+    return False
+
+
+def _is_pure_string_helper_call(node: ast.AST) -> bool:
+    """os.path.dirname / os.path.splitext / os.path.join 等純字串 helper 呼叫。"""
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+        return False
+    func = node.func
+    value = func.value
+    return (
+        isinstance(value, ast.Attribute)
+        and value.attr == "path"
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "os"
+        and func.attr in _PURE_STRING_HELPERS
+    )
+
+
+def _has_marker(source_lines: list[str], lineno: int) -> bool:
+    """呼叫所在行（1-based lineno）或緊鄰上一行是否含 marker。"""
+    idx = lineno - 1
+    if 0 <= idx < len(source_lines) and MARKER in source_lines[idx]:
+        return True
+    if 0 <= idx - 1 < len(source_lines) and MARKER in source_lines[idx - 1]:
+        return True
+    return False
+
+
+def _direct_nesting_hits_disk_io(call_node: ast.Call, funcdef: ast.AST) -> bool:
+    """從 call_node 往外找最近的 Call 祖先鏈（含穿過純字串 helper），判斷是否嵌套進磁碟 I/O 呼叫。
+
+    保守實作：走訪 funcdef 內所有 Call node，若某 Call 是磁碟 I/O 或純字串 helper，
+    且其引數鏈（可遞迴穿過純字串 helper）到達 call_node，且該鏈最終被某磁碟 I/O 呼叫吃下，判定命中。
+    """
+    # 找出「直接吃下 call_node 的 Call」，可能是磁碟 I/O，也可能是純字串 helper（需再往外一層）
+    for node in ast.walk(funcdef):
+        if not isinstance(node, ast.Call):
+            continue
+        args = list(node.args) + [kw.value for kw in node.keywords]
+        if call_node in args:
+            if _is_disk_io_call(node):
+                return True
+            if _is_pure_string_helper_call(node):
+                # 純字串 helper 消費了 call_node，再往外找是否被磁碟 I/O 呼叫吃下
+                if _direct_nesting_hits_disk_io(node, funcdef):
+                    return True
+    return False
+
+
+def _assign_then_use_hits_disk_io(assign_target_name: str, funcdef: ast.AST, after_node: ast.AST) -> bool:
+    """在同一函式 body 內，assign_target_name 是否作為引數出現在磁碟 I/O 呼叫，
+    或 Path(var).<disk-method>，或 os.path.<op>(var)。"""
+    for node in ast.walk(funcdef):
+        if not isinstance(node, ast.Call):
+            continue
+
+        # var 作為引數傳入磁碟 I/O 呼叫（含 open/FileResponse/os.*/shutil.*）
+        if _is_disk_io_call(node):
+            args = list(node.args) + [kw.value for kw in node.keywords]
+            for a in args:
+                if isinstance(a, ast.Name) and a.id == assign_target_name:
+                    return True
+
+        # Path(var).<disk-method>(...)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in _PATH_DISK_ATTRS
+            and isinstance(node.func.value, ast.Call)
+            and isinstance(node.func.value.func, ast.Name)
+            and node.func.value.func.id == "Path"
+        ):
+            path_args = node.func.value.args
+            if any(isinstance(a, ast.Name) and a.id == assign_target_name for a in path_args):
+                return True
+
+        # os.path.<op>(var) — 已被 _is_disk_io_call 涵蓋（op 屬於 _OS_PATH_DISK_ATTRS 時）
+        # 此處保留註解澄清：os.path.<op>(var) 本就落在上面 _is_disk_io_call 分支。
+
+    return False
+
+
+def _scan_source(source: str, filename: str = "<test>") -> list[str]:
+    """AST-parse source，回傳未豁免且回傳值流向磁碟 I/O 的 uri_to_fs_path(...) 呼叫 violation list。"""
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    violations = []
+
+    for funcdef in ast.walk(tree):
+        if not isinstance(funcdef, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        for node in ast.walk(funcdef):
+            if not _is_uri_to_fs_path_call(node):
+                continue
+
+            if _has_marker(source_lines, node.lineno):
+                continue
+
+            # Shape 1: direct-nesting
+            if _direct_nesting_hits_disk_io(node, funcdef):
+                violations.append(
+                    f"{filename}:{node.lineno}: unmarked uri_to_fs_path() call nested directly "
+                    f"into a disk I/O call within function `{funcdef.name}`. "
+                    f"Fix: use uri_to_local_fs_path() or add '# uri-no-reverse: <reason>'."
+                )
+                continue
+
+            # Shape 2: assign-then-use — 找出此 call 所屬的最外層 Assign（若有）
+            target_name = _find_assign_target_name(funcdef, node)
+            if target_name and _assign_then_use_hits_disk_io(target_name, funcdef, node):
+                violations.append(
+                    f"{filename}:{node.lineno}: unmarked uri_to_fs_path() call assigned to "
+                    f"`{target_name}` which later reaches disk I/O within function `{funcdef.name}`. "
+                    f"Fix: use uri_to_local_fs_path() or add '# uri-no-reverse: <reason>'."
+                )
+
+    return violations
+
+
+def _find_assign_target_name(funcdef: ast.AST, call_node: ast.Call):
+    """在 funcdef 內找出 `var = ...call_node...`（單一 Name target）的 var 名稱，
+    僅當 call_node 出現在該 Assign 的 value 運算式中（walk 整個 value 子樹）。"""
+    for node in ast.walk(funcdef):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if call_node is node.value or call_node in ast.walk(node.value):
+            return node.targets[0].id
+    return None
+
+
+def _scan_repo() -> list[str]:
+    root = Path(".")
+    violations = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.as_posix()
+        if any(rel.startswith(p) for p in EXCLUDE_PREFIXES):
+            continue
+        if rel in EXCLUDE_FILES:
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if "uri_to_fs_path(" not in source:
+            continue
+        violations.extend(_scan_source(source, filename=rel))
+    return violations
+
+
+def test_no_unmarked_uri_to_fs_path_before_disk_io():
+    """全 repo 掃描：所有裸 uri_to_fs_path() 呼叫若回傳值流向磁碟 I/O，必須有
+    '# uri-no-reverse:' marker（同行或上一行）。T5 已對現況 27 站台補齊 marker，故現況應為 0。
+    """
+    violations = _scan_repo()
+    assert violations == [], (
+        f"Found {len(violations)} unmarked uri_to_fs_path() call(s) reaching disk I/O:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_guard_catches_planted_violation_assign_then_use():
+    source = (
+        "def bad():\n"
+        "    p = uri_to_fs_path(v.cover_path)\n"
+        "    if os.path.exists(p):\n"
+        "        return p\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_catches_direct_nesting():
+    source = (
+        "def bad():\n"
+        "    if os.path.exists(uri_to_fs_path(x)):\n"
+        "        pass\n"
+    )
+    assert _scan_source(source) != []
+
+
+def test_guard_respects_marker_same_line():
+    source = (
+        "def bad():\n"
+        "    p = uri_to_fs_path(v.cover_path)  # uri-no-reverse: reason\n"
+        "    if os.path.exists(p):\n"
+        "        return p\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_respects_marker_prev_line():
+    source = (
+        "def bad():\n"
+        "    # uri-no-reverse: reason\n"
+        "    p = uri_to_fs_path(v.cover_path)\n"
+        "    if os.path.exists(p):\n"
+        "        return p\n"
+    )
+    assert _scan_source(source) == []
+
+
+def test_guard_ignores_non_disk_use():
+    source = (
+        "def ok():\n"
+        "    p = uri_to_fs_path(x)\n"
+        "    if p == other:\n"
+        "        return p\n"
+    )
+    assert _scan_source(source) == []

--- a/tests/unit/test_user_tags.py
+++ b/tests/unit/test_user_tags.py
@@ -588,6 +588,87 @@ def test_scrape_single_upserts_user_tags_to_db():
             os.unlink(video_path)
 
 
+def test_scrape_single_wsl_mapped_dir_user_tags_uses_mapped_namespace(monkeypatch):
+    """TASK-91b-T1（axis-B 子形狀 ii，scraper.py:180 live bug 回歸）。
+
+    WSL + gallery.path_mappings 下，organize_file 產出的 new_filename 是裸本機路徑
+    （非 DB URI）。scrape_single 必須用 to_file_uri(new_filename, path_mappings) 建
+    DB key（forward-map），才能命中既有 mapped 命名空間 DB row；否則
+    repo.get_by_path 落非 mapped key → miss → 既有 user_tags 被靜默遺失（不會產生
+    幽靈 row，update_user_tags 是純 UPDATE，0 行生效）。
+
+    修前 RED：get_by_path/update_user_tags 收到 unmapped file:///mnt/nas/share/...
+    key，existing_user_tags 恆 []，merged 只有新值、遺失既有 '★5'。
+    修後 GREEN：兩者收到 mapped file:///...NAS/share/... key，merged 為既有 ∪ 新值。
+    """
+    import core.path_utils as path_utils_module
+    from fastapi.testclient import TestClient
+    # gotcha: CURRENT_ENV 是 core.path_utils 的 module-global，to_file_uri/
+    # uri_to_local_fs_path 皆在同模組內查找，patch 該模組單一 binding 即可
+    # （scraper.py 只 import 函式、未 import CURRENT_ENV 本身，無需雙重 patch）。
+    monkeypatch.setattr(path_utils_module, 'CURRENT_ENV', 'wsl')
+
+    # 注意：local prefix 不可用 /mnt/X（to_file_uri 會先吃 WSL-mount 規則、
+    # 不會進 path_mappings fallback 分支），故用 /home/user/nas/share（比照
+    # test_readonly_producer.py 既有 WSL+mapping 測試慣例）。
+    path_mappings = {"/home/user/nas/share": "//NAS/share"}
+    new_filename = "/home/user/nas/share/ABC-002/ABC-002.mp4"
+    mapped_uri = to_file_uri(new_filename, path_mappings)
+    # sanity: 映射確實改變命名空間（否則本測試無意義，測不出 bug）
+    unmapped_uri = to_file_uri(new_filename)
+    assert mapped_uri != unmapped_uri
+
+    existing_video = MagicMock()
+    existing_video.user_tags = ["★5"]
+
+    def _get_by_path(path_uri):
+        if path_uri == mapped_uri:
+            return existing_video
+        return None
+
+    mock_repo = MagicMock()
+    mock_repo.get_by_path.side_effect = _get_by_path
+
+    fake_result = {
+        'success': True,
+        'duplicate': False,
+        'new_filename': new_filename,
+        'new_folder': '/home/user/nas/share/ABC-002',
+        'original_path': new_filename,
+        'cover_path': '',
+        'nfo_path': '',
+    }
+    fake_config = {'scraper': {}, 'gallery': {'path_mappings': path_mappings}}
+
+    with patch('web.routers.scraper.organize_file', return_value=fake_result), \
+         patch('web.routers.scraper.VideoRepository', return_value=mock_repo), \
+         patch('web.routers.scraper.load_config', return_value=fake_config):
+        from web.app import app
+        client = TestClient(app)
+        resp = client.post('/api/scrape-single', json={
+            'file_path': new_filename,
+            'number': 'ABC-002',
+            'metadata': {
+                'number': 'ABC-002',
+                'title': 'テスト',
+                'tags': ['HD'],
+                'user_tags': ['時間印'],
+                'cover': '',
+            },
+        })
+
+    assert resp.status_code == 200
+    mock_repo.get_by_path.assert_called_once_with(mapped_uri)
+    mock_repo.update_user_tags.assert_called_once()
+    call_args = mock_repo.update_user_tags.call_args
+    assert call_args[0][0] == mapped_uri, (
+        f"update_user_tags 的 path 應落 mapped 命名空間 {mapped_uri!r}，"
+        f"實際: {call_args[0][0]!r}"
+    )
+    merged = call_args[0][1]
+    assert set(merged) == {"★5", "時間印"}, f"既有 tags 應與新值聯集，實際: {merged}"
+
+
 # ── NFO updater ───────────────────────────────────────────────────────────────
 
 class TestUserTagsNfoUpdater:

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -28,7 +28,8 @@ from core.maker_mapping import load_prefix_mapping
 from core.database import ActressRepository, AliasRepository, VideoRepository, Actress, init_db
 from core.actress_photo import download_actress_photo, get_local_photo_path, delete_local_photo, crop_video_cover, GFRIENDS_DIR
 from core.organizer import sanitize_filename
-from core.path_utils import to_file_uri as to_file_uri, uri_to_fs_path, coerce_to_file_uri
+from core.path_utils import to_file_uri as to_file_uri, uri_to_fs_path, uri_to_local_fs_path, coerce_to_file_uri
+from core.config import load_config
 from core.scrapers.actress.orchestrator import (
     get_cached_profile,
     get_actress_profile,
@@ -394,6 +395,7 @@ async def list_photo_candidates(name: str):
 
     current_source = actress.photo_source
     cloud_sources = [s for s in ["graphis", "gfriends", "wiki", "minnano"] if s != current_source]
+    path_mappings = (await asyncio.to_thread(load_config)).get('gallery', {}).get('path_mappings', {})
 
     async def generate():
         total = 0
@@ -431,7 +433,7 @@ async def list_photo_candidates(name: str):
             )
             for video in local_videos:
                 # Fix 1 (T2): cover_path 在 DB 存 file:/// URI，crop endpoint 需要 FS path
-                cover_fs_path = uri_to_fs_path(str(video.cover_path)) if video.cover_path else ""
+                cover_fs_path = uri_to_local_fs_path(str(video.cover_path), path_mappings) if video.cover_path else ""
                 if not cover_fs_path:
                     # skip broken candidate，避免送空路徑的 URL
                     continue
@@ -520,7 +522,8 @@ async def actress_crop(path: str, spec: str = "v1"):
     spec: crop 規格版本（預設 v1）
     """
     # Fix 2 (T2): uri_to_fs_path 已 idempotent（非 URI 直接 normalize_path），直接呼叫
-    fs_path = uri_to_fs_path(path)
+    path_mappings = (await asyncio.to_thread(load_config)).get('gallery', {}).get('path_mappings', {})
+    fs_path = uri_to_local_fs_path(path, path_mappings)
     # Security: cover_path 必須是 DB 中某個 video 的 cover_path（防任意檔案讀取）
     allowed = await asyncio.to_thread(_check_cover_path, fs_path)
     if not allowed:
@@ -578,7 +581,8 @@ async def set_actress_photo(name: str, req: SetActressPhotoRequest):
         if match is None or not match.cover_path:
             return JSONResponse(status_code=404, content={"error": "video_or_cover_not_found"})
         # Fix 3 (T3): match.cover_path 也是 URI，傳給 crop_video_cover 前先轉 FS path
-        cover_fs_path = uri_to_fs_path(str(match.cover_path)) if match.cover_path else ""
+        path_mappings = (await asyncio.to_thread(load_config)).get('gallery', {}).get('path_mappings', {})
+        cover_fs_path = uri_to_local_fs_path(str(match.cover_path), path_mappings) if match.cover_path else ""
         if not cover_fs_path:
             return JSONResponse(status_code=404, content={"error": "video_or_cover_not_found"})
         # crop → bytes

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -467,7 +467,11 @@ async def list_photo_candidates(name: str):
 # ---------------------------------------------------------------------------
 
 def _check_cover_path(fs_path: str) -> bool:
-    """Threadpool helper: init DB + check cover path is known (防任意檔案讀取)."""
+    """Threadpool helper: init DB + check cover path is known (防任意檔案讀取).
+
+    db-ns-ok: enforced at callsites — 本體內 is_known_cover_path(fs_path) primitive sink
+    命名空間正確性委派給呼叫端保證（TASK-91b-T1 wrapper sink 登記，callsite 各自標記）。
+    """
     init_db()
     return VideoRepository().is_known_cover_path(fs_path)
 
@@ -522,7 +526,7 @@ async def actress_crop(path: str, spec: str = "v1"):
     """
     # Fix 2 (T2): uri_to_fs_path 已 idempotent（非 URI 直接 normalize_path），直接呼叫
     path_mappings = (await asyncio.to_thread(load_config)).get('gallery', {}).get('path_mappings', {})
-    cover_fs_for_db = uri_to_fs_path(path)  # uri-no-reverse: DB round-trip (is_known_cover_path) must stay in DB namespace; disk crop uses reverse-mapped below
+    cover_fs_for_db = uri_to_fs_path(path)  # uri-no-reverse: DB round-trip (is_known_cover_path) must stay in DB namespace; disk crop uses reverse-mapped below  # db-ns-ok: _for_db, sourced from existing DB URI (uri_to_fs_path, not reverse-mapped), round-trips to mapped namespace
     fs_path = uri_to_local_fs_path(path, path_mappings)
     # Security: cover_path 必須是 DB 中某個 video 的 cover_path（防任意檔案讀取）
     allowed = await asyncio.to_thread(_check_cover_path, cover_fs_for_db)

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -395,7 +395,6 @@ async def list_photo_candidates(name: str):
 
     current_source = actress.photo_source
     cloud_sources = [s for s in ["graphis", "gfriends", "wiki", "minnano"] if s != current_source]
-    path_mappings = (await asyncio.to_thread(load_config)).get('gallery', {}).get('path_mappings', {})
 
     async def generate():
         total = 0
@@ -433,7 +432,7 @@ async def list_photo_candidates(name: str):
             )
             for video in local_videos:
                 # Fix 1 (T2): cover_path 在 DB 存 file:/// URI，crop endpoint 需要 FS path
-                cover_fs_path = uri_to_local_fs_path(str(video.cover_path), path_mappings) if video.cover_path else ""
+                cover_fs_path = uri_to_fs_path(str(video.cover_path)) if video.cover_path else ""  # uri-no-reverse: URL identifier stays canonical; actress_crop reverse-maps at disk I/O
                 if not cover_fs_path:
                     # skip broken candidate，避免送空路徑的 URL
                     continue
@@ -523,9 +522,10 @@ async def actress_crop(path: str, spec: str = "v1"):
     """
     # Fix 2 (T2): uri_to_fs_path 已 idempotent（非 URI 直接 normalize_path），直接呼叫
     path_mappings = (await asyncio.to_thread(load_config)).get('gallery', {}).get('path_mappings', {})
+    cover_fs_for_db = uri_to_fs_path(path)  # uri-no-reverse: DB round-trip (is_known_cover_path) must stay in DB namespace; disk crop uses reverse-mapped below
     fs_path = uri_to_local_fs_path(path, path_mappings)
     # Security: cover_path 必須是 DB 中某個 video 的 cover_path（防任意檔案讀取）
-    allowed = await asyncio.to_thread(_check_cover_path, fs_path)
+    allowed = await asyncio.to_thread(_check_cover_path, cover_fs_for_db)
     if not allowed:
         return Response(b"", status_code=403)
     result = await asyncio.to_thread(crop_video_cover, fs_path, spec)

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -442,7 +442,7 @@ async def list_photo_candidates(name: str):
                 # Fix 2 (T2): video.path 在 DB 已是 file:/// URI（gallery_scanner.scan_file 透過 to_file_uri 寫入）
                 # 若萬一是 FS path（legacy / 異常），coerce_to_file_uri 做 idempotent 轉換
                 try:
-                    video_path_uri = coerce_to_file_uri(str(video.path))
+                    video_path_uri = coerce_to_file_uri(str(video.path))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
                 except Exception as e:
                     logger.warning("[actress] coerce_to_file_uri 失敗 path=%s: %s", video.path, e)
                     video_path_uri = str(video.path)
@@ -569,13 +569,13 @@ async def set_actress_photo(name: str, req: SetActressPhotoRequest):
         if not req.video_path:
             return JSONResponse(status_code=400, content={"error": "video_path_required"})
         # file:/// URI → FS path（禁止手動 strip）
-        video_fs_path = uri_to_fs_path(req.video_path)
+        video_fs_path = uri_to_fs_path(req.video_path)  # uri-no-reverse: comparison-only, matched against DB v.path below, no disk I/O
         # 從 DB 取該影片的 cover_path
         videos = await asyncio.to_thread(_get_actress_videos, name)
         # Fix 3 (T3): v.path 在 DB 存 file:/// URI（gallery_scanner 用 to_file_uri 寫入），
         # 比對前雙邊都正規化為 FS path，避免 URI vs FS path 永遠 fail
         match = next(
-            (v for v in videos if uri_to_fs_path(str(v.path)) == video_fs_path),
+            (v for v in videos if uri_to_fs_path(str(v.path)) == video_fs_path),  # uri-no-reverse: comparison-only, no disk I/O
             None,
         )
         if match is None or not match.cover_path:

--- a/web/routers/collection.py
+++ b/web/routers/collection.py
@@ -689,7 +689,7 @@ def _resolve_user_tag_paths(input_path: str) -> tuple[str, str]:
     path_mappings = config.get("gallery", {}).get("path_mappings", {}) or {}
 
     try:
-        fs_normalized = uri_to_fs_path(input_path)
+        fs_normalized = uri_to_fs_path(input_path)  # uri-no-reverse: already paired with reverse_path_mapping below (local_fs_path)
     except Exception:
         return ("", "")
 

--- a/web/routers/config.py
+++ b/web/routers/config.py
@@ -442,6 +442,7 @@ def _collect_strm_targets(repo, path_mappings: dict) -> list:
         # per-row 容錯：單列壞 output_dir（uri_to_fs_path/glob 拋錯）只 skip 該列，
         # 不害整批 rewrite 中止（比照 _write_strm 的 per-movie best-effort 契約）。
         try:
+            # uri-no-reverse: already paired with reverse_path_mapping on next line
             movie_dir_fs = uri_to_fs_path(v.output_dir)
             # 與 _resolve_movie_dir（core/readonly_producer.py）寫檔當下用同一套 targeted
             # reverse-map：WSL+UNC mapped 輸出根下，output_dir 存的是映射端 URI，需反解回
@@ -459,6 +460,7 @@ def _collect_strm_targets(repo, path_mappings: dict) -> list:
         # path_mappings 下同樣存映射端 URI，但 _write_strm 的 strm_path_mappings（播放端重寫）
         # 本機前綴 = 原始掃描路徑。若只 uri_to_fs_path 得映射端 //NAS/... 會對不上 strm 規則
         # → 改寫內容 ≠ 初次生成內容（掉了播放端映射）。反解回原掃描路徑，令改寫 == 生成。
+        # uri-no-reverse: already paired with reverse_path_mapping on next line
         source_fs_path = uri_to_fs_path(v.path)
         if CURRENT_ENV == 'wsl' and path_mappings:
             source_fs_path = reverse_path_mapping(source_fs_path, path_mappings) or source_fs_path

--- a/web/routers/motion_lab.py
+++ b/web/routers/motion_lab.py
@@ -9,7 +9,8 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from core.database import VideoRepository, get_db_path, init_db
-from core.path_utils import uri_to_fs_path
+from core.path_utils import uri_to_local_fs_path
+from core.config import load_config
 from core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -48,13 +49,15 @@ def motion_lab_data():
         all_videos = repo.get_all()
         videos_30 = all_videos[:30]
 
+        path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
+
         # 轉換為前端格式
         videos_json = []
         for v in videos_30:
             # cover_path 轉換：file:///C:/path/to/cover.jpg → /api/gallery/image?path=C:/path/to/cover.jpg
             cover_url = ""
             if v.cover_path:
-                local_path = uri_to_fs_path(v.cover_path)
+                local_path = uri_to_local_fs_path(v.cover_path, path_mappings)
                 cover_url = f"/api/gallery/image?path={quote(local_path, safe='')}"
 
             videos_json.append({

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -38,7 +38,7 @@ from starlette.background import BackgroundTask
 from core.gallery_scanner import VideoScanner, fast_scan_directory, VideoInfo, _run_sample_images_cleanup_pass
 from core.video_extensions import get_proxy_extensions, get_video_extensions
 from core.gallery_generator import HTMLGenerator
-from core.path_utils import to_file_uri, is_path_under_dir, uri_to_fs_path, coerce_to_file_uri
+from core.path_utils import to_file_uri, is_path_under_dir, uri_to_fs_path, coerce_to_file_uri, uri_to_local_fs_path
 from core.nfo_updater import check_cache_needs_update, update_videos_generator
 from core.database import VideoRepository, Video, init_db, get_db_path, migrate_json_to_sqlite
 from core.organizer import generate_jellyfin_images, HEADERS as _EMBED_HEADERS
@@ -621,7 +621,7 @@ def generate_avlist(should_abort: Optional[Callable[[], bool]] = None) -> Genera
         if not _is_aborted():
             # §b1 AC#2: sample_images 孤兒清理 pass（Scanner UI 主路徑覆蓋，共用 helper）
             try:
-                cleaned = _run_sample_images_cleanup_pass(repo)
+                cleaned = _run_sample_images_cleanup_pass(repo, path_mappings)
                 if cleaned > 0:
                     yield _sse_event({"type": "log", "level": "info", "message": f"清除 {cleaned} 筆孤兒劇照記錄"})
             except Exception as e:
@@ -1276,9 +1276,17 @@ def get_thumb(request: Request, path: str = Query(..., description="影片路徑
         return Response(status_code=404, content="無封面")
 
     # 路徑轉換一步（不疊 normalize_path）；DB 背書取代 realpath 安全鏈
-    cover_fs = uri_to_fs_path(video.cover_path)
-    if not repo.is_known_cover_path(cover_fs):
+    # TASK-91-T2b #9：is_known_cover_path 內部用「不帶 path_mappings 的 to_file_uri」
+    # 跟 DB 存的 mapped-namespace URI 字面比對（round-trip 契約），若改餵反解後的本機
+    # 路徑進去，to_file_uri 落 fallback 分支產生四斜線怪字串、永遠比對不到 → 誤判
+    # 「封面不在快取記錄中」（本 task 發現的卡片未涵蓋 gap，見 report）。
+    # 修法：DB 背書比對維持用裸 uri_to_fs_path（與改動前行為等價，零回歸）；
+    # 反解只用在「即將真的碰磁碟」的 cover_fs（generate/fallback FileResponse/os.path.isfile）。
+    path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
+    cover_fs_for_db = uri_to_fs_path(video.cover_path)
+    if not repo.is_known_cover_path(cover_fs_for_db):
         return Response(status_code=404, content="封面不在快取記錄中")
+    cover_fs = uri_to_local_fs_path(video.cover_path, path_mappings)
 
     # P2-B（TASK-71c）：miss 路徑 gate disabled，不重生 WebP。
     # 用戶關閉快取 + clear 後，stale 分頁的 miss 請求不應重建剛清的目錄。
@@ -1302,7 +1310,8 @@ def get_thumb(request: Request, path: str = Query(..., description="影片路徑
         if not fresh or not fresh.cover_path:
             thumbnail_cache.invalidate(path)
             return Response(status_code=404, content="影片已不存在")
-        fresh_fs = uri_to_fs_path(fresh.cover_path)
+        # TASK-91-T2b #10：同函式同一個 path_mappings（上方 #9 已算好）
+        fresh_fs = uri_to_local_fs_path(fresh.cover_path, path_mappings)
         if fresh_fs != cover_fs:
             thumbnail_cache.invalidate(path)
             cover_fs = fresh_fs
@@ -1345,6 +1354,9 @@ def _prewarm_worker():
         repo = VideoRepository(db_path)
         n = 0
         stopped_disabled = False  # Codex P3：被 disable 中止時跳過 done 通知
+        # TASK-91-T2b #11：迴圈外讀一次即可（mapping 配置在 prewarm 進行中變更是
+        # pathological case，非本 task 範圍，比照 thumbnail_cache_enabled 之外的容忍度）
+        path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
         # round-3 P2：snapshot（iter_missing 吃 repo.get_all()）取得後，用戶可能按
         # 「清除所有影片快取」→ clear_cache 跑 repo.clear_all()（清空 DB）+
         # thumbnail_cache.clear_all()（rmtree thumb 目錄）；單筆刪除 / prune 亦同理。
@@ -1358,7 +1370,7 @@ def _prewarm_worker():
         # fresh DB 讀「當前」cover 生成（與 get_thumb miss 路徑對稱：fresh re-read +
         # path-change 偵測）；before/after re-check 收 video 消失 / 無 cover / cover 換掉
         # 三種期間變動（≤1 generate-期間-變動窗口，與 get_thumb 同級）。
-        for video_uri, _stale_cover_fs in thumbnail_cache.iter_missing(repo.get_all()):
+        for video_uri, _stale_cover_fs in thumbnail_cache.iter_missing(repo.get_all(), path_mappings):
             # Codex P2 race：用戶可在 prewarm 進行中關閉快取（toggle false → save →
             # clear）。worker 每筆重讀 load_config()（無 lru_cache，每次讀 disk）拿前端
             # 剛 PUT 的 false → 立即 break，不再 generate 後續 item（否則在 clear 已
@@ -1370,7 +1382,7 @@ def _prewarm_worker():
             fresh = repo.get_by_path(video_uri)
             if fresh is None or not fresh.cover_path:
                 continue
-            cover_fs = uri_to_fs_path(fresh.cover_path)  # 用當前 cover，忽略 stale snapshot
+            cover_fs = uri_to_local_fs_path(fresh.cover_path, path_mappings)  # 用當前 cover，忽略 stale snapshot
             ok = thumbnail_cache.generate(cover_fs, thumbnail_cache.thumb_file_for(video_uri))
             # after-check：generate 期間影片被清 / cover 又換 / 快取被關閉（≤1 窗口）→
             # 丟棄剛寫的 stale thumb。disabled_after：再讀一次 load_config，若快取已關閉
@@ -1388,8 +1400,12 @@ def _prewarm_worker():
                 stopped_disabled = True
                 break
             # 既有孤兒處理：generate 成功但影片消失 / 無 cover / cover 換掉 → 丟棄 stale thumb
+            # 注意：此比對必須跟上面 #11 的反解入口一致，否則 WSL+mapping 環境下
+            # cover_fs（已反解為本機路徑）永遠不等於裸 uri_to_fs_path 結果，
+            # 造成每筆都被誤判「cover 換了」而錯誤 invalidate（TASK-91-T2b 修正，
+            # 卡片未列此行，但與 #11 同一變數耦合，不修會製造新 regression）
             if ok and (after is None or not after.cover_path
-                       or uri_to_fs_path(after.cover_path) != cover_fs):
+                       or uri_to_local_fs_path(after.cover_path, path_mappings) != cover_fs):
                 thumbnail_cache.invalidate(video_uri)
                 continue
             if ok:
@@ -1445,15 +1461,20 @@ def get_video(request: Request, path: str = Query(..., description="影片路徑
     # URL decode
     path = unquote(path)
 
-    # 1. 轉換為 FS 路徑
-    local_path = uri_to_fs_path(path)
+    # TASK-91-T2b #12：config/gallery_config/path_mappings 搬到 local_path 計算之前，
+    # 讓 uri_to_local_fs_path 取用得到 path_mappings（原本晚於 local_path 賦值，會 NameError）。
+    config = load_config()
+    gallery_config = config.get('gallery', {})
+    path_mappings = gallery_config.get('path_mappings', {})
+
+    # 1. 轉換為 FS 路徑（WSL+UNC path_mappings 環境下反解成真正能 open() 的本機路徑）
+    local_path = uri_to_local_fs_path(path, path_mappings)
 
     # 2. 解析 .. 並追蹤 symlink target（realpath）；FUSE/WinFsp OSError 時降級 normpath
     local_path = _safe_realpath(local_path, "get_video")
 
     # 3. 副檔名白名單（用 realpath/normpath 解析後的路徑）
     #    使用 get_proxy_extensions() = user config ∩ SAFE_PROXY_EXTENSIONS
-    config = load_config()
     allowed_extensions = get_proxy_extensions(config)
     ext = os.path.splitext(local_path)[1].lower()
     if ext not in allowed_extensions:
@@ -1461,9 +1482,6 @@ def get_video(request: Request, path: str = Query(..., description="影片路徑
         return Response(status_code=403, content="不允許的檔案類型")
 
     # 4. 目錄白名單：只允許 gallery.directories 底下的檔案
-    gallery_config = config.get('gallery', {})
-    path_mappings = gallery_config.get('path_mappings', {})
-
     # TASK-73: 兩端對稱正規化 — request_uri 用 single-form（realpath已做）；
     # dir 端用 dual-form（normpath + realpath 候選），避免 SMB mapped drive 格式不同 403 誤殺
     request_uri = to_file_uri(local_path, path_mappings)
@@ -1609,14 +1627,14 @@ def _cover_base_stem(cover_fs: str) -> str:
     return stem
 
 
-def check_jellyfin_images_needed(repo: VideoRepository) -> dict:
+def check_jellyfin_images_needed(repo: VideoRepository, path_mappings: dict = None) -> dict:
     """檢查 DB 中有多少影片缺少 poster/fanart"""
     videos = repo.get_all()
     need_update = []
     for v in videos:
         if not v.cover_path:
             continue
-        cover_fs = uri_to_fs_path(v.cover_path)
+        cover_fs = uri_to_local_fs_path(v.cover_path, path_mappings)
         if not os.path.exists(cover_fs):
             continue
         base_stem = _cover_base_stem(cover_fs)
@@ -1643,7 +1661,8 @@ def generate_jellyfin_images_stream() -> Generator[str, None, None]:
             return
 
         repo = VideoRepository(db_path)
-        result = check_jellyfin_images_needed(repo)
+        path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
+        result = check_jellyfin_images_needed(repo, path_mappings)
         items = result['items']
         total = len(items)
 
@@ -1697,7 +1716,8 @@ def _check_jellyfin_needed() -> dict | None:
     if not db_path.exists():
         return None
     repo = VideoRepository(db_path)
-    return check_jellyfin_images_needed(repo)
+    path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
+    return check_jellyfin_images_needed(repo, path_mappings)
 
 
 @router.get("/jellyfin-check")
@@ -1758,14 +1778,14 @@ _REFERER_MAP = {
 _MIN_IMAGE_SIZE = 1000  # bytes — 小於此視為無效（防空白/錯誤頁）
 
 
-def _embed_cover(img_ref: str) -> str:
+def _embed_cover(img_ref: str, path_mappings: dict = None) -> str:
     """將圖片 URL/路徑轉為 data URI。失敗時回傳原值。"""
     if not img_ref or img_ref.startswith('data:'):
         return img_ref
 
     try:
         if img_ref.startswith('file:///'):
-            local_path = uri_to_fs_path(img_ref)
+            local_path = uri_to_local_fs_path(img_ref, path_mappings)
             data = Path(local_path).read_bytes()
         elif img_ref.startswith(('http://', 'https://')):
             headers = _EMBED_HEADERS.copy()
@@ -1922,7 +1942,7 @@ def generate_from_ids(body: GenerateFromIdsRequest):
         for info in all_videos:
             if info.img:
                 original = info.img
-                info.img = _embed_cover(info.img)
+                info.img = _embed_cover(info.img, gallery_config.get('path_mappings', {}))
                 if info.img.startswith('data:'):
                     embedded_count += 1
                 elif original:  # 有原圖但 embed 失敗

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -1284,7 +1284,7 @@ def get_thumb(request: Request, path: str = Query(..., description="影片路徑
     # 修法：DB 背書比對維持用裸 uri_to_fs_path（與改動前行為等價，零回歸）；
     # 反解只用在「即將真的碰磁碟」的 cover_fs（generate/fallback FileResponse/os.path.isfile）。
     path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
-    cover_fs_for_db = uri_to_fs_path(video.cover_path)  # uri-no-reverse: DB round-trip comparison-only (is_known_cover_path), real disk path uses uri_to_local_fs_path below
+    cover_fs_for_db = uri_to_fs_path(video.cover_path)  # uri-no-reverse: DB round-trip comparison-only (is_known_cover_path), real disk path uses uri_to_local_fs_path below  # db-ns-ok: _for_db, sourced from existing DB URI (uri_to_fs_path, not reverse-mapped), round-trips to mapped namespace
     if not repo.is_known_cover_path(cover_fs_for_db):
         return Response(status_code=404, content="封面不在快取記錄中")
     cover_fs = uri_to_local_fs_path(video.cover_path, path_mappings)

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -1065,7 +1065,8 @@ def generate_nfo_update() -> Generator[str, None, None]:
         })
 
         # 執行更新
-        for msg in update_videos_generator(cache, paths_to_update):
+        path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
+        for msg in update_videos_generator(cache, paths_to_update, path_mappings):
             yield _sse_event(msg)
 
         yield _sse_event({

--- a/web/routers/scanner.py
+++ b/web/routers/scanner.py
@@ -100,7 +100,7 @@ def _dir_candidate_forms(raw_dir: str, path_mappings: dict) -> tuple:
     # 會把 file:/// 折成 file:/ 再被 to_file_uri 二次包成 file:///file:/…，image/video
     # 兩條白名單同時誤殺（PR#91 P2-D 同源）。FS 輸入行為不變 → 保留 dual-form + TASK-73
     # 跨格式 casefold。
-    fs_dir = uri_to_fs_path(raw_dir)
+    fs_dir = uri_to_fs_path(raw_dir)  # uri-no-reverse: native config path (DirectoryConfig.path), no DB-mapped namespace
     normpath_form = to_file_uri(os.path.normpath(fs_dir), path_mappings)
     try:
         realpath_form = to_file_uri(os.path.realpath(fs_dir), path_mappings)
@@ -384,7 +384,7 @@ def generate_avlist(should_abort: Optional[Callable[[], bool]] = None) -> Genera
                 # os.path.exists 只在非 readonly 分支執行，readonly 分支需要等義入口
                 # 檢查）。src.path 是 config 原始輸入，不套 reverse_path_mapping
                 # （比照 :353/:96 既定作法，見 TASK-89b-T5 現況分析 #5）。
-                reachable = os.path.exists(uri_to_fs_path(src.path))
+                reachable = os.path.exists(uri_to_fs_path(src.path))  # uri-no-reverse: native config path (src.path), no DB-mapped namespace
                 # PR #93 五審四次 P2 (option C)：注入 fresh strm 映射 getter。config 是 :303
                 # 一次載入的凍結快照；load_config() 無 lru_cache、每次讀 disk（同 :1275 prewarm
                 # pattern），故 getter 拿到的是「當下磁碟上的」映射 → 斷線尾巴那片也用當前映射。
@@ -400,7 +400,7 @@ def generate_avlist(should_abort: Optional[Callable[[], bool]] = None) -> Genera
             # 取代裸 normalize_path（後者對 URI 原樣通過 → os.path.exists 失敗 → 誤報
             # 「資料夾不存在」，非 readonly 的 URI 來源掃不到）。
             try:
-                normalized_dir = uri_to_fs_path(directory)
+                normalized_dir = uri_to_fs_path(directory)  # uri-no-reverse: native config path (DirectoryConfig.path), no DB-mapped namespace
             except ValueError:
                 logger.exception("路徑轉換失敗: %s", directory)
                 yield _sse_event({"type": "log", "level": "warn", "message": "路徑轉換失敗"})
@@ -551,7 +551,7 @@ def generate_avlist(should_abort: Optional[Callable[[], bool]] = None) -> Genera
                 # coerce_to_file_uri：來源 path 可能已是 file:/// URI（含 readonly 剛
                 # upsert 的列），已是 URI 就原樣回、FS 才轉，避免 to_file_uri 二次包成
                 # file:///file:/// 把 readonly 生成的列全數過濾掉（PR#91 P2-D）。
-                configured_dir_uris.add(coerce_to_file_uri(p, path_mappings))
+                configured_dir_uris.add(coerce_to_file_uri(p, path_mappings))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
             except ValueError:
                 continue
 
@@ -1284,7 +1284,7 @@ def get_thumb(request: Request, path: str = Query(..., description="影片路徑
     # 修法：DB 背書比對維持用裸 uri_to_fs_path（與改動前行為等價，零回歸）；
     # 反解只用在「即將真的碰磁碟」的 cover_fs（generate/fallback FileResponse/os.path.isfile）。
     path_mappings = load_config().get('gallery', {}).get('path_mappings', {})
-    cover_fs_for_db = uri_to_fs_path(video.cover_path)
+    cover_fs_for_db = uri_to_fs_path(video.cover_path)  # uri-no-reverse: DB round-trip comparison-only (is_known_cover_path), real disk path uses uri_to_local_fs_path below
     if not repo.is_known_cover_path(cover_fs_for_db):
         return Response(status_code=404, content="封面不在快取記錄中")
     cover_fs = uri_to_local_fs_path(video.cover_path, path_mappings)

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -100,6 +100,7 @@ def _readonly_source_error(file_path: str) -> Optional[dict]:
     _path_mappings = _gallery_config.get('path_mappings', {})
     _prefixes = readonly_source_prefixes(_gallery_config, _path_mappings)
     _writable = writable_source_prefixes(_gallery_config, _path_mappings)
+    # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
     if is_path_readonly(coerce_to_file_uri(file_path, _path_mappings), _prefixes, _writable):
         return {"success": False, "error": _READONLY_SOURCE_ERROR_MSG}
     return None
@@ -386,7 +387,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
         # coerce_to_file_uri（已是 URI 就原樣回），不可再套 to_file_uri 造成 file:///file:///
         # double-encode 砍錯 hash（PR #60 Codex P2）。
         if result.success:
-            thumbnail_cache.invalidate(coerce_to_file_uri(request.file_path))
+            thumbnail_cache.invalidate(coerce_to_file_uri(request.file_path))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
         from dataclasses import asdict
         return asdict(result)
     except Exception:
@@ -413,6 +414,7 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
     if _err:
         return _err
 
+    # uri-no-reverse: comparison-only (DB LIKE prefix), inner kept bare per TASK-91-T3 inner/outer analysis
     folder_uri_prefix = to_file_uri(os.path.dirname(uri_to_fs_path(req.file_path)), path_mappings) + "/"
     repo = VideoRepository()
     count = repo.count_videos_in_folder(folder_uri_prefix)
@@ -493,6 +495,7 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                 # 90c-T1 逐項唯讀 guard：唯讀來源片 yield result-item(success:False) +
                 # failed_count+=1 + continue（不 raise、不逐項 _emit_notif——批次層才發通知）。
                 # 混合批中可寫項照常 enrich，整批不中斷（spec-90 §90b(iii) 驗收 2）。
+                # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
                 if is_path_readonly(coerce_to_file_uri(item.file_path, _ro_mappings), _ro_prefixes, _ro_writable):
                     failed_count += 1
                     yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, 'success': False, 'error': _READONLY_SOURCE_ERROR_MSG})}\n\n"
@@ -546,7 +549,7 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         # feature/71 T8: 換封面成功 → 失效舊縮圖（廉價同步 unlink，不需 offload）。
                         # item.file_path 已是 DB file:/// URI → 冪等 coerce，不可 double-encode
                         # （同 enrich-single，PR #60 Codex P2）。
-                        thumbnail_cache.invalidate(coerce_to_file_uri(item.file_path))
+                        thumbnail_cache.invalidate(coerce_to_file_uri(item.file_path))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
                     else:
                         failed_count += 1
                     yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, **result_dict})}\n\n"

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -143,6 +143,7 @@ def scrape_single(request: ScrapeRequest) -> dict:
     config = load_config()
     scraper_config = config.get('scraper', {})
     _proxy_url = config.get('search', {}).get('proxy_url', '')
+    path_mappings = config.get('gallery', {}).get('path_mappings', {})
 
     # 優先使用前端傳來的 metadata
     if request.metadata:
@@ -177,7 +178,10 @@ def scrape_single(request: ScrapeRequest) -> dict:
             user_tags = metadata['user_tags']
             new_filename = result.get('new_filename', '')
             if new_filename:
-                path_uri = to_file_uri(new_filename)
+                # TASK-91b-T1（axis-B 子形狀 ii，forward-map 式）：new_filename 是
+                # organize_file 產出的裸本機路徑，需帶 path_mappings 落 mapped DB
+                # 命名空間，否則 get_by_path miss、既有 user_tags 靜默遺失。
+                path_uri = to_file_uri(new_filename, path_mappings)
                 repo = VideoRepository()
                 existing = repo.get_by_path(path_uri)
                 existing_user_tags = existing.user_tags if existing else []

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -20,7 +20,7 @@ from core.database import VideoRepository
 from core.db_inflow import try_inflow_upsert
 from core.enricher import enrich_single, fetch_samples_only, resolve_nfo_cover_paths
 from core.organizer import organize_file
-from core.path_utils import to_file_uri, uri_to_fs_path, coerce_to_file_uri
+from core.path_utils import to_file_uri, uri_to_fs_path, uri_to_local_fs_path, coerce_to_file_uri
 from core.scraper import (
     search_jav, search_jav_single_source, strip_internal_nfo_keys,
     search_javlib_versions, fetch_javlib_by_detail_url, internal_nfo_carriers,
@@ -297,6 +297,9 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
     config = load_config()
     search_cfg = config.get("search", {})
     proxy_url = search_cfg.get("proxy_url", "")
+    # TASK-91-T3：讀取端 path_mappings，供 resolve_nfo_cover_paths / uri_to_local_fs_path /
+    # enrich_single 共用一次算好的同一組值（避免重複 .get() chain）。
+    path_mappings = config.get("gallery", {}).get("path_mappings", {})
 
     # 90c-T1 唯讀來源 guard：唯讀來源片不得 enrich 寫檔。須在 refresh_full 預檢
     # （resolve_nfo_cover_paths / os.path.exists）之前——預檢對唯讀掛載可能拋錯。
@@ -313,13 +316,13 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
     # 故不得計入「保證會寫 sidecar」；補劇照請用 /api/scraper/fetch-samples（Codex PR#47 round-2 P2）。
     # 在 try 之前 raise，避免被下方 except Exception 吞成籠統 200。
     if request.mode == "refresh_full" and not request.overwrite_existing:
-        nfo_path, cover_path = resolve_nfo_cover_paths(request.file_path)
+        nfo_path, cover_path = resolve_nfo_cover_paths(request.file_path, path_mappings)
         will_write_nfo = request.write_nfo and not os.path.exists(nfo_path)
         will_write_cover = request.write_cover and not os.path.exists(cover_path)
         # 72d-P2A：外部圖寫出機會也是合法的寫出路徑（72b-T6 加入 external_manager 後守衛未同步）
         external_manager = config.get("scraper", {}).get("external_manager", "off")
         if external_manager != "off":
-            stem = os.path.splitext(uri_to_fs_path(request.file_path))[0]
+            stem = os.path.splitext(uri_to_local_fs_path(request.file_path, path_mappings))[0]
             poster_path = stem + "-poster.jpg"
             fanart_path = stem + "-fanart.jpg"
             # 底圖存在 + 至少一張外部圖缺 → _write_external_images 有寫出機會
@@ -374,6 +377,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             source=request.source,
             javbus_lang=request.javbus_lang,
             scraper_data=scraper_data,
+            path_mappings=path_mappings,
         )
         # feature/71 T8: 換封面成功 → 失效舊縮圖（下次 lazy/prewarm 重生，CD-9 / spec 2.A.7）。
         # request.file_path 已是 DB 的 file:/// URI（前端送 currentLightboxVideo.path /
@@ -400,13 +404,16 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
     config = load_config()
     search_cfg = config.get("search", {})
     proxy_url = search_cfg.get("proxy_url", "")
+    # TASK-91-T3：站台5 outer to_file_uri 補傳 path_mappings（inner uri_to_fs_path 維持不變，
+    # 見 TASK-91-T3.md 站台5 inner/outer 分析結論）。
+    path_mappings = config.get("gallery", {}).get("path_mappings", {})
 
     # 90c-T1 唯讀來源 guard：唯讀來源片不得補劇照寫檔（early-return，先於 DB/uri work）。
     _err = _readonly_source_error(req.file_path)
     if _err:
         return _err
 
-    folder_uri_prefix = to_file_uri(os.path.dirname(uri_to_fs_path(req.file_path))) + "/"
+    folder_uri_prefix = to_file_uri(os.path.dirname(uri_to_fs_path(req.file_path)), path_mappings) + "/"
     repo = VideoRepository()
     count = repo.count_videos_in_folder(folder_uri_prefix)
     if count > 1:
@@ -417,6 +424,7 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
             file_path=req.file_path,
             number=req.number,
             proxy_url=proxy_url,
+            path_mappings=path_mappings,
         )
         from dataclasses import asdict
         return asdict(result)
@@ -528,6 +536,7 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                             source=es if es != "auto" else None,
                             javbus_lang=el,
                             scraper_data=sd,
+                            path_mappings=_ro_mappings,
                         ),
                     )
                     from dataclasses import asdict

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from core.database import VideoRepository, get_db_path, init_db
-from core.path_utils import is_path_under_dir, uri_to_fs_path, coerce_to_file_uri
+from core.path_utils import is_path_under_dir, uri_to_local_fs_path, coerce_to_file_uri
 from core.logger import get_logger
 from core.config import load_config, get_gallery_source_paths
 from core.readonly_source import is_path_readonly, readonly_source_prefixes, writable_source_prefixes
@@ -28,13 +28,13 @@ def _serialize_video(v, path_mappings: dict, enabled: bool = False, readonly_pre
 
     feature/71 T4：thumbnail_cache_enabled 開關決定 cover_url 走 thumb / image 分支。
     - enabled  → cover_url 指向 T3 /api/gallery/thumb?path=<quote(v.path)>（thumb key = video path）
-    - disabled → 維持現狀 /api/gallery/image?path=<quote(uri_to_fs_path(v.cover_path))>（字節不變）
+    - disabled → 維持現狀 /api/gallery/image?path=<quote(uri_to_local_fs_path(v.cover_path, path_mappings))>（字節不變）
     cover_full_url 恆原圖（不受 flag 影響），供 T6 燈箱 blur-up 上層淡入用。
     """
     cover_url = ""
     cover_full_url = ""
     if v.cover_path:
-        original_url = f"/api/gallery/image?path={quote(uri_to_fs_path(v.cover_path), safe='')}"
+        original_url = f"/api/gallery/image?path={quote(uri_to_local_fs_path(v.cover_path, path_mappings), safe='')}"
         cover_full_url = original_url
         if enabled:
             cover_url = f"/api/gallery/thumb?path={quote(v.path, safe='')}"
@@ -43,7 +43,7 @@ def _serialize_video(v, path_mappings: dict, enabled: bool = False, readonly_pre
 
     sample_urls = []
     for img_uri in (v.sample_images or []):
-        local_path = uri_to_fs_path(img_uri)
+        local_path = uri_to_local_fs_path(img_uri, path_mappings)
         sample_urls.append(f"/api/gallery/image?path={quote(local_path, safe='')}")
 
     return {

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -68,6 +68,7 @@ def _serialize_video(v, path_mappings: dict, enabled: bool = False, readonly_pre
         "has_cover": bool(v.cover_path),             # DB 初判（不做 IO）
         "has_nfo": (v.nfo_mtime or 0) > 0,          # 對齊 41a nfo_mtime 寫入契約，防禦 NULL
         "is_readonly_source": is_path_readonly(     # 後端算：片落唯讀前綴下且不落可寫前綴→True（前端不判路徑）
+            # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
             coerce_to_file_uri(v.path, path_mappings), readonly_prefixes or [], writable_prefixes or []
         ),
     }
@@ -84,7 +85,7 @@ def _get_configured_dirs(config: dict) -> tuple[set, dict]:
             # coerce_to_file_uri：來源 path 可能已是 file:/// URI（DirectoryConfig.path
             # schema「FS 路徑或 URI」）。已是 URI 就原樣回，避免 to_file_uri 二次包成
             # file:///file:/// 把 readonly 來源的列從 Showcase 過濾掉（PR#91 P2-D 同源）。
-            configured_dir_uris.add(coerce_to_file_uri(p, path_mappings))
+            configured_dir_uris.add(coerce_to_file_uri(p, path_mappings))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
         except ValueError:
             continue
 

--- a/web/routers/similar.py
+++ b/web/routers/similar.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, HTTPException, Query
 from core.config import load_config
 from core.database import VideoRepository
 from core.logger import get_logger
-from core.path_utils import uri_to_fs_path
+from core.path_utils import uri_to_local_fs_path
 from core.similar.ranker_cache import SimilarRankerCache
 
 logger = get_logger(__name__)
@@ -26,22 +26,22 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/api", tags=["similar"])
 
 
-def _build_cover_url(video, enabled: bool = False) -> str:
+def _build_cover_url(video, enabled: bool = False, path_mappings: dict = None) -> str:
     """組封面 url（feature/71 T4）。
 
     - enabled  → /api/gallery/thumb?path=<quote(video.path)>（thumb key = video path，非 cover）。
-    - disabled → 維持現狀 /api/gallery/image?path=<quote(uri_to_fs_path(video.cover_path))>（字節不變）。
+    - disabled → 維持現狀 /api/gallery/image?path=<quote(uri_to_local_fs_path(video.cover_path, path_mappings))>（字節不變）。
     邊界：video.cover_path 為空字串 / None → 回傳空字串（enabled/disabled 皆然，無 cover 不發 thumb url）。
     """
     if not video.cover_path:
         return ""
     if enabled:
         return f"/api/gallery/thumb?path={quote(video.path, safe='')}"
-    local_path = uri_to_fs_path(video.cover_path)
+    local_path = uri_to_local_fs_path(video.cover_path, path_mappings)
     return f"/api/gallery/image?path={quote(local_path, safe='')}"
 
 
-def _build_cover_full_url(video) -> str:
+def _build_cover_full_url(video, path_mappings: dict = None) -> str:
     """組封面原圖 url（71c）。
 
     恆原圖（不受 thumbnail_cache_enabled 影響），鏡像 showcase._serialize_video 中 cover_full_url 的邏輯。
@@ -49,7 +49,7 @@ def _build_cover_full_url(video) -> str:
     """
     if not video.cover_path:
         return ""
-    local_path = uri_to_fs_path(video.cover_path)
+    local_path = uri_to_local_fs_path(video.cover_path, path_mappings)
     return f"/api/gallery/image?path={quote(local_path, safe='')}"
 
 
@@ -75,7 +75,10 @@ def _compute_similar_covers(video_id: int, limit: int) -> dict:
     results_videos = ranker.rank(target, top_k=limit)
 
     # feature/71 T4：讀一次 thumbnail_cache flag，套用於 query_video + 每個 result
-    enabled = load_config().get('thumbnail_cache_enabled', False)
+    config = load_config()
+    gallery_config = config.get('gallery', {})
+    path_mappings = gallery_config.get('path_mappings', {})
+    enabled = config.get('thumbnail_cache_enabled', False)
 
     return {
         "video_id": video_id,
@@ -84,7 +87,7 @@ def _compute_similar_covers(video_id: int, limit: int) -> dict:
             "video_id": target.id,
             "number": target.number,
             "title": target.title,
-            "cover_url": _build_cover_url(target, enabled),
+            "cover_url": _build_cover_url(target, enabled, path_mappings),
         },
         "results": [
             {
@@ -92,8 +95,8 @@ def _compute_similar_covers(video_id: int, limit: int) -> dict:
                 "number": v.number,
                 "title": v.title,
                 "cover_path": v.cover_path,
-                "cover_url": _build_cover_url(v, enabled),
-                "cover_full_url": _build_cover_full_url(v),  # 71c：恆原圖，供燈箱 blur-up .lb-full overlay
+                "cover_url": _build_cover_url(v, enabled, path_mappings),
+                "cover_full_url": _build_cover_full_url(v, path_mappings),  # 71c：恆原圖，供燈箱 blur-up .lb-full overlay
                 "cosine_score": ranker._score(target, v),
                 "penalty_applied": False,  # rule-based 無 penalty 概念，保留 key 為 fixture 相容
                 "actresses": v.actresses if isinstance(v.actresses, list) else [],

--- a/windows/pywebview_api.py
+++ b/windows/pywebview_api.py
@@ -105,7 +105,7 @@ class Api:
         - C:/path/to/file.mp4
         - C:\\path\\to\\file.mp4
         """
-        path = uri_to_fs_path(path)
+        path = uri_to_fs_path(path)  # uri-no-reverse: windows native runtime, path_mappings N/A
 
         if not os.path.exists(path):
             return False
@@ -174,7 +174,7 @@ class Api:
         macOS:   open -R          → Finder 中顯示檔案
         Linux:   xdg-open         → 打開所在資料夾
         """
-        path = uri_to_fs_path(path)
+        path = uri_to_fs_path(path)  # uri-no-reverse: windows native runtime, path_mappings N/A
 
         if not os.path.exists(path):
             # 檔案不存在，嘗試開啟父資料夾


### PR DESCRIPTION
## 主軸

**跨機器路徑映射（WSL2 + UNC `path_mappings`）讀寫全棧收斂 + DB-key 命名空間守衛**（feature/91，plan-91 axis-A ＋ plan-91b axis-B）。純 correctness 重構，**零使用者可見功能變更、零 API/schema 變動**。

情境：OpenAver 跑在 WSL、影片放在網路磁碟（UNC `//NAS/share`）、DB 存映射後路徑。兩類長期潛伏的 silent bug 一次修乾淨並上守衛擋死回不去。

## Fixed

- **讀取端（axis-A）跨機器路徑下讀圖／串流不再靜默失敗**：縮圖、封面＋劇照、影片串流（seek 206）、女優裁切、相似探索等所有「先讀 DB 路徑再碰磁碟」的入口，統一在磁碟 I/O 前經單一入口 `uri_to_local_fs_path()` 反解映射路徑。先前在 `path_mappings` 情境下這些入口拿映射後路徑直接碰磁碟 → 404／讀不到圖。
- **刮削不再掉 user_tags（axis-B live bug）**：`scraper.py` 重刮某片時 DB key 由已反解本機路徑裸建構、落成未映射命名空間 → 比對不到既有列、既有 user_tags 被當新片覆寫。改為建 key 前先 forward-map 回 DB 命名空間。
- **NFO 路徑推導反解**：`nfo_updater.py` 由影片路徑推導 NFO 位置改用顯式反解入口。

## Internal

- **axis-A**：新增單一顯式入口 `uri_to_local_fs_path()` 取代 22 站台裸呼叫；27 站台補 `# uri-no-reverse:` marker；新增 pytest AST 結構守衛 `test_uri_to_fs_path_reverse_mapping_completeness.py`（偵測反解值未經處理直接碰磁碟 → CI 擋）。含 Codex 兩輪修正。
- **axis-B**：新增 sink-anchored AST 守衛 `test_db_key_namespace_completeness.py`（錨 DB-key 建構點，非 source）；獨立 marker `# db-ns-ok:`（不 overload axis-A 的 marker）。含 Codex 二審修正。
- **已接受殘留**：`enricher.py` `_write_nfo` 的 `user_tags is None` 分支為 dead path（production 恆傳非 None），已註記；「寫入端命名空間統一」暫緩 feature/92+（守衛已達成「不容易觸發」）。

## 驗證

- pytest **5442 passed, 2 skipped**（unit + integration，排除 smoke/e2e；較 0.11.5 +77）＋ `ruff check .` 綠 ＋ `npm run lint` 綠。
- 來源金絲雀：**8 源全 PASS**。
- 真機 E2E hard-gate（WSL2+UNC+path_mappings，CDP + DB SQL）：**sign-off #1–12 全過**。
- 敏感掃描 CLEAN、COPY_ITEMS 無新增。`/simplify` 4-agent 審過、findings 皆 skip（碼確認乾淨）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)