### PR TITLE
fix(0.11.12): javdb released 版復活 — 打包 dist-info 修復 + 產物 runtime 驗證守衛

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,45 @@ jobs:
           path: dist/artifact/
           retention-days: 30
 
+      # 原封 ZIP：verify-windows 下載跑 import sweep + release 上傳（spec-97 CD-97-3）
+      - name: Upload ZIP artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: OpenAver-Windows-x64-zip
+          path: dist/*-Windows-*.zip
+          retention-days: 30
+          if-no-files-found: error
+
+  # ============ Windows verify (runtime import sweep on shipped python) ============
+  # Windows ZIP 是 ubuntu cross-build，跑不了 win embedded python → 產物 runtime
+  # 驗證必須在 windows runner、用產物自帶的 python.exe 跑（spec-97 CD-97-2）。
+  # Release 上傳 gate 在此 job（verify 綠才發，CD-97-3）。
+  verify-windows:
+    runs-on: windows-latest
+    needs: build-windows-x64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Download ZIP artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: OpenAver-Windows-x64-zip
+          path: dist
+
+      - name: Expand artifact
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem dist/*-Windows-*.zip | Select-Object -First 1
+          Expand-Archive -Path $zip.FullName -DestinationPath dist/verify -Force
+
+      - name: Runtime import sweep (shipped python.exe)
+        shell: pwsh
+        # 無 --skip：clr/pythonnet 在真 windows runner 原生解 .NET 正常。
+        # --skip 僅 WSL-interop workaround，baking 進 CI＝重造 fail-open 盲區（spec-97）。
+        run: '& dist/verify/OpenAver/python/python.exe scripts/verify_artifact_imports.py'
+
       - name: Upload to Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
@@ -97,10 +136,23 @@ jobs:
       - name: Build macOS package
         run: python build_macos.py
 
+      # mac 首次掛 audit（spec-97 G-4）：--max-mb 60（mac baseline ~49MB、uvloop
+      # 合法，不可照搬 win 48，CD-97-6）。dist-info 靜態檢查兩平台皆帶入（T3）。
+      - name: Run artifact audit
+        run: python scripts/audit_build_artifact.py "dist/*-macOS-*.zip" --platform mac --max-mb 60 --strict
+
       - name: Prepare artifact
         run: |
           cd dist
           unzip *-macOS-*.zip -d artifact
+
+      # 產物 runtime import sweep：macos runner 原生執行產物自帶 python3（CD-97-2）。
+      # 與 Upload to Release 同 job，step 順序即 gate（CD-97-3）。
+      - name: Runtime import sweep (shipped python3)
+        # chmod 防禦：zip 若丟失 exec bit 不阻斷 sweep（本步驟只驗 import，非 exec bit）。
+        run: |
+          chmod +x dist/artifact/OpenAver/python/bin/python3 || true
+          dist/artifact/OpenAver/python/bin/python3 scripts/verify_artifact_imports.py
 
       - name: Upload artifact
         uses: actions/upload-artifact@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,30 +78,39 @@
 
 ### Out of scope (handled by automated tooling)
 
-> **v0.11.11 (feature/96 test-deflation)**: static string/structure existence checks on
-> HTML/JS/CSS/Python-literals are the lint layer's job, enforced in CI (`lint-frontend`
-> job = `npm run lint` + `npm test` + `ruff check .`). DO NOT spend review attention
-> re-verifying them, and DO NOT request pytest tests for them. If a guard of this class
-> is missing, the finding is "add a lint rule", not a code-review blocker.
+> **v0.11.11 (feature/96 test-deflation)**: For ordinary product-code PRs, do NOT redo the
+> mechanical checks that unchanged lint rules already cover, and trust the author's
+> lint/test summary. This exemption does NOT apply to changes to the lint/test
+> infrastructure itself, to guard migration or deletion, or to coverage/exhaustiveness
+> claims. Those must be reviewed statically for target set, scope, first-vs-all match,
+> count/order, positive/negative polarity, anchor-absent behavior, and granularity
+> equivalence with the guard they replace — still without running lint or tests.
+>
+> When a guard is genuinely missing, adding a lint rule is the fix, not a pytest string
+> test — but a missing guard does NOT by itself lower severity. An actual product defect
+> it would have caught is graded by product impact regardless of whether automation exists.
 
-The lint layer (all wired into `npm run lint`):
+The lint layer. CI `lint-frontend` runs three phases: `npm run lint` (eslint + stylelint +
+the four `.mjs` guards below), then `npm test` (node structural/unit tests), then
+`ruff check .`. Counts below are indicative only — the live config/script is the source
+of truth:
 
-- **`scripts/static_guard_lint.mjs`** — table-driven static guard engine, ~886 rules,
-  9 kinds (`required-string` / `forbidden-string` / `dup-id` / `structure-count` /
-  `tag-scan` / `inline-style-token` / `order` / `file-absent` / `paired-string`), with
-  scoped matching (anchor-missing = fail-closed RED, brace-balanced method-body windows,
-  comment stripping). Covers HTML templates (which eslint cannot parse), JS string
-  fingerprints, and Python hardcoded-literal bans. This is the default home for any
-  "string X must (not) appear in file Y" guard — including the former pytest guards for
-  inline handlers, inline `style=display:none`, native-dialog strings, and clipboard
-  optional-chaining, all migrated here.
-- **`scripts/css-guard.mjs`** — 41 CSS-block rules (Fluent token families, poster-crop,
+- **`scripts/static_guard_lint.mjs`** — table-driven static guard engine (kinds:
+  `required-string` / `forbidden-string` / `dup-id` / `structure-count` / `tag-scan` /
+  `inline-style-token` / `order` / `file-absent` / `paired-string`), with scoped matching
+  (anchor-missing = fail-closed RED, brace-balanced method-body windows, comment
+  stripping). Covers HTML templates (which eslint cannot parse), JS string fingerprints,
+  and Python hardcoded-literal bans. This is the default home for any "string X must (not)
+  appear in file Y" guard — including the former pytest guards for inline handlers, inline
+  `style=display:none`, native-dialog strings, and clipboard optional-chaining, all
+  migrated here.
+- **`scripts/css-guard.mjs`** — CSS-block rules (Fluent token families, poster-crop,
   z-index cross-file ordering, vt-anchor, selector scoping, whole-text property scans).
 - **`scripts/i18n_lint.mjs`** — used-but-missing i18n keys (RED), 4-locale parity (warn),
   orphan keys (warn), forbidden words in translations (「推薦」「風味」, RED).
 - **`scripts/lint-settings-ia.mjs`** — settings.html IA layering (DOM-ancestry lock).
-- **ESLint** (`eslint.config.mjs`, flat config, 11 `no-restricted-syntax` groups,
-  **17 `SEL_*` constants** — `SEL_SHOW_MODAL`, `SEL_TRACKED_EVENTSOURCE`, `SEL_CLIP_BAN`,
+- **ESLint** (`eslint.config.mjs`, flat config; `no-restricted-syntax` groups + `SEL_*`
+  selector constants — `SEL_SHOW_MODAL`, `SEL_TRACKED_EVENTSOURCE`, `SEL_CLIP_BAN`,
   `SEL_NO_WINDOW_OPEN_PATH`, etc.): anything expressed in the live config is out of review
   scope — consult the config, not a duplicate list here. Scope caveats that ARE still
   review territory: `no-console` covers **search pages only** (`console.error`/`warn`
@@ -112,17 +121,20 @@ The lint layer (all wired into `npm run lint`):
   `F`, `E722`, `B` (incl. `B904`/`B905`/`B023`), `T201`, `S110`/`S112`.
 
 **Still enforced by pytest** (deliberate KEEPs — flag these in review if violated):
-- **`tests/unit/frontend_contracts/`** (6 files) — true cross-file / cross-language
-  contracts: API route pairing, layout/lifecycle/animation contracts, and code-shape
-  guards (method-body ordering, call-counts, brace-scoped semantics) that string-scan
-  lint cannot faithfully express.
+- **`tests/unit/frontend_contracts/`** — true cross-file / cross-language contracts: API
+  route pairing, layout/lifecycle/animation contracts, and code-shape guards (method-body
+  ordering, call-counts, brace-scoped semantics) that string-scan lint cannot faithfully
+  express.
 - **`[lint-guard: pytest-justified]`-tagged classes** in `tests/unit/test_frontend_lint.py`
   (each tag states its reason), incl. `TestPathContract` — the path_utils contract
   (manual `file:///` strip/construct bans; Python source semantics ruff cannot express).
 - The remaining untagged classes in `test_frontend_lint.py` are the **E2E-block**
-  (~52 classes guarding user journeys — swipe/keyboard/lightbox/actress flows). They stay
-  as pytest until a future E2E branch replaces them with browser journeys; do not request
-  their migration to lint, and do not add new classes to this bucket.
+  (user-journey guards — swipe/keyboard/lightbox/actress flows). They stay as pytest until
+  a future E2E branch replaces them with browser journeys; do not request their migration
+  to lint, and do not add new classes to this bucket.
+
+Only read a KEEP test when the changed hunk touches the contract's producer, consumer, or
+the contract test itself — do not routinely sweep all KEEPs.
 
 (Anything outside the lint layer's expressed rules — formatting, dead code not caught by
 ruff `F`, logic — is still in code-review scope.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.12] - 2026-07-12
+
+本版主軸：**javdb 在 released 版復活 — 打包 metadata 修復 + 打包產物 runtime 驗證守衛**（feature/97，spec-97／plan-97，T1–T5）。**這是 0.11.10 之後第一個實際面向用戶的 GitHub release**（0.11.11 為純內部 test-deflation 里程碑、不單獨發版）。使用者唯一可感知的變化：**released 版（Windows/macOS ZIP）指定 javdb 來源搜尋，行為終於與開發環境一致**——能命中就命中，真的查無才回「無結果」。
+
+根因已實證（非推理）：`build.py`／`build_macos.py` 打包瘦身刪除**所有 `*.dist-info`**；`curl_cffi` 的 `__init__` 在 **import 當下**讀自己的 package metadata（`importlib.metadata`），dist-info 不在 → 拋 `PackageNotFoundError`（`ImportError` 子類）→ 被 `core/scrapers/javdb.py` 的 `except ImportError` **靜默吞掉** → `CURL_CFFI_AVAILABLE=False` → 之後每次 javdb 搜尋在第一行就 `return None`、**零 HTTP 請求、零 log**。8 源金絲雀／全套 pytest／smoke 全在 dev venv 跑（dist-info 完好），永遠測不到 packaged 環境的斷裂——所以「測試全綠 → 出貨 → 用戶回報壞的」這條路一直沒被堵。**歷來所有 released Windows/macOS 版的 javdb 從第一天就不能用**（不是先前假設的 CF ban——released 版根本沒發過 HTTP）。
+
+### Fixed
+- **javdb released 版永遠「無結果」**：打包不再剝除 `.dist-info`，curl_cffi 在產物內能正常 import，javdb 恢復可用（owner 真機 2026-07-12 實證：補 dist-info + 重啟後搜 DLDSS-491 命中）。全保留 dist-info 壓縮代價僅 ~0.3MB（Windows ZIP 34.8 → 35.1MB，遠低於 48MB 上限）。
+
+### Added
+#### 🛡️ 打包產物 runtime 驗證守衛（制度化，堵死 dev-only 測試盲區）
+- **`scripts/verify_artifact_imports.py`**：用**產物自帶的 Python** 全量 import site-packages 每個頂層套件，任一 fail → build fail。stdlib-only（跑在尚未驗證的 embedded python 上）、layout 無關（`sys.path` 探測，不寫死 Windows `Lib/` vs macOS `lib/pythonX.Y/`）。這正是「dev venv 測全綠、released curl_cffi import 就炸」盲區的守衛本體——刪掉任一套件的 dist-info 或整包，守衛必紅。
+- **`scripts/audit_build_artifact.py` 加 dist-info 靜態檢查**（廉價第一道，掃 ZIP 不 import，兩平台皆查）：(a) curl_cffi 套件在但其 `*.dist-info/METADATA` 缺 → hard-fail（點名真兇）；(b) 大規模零 dist-info → hard-fail（防未來全刪回歸）。靜態不取代真 import（「檔案都在，跑起來才知道壞」）。
+- **CI `build.yml` 重排**：新增 `verify-windows`（windows-latest）job 下載 Windows ZIP、用產物自帶 `python.exe` 跑 import sweep（Windows ZIP 是 ubuntu cross-build，build 機跑不了 win embedded python）；macOS build job 內就地跑 audit + sweep。**Release 上傳 gate 在 verify 之後**（守衛綠才發版）；macOS 首次掛上 audit（`--max-mb 60`，因 mac baseline 49MB、uvloop 為合法依賴，不照搬 Windows 48）。
+
+### Changed
+- **javdb 兩條靜默失敗路徑補診斷 log**（零行為變更，只加可觀測性）：curl_cffi 不可用 → 首次搜尋 log 一次 warning（含原始例外，一次性不刷屏）；HTTP 非 200 → log status code。排查本 bug 最貴的成本就是「零 log」——連「有沒有發請求」都要靠猜。
+
+### 測試
+- 全套 pytest **4995 passed, 1 skipped**（unit + integration，排除 smoke／e2e，較 0.11.11 的 4985 +10：dist-info 靜態檢查 7 案例〔curl_cffi 缺 metadata／大規模零 dist-info／mac 皆 hard-fail，含 mutation〕+ javdb 診斷 log 3 案例〔warning 一次含例外／None 容錯不 NameError／非 200 status code，含 mutation〕）＋ `ruff check .` 綠 ＋ `npm run lint` 綠。
+- 產物守衛 mutation 實證（對本機 Windows 產物、WSL interop 跑產物自帶 python.exe）：正常 GREEN；刪 curl_cffi dist-info → `PackageNotFoundError` exit 1（本次事故的自動化重演）；刪整包 → 依賴鏈全列 exit 1；還原 → GREEN。audit 真 fixture：新 build GREEN、歷史壞 ZIP（v0.11.10，零 dist-info）RED。
+- 來源金絲雀：**7 源 PASS + fc2 SKIP**（unreachable／no probe，站方連線問題非 parser 回歸，advisory；**javdb 本身金絲雀 PASS**——parser 一直健康，壞的是打包）。
+- 每 task 獨立 Sonnet structured review（T2/T3/T4/T5 findings 皆修：產物守衛 scanned==0 假綠守衛／audit if-no-files-found／CI YAML semantics／javdb test importorskip）。CI dispatch dry-run + Codex PR review 為 push 後最終網。
+
 ## [0.11.11] - 2026-07-12
 
 本版主軸：**前端靜態守衛 pytest → lint 全面遷移（test-deflation）**（feature/96，5 plan 96a–96e／3 PR `0.11.11ab`→`0.11.11cd`→`0.11.11`）——**純內部工程里程碑：零產品碼、對使用者完全隱形、不單獨發 GitHub release**（下一個面向用戶的 0.11.12 才是 0.11.10 後第一個實際 release）。north-star（owner 拍板）：**能用 lint 機械處理的，就不該進 pytest、也不該耗 Codex 審**——把 `tests/unit/test_frontend_lint.py` 裡「讀原始碼做字串/結構斷言」的前端靜態守衛搬回它們該去的工具層（eslint／stylelint／node `.mjs` lint 腳本），並止血讓它不再長回來。收益不是測試數字，是把機械式字串存在檢查移出 AI review 的注意力預算。

--- a/build.py
+++ b/build.py
@@ -748,26 +748,17 @@ def get_directory_size(path):
 
 
 def optimize_package():
-    """優化打包體積：刪除 .dist-info、清理 __pycache__"""
+    """優化打包體積：清理 __pycache__ / .egg-info
+
+    注意：**不刪 .dist-info** —— curl_cffi 等套件在 import 當下讀自身 metadata
+    （importlib.metadata），dist-info 缺失會拋 PackageNotFoundError 導致 released
+    版該功能靜默失效（spec-97 根因）。全保留代價壓縮後僅 ~0.5MB。"""
     print("\n[5.5/6] 優化打包體積...")
 
     app_dir = BUILD_DIR / "OpenAver"
     size_before = get_directory_size(app_dir)
 
-    # 1. 刪除 .dist-info 資料夾
-    dist_info_count = 0
-    dist_info_size = 0
-    for dist_info in app_dir.rglob("*.dist-info"):
-        if dist_info.is_dir():
-            size = sum(f.stat().st_size for f in dist_info.rglob('*') if f.is_file())
-            dist_info_size += size
-            shutil.rmtree(dist_info)
-            dist_info_count += 1
-
-    if dist_info_count > 0:
-        print(f"  刪除 {dist_info_count} 個 .dist-info 資料夾，節省 {dist_info_size / 1024 / 1024:.2f} MB")
-
-    # 2. 清理 __pycache__ 資料夾
+    # 1. 清理 __pycache__ 資料夾
     pycache_count = 0
     pycache_size = 0
     for pycache in app_dir.rglob("__pycache__"):
@@ -780,7 +771,7 @@ def optimize_package():
     if pycache_count > 0:
         print(f"  刪除 {pycache_count} 個 __pycache__ 資料夾，節省 {pycache_size / 1024 / 1024:.2f} MB")
 
-    # 3. 刪除 .egg-info 資料夾
+    # 2. 刪除 .egg-info 資料夾
     egg_info_count = 0
     egg_info_size = 0
     for egg_info in app_dir.rglob("*.egg-info"):

--- a/build_macos.py
+++ b/build_macos.py
@@ -403,12 +403,8 @@ def optimize_package():
             shutil.rmtree(pycache)
             pycache_count += 1
 
-    # 刪除 .dist-info
-    dist_info_count = 0
-    for dist_info in app_dir.rglob("*.dist-info"):
-        if dist_info.is_dir():
-            shutil.rmtree(dist_info)
-            dist_info_count += 1
+    # 不刪 .dist-info：curl_cffi 等 import 當下讀自身 metadata，缺 dist-info
+    # 會拋 PackageNotFoundError 導致 released 版該功能靜默失效（spec-97 根因）。
 
     # 刪除不需要的開發工具套件
     removed_packages = []
@@ -423,7 +419,7 @@ def optimize_package():
                     removed_packages.append(item.name)
                     break
 
-    print(f"  刪除 {pycache_count} 個 __pycache__, {dist_info_count} 個 .dist-info")
+    print(f"  刪除 {pycache_count} 個 __pycache__（保留 .dist-info）")
     if removed_packages:
         print(f"  移除 {len(removed_packages)} 個開發工具: {', '.join(removed_packages[:5])}{'...' if len(removed_packages) > 5 else ''}")
 

--- a/core/scrapers/javdb.py
+++ b/core/scrapers/javdb.py
@@ -12,11 +12,20 @@ from .models import Video, Actress
 from .utils import rate_limit, strip_number_prefix
 
 # 嘗試載入 curl_cffi
+# CURL_CFFI_IMPORT_ERROR 先在頂層初始化：正常 import 成功時此變數仍須存在，否則單獨
+# patch CURL_CFFI_AVAILABLE=False 的測試會 NameError（spec-97 Codex P2）。
+CURL_CFFI_IMPORT_ERROR: Optional[BaseException] = None
 try:
     from curl_cffi import requests as curl_requests
     CURL_CFFI_AVAILABLE = True
-except ImportError:
+except ImportError as e:
     CURL_CFFI_AVAILABLE = False
+    CURL_CFFI_IMPORT_ERROR = e
+
+# curl_cffi 不可用時 _get_html 首次呼叫發一次 warning（module flag 一次性，spec-97 CD-97-5）。
+# 歷史教訓：released 版 dist-info 被剝除 → curl_cffi PackageNotFoundError → 這裡靜默
+# 吞掉 → javdb 瞬回無結果、零 log。補此可觀測性（不改降級行為本身）。
+_warned = False
 
 
 class JavDBScraper(BaseScraper):
@@ -38,6 +47,13 @@ class JavDBScraper(BaseScraper):
     def _get_html(self, url: str) -> Optional[str]:
         """使用 curl_cffi 發送請求（偽造 Chrome TLS 指紋）"""
         if not CURL_CFFI_AVAILABLE:
+            global _warned
+            if not _warned:
+                _warned = True
+                if CURL_CFFI_IMPORT_ERROR is not None:
+                    logger.warning("javdb 已停用：curl_cffi 不可用: %s", CURL_CFFI_IMPORT_ERROR)
+                else:
+                    logger.warning("javdb 已停用：curl_cffi 不可用")
             return None
 
         try:
@@ -55,6 +71,7 @@ class JavDBScraper(BaseScraper):
 
             if response.status_code == 200:
                 return str(response.text)
+            logger.debug("JavDB non-200 for %s: %s", url, response.status_code)
         except Exception as e:
             logger.debug(f"JavDB request failed for {url}: {e}")
 

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.11.11"
+__version__ = "0.11.12"
 VERSION = __version__
 
 # 版本資訊

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,4 @@ select = ["E722", "F", "B", "T201", "S110", "S112"]
 "build.py" = ["T201"]
 "build_macos.py" = ["T201"]
 "scripts/audit_build_artifact.py" = ["T201"]  # CLI build 工具，print 為正常輸出（同 build.py）
+"scripts/verify_artifact_imports.py" = ["T201"]  # 產物 import sweep 守衛，print 即輸出（跑在 embedded python，stdlib-only）

--- a/scripts/audit_build_artifact.py
+++ b/scripts/audit_build_artifact.py
@@ -40,15 +40,42 @@ Ban-list tiers:
 Sync point with TASK-80-BUILD-T2:
     T2 adjusts which packages are runtime deps; if it removes uvloop from the
     Windows release, flip uvloop to HARD_FAIL here (same follow-up commit).
+
+dist-info existence check (spec-97 G-2, added in feature/97):
+    Two HARD-FAIL checks (both platforms, see _dist_info_check):
+      (a) curl_cffi package present ⟹ curl_cffi-*.dist-info/METADATA present.
+          The exact spec-97 root cause: build.py used to strip every .dist-info,
+          so curl_cffi raised PackageNotFoundError at import → javdb silently
+          disabled in every released build. dev-venv tests never caught it.
+      (b) At >= 20 top-level packages, dist-info dirs must be >= 50% of packages
+          (blanket-strip sanity net; loose ratio, gated so small ZIPs don't trip).
+    This static ZIP scan is the CHEAP first pass; it does NOT replace the real
+    runtime import sweep (scripts/verify_artifact_imports.py, run on the shipped
+    interpreter) — "files present" ≠ "imports clean".
+
+macOS ceiling (spec-97 CD-97-6):
+    macOS gets its FIRST audit in feature/97 with --max-mb 60 (not 48): the mac
+    ZIP baseline is ~49 MB (v0.10.11 release asset; uvloop is a valid macOS
+    runtime dep). 60 = baseline + dist-info (~50) with ~10 MB legit headroom,
+    still catching mypy-class (~62) and playwright-class regressions. Windows
+    stays at 48 (dist-info adds only ~0.5 MB compressed, ZIP ~35 MB).
 """
 
 from __future__ import annotations
 
 import argparse
 import glob
+import re
 import sys
 import zipfile
 from pathlib import Path
+
+# Matches site-packages/curl_cffi-<ver>.dist-info/METADATA anywhere in the ZIP.
+_CURL_CFFI_METADATA_RE = re.compile(r"site-packages/curl_cffi-[^/]+\.dist-info/METADATA$")
+
+# Top-level scale at/above which the dist-info ratio sanity net engages. Real
+# artifacts bundle ~50 packages; synthetic test ZIPs stay well below this.
+_DIST_INFO_SCALE_GATE = 20
 
 
 # ── Ban-list definition ──────────────────────────────────────────────────────
@@ -118,6 +145,49 @@ def _site_packages_top_dirs(zf: zipfile.ZipFile) -> set[str]:
     return top_dirs
 
 
+def _dist_info_check(zf: zipfile.ZipFile, top_dirs: set[str]) -> list[str]:
+    """Return HARD-FAIL messages for missing .dist-info metadata (spec-97 G-2).
+
+    Two platform-agnostic checks — both hard-fail (never warn-tier):
+
+    (a) curl_cffi named check (conditional on the package shipping): if the
+        curl_cffi PACKAGE dir is present but no curl_cffi-*.dist-info/METADATA
+        exists, that is the EXACT spec-97 regression — curl_cffi reads its own
+        metadata at import, so a stripped dist-info raises PackageNotFoundError,
+        silently disabling the javdb scraper in every release.
+
+    (b) Scale sanity net: at real-artifact scale (>= _DIST_INFO_SCALE_GATE
+        top-level package dirs), the dist-info dir count must be >= half the
+        package count. Catches a future blanket dist-info strip. A loose 50%
+        ratio avoids brittle coupling to exact transitive-dependency counts;
+        the gate keeps small synthetic ZIPs from tripping it.
+    """
+    messages: list[str] = []
+    dist_info_dirs = {n for n in top_dirs if n.endswith(".dist-info")}
+    packages = {n for n in top_dirs if not n.endswith((".dist-info", ".data"))}
+
+    # (a) curl_cffi — the named root cause.
+    if "curl_cffi" in packages:
+        has_metadata = any(_CURL_CFFI_METADATA_RE.search(n) for n in zf.namelist())
+        if not has_metadata:
+            messages.append(
+                "[FAIL] DIST-INFO: curl_cffi package present but its"
+                " *.dist-info/METADATA is missing — this is the exact spec-97"
+                " regression (curl_cffi raises PackageNotFoundError at import,"
+                " silently disabling javdb). The build must NOT strip .dist-info."
+            )
+
+    # (b) Blanket-strip sanity net (only at real-artifact scale).
+    if len(packages) >= _DIST_INFO_SCALE_GATE and len(dist_info_dirs) < len(packages) / 2:
+        messages.append(
+            f"[FAIL] DIST-INFO: only {len(dist_info_dirs)} .dist-info dirs for"
+            f" {len(packages)} top-level packages (< 50%) — looks like a blanket"
+            f" .dist-info strip regression (spec-97). Keep dist-info in the build."
+        )
+
+    return messages
+
+
 def audit(
     zip_path: str | Path,
     platform: str,
@@ -158,11 +228,17 @@ def audit(
 
     with zipfile.ZipFile(zip_path) as zf:
         top_dirs = _site_packages_top_dirs(zf)
+        dist_info_msgs = _dist_info_check(zf, top_dirs)
 
     messages.append(
         f"[INFO] Scanned {zip_path.name} — platform={platform},"
         f" strict={strict}, found {len(top_dirs)} top-level site-packages dirs"
     )
+
+    # ── dist-info existence (spec-97 G-2 static first pass; both platforms) ────
+    if dist_info_msgs:
+        messages.extend(dist_info_msgs)
+        failed = True
 
     # Hard-fail tier
     for pkg in sorted(HARD_FAIL_PKGS):

--- a/scripts/verify_artifact_imports.py
+++ b/scripts/verify_artifact_imports.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Verify a packaged OpenAver artifact can import every bundled top-level package.
+
+Runs ON the artifact's OWN interpreter (Windows embedded ``python.exe`` /
+macOS ``python/bin/python3``), so it MUST be stdlib-only and layout-agnostic
+(Windows ``Lib/site-packages`` vs macOS ``lib/pythonX.Y/site-packages``).
+
+Why this guard exists (spec-97 G-2):
+    ``build.py``/``build_macos.py`` used to strip every ``*.dist-info`` to save
+    ~0.5 MB. ``curl_cffi.__init__`` reads its own metadata at import time
+    (``importlib.metadata.metadata("curl_cffi")``); with dist-info gone that
+    raised ``PackageNotFoundError`` (an ``ImportError`` subclass), which
+    ``core/scrapers/javdb.py`` swallowed via ``except ImportError`` — silently
+    disabling javdb in EVERY released Windows/macOS build. Dev-venv tests never
+    caught it because the venv keeps its dist-info. This sweep imports every
+    bundled package using the SHIPPED interpreter, so such breakage fails the
+    build (wired into CI as a release gate — see build.yml verify jobs).
+
+Usage:
+    <artifact>/python/python.exe scripts/verify_artifact_imports.py [--skip pkg ...]
+
+Exit codes:
+    0 — every discovered top-level package imported cleanly.
+    1 — at least one import failed (list printed), OR no site-packages was found
+        on sys.path (guards against a false-green run on the wrong interpreter).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+# Directory / file names that are not importable top-level packages.
+_SKIP_DIRS = {"__pycache__", "bin", "Scripts"}
+_SKIP_SUFFIXES = (".dist-info", ".data")
+_EXT_SUFFIXES = (".pyd", ".so")
+
+
+def _site_packages_dirs() -> list[Path]:
+    """Return every ``site-packages`` directory on this interpreter's sys.path.
+
+    Layout-agnostic: we do not hardcode ``Lib/`` vs ``lib/pythonX.Y/`` — we trust
+    the shipped interpreter's own resolved sys.path (the artifact ``._pth`` /
+    site config puts its site-packages there).
+    """
+    seen: set[Path] = set()
+    dirs: list[Path] = []
+    for entry in sys.path:
+        if not entry:
+            continue
+        p = Path(entry)
+        if p.name == "site-packages" and p.is_dir():
+            rp = p.resolve()
+            if rp not in seen:
+                seen.add(rp)
+                dirs.append(p)
+    return dirs
+
+
+def _top_level_modules(sp_dir: Path) -> tuple[list[str], list[str]]:
+    """Collect importable top-level module names inside one site-packages dir.
+
+    Returns (names, skipped) where ``skipped`` lists non-identifier entries
+    (namespace dirs, hyphenated names) recorded for transparency.
+    """
+    names: set[str] = set()
+    skipped: list[str] = []
+    for entry in sorted(sp_dir.iterdir()):
+        name = entry.name
+        if name in _SKIP_DIRS or name.endswith(_SKIP_SUFFIXES):
+            continue
+        if entry.is_dir():
+            if (entry / "__init__.py").is_file():
+                mod = name
+            else:
+                continue  # namespace pkg / data dir — not counted
+        elif name.endswith(_EXT_SUFFIXES):
+            mod = name.split(".")[0]  # _cffi_backend.cp312-win_amd64.pyd -> _cffi_backend
+        elif name.endswith(".py"):
+            if name == "__init__.py":
+                continue
+            mod = entry.stem
+        else:
+            continue
+        if not mod.isidentifier():
+            skipped.append(name)
+            continue
+        names.add(mod)
+    return sorted(names), skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Import every bundled top-level package using the artifact's own interpreter.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        metavar="PKG",
+        help="Top-level module name to skip (repeatable). Use only for a "
+        "documented platform-specific special case; prints a SKIP line.",
+    )
+    args = parser.parse_args(argv)
+    skip = set(args.skip)
+
+    print(f"[INFO] interpreter: {sys.executable}")
+    sp_dirs = _site_packages_dirs()
+    if not sp_dirs:
+        print(
+            "[FAIL] no site-packages directory found on sys.path — "
+            "is this the artifact's own interpreter? (false-green guard)",
+            file=sys.stderr,
+        )
+        return 1
+
+    modules: set[str] = set()
+    for sp in sp_dirs:
+        print(f"[INFO] site-packages: {sp}")
+        names, skipped = _top_level_modules(sp)
+        modules.update(names)
+        for s in skipped:
+            print(f"SKIP  {s} (not an import name)")
+
+    fails: list[tuple[str, str, str]] = []
+    for mod in sorted(modules):
+        if mod in skip:
+            print(f"SKIP  {mod} (--skip)")
+            continue
+        try:
+            importlib.import_module(mod)
+        except BaseException as exc:  # noqa: BLE001 — a sweep must catch everything
+            fails.append((mod, type(exc).__name__, str(exc)))
+
+    scanned = len(modules) - len(skip & modules)
+    print(f"TOTAL {scanned} FAILS {len(fails)}")
+    for mod, exc_type, msg in fails:
+        print(f"FAIL  {mod}: {exc_type}: {msg}")
+
+    if scanned == 0:
+        # A real artifact bundles ~50 packages; zero attempted imports means the
+        # sweep found a site-packages dir but nothing importable in it (e.g. a
+        # build that stripped every package). Never a legitimate GREEN.
+        print(
+            "[FAIL] 0 packages attempted — site-packages present but empty of "
+            "importable modules (false-green guard)",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_build_artifact_audit.py
+++ b/tests/unit/test_build_artifact_audit.py
@@ -244,6 +244,87 @@ def test_pytest_base_url_not_flagged(tmp_path):
     )
 
 
+# ── dist-info existence checks (spec-97 G-2 static first pass) ─────────────────
+
+
+def _dist_info(pkg_ver: str) -> str:
+    """Return a canonical site-packages .dist-info/METADATA path.
+
+    pkg_ver e.g. 'curl_cffi-0.15.0' → .../site-packages/curl_cffi-0.15.0.dist-info/METADATA
+    """
+    return f"OpenAver/python/Lib/site-packages/{pkg_ver}.dist-info/METADATA"
+
+
+def test_curl_cffi_pkg_without_dist_info_fails(tmp_path):
+    """curl_cffi package present but its .dist-info stripped → HARD-FAIL.
+
+    This is the EXACT spec-97 regression: dist-info gone → PackageNotFoundError
+    at import → javdb silently disabled in every release. The audit must catch it.
+    """
+    zp = _make_zip(tmp_path, {_site("curl_cffi", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 1, f"curl_cffi without dist-info must hard-fail, got {code}\n" + "\n".join(msgs)
+    assert any("curl_cffi" in m and "FAIL" in m for m in msgs)
+
+
+def test_curl_cffi_pkg_with_dist_info_passes(tmp_path):
+    """curl_cffi package WITH its .dist-info/METADATA → pass."""
+    zp = _make_zip(
+        tmp_path,
+        {
+            _site("curl_cffi", "__init__.py"): b"x",
+            _dist_info("curl_cffi-0.15.0"): b"Name: curl_cffi\n",
+        },
+    )
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, f"curl_cffi with dist-info must pass, got {code}\n" + "\n".join(msgs)
+
+
+def test_curl_cffi_absent_without_dist_info_ok(tmp_path):
+    """The curl_cffi check is CONDITIONAL: a ZIP that doesn't ship curl_cffi at
+    all must not be forced to carry curl_cffi dist-info (guards existing tests)."""
+    zp = _make_zip(tmp_path, {_site("fastapi", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, f"no-curl_cffi ZIP must pass, got {code}\n" + "\n".join(msgs)
+
+
+def test_large_pkgset_zero_dist_info_fails(tmp_path):
+    """At real-artifact scale (>=20 top-level packages) a blanket dist-info
+    strip (0 dist-info dirs) must hard-fail via the ratio sanity net."""
+    entries = {_site(f"pkg{i:02d}", "__init__.py"): b"x" for i in range(22)}
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 1, f"22 pkgs / 0 dist-info must hard-fail, got {code}\n" + "\n".join(msgs)
+    assert any("dist-info" in m.lower() and "FAIL" in m for m in msgs)
+
+
+def test_large_pkgset_with_dist_info_passes(tmp_path):
+    """22 packages each with a matching .dist-info → ratio satisfied → pass."""
+    entries = {}
+    for i in range(22):
+        entries[_site(f"pkg{i:02d}", "__init__.py")] = b"x"
+        entries[_dist_info(f"pkg{i:02d}-1.0.0")] = b"Name: pkg\n"
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, f"22 pkgs / 22 dist-info must pass, got {code}\n" + "\n".join(msgs)
+
+
+def test_small_pkgset_zero_dist_info_ok(tmp_path):
+    """Below the scale gate (<20 packages) the ratio net does NOT engage —
+    small synthetic ZIPs without dist-info stay green (existing behavior)."""
+    entries = {_site(f"pkg{i}", "__init__.py"): b"x" for i in range(8)}
+    zp = _make_zip(tmp_path, entries)
+    code, msgs = audit(zp, "win", 55.0, False)
+    assert code == 0, f"8 pkgs / 0 dist-info must stay green, got {code}\n" + "\n".join(msgs)
+
+
+def test_dist_info_check_runs_on_mac(tmp_path):
+    """dist-info checks are platform-agnostic — curl_cffi strip fails on mac too."""
+    zp = _make_zip(tmp_path, {_site("curl_cffi", "__init__.py"): b"x"})
+    code, msgs = audit(zp, "mac", 60.0, False)
+    assert code == 1, f"curl_cffi strip must hard-fail on mac too, got {code}\n" + "\n".join(msgs)
+
+
 # ── Glob resolution errors ────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_javdb_scraper.py
+++ b/tests/unit/test_javdb_scraper.py
@@ -248,3 +248,81 @@ class TestJavdbRating:
         assert video is not None
         assert video.rating == 4.46
         assert video.rating != 2105
+
+
+# ============================================================
+# curl_cffi 缺失 / 非 200 診斷 log（spec-97 T5，G-3）
+# ============================================================
+
+
+class TestJavdbCurlCffiDiagnostics:
+    """javdb 兩條靜默失敗路徑補 log（零行為變更，只加可觀測性）。
+
+    patch target 一律 core.scrapers.javdb.*（旗標/錯誤物件/_warned 定義端＝使用端
+    同模組）；每測例重置 module-level _warned 避免測試間洩漏。
+    """
+
+    def test_curl_cffi_unavailable_warns_once_with_error(self, caplog, monkeypatch):
+        """curl_cffi 不可用（帶原始例外）→ _get_html 首次呼叫 log 一次 warning 含例外
+        訊息；連呼兩次只 log 一次；仍 return None（行為不變）。"""
+        import logging
+        from core.scrapers import javdb
+
+        fake_exc = ImportError("No package metadata was found for curl_cffi")
+        monkeypatch.setattr(javdb, "CURL_CFFI_AVAILABLE", False)
+        monkeypatch.setattr(javdb, "CURL_CFFI_IMPORT_ERROR", fake_exc)
+        monkeypatch.setattr(javdb, "_warned", False)
+
+        s = javdb.JavDBScraper()
+        with caplog.at_level(logging.WARNING, logger="OpenAver.core.scrapers.javdb"):
+            r1 = s._get_html("https://javdb.com/search?q=SONE-103")
+            r2 = s._get_html("https://javdb.com/search?q=SONE-103")
+
+        assert r1 is None and r2 is None  # 行為不變
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"應只 warn 一次，實得 {len(warnings)}"
+        msg = warnings[0].getMessage()
+        assert "curl_cffi" in msg
+        assert "No package metadata was found for curl_cffi" in msg  # 含原始例外
+
+    def test_curl_cffi_unavailable_error_none_no_nameerror(self, caplog, monkeypatch):
+        """單獨 patch CURL_CFFI_AVAILABLE=False、CURL_CFFI_IMPORT_ERROR 維持 None →
+        不 NameError（Codex P2：頂層先初始化），warning 仍發（None 容錯路徑）。"""
+        import logging
+        from core.scrapers import javdb
+
+        monkeypatch.setattr(javdb, "CURL_CFFI_AVAILABLE", False)
+        monkeypatch.setattr(javdb, "CURL_CFFI_IMPORT_ERROR", None)
+        monkeypatch.setattr(javdb, "_warned", False)
+
+        s = javdb.JavDBScraper()
+        with caplog.at_level(logging.WARNING, logger="OpenAver.core.scrapers.javdb"):
+            result = s._get_html("https://javdb.com/search?q=SONE-103")
+
+        assert result is None  # 不炸 NameError
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "curl_cffi" in warnings[0].getMessage()
+
+    def test_non_200_logs_status_code(self, caplog, monkeypatch):
+        """非 200 response → debug log 含 url + status code；仍 return None。"""
+        import logging
+        from unittest.mock import MagicMock
+
+        # 本測 patch javdb.curl_requests.get，該屬性僅在 curl_cffi 可 import 時存在
+        # （dev venv / CI 為硬依賴恆有）；真缺 curl_cffi 的環境 skip 而非 AttributeError。
+        pytest.importorskip("curl_cffi")
+        from core.scrapers import javdb
+
+        monkeypatch.setattr(javdb, "CURL_CFFI_AVAILABLE", True)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        monkeypatch.setattr(javdb.curl_requests, "get", lambda *a, **k: mock_resp)
+
+        s = javdb.JavDBScraper()
+        with caplog.at_level(logging.DEBUG, logger="OpenAver.core.scrapers.javdb"):
+            result = s._get_html("https://javdb.com/v/Ww9zN8")
+
+        assert result is None
+        debug_msgs = [r.getMessage() for r in caplog.records]
+        assert any("403" in m for m in debug_msgs), f"應 log status code，實得 {debug_msgs}"


### PR DESCRIPTION
## 摘要

feature/97（spec-97／plan-97，T1–T5）。**0.11.10 後第一個實際面向用戶的 GitHub release**（0.11.11 為純內部 test-deflation）。使用者唯一可感知變化：**released 版指定 javdb 搜尋，行為終於與 dev 一致**。

### 根因（已實證，非推理）
`build.py`／`build_macos.py` 打包瘦身刪除**所有 `*.dist-info`** → `curl_cffi.__init__` import 當下讀自身 metadata → `PackageNotFoundError`（`ImportError` 子類）→ javdb `except ImportError` 靜默吞 → `CURL_CFFI_AVAILABLE=False` → **全 released Windows/macOS 版 javdb 從第一天瞬回無結果、零 HTTP、零 log**（非 CF ban）。8 源金絲雀／pytest／smoke 全在 dev venv 跑（dist-info 完好）→ 測不到 packaged 斷裂＝「測全綠→出貨→用戶回報壞」盲區。owner 真機 2026-07-12 補 dist-info + 重啟 → 搜 DLDSS-491 命中，修復定案。

## Task → Commit

| Task | Commit | 內容 |
|------|--------|------|
| T1 | `40f286ac` | build.py/build_macos.py 停止剝除 `.dist-info`（根因修復，+0.3MB） |
| T2 | `28bf94d2` | `scripts/verify_artifact_imports.py` 產物自帶 python 全量 import sweep 守衛（stdlib-only、layout 無關、雙 false-green 守衛） |
| T3 | `650e1476` | `audit_build_artifact.py` dist-info 靜態檢查（curl_cffi 點名 + 規模 ratio，mac 首掛 --max-mb 60） |
| T4 | `e9f9319d` | `build.yml` 加 verify-windows job + mac sweep，Release gate 在 verify 後 |
| T5 | `23c1320b` | javdb curl_cffi 缺失／非 200 補診斷 log（唯一產品碼，零行為變更） |
| docs | `cf604135` | VERSION 0.11.11→0.11.12 + CHANGELOG |

## 測試

- 全套 pytest **4995 passed, 1 skipped**（+10：dist-info 靜態 7 案 + javdb log 3 案，皆含 mutation）＋ `ruff check .` 綠 ＋ `npm run lint` 綠。
- **產物守衛 mutation 實證**（本機 Windows 產物、WSL interop 跑產物 python.exe）：正常 GREEN；刪 curl_cffi dist-info → `PackageNotFoundError` exit 1（**事故自動化重演**）；刪整包 → 依賴鏈全列 exit 1；還原 GREEN。
- **audit 真 fixture**：新 build（v0.11.11，44 dist-info）GREEN；歷史壞 ZIP（v0.11.10，0 dist-info，curl_cffi pkg 在但 metadata 缺）RED，兩檢查同時 fire。
- 來源金絲雀：7 源 PASS + fc2 SKIP（unreachable，advisory）；**javdb 金絲雀 PASS**（parser 一直健康，壞的是打包）。
- 每 task 獨立 Sonnet structured review，findings 皆修（T2 scanned==0 假綠守衛／T3 —／T4 if-no-files-found:error／T5 test importorskip）。

## Plan deviations / accepted residuals

- **T2 `--skip clr`**：僅本地 WSL-interop 用（pythonnet 無法在 `\\wsl.localhost` UNC 下解 .NET）；**CI 一律不帶 `--skip`**（真 windows-latest runner 原生解 .NET，owner 50/50）——baking 進 CI 會重造 fail-open 盲區。
- **T4 dispatch dry-run + RED 案**：CI 編排無法本機驗，為 **push 後 GitHub Actions 驗收點**（本 PR 觸發）；本地已驗 YAML 結構 + GHA-semantics review。
- **T5 `_warned` 非原子**（多執行緒理論上重複一條 log）：harmless，不加鎖（over-engineering）。
- macOS 產物 exec-bit 完整性：sweep `chmod +x` 防禦繞過（本步只驗 import 非 exec bit），為已知 scoped-out gap。
- agy Gemini branch review 落入對話式假審 fallback（已知失敗態，advisory 非 gate，工作區驗淨）；correctness 由 per-task Sonnet + 本 Codex review 覆蓋。

## Non-Goals（defer）

javdb 單線程化／防 ban（根因排除後待真 ban 實證再開）、`impersonate` 升版、UI 顯示停用原因、回溯重發舊 ZIP。

🤖 Generated with [Claude Code](https://claude.com/claude-code)