### PR TITLE
fix: $nextTick hydrate-race 全庫清償（nexttick-hydrate hardening）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Run frontend lint (eslint + stylelint)
         run: npm run lint
 
+      - name: Run frontend node tests (structural guards + unit)
+        run: npm test
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint:js": "eslint web/static/js/",
     "lint:css": "stylelint \"web/static/css/**/*.css\"",
     "lint:html": "node scripts/lint-settings-ia.mjs",
-    "test:tokenizer": "node --test \"web/static/js/pages/settings/__tests__/**/*.test.mjs\""
+    "test:tokenizer": "node --test \"web/static/js/pages/settings/__tests__/**/*.test.mjs\"",
+    "test:dom-timing": "node --test \"web/static/js/shared/__tests__/**/*.test.mjs\""
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "lint:js": "eslint web/static/js/",
     "lint:css": "stylelint \"web/static/css/**/*.css\"",
     "lint:html": "node scripts/lint-settings-ia.mjs",
+    "test": "node --test \"web/static/js/**/__tests__/**/*.test.mjs\"",
     "test:tokenizer": "node --test \"web/static/js/pages/settings/__tests__/**/*.test.mjs\"",
-    "test:dom-timing": "node --test \"web/static/js/shared/__tests__/**/*.test.mjs\""
+    "test:dom-timing": "node --test \"web/static/js/shared/__tests__/**/*.test.mjs\"",
+    "test:scanner-order": "node --test \"web/static/js/pages/scanner/__tests__/**/*.test.mjs\""
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/web/static/js/pages/scanner/__tests__/init-order.test.mjs
+++ b/web/static/js/pages/scanner/__tests__/init-order.test.mjs
@@ -1,0 +1,65 @@
+// Tier 1 結構回歸鎖（nexttick-hydrate T1/T5、CD-2/CD-6）。
+// 零新依賴：Node 內建 node:test。跑：npm run test:scanner-order（或 npm test）
+//
+// 守 state-scan.js init() 的「__registerPage 註冊必須在第一個 await 之前」時序契約——
+// 若退回把 lifecycle 註冊放到 await/$nextTick 之後（冷載 tick 不 fire → 離頁 dirty-guard /
+// cleanup 永不註冊，SCAN HIGH #1），本測試 RED。
+//
+// 依 gotchas-frontend「字串存在性 ≠ contract」：先 brace-match 抽出 init() body 再斷言
+// 兩者在 body 內的相對位置，而非全檔 grep 字串。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(new URL('../state-scan.js', import.meta.url), 'utf8');
+
+// 移除 // 行註解與 /* */ 塊註解（防「await」等關鍵字出現在中文註解裡造成偽命中）。
+// init() 內無正則字面 / 含 // 的字串，簡易剝除即足。
+function stripComments(code) {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+}
+
+// 抽 init() body：從 `async init() {` 的 `{` 起，brace-match 到對應 `}`，再剝註解。
+function extractInitBody(code) {
+  const sig = code.indexOf('async init()');
+  assert.ok(sig >= 0, 'state-scan.js 應有 async init()');
+  const open = code.indexOf('{', sig);
+  assert.ok(open >= 0, 'init() 應有 {');
+  let depth = 0;
+  for (let i = open; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return stripComments(code.slice(open + 1, i));
+    }
+  }
+  throw new Error('init() 大括號未閉合（brace-match 失敗）');
+}
+
+test('__registerPage 註冊在 init() 第一個 await 之前（Tier 1 時序鎖）', () => {
+  const body = extractInitBody(src);
+
+  const regIdx = body.indexOf('window.__registerPage');
+  assert.ok(regIdx >= 0, 'init() 內應呼叫 window.__registerPage');
+
+  const awaitIdx = body.search(/\bawait\b/);
+  assert.ok(awaitIdx >= 0, 'init() 內應至少有一個 await（loadConfig）');
+
+  assert.ok(
+    regIdx < awaitIdx,
+    'window.__registerPage 必須在 init() 第一個 await 之前註冊；'
+    + '否則冷載 tick/loadConfig 卡住時離頁 dirty-guard / cleanup 永不註冊（SCAN HIGH #1 回歸）。',
+  );
+});
+
+test('init() 內不得殘留 await this.$nextTick()（多餘 tick 已移除）', () => {
+  const body = extractInitBody(src);
+  assert.ok(
+    !/await\s+this\.\$nextTick\s*\(/.test(body),
+    'init() 不應有 await this.$nextTick()（logOutput 為靜態元素，restoreLogs 直接同步還原）。',
+  );
+});

--- a/web/static/js/pages/scanner/state-scan.js
+++ b/web/static/js/pages/scanner/state-scan.js
@@ -156,30 +156,10 @@ export function stateScan() {
             // 暴露 PyWebView 回調
             window.addScannerFolder = (path) => self.addFolderPath(path);
 
-            // 初始載入
-            await this.loadConfig();
-            this.loadStats();
-
-            // T7b: 恢復日誌（確保 DOM 已渲染）
-            await this.$nextTick();
-            this.restoreLogs();
-
-            // T10: 觸發 missing check（loadStats 後）
-            this.checkMissing();
-
-            // T10: restore pending enrich
-            const pending = localStorage.getItem('avlist_enrich_pending');
-            if (pending) {
-                try {
-                    const items = JSON.parse(pending);
-                    if (Array.isArray(items) && items.length > 0) {
-                        this.missingItems = items;
-                        this.resumePillVisible = true;
-                    }
-                } catch { localStorage.removeItem('avlist_enrich_pending'); }
-            }
-
             // T5.1: 接入統一 page lifecycle
+            // 提前到所有 await 之前註冊：closure 讀的都是 this.* runtime state，
+            // 提前註冊不改變行為；但避免 loadConfig fetch 卡住時離頁 dirty-guard /
+            // beforeunload / cleanup hook 永遠不註冊（SCAN HIGH #1）。
             if (window.__registerPage) {
                 window.__registerPage({
                     beforeLeave: (href) => {
@@ -236,6 +216,29 @@ export function stateScan() {
                         }
                     }
                 });
+            }
+
+            // 初始載入
+            await this.loadConfig();
+            this.loadStats();
+
+            // T7b: 恢復日誌（logOutput 為 scanner.html 靜態 x-ref 元素，
+            // init 時早已 mount，直接同步還原、無需等 $nextTick）
+            this.restoreLogs();
+
+            // T10: 觸發 missing check（loadStats 後）
+            this.checkMissing();
+
+            // T10: restore pending enrich
+            const pending = localStorage.getItem('avlist_enrich_pending');
+            if (pending) {
+                try {
+                    const items = JSON.parse(pending);
+                    if (Array.isArray(items) && items.length > 0) {
+                        this.missingItems = items;
+                        this.resumePillVisible = true;
+                    }
+                } catch { localStorage.removeItem('avlist_enrich_pending'); }
             }
         },
 

--- a/web/static/js/pages/search/state/search-flow.js
+++ b/web/static/js/pages/search/state/search-flow.js
@@ -12,13 +12,10 @@ export function searchStateSearchFlow() {
             const data = await resp.json();
             if (data.success) {
                 this.appConfig = data.data;
-                // btnFavorite tooltip 由 Alpine :title binding 管理
-                this.$nextTick(() => {
-                    if (this.$refs.btnFavorite) {
-                        const favoriteFolder = this.appConfig?.search?.favorite_folder || window.t('search.action.load_favorite');
-                        this.$refs.btnFavorite.title = window.t('search.action.load_favorite_folder', { folder: favoriteFolder });
-                    }
-                });
+                // nexttick-hydrate T4.1：移除 $nextTick imperative title 寫入死碼——
+                // #btnFavorite 是 id、非 x-ref，this.$refs.btnFavorite 恆 undefined，此 tick
+                // 從未生效（tooltip 一直是 template 靜態 title=favorite_note 的釐清說明）。
+                // 若要改動態「載入：{folder}」tooltip 屬 UX 變更、非 cleanup，留待 owner 定奪。
             }
         } catch (e) {
             console.error('載入設定失敗:', e);

--- a/web/static/js/pages/settings/state-config.js
+++ b/web/static/js/pages/settings/state-config.js
@@ -717,10 +717,13 @@ export function stateConfig() {
                     //   ready」的冷載時序）；mountFilenameEditor 尾端亦呼叫同方法（imperative
                     //   路徑，覆蓋「mount 晚於 ready」）。one-shot（naming.filenameHydrated）
                     //   保證只載一次，避免打斷編輯游標。
-                    // - folder：層 editor 於 folderLayerList 設後 x-for render self-hydrate；
-                    //   既有 $nextTick(_hydrateNamingEditors) 保留給 folder 層（本 task 不動）。
+                    // - folder：層 editor 於 folderLayerList 設後 x-for render 時，mountLayerEditor
+                    //   的 if(naming.ready) 同步 self-hydrate（naming.ready 早在 :574 已 true）。
+                    // nexttick-hydrate T4.3：移除既有 $nextTick(_hydrateNamingEditors) 死備援——
+                    //   filename 有 x-effect + mountFilenameEditor 兩活觸發、folder 有 mount 時
+                    //   self-hydrate，此 tick（及其 _hydrateNamingEditors）全冗餘且複現 95a-T8 冷載
+                    //   $nextTick 不 fire 的隱患，故整條移除。
                     this.namingConfigReady = true;
-                    this.$nextTick(() => this._hydrateNamingEditors());
 
                     // Hydrate metatube fields from config + /status (CD-63b-3)
                     this.metatubeEnabled = config.metatube?.enabled || false;
@@ -1188,19 +1191,6 @@ export function stateConfig() {
             naming.layerEditors[layerId] = ed;
             if (naming.ready) {
                 const l = this.form.folderLayerList.find(x => x.id === layerId);
-                ed.whitelist = this._whitelistFor('folder');
-                ed.load(l ? l.value : '');
-                ed.setDisabled(!this.form.createFolder);
-            }
-        },
-
-        _hydrateNamingEditors() {
-            // 95a-T8: filename 分支改走 hydrateFilenameEditor() one-shot 收斂——這條 $nextTick
-            // 若在冷載下遲來 release，可能與 x-effect / mount imperative 路徑重複觸發；one-shot
-            // guard 統一收斂在單一方法，避免重複 load 打斷編輯游標。folder 迴圈不動（95a-T8 範圍外）。
-            this.hydrateFilenameEditor();
-            for (const [id, ed] of Object.entries(naming.layerEditors)) {
-                const l = this.form.folderLayerList.find(x => String(x.id) === String(id));
                 ed.whitelist = this._whitelistFor('folder');
                 ed.load(l ? l.value : '');
                 ed.setDisabled(!this.form.createFolder);

--- a/web/static/js/pages/showcase/state-base.js
+++ b/web/static/js/pages/showcase/state-base.js
@@ -214,7 +214,12 @@ export function stateBase() {
                         if (this.lightboxCloseTimer) clearTimeout(this.lightboxCloseTimer);  // F2: cleanup delayed clear timer
                         if (this.toastTimer) clearTimeout(this.toastTimer);
                         if (this.lightboxOpen) document.body.classList.remove('overflow-hidden');
-                        this._resetPicker();                                  // 53a-T1: 清場 picker 狀態
+                        this._resetPicker();                                  // 53a-T1: 清場 picker 狀態（含 abort _pickerReadyAbort）
+                        // nexttick-hydrate P2-2：離頁時 mobile 面板不走 closeMobilePanel（僅 matchMedia
+                        // 960 觸發），故其 in-flight waitForMount observer 不會被 abort → 顯式收（與
+                        // _resetPicker 對稱，冪等）。
+                        this._mobileReadyAbort?.abort();
+                        this._mobileReadyAbort = null;
                         window.GhostFly?.cleanupStaleGhosts?.();              // 53a-T1: 移除殘留 ghost（沿 v0.8.1 T4 optional-chaining pattern）
                         if (this._scrollHideHandler) window.removeEventListener('scroll', this._scrollHideHandler);  // T1: cleanup scroll collapse listener
                     }

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -11,6 +11,7 @@
 import { _filteredVideos, _filteredActresses, _killLightboxTimelines, _NO_COVER_PLACEHOLDER } from '@/showcase/state-base.js';
 import { POSTER_CROP_MAX_W } from '@/shared/breakpoints.js';
 import { detectSwipe } from '@/shared/swipe.js';
+import { waitForMount } from '@/shared/dom-timing.js';
 
 export function stateLightbox() {
     // 49b T4cd: Picker 動畫參數（T1 fix2 定案，2026-04-25）
@@ -62,6 +63,7 @@ export function stateLightbox() {
         _pickerRunId: 0,
         _pickerSSE: null,
         _pickerBurstFired: false,       // SSE 收齊後一次 burst（防 done/error 重複觸發）
+        _pickerReadyAbort: null,        // T3: _burstAllPickerCandidates waitForMount 的 per-run AbortController
 
         // User Tags 狀態 (T4)
         addingLbTag: false,
@@ -920,12 +922,22 @@ export function stateLightbox() {
             if (this._pickerRunId !== runId) return;
             if (this._candidates.length === 0) return;
             if (this._pickerBurstFired) return;     // 防 done/timeout/error 重複觸發
-            this._pickerBurstFired = true;
+            this._pickerBurstFired = true;          // dedup latch 維持在等待前（位置不動）
 
-            await this.$nextTick();
+            // T3（CD-3/CD-3a）：waitForMount 等候選卡 mount 取代 $nextTick。predicate 用
+            // expected（burst 時 _candidates 已定，SSE 已 close 不再增）非硬編；observer root =
+            // 恆掛載的 pickerGrid（overlay x-show）。ready===false 只來自 abort（_resetPicker /
+            // close / 換 run）→ 靜默 bail；不做任何 timeout give-up（observer 承擔 late-mount）。
+            const expected = this._candidates.length;
+            const grid = this.$refs.pickerGrid;
+            const { ready } = await waitForMount(
+                grid,
+                () => (grid?.querySelectorAll('.picker-candidate-card').length || 0) >= expected,
+                { signal: this._pickerReadyAbort?.signal },
+            );
+            if (!ready) return;
             if (this._pickerRunId !== runId) return;
 
-            const grid = this.$refs.pickerGrid;
             const coverEl = this.$refs.pickerCoverImg;
             if (!grid || !coverEl || typeof window.BurstPicker === 'undefined') return;
 
@@ -954,6 +966,9 @@ export function stateLightbox() {
             const sse = new EventSource(url);
             this._pickerSSE = sse;
             this._pickerBurstFired = false;
+            // T3: per-run readiness abort（_resetPicker / close / 換 run 時 abort → observer disconnect）
+            this._pickerReadyAbort?.abort();
+            this._pickerReadyAbort = new AbortController();
 
             sse.addEventListener('candidate', (e) => {
                 if (this._pickerRunId !== runId) { sse.close(); return; }
@@ -1165,6 +1180,10 @@ export function stateLightbox() {
             this._candidates = [];
             this._pickerCurrentSource = null;
             this._pickerBurstFired = false;
+            // T3（CD-3a）：abort in-flight readiness observer（冪等）。_resetPicker 是所有 teardown
+            // 路徑（_closePicker / _cancelPicker / re-open / lightbox cleanup）的共同匯流點。
+            this._pickerReadyAbort?.abort();
+            this._pickerReadyAbort = null;
             this._pickerFloatTweens.forEach(t => t && t.kill && t.kill());
             this._pickerFloatTweens = [];
             // 清掉 _burstAllPickerCandidates 設的 --picker-cols

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -42,6 +42,7 @@ import {
   playExit,
 } from '@/shared/constellation/animations.js';
 import { BreathingManager } from '@/shared/constellation/breathing.js';
+import { waitForMount } from '@/shared/dom-timing.js';
 
 // T6 (CD-T6-1)：hover corridor half-width（與 motion-lab host 同值 40px）
 const HOVER_DISTANCE = 40;
@@ -103,6 +104,8 @@ export function stateSimilar() {
     _similarRailStarMap: {},
     _similarGsapCtx: null,
     _similarGeneration: 0,            // stale callback invalidation
+    _similarReadyAbort: null,         // T2: initSimilarStage waitForMount 的 per-open AbortController
+    _mobileReadyAbort: null,          // T2: 手機面板 open/drill waitForMount 的 per-run AbortController
     // 56c-T4: ghost-fly enter onComplete 後 park 到 .similar-stage-inner 變 static img
     // 取代既有 fixed ghost（resize-frozen），與 8 cards 同 layout 路徑 → resize-safe
     _similarMainStatic: null,
@@ -132,10 +135,20 @@ export function stateSimilar() {
      * initSimilarStage — x-effect 在 similarModeOpen=true 時觸發。
      * Alpine 10 gotcha：12 slot card / 12 rail 由 <template x-for> 渲染，
      * Alpine reactive flush 是 microtask，同 sync 路徑 querySelector 拿到 0 個。
-     * 必須 await this.$nextTick() 才能取到 DOM refs（56b motion-lab host 已踩過）。
+     * T2（CD-3）：改 waitForMount 等 `#similar-card-01` mount（取代 $nextTick——
+     * 冷模組快取下 $nextTick 可能不 fire → stage 永久空白）。observer 存活到
+     * destroySimilarStage abort；ready===false 只會來自 abort → 靜默 bail。
      */
     async initSimilarStage() {
-      await this.$nextTick();
+      this._similarReadyAbort?.abort();          // 前一次殘留（連開）先收
+      this._similarReadyAbort = new AbortController();
+      const stageRoot = this.$el.querySelector('.similar-stage') || this.$el;
+      const { ready } = await waitForMount(
+        stageRoot,
+        () => !!document.getElementById('similar-card-01'),
+        { signal: this._similarReadyAbort.signal },
+      );
+      if (!ready) return;   // abort（destroySimilarStage）→ 不對 null refs 建 stage
       const generation = ++this._similarGeneration;
 
       // 1. 建立 GSAP context（destroy 時 revert 收所有 ctx scope tween）
@@ -187,6 +200,11 @@ export function stateSimilar() {
      */
     destroySimilarStage() {
       this._similarGeneration += 1; // invalidate in-flight callbacks
+
+      // T2（CD-3a）：abort in-flight waitForMount → observer disconnect（冪等）；
+      // 若 initSimilarStage 仍卡在等 card mount（冷載 stall），ready===false 靜默 bail。
+      this._similarReadyAbort?.abort();
+      this._similarReadyAbort = null;
 
       this._cancelSimilarIdleAcknowledge();
 
@@ -1253,6 +1271,13 @@ export function stateSimilar() {
         return;
       }
 
+      // T2 fix（sonnet review F1）：swap 前 snapshot 舊卡。similarResults 關面板時不清空，
+      // 且桌面相似流程也會填 similarResults → 面板重開/首開時 DOM 常有前一輪殘卡。若 predicate
+      // 只數總量，entry-sync 會被殘卡騙成「已就緒」→ observer 從不掛上（hardening 變空砲）。
+      // 故與 drill 同法濾掉 preCards，只認 swap 後新 mount 的卡。
+      const preCards = [...document.querySelectorAll(
+        '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')];
+
       // 填資料 + 重置 drill 歷史
       this.similarResults = items;
       this.similarQueryVideo = data.query_video;
@@ -1277,8 +1302,20 @@ export function stateSimilar() {
       const panelEl = document.querySelector('.similar-mobile-panel');
       if (panelEl) panelEl.classList.add('show');
 
-      // 等 x-for 渲染 6 卡 + layout flush（$nextTick 讓 mobilePanelCoverImg rect 有效）
-      await this.$nextTick();
+      // 等 x-for 渲染卡 + layout flush（T2/CD-3：waitForMount 取代 $nextTick——冷載
+      // stall 時 observer 於卡片插入當下就緒，非放棄）。predicate 用 items.length 非硬編 6
+      // （相似結果可能 <6）；observer root = 恆掛載的 .similar-mobile-panel；close/新 drill abort。
+      this._mobileReadyAbort?.abort();
+      this._mobileReadyAbort = new AbortController();
+      const mobilePanelRoot = document.querySelector('.similar-mobile-panel');
+      const openReady = await waitForMount(
+        mobilePanelRoot,
+        () => [...document.querySelectorAll(
+          '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
+          .filter(el => !preCards.includes(el)).length >= items.length,
+        { signal: this._mobileReadyAbort.signal },
+      );
+      if (!openReady.ready) return;   // abort（closeMobilePanel / 新 drill）→ 靜默 bail
 
       // 83b-T3：進場 ghost 飛行（similarModeAnimating 保持 true 直到飛行完成）
       if (window.GhostFly && window.BurstPicker &&
@@ -1486,7 +1523,20 @@ export function stateSimilar() {
       if (!(window.BurstPicker && coverEl) && coverEl && item.cover_url) {
         coverEl.src = item.cover_url;
       }
-      await this.$nextTick();
+      // T2/CD-3：waitForMount 等 swap 後的新卡（非 oldCards）mount。predicate 用 items.length
+      // 非硬編 6；observer root = 恆掛載的 .similar-mobile-panel；close（closeMobilePanel abort
+      // + bump runId）→ ready:false 提前 bail（等同下方 runId stale-check，只是更早）。
+      this._mobileReadyAbort?.abort();
+      this._mobileReadyAbort = new AbortController();
+      const drillPanelRoot = document.querySelector('.similar-mobile-panel');
+      const drillReady = await waitForMount(
+        drillPanelRoot,
+        () => [...document.querySelectorAll(
+          '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
+          .filter(el => !oldCards.includes(el)).length >= items.length,
+        { signal: this._mobileReadyAbort.signal },
+      );
+      if (!drillReady.ready) return;   // abort（close / 新 drill）→ 靜默 bail
       const newCards = [...document.querySelectorAll(
         '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
         .filter(el => !oldCards.includes(el));
@@ -1539,6 +1589,10 @@ export function stateSimilar() {
       // 不在已清空/已關的面板上啟動 float tween（避免 leak）。亦與第二道 drill stale-check 協同：
       // 重開面板取得全新 runId，不被舊 in-flight burst 汙染。
       this._mobilePanelRunId++;
+
+      // T2（CD-3a）：abort in-flight open/drill waitForMount → observer disconnect（冪等）
+      this._mobileReadyAbort?.abort();
+      this._mobileReadyAbort = null;
 
       // 83b-T1fix1: 清掉仍在墜落的 detached fixed 舊卡（ExitAll Promise 尚未 resolve 時關面板），避免殘留 overlay
       document.querySelectorAll('.similar-mobile-card-detached').forEach(el => el.remove());

--- a/web/static/js/pages/showcase/state-similar.js
+++ b/web/static/js/pages/showcase/state-similar.js
@@ -1303,8 +1303,12 @@ export function stateSimilar() {
       if (panelEl) panelEl.classList.add('show');
 
       // 等 x-for 渲染卡 + layout flush（T2/CD-3：waitForMount 取代 $nextTick——冷載
-      // stall 時 observer 於卡片插入當下就緒，非放棄）。predicate 用 items.length 非硬編 6
+      // stall 時 observer 於卡片插入當下就緒，非放棄）。predicate 用 expectedCards 非硬編 6
       // （相似結果可能 <6）；observer root = 恆掛載的 .similar-mobile-panel；close/新 drill abort。
+      // expectedCards = 唯一 video_id 數（x-for :key=runId+'-'+video_id）：正常皆相異＝items.length，
+      // 但若後端誤傳重複 video_id，Alpine keyed dedup 只渲染唯一數 → 用 length 會 predicate 永不成立
+      // 卡死 similarModeAnimating（Opus review P2-1）。uniq ≤ length，只會更早/相等 resolve、不影響暖路徑。
+      const expectedCards = new Set(items.map(i => i.video_id)).size;
       this._mobileReadyAbort?.abort();
       this._mobileReadyAbort = new AbortController();
       const mobilePanelRoot = document.querySelector('.similar-mobile-panel');
@@ -1312,7 +1316,7 @@ export function stateSimilar() {
         mobilePanelRoot,
         () => [...document.querySelectorAll(
           '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
-          .filter(el => !preCards.includes(el)).length >= items.length,
+          .filter(el => !preCards.includes(el)).length >= expectedCards,
         { signal: this._mobileReadyAbort.signal },
       );
       if (!openReady.ready) return;   // abort（closeMobilePanel / 新 drill）→ 靜默 bail
@@ -1523,9 +1527,11 @@ export function stateSimilar() {
       if (!(window.BurstPicker && coverEl) && coverEl && item.cover_url) {
         coverEl.src = item.cover_url;
       }
-      // T2/CD-3：waitForMount 等 swap 後的新卡（非 oldCards）mount。predicate 用 items.length
-      // 非硬編 6；observer root = 恆掛載的 .similar-mobile-panel；close（closeMobilePanel abort
-      // + bump runId）→ ready:false 提前 bail（等同下方 runId stale-check，只是更早）。
+      // T2/CD-3：waitForMount 等 swap 後的新卡（非 oldCards）mount。predicate 用 expectedCards
+      // = 唯一 video_id 數（非硬編 6、非裸 length——重複 video_id 時 keyed dedup 渲染較少，用
+      // length 會卡死 similarModeAnimating，Opus review P2-1）；observer root = 恆掛載的
+      // .similar-mobile-panel；close（closeMobilePanel abort + bump runId）→ ready:false 提前 bail。
+      const expectedCards = new Set(items.map(i => i.video_id)).size;
       this._mobileReadyAbort?.abort();
       this._mobileReadyAbort = new AbortController();
       const drillPanelRoot = document.querySelector('.similar-mobile-panel');
@@ -1533,7 +1539,7 @@ export function stateSimilar() {
         drillPanelRoot,
         () => [...document.querySelectorAll(
           '.similar-mobile-burst-card:not(.similar-mobile-card-detached)')]
-          .filter(el => !oldCards.includes(el)).length >= items.length,
+          .filter(el => !oldCards.includes(el)).length >= expectedCards,
         { signal: this._mobileReadyAbort.signal },
       );
       if (!drillReady.ready) return;   // abort（close / 新 drill）→ 靜默 bail

--- a/web/static/js/shared/__tests__/dom-timing.test.mjs
+++ b/web/static/js/shared/__tests__/dom-timing.test.mjs
@@ -1,0 +1,125 @@
+// waitForMount 五路徑守衛（nexttick-hydrate T2 / CD-3、Codex round-3）。
+// 零新依賴：Node 內建 node:test + 假 MutationObserver。跑：npm run test:dom-timing
+//
+// 守 waitForMount 的 settle 契約：只在 (a) predicate 通過 或 (b) abort 兩種情況 resolve；
+// warn timer 逾時**不 settle、不 disconnect**（Codex round-3：終止式放棄與「無論何時
+// mount 都 reveal」矛盾）。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ── 假 MutationObserver：手動 flush 模擬 late mount ────────────────────────
+let liveObservers = [];
+class FakeMutationObserver {
+  constructor(cb) { this.cb = cb; this.connected = false; liveObservers.push(this); }
+  observe() { this.connected = true; }
+  disconnect() { this.connected = false; }
+  // 測試用：模擬一次 DOM mutation
+  fire() { if (this.connected) this.cb(); }
+}
+
+// ── 假 timer：手動觸發 warn timer，不真的等 4s ───────────────────────────
+let scheduledTimers = [];
+function fakeSetTimeout(fn) { const id = scheduledTimers.length; scheduledTimers.push(fn); return id; }
+function fakeClearTimeout(id) { if (id != null) scheduledTimers[id] = null; }
+
+function withStubs(run) {
+  const origMO = globalThis.MutationObserver;
+  const origST = globalThis.setTimeout;
+  const origCT = globalThis.clearTimeout;
+  const origWarn = console.warn;
+  let warnCalls = 0;
+  liveObservers = [];
+  scheduledTimers = [];
+  globalThis.MutationObserver = FakeMutationObserver;
+  globalThis.setTimeout = fakeSetTimeout;
+  globalThis.clearTimeout = fakeClearTimeout;
+  console.warn = () => { warnCalls += 1; };
+  const fireWarnTimers = () => scheduledTimers.forEach((fn) => fn && fn());
+  return Promise.resolve(run({ getWarnCalls: () => warnCalls, fireWarnTimers }))
+    .finally(() => {
+      globalThis.MutationObserver = origMO;
+      globalThis.setTimeout = origST;
+      globalThis.clearTimeout = origCT;
+      console.warn = origWarn;
+    });
+}
+
+// import 需在 stub 後，但 ESM import 是 hoisted static；waitForMount 內部用的是
+// 「呼叫時」的 globalThis.MutationObserver/setTimeout，故 stub 於呼叫前設好即可。
+const { waitForMount } = await import('../dom-timing.js');
+
+const fakeRoot = { nodeType: 1 };  // 非 null 即可（FakeMutationObserver.observe 不讀它）
+
+test('〔1〕already-aborted-signal-at-entry → 立即 resolve aborted，不掛 observer', async () => {
+  await withStubs(async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const res = await waitForMount(fakeRoot, () => false, { signal: ctrl.signal });
+    assert.deepEqual(res, { ready: false, aborted: true });
+    assert.equal(liveObservers.length, 0, 'entry 已中止不應建 observer');
+  });
+});
+
+test('〔2〕initial-true → 同步 resolve ready，不掛 observer', async () => {
+  await withStubs(async () => {
+    const res = await waitForMount(fakeRoot, () => true, {});
+    assert.deepEqual(res, { ready: true });
+    assert.equal(liveObservers.length, 0, 'predicate 同步命中不應建 observer');
+  });
+});
+
+test('〔3〕observer-fires-on-late-mount → mutation 後 resolve ready + disconnect', async () => {
+  await withStubs(async () => {
+    let mounted = false;
+    const p = waitForMount(fakeRoot, () => mounted, {});
+    assert.equal(liveObservers.length, 1);
+    assert.equal(liveObservers[0].connected, true);
+    // 尚未就緒：fire 一次 mutation（predicate 仍 false）不 resolve
+    liveObservers[0].fire();
+    // late mount
+    mounted = true;
+    liveObservers[0].fire();
+    const res = await p;
+    assert.deepEqual(res, { ready: true });
+    assert.equal(liveObservers[0].connected, false, 'ready 後 observer 應 disconnect');
+  });
+});
+
+test('〔4〕abort-settles-false → abort 後 resolve aborted + disconnect', async () => {
+  await withStubs(async () => {
+    const ctrl = new AbortController();
+    const p = waitForMount(fakeRoot, () => false, { signal: ctrl.signal });
+    assert.equal(liveObservers[0].connected, true);
+    ctrl.abort();
+    const res = await p;
+    assert.deepEqual(res, { ready: false, aborted: true });
+    assert.equal(liveObservers[0].connected, false, 'abort 後 observer 應 disconnect');
+  });
+});
+
+test('〔5〕warn-timer-fires-but-does-NOT-settle → observer 續存活，之後 late mount 仍 reveal', async () => {
+  await withStubs(async ({ getWarnCalls, fireWarnTimers }) => {
+    let mounted = false;
+    let resolved = false;
+    const p = waitForMount(fakeRoot, () => mounted, { warnAfterMs: 10 }).then((r) => { resolved = true; return r; });
+    // 觸發 warn timer
+    fireWarnTimers();
+    assert.equal(getWarnCalls(), 1, 'warn timer 應 console.warn 一次');
+    assert.equal(resolved, false, 'warn 逾時不得 settle promise');
+    assert.equal(liveObservers[0].connected, true, 'warn 逾時不得 disconnect observer');
+    // 逾時後才 mount → observer 仍捕捉 → reveal
+    mounted = true;
+    liveObservers[0].fire();
+    const res = await p;
+    assert.deepEqual(res, { ready: true });
+  });
+});
+
+test('〔6〕root=null → 靜默 resolve {ready:false}，不掛 observer', async () => {
+  await withStubs(async () => {
+    const res = await waitForMount(null, () => false, {});
+    assert.deepEqual(res, { ready: false });
+    assert.equal(liveObservers.length, 0);
+  });
+});

--- a/web/static/js/shared/dom-timing.js
+++ b/web/static/js/shared/dom-timing.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * waitForMount — MutationObserver 版「等 DOM 就緒」（nexttick-hydrate T2 / CD-3）。
+ *
+ * 取代脆弱的 `await this.$nextTick()`：95a-T8 證實 `$nextTick` 在冷模組快取下
+ * callback / promise 可能不 fire → 一次性 mount-dependent 副作用永久不執行。
+ *
+ * 本 util 改用 MutationObserver 觀察「同步即存在的容器 root」，每次子樹 mutation
+ * 重檢 predicate，就緒即 resolve。**只在兩種情況 settle**：
+ *   (a) predicate 通過（entry 同步命中 or observer 觀察到）→ { ready: true }
+ *   (b) signal abort（含 entry 已中止）→ { ready: false, aborted: true }
+ * **無時間性 settle**：`warnAfterMs` 逾時只 console.warn 診斷、不 disconnect、不 settle
+ * （Codex round-3：timeout settle(false)+disconnect 是終止式放棄，卡片第 4.1 秒才 mount
+ *  會回到永久隱藏，與「無論何時 mount 都 reveal」矛盾）。observer 存活到 abort。
+ *
+ * 為何 MutationObserver 而非 rAF poll：observer callback 走 microtask，不受 paint / 背景頁
+ * 節流影響（Codex P2）；且 observer 唯讀（只在 mutation 時測 predicate，不 clone / 不注入
+ * Alpine-bound 節點）→ 與 Alpine 全域 observer 正交，不觸「cloneNode 洪水」。
+ *
+ * @param {Element|null} root       同步即存在的容器（必須 x-show / 恆掛載，非 x-if 內元素）
+ * @param {() => boolean} predicate  就緒判定（通常查子孫元素是否 mount）
+ * @param {{ signal?: AbortSignal, warnAfterMs?: number }} [opts]
+ *        signal      — per-open/per-run AbortController.signal；abort → disconnect + resolve aborted
+ *        warnAfterMs — 逾時只 console.warn 診斷（預設 4000）；不影響 settle
+ * @returns {Promise<{ ready: boolean, aborted?: boolean }>}
+ */
+export function waitForMount(root, predicate, { signal, warnAfterMs = 4000 } = {}) {
+    // 〔0〕入口同步防呆：傳入已中止 signal → 不掛 observer 空等（Codex round-3）
+    if (signal && signal.aborted) {
+        return Promise.resolve({ ready: false, aborted: true });
+    }
+    // 〔0b〕root 不存在無從 observe（observe(null) 會 throw）→ 靜默 bail
+    if (!root) {
+        return Promise.resolve({ ready: false });
+    }
+    // 〔1〕同步命中即返回
+    if (predicate()) {
+        return Promise.resolve({ ready: true });
+    }
+    // 〔2〕掛 observer，等就緒 or abort
+    return new Promise((resolve) => {
+        let settled = false;
+        let observer = null;
+        let warnTimer = null;
+
+        function settle(result) {
+            if (settled) return;
+            settled = true;
+            if (observer) { observer.disconnect(); observer = null; }
+            if (warnTimer !== null) { clearTimeout(warnTimer); warnTimer = null; }
+            if (signal) signal.removeEventListener('abort', onAbort);
+            resolve(result);
+        }
+
+        function onAbort() {
+            settle({ ready: false, aborted: true });
+        }
+
+        observer = new MutationObserver(() => {
+            if (predicate()) settle({ ready: true });
+        });
+        observer.observe(root, { childList: true, subtree: true });
+
+        if (signal) signal.addEventListener('abort', onAbort);
+
+        // 診斷用 warn timer：**不 settle、不 disconnect**，observer 續存活到 ready / abort
+        warnTimer = setTimeout(() => {
+            warnTimer = null;
+            if (!settled) {
+                console.warn(   // 診斷用；observer 仍存活，非放棄
+                    '[waitForMount] predicate 逾 ' + warnAfterMs +
+                    'ms 仍未就緒；observer 續等 ready 或 abort（非放棄）。',
+                );
+            }
+        }, warnAfterMs);
+    });
+}


### PR DESCRIPTION
## 摘要

清掉 95a-T8 冷載空白 bug 同一 pattern（`$nextTick` callback/promise 在冷模組快取下可能不 fire）在全庫的殘餘隱患。**純前端 JS hardening，後端/schema/DB/template 零改**（`git diff main --name-only` 已驗）。不進版號、不編 96/97。

Plan：`feature/95-naming-gallery-settings/nexttick-hydrate-hardening/plan-nexttick-hydrate.md`（feature/ 為 local-only，review 請開檔或跑瀏覽器）。

## Task → Commit

| Task | Commit | 內容 | Tier |
|---|---|---|---|
| T1 | `1b4edd0c` | scanner `init()` 把 `__registerPage` 提到所有 await 之前 + 移除多餘 `await $nextTick`（冷載/loadConfig 卡住時離頁 dirty-guard 仍註冊） | 1（唯一真功能） |
| T2 | `b0b6f5f7` | 新 `shared/dom-timing.js` `waitForMount`（MutationObserver readiness）+ 6 路徑 node:test；`state-similar.js` 三站台改用 + per-open/run AbortController | 2（防禦性 hardening） |
| T3 | `b257e393` | desktop 女優照 picker `_burstAllPickerCandidates` 改 waitForMount + `_pickerReadyAbort` | 2 |
| T4 | `0b1c9fed` | 兩處 `$nextTick` 死碼移除（favorite tooltip / folder hydrate 死備援）；filename hydrate 路徑零改 | 3（死碼清理） |
| T5 | `efb2f64b` | Tier 1 結構回歸鎖（`scanner/__tests__/init-order.test.mjs`，brace-match 抽 init() body 斷言 `__registerPage` 在首個 await 之前）+ `npm test` glob | 守衛 |
| CI | `2bcf16a7` | `npm test` 接入 lint-frontend job（Codex P1：守衛未 CI-gate） | — |
| P2 | `64aa9a65` | Opus 全 branch review P2 修正（mobile predicate uniq-count 防 dedup 卡死 + page-cleanup abort 對稱） | — |

## waitForMount 契約（CD-3 / Codex round-3）

只在 (a) predicate 通過 或 (b) signal abort 兩種情況 resolve。`warnAfterMs` 逾時只 `console.warn`、**不 disconnect、不 settle**（終止式放棄與「無論何時 mount 都 reveal」矛盾）。observer 存活到 abort；走 microtask 不受 paint 節流；observer 唯讀，與 Alpine 全域 observer 正交。

## 審查歷程

- 每 task 獨立 sonnet review（T2 抓 F1〔open-path predicate 被殘卡騙過 entry-sync〕→ 修 → APPROVE）
- Codex PR review P1（T5 守衛未接 CI）→ 已修（`2bcf16a7`）
- **Opus 全 branch review：SHIP-WITH-NITS（無 P0/P1）**；2 P2 已修（`64aa9a65`），3 nits 接受為 residual（見 `REVIEW-PACKET.md`）

## 驗證

- node:test 28 綠（waitForMount 6 + init-order 2 + tokenizer 20）、`ruff` 全庫綠、`npm run lint` 綠、pytest **5523 passed / 2 skipped**（後端零改）
- **CDP 真機功能驗證**：T1〔延遲 /api/config 2.5s → `__registerPage` 於 272ms 註冊、config 3315ms 才 resolve〕、T4.3〔cache-disabled 冷載 folder/filename 膠囊正確 hydrate〕、T4.1〔tooltip 保留 + appConfig 載入〕、T2/T3〔showcase 0 console error，import 乾淨〕
- owner 已真機驗收動畫節奏零回歸（相似星座 / 手機面板 / drill / picker）

🤖 Generated with [Claude Code](https://claude.com/claude-code)