### PR TITLE
v0.12.4: 女優換圖 alias 對稱與別名輪替（spec-102 Part A+B）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.4] - 2026-07-18
+
+本版修好「改過名（有別名）的女優換照片特別難」的兩個問題（feature/102，spec-102 Part A＋B）。之前這類女優在照片挑選視窗裡：本機候選一選就失敗、雲端又永遠查不到圖，體感就是「換圖整個壞掉」。
+
+### Fixed
+#### 🖼️ 別名片的本機候選選了就能換（Part A）
+- 修好「照片挑選視窗給我看的本機封面候選，只要那張封面來自她改名前（別名）名下的影片，一選必跳『抓取失敗，請稍後再試』」。根因是產生候選與儲存驗證用了不同的名字展開範圍；現在兩端一致，**看得到的候選就選得了**。
+- 安全邊界不變：不屬於這位女優（含其別名）名下的影片路徑，仍然一律拒絕。無別名的女優行為與以前完全一致。
+
+### Added
+#### 🔄 重抓時自動輪流用別名向線上圖庫查詢（Part B）
+- 在照片挑選視窗按 🔄 重抓，雲端查詢會自動輪流用她的每個名字查（主名 → 別名依序 → 繞回主名）。剛改名的女優線上圖庫多半只認舊名，之前永遠 0 命中；現在多按幾次 🔄 就能撈到掛在舊名下的雲端照片。
+- **使用者無感、UI 零改動**：沒有新按鈕、不顯示目前用哪個名字查（刻意設計——這是「增加圖片來源」的內部機制，不是要操作的功能）。無別名的女優按 🔄 行為與以前完全一致。換一位女優後輪替自動從主名重新開始。
+
+### 測試
+- 全套 pytest **5348 passed, 1 skipped**（unit + integration，排除 smoke／e2e）＋ `ruff check .` 綠 ＋ `npm run lint` 綠（static_guard_lint 1034 條）＋ `npm test`（node:test 118）。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live 健康檢查）。
+- 輪替全序列以 **CDP 真機實測**（headless Playwright 真 click）：首開無參數、三連 🔄 查詢名 主名→別名1→別名2→繞回、換人歸零、無別名逐位一致、儲存身分正確（驗後資料已還原）。
+- 每 task 獨立 Sonnet review ＋ Codex PR review（P0 手刻 URI 已修、二審通過）＋ Gemini 整支 branch 第二意見（5 條 findings 全數為既有設計已覆蓋，0 採納）。
+- 本版 **UI 零改動、零新增 i18n key**。
+
 ## [0.12.3] - 2026-07-18
 
 本版把焦點（對臉裁切）這條線的尾巴收乾淨（feature/101，spec-101 四部分 A/B/C/D）。前幾版已經讓無碼封面在 app 裡自動對準人臉、也能手動微調；這版補上「媒體伺服器海報也對臉」、把燈箱按下對焦鈕的等待過程做得更連續好懂、清掉兩塊內部技術債，並讓影片對焦鈕只在真的會用到時才出現。承重牆不變：**全程只存焦點座標，你的封面圖檔一個位元都不會被改寫**。
@@ -180,134 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 來源金絲雀：**7 源 PASS + fc2 SKIP**（unreachable／no probe，站方連線問題非 parser 回歸，advisory 記錄）。
 - Codex PR review：PR-1 P2×1（eslint persistence.js group 補 selector）、PR-2 P1/P2/P3×4（scope-narrowing）、PR-3 前置審 P1×2+P2×1（1200 窗上限＋lazy 量詞＋multi-tag defer）皆修復並 mutation 證明（修前 GREEN=缺口證實 → 修後 RED）。
 
-## [0.11.10] - 2026-07-10
-
-本版主軸：**設定頁「命名區」膠囊化 + 「列表生成」兩層 IA 重排**（feature/95，Part A spec-95a／Part B spec-95b，兩個獨立部分）——把設定頁兩塊長期是「純文字輸入框 + 一長串控制項」的區域，改成更好懂、更難出錯的形態：命名區（資料夾層級／檔名格式）從手打 `{token}` 字串改成「原子變數膠囊（pill）+ 字面文字自由混排」的視覺化編輯器；列表生成設定拆成「日常常用（外層常駐）」+「離線 HTML 匯出（摺疊進階）」兩層。後端零 schema／DB 變更（僅 format-variables SSOT 端點加情境旗標）。
-
-### Added
-#### 🏷️ 命名區膠囊化（Part A）
-- **資料夾層級／檔名格式改膠囊編輯器**：每個變數（番號／女優／片商／標題／後綴…）以原子「膠囊」呈現，不再是手打 `{num}` 這種容易打錯的字串；膠囊間可自由插入字面分隔符（`[` `]` `-` `_` 等）。變數選單一鍵插入、膠囊整顆刪除（× 或 Backspace 邊界原子刪，不留 `{titl` 半截），貼上時已知變數自動 tokenize、未知 `{foo}` 保留字面。複用既有 source-pill 視覺（999px accent），與 8+30 來源膠囊一致；IME 組字 / Enter guard 不誤送。
-- **資料夾層級改動態清單 + 硬上限 3 層**：可「新增一層／移除此層」，最多 3 層（第 4 層 add 鈕灰化）；載入 >3 層的舊設定自動正規化為前 3 層（保後端有效層、棄第 4 層以上死資料，先 slice 再剝 `{suffix}`）。層順序以穩定 id keying，移除中間層不錯置。
-- **`{suffix}` 情境隔離**：後綴變數只在「檔名格式」可用、資料夾層級選單不出現（`folder_ok` 情境旗標，由 format-variables SSOT 端點下發，前後端不再各自硬編變數清單）。
-
-#### 🗂️ 列表生成設定兩層 IA（Part B）
-- **sec-gallery 拆兩層**：外層常駐＝日常會調的（排序／順序／每頁數量／最小影片尺寸）；摺疊進階層＝只有匯出離線 HTML 才需要的（顯示模式／輸出目錄／輸出檔名），預設收合。
-- **揭露文案克制化**：排序／順序／每頁加「也是你瀏覽頁（Showcase）的預設」揭露；最小尺寸 hint 改寫成「掃描／入庫閾值 — 0 = 不過濾；小於此不入庫（決定你看得到哪些片）」；離線匯出層加 Windows 本機檢視說明條（含 `file://` 成因，材質克制不搶眼）。
-
-### Changed
-- 「進階刮削設定」內的命名區改用膠囊編輯器（取代純文字輸入框）；預覽區改以 `x-text` 渲染（移除舊手動 regex escape，天然防 XSS）。
-- 列表生成設定 state 旗標 `galleryAdvanced` → `galleryExport` rename（語意更準）。
-
-### Fixed
-- **冷模組快取下檔名格式膠囊編輯器持續空白**（95a-T8）：使用者首次開 app／清快取後首載時，「檔案命名格式」膠囊編輯器有時完全空白（存的格式沒渲染成膠囊）。成因是 `loadConfig` 靠單一 `$nextTick` 排的一次性 hydrate callback 在冷模組載入時序下不觸發，而該編輯器又早 mount 過了 ready-gate（資料夾層走 `x-for` 自載、不受影響）。改用 reactive `x-effect` + 響應式就緒旗標 + one-shot 收斂補載，繞過不可靠的單發 `$nextTick`（暖快取本就正常，故只在首次冷載可見）。
-
-### Internal
-- format-variables 抽成單一真理來源端點（`/api/config/format-variables`）+ `folder_ok` 情境旗標；補「format-variables ⊆ organizer 消費」契約守衛（pytest）。
-- 膠囊 tokenizer（`tokenize` / `serializeTokens`）抽成純函式 + node:test round-trip 守衛（`serialize(tokenize(s)) === s`，與 whitelist 無關）；ChipEditor 為非受控 widget，`naming` closure 存參考不進 Alpine x-data（避免 contentEditable 響應式追蹤導致游標跳）。
-- 命名區 ESLint 守衛（膠囊 label brace-strip／禁 raw key）+ orphan 清理 + `/design-system` 同步；列表生成 IA 加 zero-dep lint script（`scripts/lint-settings-ia.mjs` 串 `npm run lint:html`，DOM-ancestry 守 export 控制項必在摺疊內）。
-- 命名區新增 i18n key 只寫 `zh_TW`（其餘三語留空靠 fallback，milestone 補譯——已知缺 16 key warning）。
-- Codex PR review：95a P1（`{suffix}` 資料夾主動移除 + 前 3 層正規化「先 slice 再剝」順序）、95b P2（IA 守衛補鎖 `avlistOutputDir`／`Filename` 在摺疊內）皆已修。
-
-### 測試
-- 全套 pytest **5523 passed, 2 skipped**（unit + integration，排除 smoke／e2e）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint + lint-settings-ia）綠。
-- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm）。
-- Gemini 3.1 Pro 整支 branch 第二意見：Part A（命名膠囊）**Approved**（讚 SSOT／closure 隔離 contentEditable／純函式 tokenize／slice-before-filter 順序／x-text 天然防 XSS；4 條 advisory 皆低 severity 或 future-note、無 P1）；Part B 本輪 agy 落入 sandbox 對話式 fallback 未取得有效審查（已知失敗態），correctness 由 per-task Sonnet review + Codex PR review 覆蓋。
-- **95a-T8 冷載修復由 coordinator CDP 實測驗收**（`cacheDisabled` 冷載 3/3 正確 hydrate、暖載／folder 零回歸、編輯游標不跳、reset 重新 hydrate）。
-- E2E-95 runbook 全跑：Part A（A1–A11）+ Part B（B0–B7）全 PASS（A0 即本版修復的 bug）。
-- 視覺 hard-gate：命名膠囊觀感／兩層 IA 可掃讀性／Windows 說明條材質克制由 owner 真機驗收。
-
-## [0.11.9] - 2026-07-10
-
-本版主軸：**掃描頁「補資料」升級成逐片「工人在幹活」進度卡 + 命中封面飛入圖書館**（feature/94，spec-94 G1–G7）——把掃描頁「補資料」（batch-enrich SSE）從一個乾計數器 + 終端 log，升級成逐片可視的進度卡：每片輪到時即顯示「番號 · 搜尋中…」，結果回來後切到對應結局（命中／命中無封面／查無／失敗／唯讀跳過）；**命中且有可服務封面時，真封面從進度卡飛進側邊欄「瀏覽」**（＝我的圖書館），落地帶 scale/glow + 微光，進度卡上累計 badge。承接 spec-92 D 項「入庫飛入抽成共用元件（`GhostFly.playInboundFly`）、scanner 接線留未來」——本 branch 就是那個未來，**直接複用該共用入口、不新增動畫 primitive**。後端極小擴充（`EnrichResult.reason` 欄位 + SSE `result-item` 帶 reason），**刻意不碰核心 `search_jav`、零 schema/DB 變更**。
-
-### Added
-#### 🎬 掃描頁補資料逐片進度卡 + 命中封面飛入
-- **逐片「工人在幹活」進度卡**：補資料時，進度區顯示「目前這片」的可視卡（番號從一開始就在，不等結果），取代乾計數器；五態可辨識——`搜尋中…`／命中封面浮現／`補到資料（無封面）`（文字非破圖）／`查無`（琥珀安靜一閃換片）／`失敗`（進 log）／`跳過（唯讀）`。**命中大聲、落空安靜**：只有真的補到可服務封面才飛入 + badge + 微光，其餘小 glyph 一閃就換片、不搶注意力。
-- **命中封面飛入圖書館（兩格待命位 + 延後飛）**：進度卡分兩格——左「待命格」停駐前一片命中封面、右格顯示目前搜尋中；命中封面先進待命格停一個搜尋週期（不一出現就飛），**下一片命中時**前一片才飛向側邊欄「瀏覽」入口（複用 spec-92 `playInboundFly`），run 結束時 flush 最後一片；落地 scale/glow + 側邊欄微光；進度卡上累計 badge（本次 run 補到資料片數，run 後淡出，不做持久紅點）。延後飛用真實補資料節奏當 dwell，讓每顆封面看得清；待命格容器恆渲染固定尺寸，飛入起點 rect 恆有效、免時序 race。
-- **手機／減少動態不靜默**：窄螢幕（側邊欄隱藏）逐片反饋交給本就可見的進度卡 + badge，收尾用既有 run-end summary toast（不做 per-item toast，避免批次刷屏）；減少動態下命中僅微光、不播飛行。
-
-### Internal
-- 後端只加「scraper parse → `EnrichResult.reason`」+ SSE `result-item` 帶 reason（`reason` ∈ hit／no_cover／not_found／error／readonly；normal 站台靠 `asdict` 自動流出、唯讀/例外站台字面補）；**`search_jav` 零改動**（`git diff` 該檔為空）。前端命中封面 URL 由 `file_path` 自組 `/api/gallery/thumb`，後端不吐 `cover_url`。`GET /api/capabilities` 的 batch_enrich `result_item` output_schema 同步補 `reason`。
-- **獨立 sonnet review 抓到並修復一個 bulk race（P1）**：bulk 下片 A 命中排了飛入後，片 B 的 progress 於同一同步 SSE chunk 覆寫進度卡狀態會隱藏片 A 的命中封面 img（rect=0），使片 A 的 `$nextTick` 讀到退化不飛。修法：飛入起點 `x-ref` 從會隱藏的 `<img>` 移到固定尺寸、恆渲染的容器 div，rect 跨換片穩定。
-- **Codex PR review P1**：`reason=hit` 原用「cover.jpg 磁碟真相」判，但前端命中封面走 `/api/gallery/thumb`，而 `/thumb` 硬性要求 DB `cover_path` 非空、不 fallback 磁碟 sidecar。兩者判準不同 → 「磁碟有 .jpg 但 DB cover_path 空」（掃描後才丟封面／db·nfo-sourced 命中跳過 `_db_upsert`）時卡片顯示 hit、`/thumb` 404 破圖、且該片仍留 missing_cover 清單。修：`reason=hit` 改為鏡射 `/thumb` 的 gate——所有寫檔完成後重讀 DB 最終狀態，`cover_path` 有值才 hit（散落 sidecar 未入 DB → 誠實回報 no_cover、不飛、不破圖）。含 P3 stale wording 併修。
-- **Codex PR #98 review P2**：上條只鏡射了 `/thumb` 第一道 gate（DB `cover_path` 非空）。但 `/thumb` cache miss/disabled 時還有第二道——要讀**實體封面檔**（`uri_to_local_fs_path` 反解後 generate／fallback），檔不在 → 404。故「DB 有記 `cover_path`、但實體封面檔已被刪/移／path_mapping 失效」時仍會誤判 hit → 飛入破圖。修：`reason=hit` 改為**同時**要求 DB `cover_path` 有值 **且**用 `/thumb` 同一解析確認實體檔存在（第三個互補回歸鎖固化；stale-WebP-cache 的 false-negative 是安全方向＝不破圖，已知接受）。
-
-### 測試
-- 全套 pytest **5521 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.8 的 5498 +23：reason 映射邊界〔hit/no_cover 依「/thumb 可服務真相＝DB cover_path 有值 + 實體檔存在」分流、not_found/error 各分支〕+ 三個互補 mutation-verified 回歸鎖〔擋「cover_written alone」+ 擋「退回磁碟真相」+ 擋「只鏡射 DB gate 漏實體檔」〕+ result-item 三站台 SSE reason 契約 + /thumb 時序鎖）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
-- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，dmm 經 JP proxy live）。
-- Gemini 3.1 Pro 整支 branch 第二意見：本輪未取得有效審查——agy headless 落入 apply-patch 假審模式（已知失敗態，見 AI_COLLABORATION 註記），已清理工作區殘留、確認 committed code 零污染；correctness 由 Codex auto-review（P1 已修）+ 獨立 sonnet review（P1 已修）覆蓋。
-- 視覺 hard-gate：進度卡五態 + 命中飛入節奏 + badge + 手機 fallback 由 owner 真機驗收。
-
-## [0.11.8] - 2026-07-09
-
-本版主軸：**各刮削來源的評分/簡介補進 NFO（NFO-only，服務媒體伺服器用戶）+ 燈箱中繼資訊美化**（feature/93，spec-93 A/B）——把各來源網站**已提供**的「評分/簡介」在刮削時一併抓出、寫進該片 NFO 的 `<rating>`/`<plot>`，純粹服務透過 OpenAver 唯讀產生庫 + `.strm` 餵 Jellyfin/Emby/Kodi 的用戶（那些媒體伺服器把 `<rating>`/`<plot>` 當顯示格，現在這些格不再是空的）。**OpenAver 自身介面刻意不顯示、不進 DB、不翻譯**——延續既有 US7「NFO-only」契約，owner 判斷評分擠高分帶區辨力低、簡介是行銷文案，對自身瀏覽低價值，顯示外包給 Jellyfin。另獨立做燈箱中繼資訊的視覺層次美化。零 API/schema/DB 變更。
-
-### Added
-#### 🎬 評分/簡介補進 NFO（媒體伺服器 enrichment）
-- **六個來源開始填評分 + 簡介**：刮到的評分一律正規化到 0–5，經既有 NFO writer ×2 輸出 Jellyfin 0–10 尺度。
-  - **評分**（7 源）：dmm / heyzo / 1pondo・10musume / jav321 / fc2 / javdb / caribbean。
-  - **簡介**（6 源）：dmm / heyzo / 1pondo・10musume / jav321 / fc2 / caribbean。
-  - javbus / avsox 站上無此兩格 → 不做。
-- **各來源取得方式**（除 DMM 評分外皆「同一請求免費、零額外請求」）：
-  - **DMM**：簡介＝主查詢已抓回的 `description` 接線；評分＝**獨立 root probe** `reviewSummary(contentId:){average}`（比照既有 genres/sample 三態 cache，schema 不支援即永久停用、probe 失敗降級不影響主 metadata，**硬性禁止擴充主 `DETAIL_QUERY`**——那是 DMM 命脈，未知欄位會讓全片刮不到）。
-  - **jav321**：同頁文字 `平均評価: N.N`（直接 0–5，非 GIF 形式，勿 ÷10）+ 描述 div。
-  - **fc2**：JSON-LD `aggregateRating.ratingValue`（支援單一物件／頂層陣列／`@graph` 包裹三形狀）+ 接既有已抽卻未使用的 `div.col.des` 簡介。
-  - **heyzo**：同一 JSON-LD `description`（評分早已抓）。
-  - **d2pass（1pondo/10musume）**：同一 phpauto JSON 加讀 `Desc` + rating 補 `<=5` sanity guard（擋畸形值）。
-  - **javdb**：`.panel-block` 文字 `評分: N.N分`（真實用戶評分；站上無簡介）。
-  - **caribbean**：其 phpauto JSON API 已全面死→改走 moviepage HTML fallback 解析 `itemprop="description"` 簡介 + `meta-rating` 星數 rune-count（0–5）評分（同一已抓 HTML、零額外請求）。
-
-### Changed
-#### 🎨 燈箱中繼資訊視覺層次
-- 燈箱詳情列（番號 · 片商 · 導演 · 片長 · 系列 · 發行商 · 發行日期）從同色扁平長串改為可掃讀：番號升一階色階（`--text-secondary`）+ 微加粗一眼可辨、欄位標籤微分層、中繼區以髮絲線（`--stroke-subtle`）與上方克制分隔。不加色塊/玻璃卡/accent 底，封面仍視覺主角。
-
-### Internal
-- 評分/簡介只改「scraper parse → `Video.rating`/`Video.summary`」這一段；carrier 產生（`internal_nfo_carriers`）、前端 strip（`strip_internal_nfo_keys`）、NFO fill-if-missing 寫入管線（`nfo_updater`/`organizer`/`enricher`/`readonly_producer`）皆為既有機制、不動；`needs_update()` 不把 plot/rating 列缺料（不觸發掃描頁「缺資料」提醒）。補回歸鎖 `TestNeedsUpdateNeverNagsPlotRating` 固化此契約。
-- **Codex PR review P1**：T2 的 D4-gap mutation 驗證用的 restore `sed` 無 count、over-match，把 `_probe_genres`/`_probe_sample_images`/`DETAIL_QUERY` 三個 `{'id': content_id}` payload 一併誤改成 `{'contentId'}`，但這三個 query 宣告的是 `$id` → `DETAIL_QUERY` 送 `contentId` 使 `ppvContent(id:null)` 失敗、DMM exact/producer/enrich 全掉；DMM unit test 全 mock 在 HTTP 層、對 query↔variables 契約盲故未攔到。已修（三 payload 還原 `id`，僅 review probe 保留 `contentId`）+ 補 `TestDMMProbePayloadVariables` 監看真實 POST 斷言各 method 送出的 variables key 對應其 query `$var`（mutation 驗證會攔）。**P2**：fc2 `_get_rating` 補 `{"@graph":[…]}` 包裹形狀防禦。
-- **Codex PR #97 re-review P2×3**（皆真實資料流 gap，HTTP-mock 單測看不到、靠讀真 fixture/merge 路徑抓）：〔P2-1〕自動模式 `source_merger.merge_results` backfill 欄位群含 `rating` 卻漏 `summary` → 贏的來源無簡介時合併後簡介遺失、NFO `<plot>` 恆空（多源模式下本功能形同虛設），修：`summary` 加進 `_STR_META_FIELDS`；〔P2-2〕`.get(k,'')` 在「欄位在、值 JSON null」時回 `None`，`Video.summary` 非 Optional str → `Video(summary=None)` 拋 ValidationError 被 broad except 吞 → 整片結果被丟，修：dmm/heyzo/d2pass 三處 `.get(k) or ''`；〔P2-3〕jav321 詳情頁真描述前有空 `.col-md-12` 佔位、`select_one` 停在空佔位 → summary 恆空（T3 合成 fixture 無此佔位故漏），修：scope 主 panel-body 取第一個非空 `.col-md-12`、用真實 fixture 鎖死。三者皆補回歸。
-- caribbean 覆蓋經 JP proxy live 驗證（解 plan-93 D9 defer）：其 JSON API 對真實現行番號全面 404，推翻「1pondo 同一 `_parse_json` 代表家族」假設 → caribbean 走 `_parse_caribbeancom_html`，補值落該 HTML fallback。
-- `core/scrapers/README.md` §1.4 新增「評分/簡介覆蓋（NFO-only）」矩陣。
-
-### 測試
-- 全套 pytest **5498 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.7 的 5447 +51：六源 rating/summary parse 邊界〔0–5 尺度、勿 ÷10 防呆、JSON-LD dict/list/@graph、rune-count 星數、正則 None fallback〕+ DMM `_probe_review` 三態＋降級不影響主 metadata＋query↔variables 契約守衛 + d2pass `<=5` guard 新舊對照 + fc2 dead 變數接線 + NFO 管線回歸鎖〔fill-if-missing 不覆蓋／不 nag plot/rating／echo 路徑空 plot〕+ Codex PR #97 re-review P2×3〔merge summary backfill／null 描述不丟片／jav321 空 col 佔位真實 fixture〕）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
-- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，dmm 經 JP proxy live）。
-- Gemini 3.1 Pro 整支 branch 第二意見：**LGTM、零 P1/P2**（跨源一致性、parse 防禦、UI 克制皆讚，無須修改）。
-- 視覺 hard-gate：燈箱 `.lb-details` 層次由 owner 真機驗收。
-
-## [0.11.7] - 2026-07-07
-
-本版主軸：**搜尋頁體驗優化（搜尋列不擠壓 + 整理發現性 + 入庫飛入動畫加強）**（feature/92，spec-92 A/B/C/D 四項）——純前端 UX polish + 一個 latent 正確性 bug 修復，零 API/schema/DB 變更。四個彼此獨立的痛點：搜尋列右側控制項擠壓變形、整理入口埋在頁尾難發現、整理入庫的「飛入側邊欄」動畫太不明顯、以及把該動畫抽成可跨頁複用的共用元件（本版只做 search 端接線，scanner 接線留未來 branch）。
-
-### Added
-#### 🎯 入庫飛入動畫加強（C）
-- **整理入庫回饋更有實感**：某片整理成功並寫進資料庫後，一顆封面 ghost 從該片飛向側邊欄「瀏覽」入口——改為三段節奏（起飛 → 於入口旁懸停約 0.5s 微發光讓眼睛看清是哪片 → 縮入落地並帶 scale 彈跳 + 光暈），取代舊版「抵達即淡掉的小點」。
-- **窄螢幕／手機不再靜默**：側邊欄隱藏時退化為「已入庫」輕量提示，不再毫無反饋；系統開啟「減少動態效果」時保留輕量落地反饋、不播飛行與縮放。
-
-#### 🎯 整理入口更好找（B）
-- **批次整理鈕常駐可見**：拖入一批檔案整理時，「批次整理 N 片」主動作恆在視線內（桌面靠既有固定插槽 + 表頭 sticky；窄視窗改貼底浮動列），不再因結果卡過高被推到畫面外要捲動才找得到。
-- **單片／批次整理各有可辨識 icon**：單片＝單一檔案 icon、批次＝資料夾 icon，一眼分辨；空狀態說明文字旁內嵌同款 icon + 同色，文字與畫面上那顆按鈕對得上。
-
-### Changed
-#### ⌨️ 搜尋列右側控制項不再擠壓變形（A）
-- **「自動」來源膠囊不變形**：在已有結果的頁面回搜尋框打新番號時，「自動」／來源名膠囊不再被壓縮擠壓；右側控制區預留足夠寬度（CDP 實測定值）容納最長來源名 + 清除 + 送出。
-- **格狀／詳情切換鈕穩定可見**：女優／前綴搜尋有結果時，格狀↔詳情切換鈕穩定可見可點、不被裁切；打字搜尋新片時暫時讓位屬預期，結果落定後回來。
-
-### Fixed
-- **不再出現「兩組相同的 ✕」**：在已有結果的頁面重新搜尋（含用「自動」膠囊重搜）進入載入態時，取消鈕與清除鈕不再並排出現兩顆一樣的 ✕——`hasContent` 由手動維護的旗標改為自動推導的 computed 值，根治整類「漏同步一處就出 bug」的結構性缺陷。
-- **整理飛入的封面永遠是「正確那片」**：先前在詳情檢視 X 片時、點清單裡另一片 Y 的「整理此片」，飛出去的會是 X 的封面；改為封面身份永久綁定被整理那片自己的資料（起飛位置才有條件借用目前顯示中的元素）。
-
-### Internal
-- 新增參數化共用動畫入口 `GhostFly.playInboundFly`（起點元素／封面 src／終點／fallback 由呼叫端傳入、不綁 search 專屬假設）取代 `playToIcon`：三段 timeline、對稱 `onComplete`/`onInterrupt` cleanup（C21，契約源 `playMobilePanelEnter/Exit`）、通用 scale/glow 落地反饋、並發序列化（`killTweensOf(toEl)` 讓最新落地勝出）。scanner 端接線留未來 branch（共用入口簽章刻意不含 search 假設）。
-- `hasContent` 改 Alpine computed getter（移除散落 7 處手動賦值）；`playToIcon` 移除並加 ESLint `no-restricted-syntax` 守衛（definition site + caller site 兩 scope，mutation 自驗 RED 防復活）。i18n 新 key `search.toast.db_synced_mobile` 只寫 zh_TW（其餘三語 fallback）。守衛一律走 ESLint 不落 pytest（本版測試數持平）。
-
-### 測試
-- 全套 pytest **5447 passed, 2 skipped**（unit + integration，排除 smoke／e2e，與 0.11.6 baseline 一致、零回歸；本版守衛全走 ESLint，故測試數持平）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
-- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live 健康檢查）。
-- ESLint 守衛 mutation 自驗：植入 `this.hasContent = ...`（Group 1）／`playToIcon` 定義或呼叫（Group 1 caller + Group 6 definition）皆轉 RED。
-- Codex 二審 F1（P2 並發落地反饋 race）已修（`killTweensOf` 序列化）；F2（P3，無現行回歸）記 accepted residual（`.gsap-animating` 通用性邊界＝各元件 scoped，現行 `#sidebar-showcase-link` 只 transition color/background 不觸 C21；未來 transform/filter transition 的 toEl caller 須補 scoped 規則，scanner 接線 branch 一併補、端到端驗）。
-- 視覺 hard-gate：owner 真機一次驗收通過（A pill 不變形／無兩組 X、B icon 辨識 + 常駐鈕、C 飛入節奏 + 手機 fallback）。
-
-## 0.11.x 系列 (v0.11.0 ~ v0.11.6, 2026-06-27 ~ 2026-07-06)
+## 0.11.x 系列 (v0.11.0 ~ v0.11.10, 2026-06-27 ~ 2026-07-10)
 
 - **v0.11.0**：JavBus 過度泛用清償 + exact 番號搜尋改優先序 cascade（feature/85）——直接搜番號改為依你拖曳的來源優先順序逐一查詢（cascade，命中即回），JavBus 不再無視優先序搶先短路；DMM proxy 透傳修復、前綴搜尋 `type` 參數修正；拔除已死的 JavBus variant（同番號多版本）探查死碼。
 - **v0.11.1**：JavLibrary 同番號多版本手動切換（feature/86）——搜尋框直搜／燈箱換來源／結果卡替換來源三入口皆可看封面手動挑撞號版本（游標預設停最新發行日），桌面 standalone 限定（需 CF transport）。
@@ -318,7 +212,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **v0.11.5**：唯讀來源生成媒體伺服器庫「.strm 風味」+ 跨機器路徑映射 + 唯讀寫入全面封鎖（feature/90）——唯讀來源可產出 `.strm` 捷徑檔給 Emby/Jellyfin/Kodi 掃描播放，跨機器「播放端路徑替換」規則讓 `.strm` 內路徑翻成播放端看得懂的形式、改規則一鍵同步改寫既有 `.strm`；同時把唯讀來源「零寫入」補到滴水不漏（勾唯讀破壞性確認、四個寫入入口全面停用、切模式清舊媒體卡、產生中斷乾淨收尾）。
 - **v0.11.6**：跨機器路徑映射（WSL2+UNC）讀寫全棧收斂 + DB-key 命名空間守衛（feature/91）——純 correctness 重構：修好「讀取端忘了在碰磁碟前把映射路徑反解回本機路徑」導致縮圖／封面／串流跨機器讀不到的一類 silent bug，以及「已反解路徑又被裸餵回 DB key」導致重刮掉使用者標籤、女優照 403 的另一類；兩支 AST 結構守衛擋死回歸。
 
-測試數 4735 → 5447。
+- **v0.11.7**：搜尋頁體驗優化（feature/92）——搜尋列右側控制項不再擠壓變形、整理入口常駐可見更好找、整理入庫「飛入側邊欄」動畫加強為三段節奏，並抽成可跨頁複用的共用元件；順手修好「重新整理已有結果頁面時出現兩組 ✕」的 latent bug。
+- **v0.11.8**：各刮削來源評分/簡介補進 NFO（feature/93，NFO-only）——七源評分、六源簡介寫進 `<rating>`/`<plot>`，純服務媒體伺服器（Jellyfin/Emby/Kodi）用戶，OpenAver 自身介面不顯示；順手美化燈箱中繼資訊視覺層次。
+- **v0.11.9**：掃描頁「補資料」升級成逐片進度卡 + 命中封面飛入圖書館（feature/94）——補資料時逐片可視進度（搜尋中／命中／查無／失敗／唯讀跳過），真封面命中飛入側邊欄「瀏覽」入口。
+- **v0.11.10**：設定頁命名區膠囊化 + 列表生成兩層 IA 重排（feature/95）——檔案命名格式從手打字串改成「變數膠囊 + 字面文字」視覺化編輯器、資料夾層級改動態清單（硬上限 3 層）；列表生成設定拆成日常常用（常駐）+ 離線 HTML 匯出（摺疊進階）。
+
+測試數 4735 → 5523。
 
 ## 0.10.x 系列 (v0.10.0 ~ v0.10.11, 2026-06-18 ~ 2026-06-24)
 

--- a/CHANGELOG_ARCHIVE.md
+++ b/CHANGELOG_ARCHIVE.md
@@ -1,4 +1,4 @@
-# Changelog Archive (v0.1.0 ~ v0.11.6)
+# Changelog Archive (v0.1.0 ~ v0.11.10)
 
 All notable changes to this project will be documented in this file.
 
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 0.11.x
 
+- [0.11.10] 2026-07-10 — 設定頁命名區膠囊化 + 列表生成兩層 IA 重排
+- [0.11.9] 2026-07-10 — 掃描頁補資料逐片進度卡 + 命中封面飛入圖書館
+- [0.11.8] 2026-07-09 — 各來源評分/簡介補進 NFO（媒體伺服器 enrichment）+ 燈箱中繼資訊美化
+- [0.11.7] 2026-07-07 — 搜尋頁體驗優化（搜尋列不擠壓 + 整理發現性 + 入庫飛入動畫加強）
 - [0.11.6] 2026-07-06 — 跨機器路徑映射（WSL2+UNC）讀寫全棧收斂 + DB-key 命名空間守衛
 - [0.11.5] 2026-07-05 — 唯讀來源生成媒體伺服器庫（.strm 風味）+ 跨機器路徑映射 + 唯讀寫入全面封鎖
 - [0.11.4] 2026-07-04 — 唯讀產生庫地基（output_dir 記憶原地更新）+ 掃描頁「試過」記憶 + 來源刪檔 DB-only 清死卡
@@ -130,6 +134,133 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.1.3] 2026-01-17 — path_utils 集中化路徑處理，NFO updater / image proxy 全部改用
 - [0.1.1] 2026-01-17 — 圖片 proxy Windows 路徑修正 + Settings 手動更新檢查按鈕
 - [0.1.0] 2026-01-15 — 初始版本（Spotlight Search + Gallery Generator + Ollama 翻譯 + PyWebView）
+
+## [0.11.10] - 2026-07-10
+
+本版主軸：**設定頁「命名區」膠囊化 + 「列表生成」兩層 IA 重排**（feature/95，Part A spec-95a／Part B spec-95b，兩個獨立部分）——把設定頁兩塊長期是「純文字輸入框 + 一長串控制項」的區域，改成更好懂、更難出錯的形態：命名區（資料夾層級／檔名格式）從手打 `{token}` 字串改成「原子變數膠囊（pill）+ 字面文字自由混排」的視覺化編輯器；列表生成設定拆成「日常常用（外層常駐）」+「離線 HTML 匯出（摺疊進階）」兩層。後端零 schema／DB 變更（僅 format-variables SSOT 端點加情境旗標）。
+
+### Added
+#### 🏷️ 命名區膠囊化（Part A）
+- **資料夾層級／檔名格式改膠囊編輯器**：每個變數（番號／女優／片商／標題／後綴…）以原子「膠囊」呈現，不再是手打 `{num}` 這種容易打錯的字串；膠囊間可自由插入字面分隔符（`[` `]` `-` `_` 等）。變數選單一鍵插入、膠囊整顆刪除（× 或 Backspace 邊界原子刪，不留 `{titl` 半截），貼上時已知變數自動 tokenize、未知 `{foo}` 保留字面。複用既有 source-pill 視覺（999px accent），與 8+30 來源膠囊一致；IME 組字 / Enter guard 不誤送。
+- **資料夾層級改動態清單 + 硬上限 3 層**：可「新增一層／移除此層」，最多 3 層（第 4 層 add 鈕灰化）；載入 >3 層的舊設定自動正規化為前 3 層（保後端有效層、棄第 4 層以上死資料，先 slice 再剝 `{suffix}`）。層順序以穩定 id keying，移除中間層不錯置。
+- **`{suffix}` 情境隔離**：後綴變數只在「檔名格式」可用、資料夾層級選單不出現（`folder_ok` 情境旗標，由 format-variables SSOT 端點下發，前後端不再各自硬編變數清單）。
+
+#### 🗂️ 列表生成設定兩層 IA（Part B）
+- **sec-gallery 拆兩層**：外層常駐＝日常會調的（排序／順序／每頁數量／最小影片尺寸）；摺疊進階層＝只有匯出離線 HTML 才需要的（顯示模式／輸出目錄／輸出檔名），預設收合。
+- **揭露文案克制化**：排序／順序／每頁加「也是你瀏覽頁（Showcase）的預設」揭露；最小尺寸 hint 改寫成「掃描／入庫閾值 — 0 = 不過濾；小於此不入庫（決定你看得到哪些片）」；離線匯出層加 Windows 本機檢視說明條（含 `file://` 成因，材質克制不搶眼）。
+
+### Changed
+- 「進階刮削設定」內的命名區改用膠囊編輯器（取代純文字輸入框）；預覽區改以 `x-text` 渲染（移除舊手動 regex escape，天然防 XSS）。
+- 列表生成設定 state 旗標 `galleryAdvanced` → `galleryExport` rename（語意更準）。
+
+### Fixed
+- **冷模組快取下檔名格式膠囊編輯器持續空白**（95a-T8）：使用者首次開 app／清快取後首載時，「檔案命名格式」膠囊編輯器有時完全空白（存的格式沒渲染成膠囊）。成因是 `loadConfig` 靠單一 `$nextTick` 排的一次性 hydrate callback 在冷模組載入時序下不觸發，而該編輯器又早 mount 過了 ready-gate（資料夾層走 `x-for` 自載、不受影響）。改用 reactive `x-effect` + 響應式就緒旗標 + one-shot 收斂補載，繞過不可靠的單發 `$nextTick`（暖快取本就正常，故只在首次冷載可見）。
+
+### Internal
+- format-variables 抽成單一真理來源端點（`/api/config/format-variables`）+ `folder_ok` 情境旗標；補「format-variables ⊆ organizer 消費」契約守衛（pytest）。
+- 膠囊 tokenizer（`tokenize` / `serializeTokens`）抽成純函式 + node:test round-trip 守衛（`serialize(tokenize(s)) === s`，與 whitelist 無關）；ChipEditor 為非受控 widget，`naming` closure 存參考不進 Alpine x-data（避免 contentEditable 響應式追蹤導致游標跳）。
+- 命名區 ESLint 守衛（膠囊 label brace-strip／禁 raw key）+ orphan 清理 + `/design-system` 同步；列表生成 IA 加 zero-dep lint script（`scripts/lint-settings-ia.mjs` 串 `npm run lint:html`，DOM-ancestry 守 export 控制項必在摺疊內）。
+- 命名區新增 i18n key 只寫 `zh_TW`（其餘三語留空靠 fallback，milestone 補譯——已知缺 16 key warning）。
+- Codex PR review：95a P1（`{suffix}` 資料夾主動移除 + 前 3 層正規化「先 slice 再剝」順序）、95b P2（IA 守衛補鎖 `avlistOutputDir`／`Filename` 在摺疊內）皆已修。
+
+### 測試
+- 全套 pytest **5523 passed, 2 skipped**（unit + integration，排除 smoke／e2e）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint + lint-settings-ia）綠。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm）。
+- Gemini 3.1 Pro 整支 branch 第二意見：Part A（命名膠囊）**Approved**（讚 SSOT／closure 隔離 contentEditable／純函式 tokenize／slice-before-filter 順序／x-text 天然防 XSS；4 條 advisory 皆低 severity 或 future-note、無 P1）；Part B 本輪 agy 落入 sandbox 對話式 fallback 未取得有效審查（已知失敗態），correctness 由 per-task Sonnet review + Codex PR review 覆蓋。
+- **95a-T8 冷載修復由 coordinator CDP 實測驗收**（`cacheDisabled` 冷載 3/3 正確 hydrate、暖載／folder 零回歸、編輯游標不跳、reset 重新 hydrate）。
+- E2E-95 runbook 全跑：Part A（A1–A11）+ Part B（B0–B7）全 PASS（A0 即本版修復的 bug）。
+- 視覺 hard-gate：命名膠囊觀感／兩層 IA 可掃讀性／Windows 說明條材質克制由 owner 真機驗收。
+
+## [0.11.9] - 2026-07-10
+
+本版主軸：**掃描頁「補資料」升級成逐片「工人在幹活」進度卡 + 命中封面飛入圖書館**（feature/94，spec-94 G1–G7）——把掃描頁「補資料」（batch-enrich SSE）從一個乾計數器 + 終端 log，升級成逐片可視的進度卡：每片輪到時即顯示「番號 · 搜尋中…」，結果回來後切到對應結局（命中／命中無封面／查無／失敗／唯讀跳過）；**命中且有可服務封面時，真封面從進度卡飛進側邊欄「瀏覽」**（＝我的圖書館），落地帶 scale/glow + 微光，進度卡上累計 badge。承接 spec-92 D 項「入庫飛入抽成共用元件（`GhostFly.playInboundFly`）、scanner 接線留未來」——本 branch 就是那個未來，**直接複用該共用入口、不新增動畫 primitive**。後端極小擴充（`EnrichResult.reason` 欄位 + SSE `result-item` 帶 reason），**刻意不碰核心 `search_jav`、零 schema/DB 變更**。
+
+### Added
+#### 🎬 掃描頁補資料逐片進度卡 + 命中封面飛入
+- **逐片「工人在幹活」進度卡**：補資料時，進度區顯示「目前這片」的可視卡（番號從一開始就在，不等結果），取代乾計數器；五態可辨識——`搜尋中…`／命中封面浮現／`補到資料（無封面）`（文字非破圖）／`查無`（琥珀安靜一閃換片）／`失敗`（進 log）／`跳過（唯讀）`。**命中大聲、落空安靜**：只有真的補到可服務封面才飛入 + badge + 微光，其餘小 glyph 一閃就換片、不搶注意力。
+- **命中封面飛入圖書館（兩格待命位 + 延後飛）**：進度卡分兩格——左「待命格」停駐前一片命中封面、右格顯示目前搜尋中；命中封面先進待命格停一個搜尋週期（不一出現就飛），**下一片命中時**前一片才飛向側邊欄「瀏覽」入口（複用 spec-92 `playInboundFly`），run 結束時 flush 最後一片；落地 scale/glow + 側邊欄微光；進度卡上累計 badge（本次 run 補到資料片數，run 後淡出，不做持久紅點）。延後飛用真實補資料節奏當 dwell，讓每顆封面看得清；待命格容器恆渲染固定尺寸，飛入起點 rect 恆有效、免時序 race。
+- **手機／減少動態不靜默**：窄螢幕（側邊欄隱藏）逐片反饋交給本就可見的進度卡 + badge，收尾用既有 run-end summary toast（不做 per-item toast，避免批次刷屏）；減少動態下命中僅微光、不播飛行。
+
+### Internal
+- 後端只加「scraper parse → `EnrichResult.reason`」+ SSE `result-item` 帶 reason（`reason` ∈ hit／no_cover／not_found／error／readonly；normal 站台靠 `asdict` 自動流出、唯讀/例外站台字面補）；**`search_jav` 零改動**（`git diff` 該檔為空）。前端命中封面 URL 由 `file_path` 自組 `/api/gallery/thumb`，後端不吐 `cover_url`。`GET /api/capabilities` 的 batch_enrich `result_item` output_schema 同步補 `reason`。
+- **獨立 sonnet review 抓到並修復一個 bulk race（P1）**：bulk 下片 A 命中排了飛入後，片 B 的 progress 於同一同步 SSE chunk 覆寫進度卡狀態會隱藏片 A 的命中封面 img（rect=0），使片 A 的 `$nextTick` 讀到退化不飛。修法：飛入起點 `x-ref` 從會隱藏的 `<img>` 移到固定尺寸、恆渲染的容器 div，rect 跨換片穩定。
+- **Codex PR review P1**：`reason=hit` 原用「cover.jpg 磁碟真相」判，但前端命中封面走 `/api/gallery/thumb`，而 `/thumb` 硬性要求 DB `cover_path` 非空、不 fallback 磁碟 sidecar。兩者判準不同 → 「磁碟有 .jpg 但 DB cover_path 空」（掃描後才丟封面／db·nfo-sourced 命中跳過 `_db_upsert`）時卡片顯示 hit、`/thumb` 404 破圖、且該片仍留 missing_cover 清單。修：`reason=hit` 改為鏡射 `/thumb` 的 gate——所有寫檔完成後重讀 DB 最終狀態，`cover_path` 有值才 hit（散落 sidecar 未入 DB → 誠實回報 no_cover、不飛、不破圖）。含 P3 stale wording 併修。
+- **Codex PR #98 review P2**：上條只鏡射了 `/thumb` 第一道 gate（DB `cover_path` 非空）。但 `/thumb` cache miss/disabled 時還有第二道——要讀**實體封面檔**（`uri_to_local_fs_path` 反解後 generate／fallback），檔不在 → 404。故「DB 有記 `cover_path`、但實體封面檔已被刪/移／path_mapping 失效」時仍會誤判 hit → 飛入破圖。修：`reason=hit` 改為**同時**要求 DB `cover_path` 有值 **且**用 `/thumb` 同一解析確認實體檔存在（第三個互補回歸鎖固化；stale-WebP-cache 的 false-negative 是安全方向＝不破圖，已知接受）。
+
+### 測試
+- 全套 pytest **5521 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.8 的 5498 +23：reason 映射邊界〔hit/no_cover 依「/thumb 可服務真相＝DB cover_path 有值 + 實體檔存在」分流、not_found/error 各分支〕+ 三個互補 mutation-verified 回歸鎖〔擋「cover_written alone」+ 擋「退回磁碟真相」+ 擋「只鏡射 DB gate 漏實體檔」〕+ result-item 三站台 SSE reason 契約 + /thumb 時序鎖）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，dmm 經 JP proxy live）。
+- Gemini 3.1 Pro 整支 branch 第二意見：本輪未取得有效審查——agy headless 落入 apply-patch 假審模式（已知失敗態，見 AI_COLLABORATION 註記），已清理工作區殘留、確認 committed code 零污染；correctness 由 Codex auto-review（P1 已修）+ 獨立 sonnet review（P1 已修）覆蓋。
+- 視覺 hard-gate：進度卡五態 + 命中飛入節奏 + badge + 手機 fallback 由 owner 真機驗收。
+
+## [0.11.8] - 2026-07-09
+
+本版主軸：**各刮削來源的評分/簡介補進 NFO（NFO-only，服務媒體伺服器用戶）+ 燈箱中繼資訊美化**（feature/93，spec-93 A/B）——把各來源網站**已提供**的「評分/簡介」在刮削時一併抓出、寫進該片 NFO 的 `<rating>`/`<plot>`，純粹服務透過 OpenAver 唯讀產生庫 + `.strm` 餵 Jellyfin/Emby/Kodi 的用戶（那些媒體伺服器把 `<rating>`/`<plot>` 當顯示格，現在這些格不再是空的）。**OpenAver 自身介面刻意不顯示、不進 DB、不翻譯**——延續既有 US7「NFO-only」契約，owner 判斷評分擠高分帶區辨力低、簡介是行銷文案，對自身瀏覽低價值，顯示外包給 Jellyfin。另獨立做燈箱中繼資訊的視覺層次美化。零 API/schema/DB 變更。
+
+### Added
+#### 🎬 評分/簡介補進 NFO（媒體伺服器 enrichment）
+- **六個來源開始填評分 + 簡介**：刮到的評分一律正規化到 0–5，經既有 NFO writer ×2 輸出 Jellyfin 0–10 尺度。
+  - **評分**（7 源）：dmm / heyzo / 1pondo・10musume / jav321 / fc2 / javdb / caribbean。
+  - **簡介**（6 源）：dmm / heyzo / 1pondo・10musume / jav321 / fc2 / caribbean。
+  - javbus / avsox 站上無此兩格 → 不做。
+- **各來源取得方式**（除 DMM 評分外皆「同一請求免費、零額外請求」）：
+  - **DMM**：簡介＝主查詢已抓回的 `description` 接線；評分＝**獨立 root probe** `reviewSummary(contentId:){average}`（比照既有 genres/sample 三態 cache，schema 不支援即永久停用、probe 失敗降級不影響主 metadata，**硬性禁止擴充主 `DETAIL_QUERY`**——那是 DMM 命脈，未知欄位會讓全片刮不到）。
+  - **jav321**：同頁文字 `平均評価: N.N`（直接 0–5，非 GIF 形式，勿 ÷10）+ 描述 div。
+  - **fc2**：JSON-LD `aggregateRating.ratingValue`（支援單一物件／頂層陣列／`@graph` 包裹三形狀）+ 接既有已抽卻未使用的 `div.col.des` 簡介。
+  - **heyzo**：同一 JSON-LD `description`（評分早已抓）。
+  - **d2pass（1pondo/10musume）**：同一 phpauto JSON 加讀 `Desc` + rating 補 `<=5` sanity guard（擋畸形值）。
+  - **javdb**：`.panel-block` 文字 `評分: N.N分`（真實用戶評分；站上無簡介）。
+  - **caribbean**：其 phpauto JSON API 已全面死→改走 moviepage HTML fallback 解析 `itemprop="description"` 簡介 + `meta-rating` 星數 rune-count（0–5）評分（同一已抓 HTML、零額外請求）。
+
+### Changed
+#### 🎨 燈箱中繼資訊視覺層次
+- 燈箱詳情列（番號 · 片商 · 導演 · 片長 · 系列 · 發行商 · 發行日期）從同色扁平長串改為可掃讀：番號升一階色階（`--text-secondary`）+ 微加粗一眼可辨、欄位標籤微分層、中繼區以髮絲線（`--stroke-subtle`）與上方克制分隔。不加色塊/玻璃卡/accent 底，封面仍視覺主角。
+
+### Internal
+- 評分/簡介只改「scraper parse → `Video.rating`/`Video.summary`」這一段；carrier 產生（`internal_nfo_carriers`）、前端 strip（`strip_internal_nfo_keys`）、NFO fill-if-missing 寫入管線（`nfo_updater`/`organizer`/`enricher`/`readonly_producer`）皆為既有機制、不動；`needs_update()` 不把 plot/rating 列缺料（不觸發掃描頁「缺資料」提醒）。補回歸鎖 `TestNeedsUpdateNeverNagsPlotRating` 固化此契約。
+- **Codex PR review P1**：T2 的 D4-gap mutation 驗證用的 restore `sed` 無 count、over-match，把 `_probe_genres`/`_probe_sample_images`/`DETAIL_QUERY` 三個 `{'id': content_id}` payload 一併誤改成 `{'contentId'}`，但這三個 query 宣告的是 `$id` → `DETAIL_QUERY` 送 `contentId` 使 `ppvContent(id:null)` 失敗、DMM exact/producer/enrich 全掉；DMM unit test 全 mock 在 HTTP 層、對 query↔variables 契約盲故未攔到。已修（三 payload 還原 `id`，僅 review probe 保留 `contentId`）+ 補 `TestDMMProbePayloadVariables` 監看真實 POST 斷言各 method 送出的 variables key 對應其 query `$var`（mutation 驗證會攔）。**P2**：fc2 `_get_rating` 補 `{"@graph":[…]}` 包裹形狀防禦。
+- **Codex PR #97 re-review P2×3**（皆真實資料流 gap，HTTP-mock 單測看不到、靠讀真 fixture/merge 路徑抓）：〔P2-1〕自動模式 `source_merger.merge_results` backfill 欄位群含 `rating` 卻漏 `summary` → 贏的來源無簡介時合併後簡介遺失、NFO `<plot>` 恆空（多源模式下本功能形同虛設），修：`summary` 加進 `_STR_META_FIELDS`；〔P2-2〕`.get(k,'')` 在「欄位在、值 JSON null」時回 `None`，`Video.summary` 非 Optional str → `Video(summary=None)` 拋 ValidationError 被 broad except 吞 → 整片結果被丟，修：dmm/heyzo/d2pass 三處 `.get(k) or ''`；〔P2-3〕jav321 詳情頁真描述前有空 `.col-md-12` 佔位、`select_one` 停在空佔位 → summary 恆空（T3 合成 fixture 無此佔位故漏），修：scope 主 panel-body 取第一個非空 `.col-md-12`、用真實 fixture 鎖死。三者皆補回歸。
+- caribbean 覆蓋經 JP proxy live 驗證（解 plan-93 D9 defer）：其 JSON API 對真實現行番號全面 404，推翻「1pondo 同一 `_parse_json` 代表家族」假設 → caribbean 走 `_parse_caribbeancom_html`，補值落該 HTML fallback。
+- `core/scrapers/README.md` §1.4 新增「評分/簡介覆蓋（NFO-only）」矩陣。
+
+### 測試
+- 全套 pytest **5498 passed, 2 skipped**（unit + integration，排除 smoke／e2e，較 0.11.7 的 5447 +51：六源 rating/summary parse 邊界〔0–5 尺度、勿 ÷10 防呆、JSON-LD dict/list/@graph、rune-count 星數、正則 None fallback〕+ DMM `_probe_review` 三態＋降級不影響主 metadata＋query↔variables 契約守衛 + d2pass `<=5` guard 新舊對照 + fc2 dead 變數接線 + NFO 管線回歸鎖〔fill-if-missing 不覆蓋／不 nag plot/rating／echo 路徑空 plot〕+ Codex PR #97 re-review P2×3〔merge summary backfill／null 描述不丟片／jav321 空 col 佔位真實 fixture〕）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，dmm 經 JP proxy live）。
+- Gemini 3.1 Pro 整支 branch 第二意見：**LGTM、零 P1/P2**（跨源一致性、parse 防禦、UI 克制皆讚，無須修改）。
+- 視覺 hard-gate：燈箱 `.lb-details` 層次由 owner 真機驗收。
+
+## [0.11.7] - 2026-07-07
+
+本版主軸：**搜尋頁體驗優化（搜尋列不擠壓 + 整理發現性 + 入庫飛入動畫加強）**（feature/92，spec-92 A/B/C/D 四項）——純前端 UX polish + 一個 latent 正確性 bug 修復，零 API/schema/DB 變更。四個彼此獨立的痛點：搜尋列右側控制項擠壓變形、整理入口埋在頁尾難發現、整理入庫的「飛入側邊欄」動畫太不明顯、以及把該動畫抽成可跨頁複用的共用元件（本版只做 search 端接線，scanner 接線留未來 branch）。
+
+### Added
+#### 🎯 入庫飛入動畫加強（C）
+- **整理入庫回饋更有實感**：某片整理成功並寫進資料庫後，一顆封面 ghost 從該片飛向側邊欄「瀏覽」入口——改為三段節奏（起飛 → 於入口旁懸停約 0.5s 微發光讓眼睛看清是哪片 → 縮入落地並帶 scale 彈跳 + 光暈），取代舊版「抵達即淡掉的小點」。
+- **窄螢幕／手機不再靜默**：側邊欄隱藏時退化為「已入庫」輕量提示，不再毫無反饋；系統開啟「減少動態效果」時保留輕量落地反饋、不播飛行與縮放。
+
+#### 🎯 整理入口更好找（B）
+- **批次整理鈕常駐可見**：拖入一批檔案整理時，「批次整理 N 片」主動作恆在視線內（桌面靠既有固定插槽 + 表頭 sticky；窄視窗改貼底浮動列），不再因結果卡過高被推到畫面外要捲動才找得到。
+- **單片／批次整理各有可辨識 icon**：單片＝單一檔案 icon、批次＝資料夾 icon，一眼分辨；空狀態說明文字旁內嵌同款 icon + 同色，文字與畫面上那顆按鈕對得上。
+
+### Changed
+#### ⌨️ 搜尋列右側控制項不再擠壓變形（A）
+- **「自動」來源膠囊不變形**：在已有結果的頁面回搜尋框打新番號時，「自動」／來源名膠囊不再被壓縮擠壓；右側控制區預留足夠寬度（CDP 實測定值）容納最長來源名 + 清除 + 送出。
+- **格狀／詳情切換鈕穩定可見**：女優／前綴搜尋有結果時，格狀↔詳情切換鈕穩定可見可點、不被裁切；打字搜尋新片時暫時讓位屬預期，結果落定後回來。
+
+### Fixed
+- **不再出現「兩組相同的 ✕」**：在已有結果的頁面重新搜尋（含用「自動」膠囊重搜）進入載入態時，取消鈕與清除鈕不再並排出現兩顆一樣的 ✕——`hasContent` 由手動維護的旗標改為自動推導的 computed 值，根治整類「漏同步一處就出 bug」的結構性缺陷。
+- **整理飛入的封面永遠是「正確那片」**：先前在詳情檢視 X 片時、點清單裡另一片 Y 的「整理此片」，飛出去的會是 X 的封面；改為封面身份永久綁定被整理那片自己的資料（起飛位置才有條件借用目前顯示中的元素）。
+
+### Internal
+- 新增參數化共用動畫入口 `GhostFly.playInboundFly`（起點元素／封面 src／終點／fallback 由呼叫端傳入、不綁 search 專屬假設）取代 `playToIcon`：三段 timeline、對稱 `onComplete`/`onInterrupt` cleanup（C21，契約源 `playMobilePanelEnter/Exit`）、通用 scale/glow 落地反饋、並發序列化（`killTweensOf(toEl)` 讓最新落地勝出）。scanner 端接線留未來 branch（共用入口簽章刻意不含 search 假設）。
+- `hasContent` 改 Alpine computed getter（移除散落 7 處手動賦值）；`playToIcon` 移除並加 ESLint `no-restricted-syntax` 守衛（definition site + caller site 兩 scope，mutation 自驗 RED 防復活）。i18n 新 key `search.toast.db_synced_mobile` 只寫 zh_TW（其餘三語 fallback）。守衛一律走 ESLint 不落 pytest（本版測試數持平）。
+
+### 測試
+- 全套 pytest **5447 passed, 2 skipped**（unit + integration，排除 smoke／e2e，與 0.11.6 baseline 一致、零回歸；本版守衛全走 ESLint，故測試數持平）＋ `ruff check .` 綠 ＋ `npm run lint`（eslint + stylelint）綠。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live 健康檢查）。
+- ESLint 守衛 mutation 自驗：植入 `this.hasContent = ...`（Group 1）／`playToIcon` 定義或呼叫（Group 1 caller + Group 6 definition）皆轉 RED。
+- Codex 二審 F1（P2 並發落地反饋 race）已修（`killTweensOf` 序列化）；F2（P3，無現行回歸）記 accepted residual（`.gsap-animating` 通用性邊界＝各元件 scoped，現行 `#sidebar-showcase-link` 只 transition color/background 不觸 C21；未來 transform/filter transition 的 toEl caller 須補 scoped 規則，scanner 接線 branch 一併補、端到端驗）。
+- 視覺 hard-gate：owner 真機一次驗收通過（A pill 不變形／無兩組 X、B icon 辨識 + 常駐鈕、C 飛入節奏 + 手機 fallback）。
 
 ## [0.11.6] - 2026-07-06
 

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/en.json
+++ b/locales/en.json
@@ -843,7 +843,13 @@
       "tag_api_failed": "Failed to save tag, please try again",
       "user_tags_label": "Custom Tags",
       "alias_label": "Aliases",
-      "alias_source_hint": "Synced from Scanner"
+      "alias_source_hint": "Synced from Scanner",
+      "mask_toggle": "Cover crop preview",
+      "mask_detect_failed": "Focal detection failed. Please try again later.",
+      "mask_save_failed": "Failed to save crop settings. Please try again later.",
+      "mask_cover_changed": "Cover has changed. Please reopen the crop tool and try again.",
+      "mask_confirm": "Confirm crop position",
+      "mask_cancel": "Cancel crop adjustment"
     },
     "gallery": {
       "prev": "Previous (←)",
@@ -910,7 +916,12 @@
         "source_graphis": "Graphis",
         "source_gfriends": "gfriends",
         "source_wiki": "Wiki",
-        "source_minnano": "Minnano"
+        "source_minnano": "Minnano",
+        "source_upload": "Upload",
+        "upload_btn": "Upload your own photo",
+        "upload_too_large": "Image too large (max 10MB file, 50M pixels)",
+        "upload_bad_format": "Unsupported image format",
+        "upload_failed": "Upload failed. Please try again later."
       }
     },
     "samples": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -843,7 +843,13 @@
       "tag_api_failed": "タグの保存に失敗しました",
       "user_tags_label": "カスタムタグ",
       "alias_label": "別名",
-      "alias_source_hint": "Scanner から同期"
+      "alias_source_hint": "Scanner から同期",
+      "mask_toggle": "カバーの切り抜きプレビュー",
+      "mask_detect_failed": "焦点の検出に失敗しました。しばらくしてからもう一度お試しください。",
+      "mask_save_failed": "切り抜き設定の保存に失敗しました。しばらくしてからもう一度お試しください。",
+      "mask_cover_changed": "カバーが変更されました。切り抜きツールを開き直してもう一度お試しください。",
+      "mask_confirm": "切り抜き位置を確定",
+      "mask_cancel": "切り抜き調整をキャンセル"
     },
     "gallery": {
       "prev": "前の画像 (←)",
@@ -910,7 +916,12 @@
         "source_graphis": "Graphis",
         "source_gfriends": "gfriends",
         "source_wiki": "Wiki",
-        "source_minnano": "Minnano"
+        "source_minnano": "Minnano",
+        "source_upload": "アップロード",
+        "upload_btn": "自分の写真をアップロード",
+        "upload_too_large": "画像が大きすぎます（ファイル上限 10MB、サイズ上限 50M ピクセル）",
+        "upload_bad_format": "対応していない画像形式です",
+        "upload_failed": "アップロードに失敗しました。しばらくしてからもう一度お試しください。"
       }
     },
     "samples": {

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -843,7 +843,13 @@
       "tag_api_failed": "标签保存失败，请稍后再试",
       "user_tags_label": "自定义标签",
       "alias_label": "别名",
-      "alias_source_hint": "由 Scanner 同步"
+      "alias_source_hint": "由 Scanner 同步",
+      "mask_toggle": "封面裁切预览",
+      "mask_detect_failed": "焦点检测失败，请稍后再试",
+      "mask_save_failed": "裁切设置保存失败，请稍后再试",
+      "mask_cover_changed": "封面已变更，请重新打开裁切工具再试一次",
+      "mask_confirm": "确认裁切位置",
+      "mask_cancel": "取消裁切调整"
     },
     "gallery": {
       "prev": "上一张 (←)",
@@ -910,7 +916,12 @@
         "source_graphis": "Graphis",
         "source_gfriends": "gfriends",
         "source_wiki": "Wiki",
-        "source_minnano": "Minnano"
+        "source_minnano": "Minnano",
+        "source_upload": "上传",
+        "upload_btn": "上传自己的照片",
+        "upload_too_large": "图片太大（文件上限 10MB、尺寸上限 50M 像素）",
+        "upload_bad_format": "不支持的图片格式",
+        "upload_failed": "上传失败，请稍后再试"
       }
     },
     "samples": {

--- a/tests/integration/test_actress_photo.py
+++ b/tests/integration/test_actress_photo.py
@@ -442,13 +442,15 @@ class TestActressPathMappingsReverse:
 
         with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
              patch('web.routers.actress.init_db'), \
+             patch('web.routers.actress.AliasRepository') as mock_alias_repo_cls, \
              patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
              patch('web.routers.actress.crop_video_cover', return_value=b"fakejpeg") as mock_crop, \
              patch('web.routers.actress._write_actress_photo'), \
              patch('web.routers.actress.get_local_photo_path', return_value=fake_photo):
             mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
             mock_actress_repo_cls.return_value.save = MagicMock()
-            mock_video_repo_cls.return_value.get_videos_by_actress.return_value = [mock_video]
+            mock_alias_repo_cls.return_value.resolve.return_value = {"alice"}
+            mock_video_repo_cls.return_value.get_videos_by_actress_names.return_value = [mock_video]
 
             response = client.post(
                 "/api/actresses/alice/photo",

--- a/tests/integration/test_actress_photo.py
+++ b/tests/integration/test_actress_photo.py
@@ -176,6 +176,9 @@ def test_cloud_sources_use_primary_name_only(client):
     """
     雲端 scraper（graphis / gfriends / wiki / minnano）的 _fetch_single_source
     應收到 URL path param（即 "alice"），不被 alias set 污染。
+
+    本測試涵蓋 attempt 省略/0 情境；attempt>0 的雲端換名輪替行為見
+    test_cloud_attempt_rotation_sequence 等 TASK-102b-T1 輪替測試。
     """
     mock_actress = _make_mock_actress("alice")
     # photo_source=None → 所有雲端都在 cloud_sources
@@ -209,6 +212,217 @@ def test_cloud_sources_use_primary_name_only(client):
         assert name_arg == "alice", (
             f"雲端 scraper '{src_arg}' 收到 '{name_arg}'，應只收到 'alice'（primary/URL param）"
         )
+
+
+# ---------------------------------------------------------------------------
+# TASK-102b-T1: attempt query param 輪替（CD-1/CD-2/CD-6/CD-7/CD-8）
+# ---------------------------------------------------------------------------
+
+def test_cloud_attempt_rotation_sequence(client):
+    """
+    CD-6：mock resolve('alice') → {"alice","bob","cody"}。
+    attempt=0/1/2/3 之雲端 _fetch_single_source 收到的 name 依 sorted 序輪替：
+    alice → bob → cody → alice（sorted(["bob","cody"]) == ["bob","cody"]）。
+    attempt=1 這一格即 RED 先行斷言（DoD ⑦）：改端點前 param 被忽略，fetch name 仍是
+    "alice"，斷言 == "bob" 會先紅。
+    """
+    mock_actress = _make_mock_actress("alice")
+    mock_actress.photo_source = None  # 全部 4 源皆在 cloud_sources
+
+    mock_resolve = MagicMock(return_value={"alice", "bob", "cody"})
+    mock_get_videos = MagicMock(return_value=[])
+
+    expected_sequence = ["alice", "bob", "cody", "alice"]
+
+    for attempt, expected_name in enumerate(expected_sequence):
+        fetch_calls = []
+
+        def mock_fetch(name, src, _calls=fetch_calls):
+            _calls.append(name)
+            return None
+
+        with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+             patch('web.routers.actress.AliasRepository') as mock_alias_repo_cls, \
+             patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+             patch('web.routers.actress.init_db'), \
+             patch('web.routers.actress._fetch_single_source', side_effect=mock_fetch):
+
+            mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+            mock_alias_repo_cls.return_value.resolve = mock_resolve
+            mock_video_repo_cls.return_value.get_videos_by_actress_names = mock_get_videos
+
+            params = {} if attempt == 0 else {"attempt": attempt}
+            response = client.get("/api/actresses/alice/photo-candidates", params=params)
+            assert response.status_code == 200
+
+        assert fetch_calls, f"attempt={attempt} 應有雲端 fetch 呼叫"
+        assert all(n == expected_name for n in fetch_calls), (
+            f"attempt={attempt} 預期雲端 fetch name 全為 {expected_name!r}，實際: {fetch_calls}"
+        )
+
+
+def test_cloud_attempt_omitted_equals_attempt_zero(client):
+    """
+    省略 attempt 與 attempt=0 的雲端 fetch name 序列相同（spec §4.3-3）。
+    """
+    mock_actress = _make_mock_actress("alice")
+    mock_actress.photo_source = None
+
+    mock_resolve = MagicMock(return_value={"alice", "bob", "cody"})
+    mock_get_videos = MagicMock(return_value=[])
+
+    def _run(params):
+        fetch_calls = []
+
+        def mock_fetch(name, src, _calls=fetch_calls):
+            _calls.append(name)
+            return None
+
+        with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+             patch('web.routers.actress.AliasRepository') as mock_alias_repo_cls, \
+             patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+             patch('web.routers.actress.init_db'), \
+             patch('web.routers.actress._fetch_single_source', side_effect=mock_fetch):
+
+            mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+            mock_alias_repo_cls.return_value.resolve = mock_resolve
+            mock_video_repo_cls.return_value.get_videos_by_actress_names = mock_get_videos
+
+            response = client.get("/api/actresses/alice/photo-candidates", params=params)
+            assert response.status_code == 200
+        return fetch_calls
+
+    omitted = _run({})
+    explicit_zero = _run({"attempt": 0})
+    assert omitted and explicit_zero, "應有雲端 fetch 呼叫"
+    assert set(omitted) == set(explicit_zero) == {"alice"}
+    assert len(omitted) == len(explicit_zero)
+
+
+def test_cloud_attempt_no_alias_degrades(client):
+    """
+    無 alias 退化（spec §4.1-6）：resolve('dana') → {"dana"}，attempt=5 → fetch name
+    仍是 "dana"，行為與省略時一致。
+    """
+    mock_actress = _make_mock_actress("dana")
+    mock_actress.photo_source = None
+
+    mock_resolve = MagicMock(return_value={"dana"})
+    mock_get_videos = MagicMock(return_value=[])
+    fetch_calls = []
+
+    def mock_fetch(name, src):
+        fetch_calls.append(name)
+        return None
+
+    with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+         patch('web.routers.actress.AliasRepository') as mock_alias_repo_cls, \
+         patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+         patch('web.routers.actress.init_db'), \
+         patch('web.routers.actress._fetch_single_source', side_effect=mock_fetch):
+
+        mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+        mock_alias_repo_cls.return_value.resolve = mock_resolve
+        mock_video_repo_cls.return_value.get_videos_by_actress_names = mock_get_videos
+
+        response = client.get(
+            "/api/actresses/dana/photo-candidates", params={"attempt": 5}
+        )
+        assert response.status_code == 200
+
+    assert fetch_calls, "應有雲端 fetch 呼叫"
+    assert all(n == "dana" for n in fetch_calls), (
+        f"無 alias 女優 attempt=5 應仍以 'dana' 查詢，實際: {fetch_calls}"
+    )
+
+
+def test_cloud_attempt_local_crop_unaffected(client):
+    """
+    本機補位不受輪替影響（spec §4.3-5）：attempt=2 時 get_videos_by_actress_names
+    仍收到全展開 set，resolve() 仍以請求 name（"alice"）呼叫。
+    """
+    mock_actress = _make_mock_actress("alice")
+    mock_actress.photo_source = None
+
+    mock_resolve = MagicMock(return_value={"alice", "bob", "cody"})
+    mock_get_videos = MagicMock(return_value=[])
+
+    with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+         patch('web.routers.actress.AliasRepository') as mock_alias_repo_cls, \
+         patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+         patch('web.routers.actress.init_db'), \
+         patch('web.routers.actress._fetch_single_source', return_value=None):
+
+        mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+        mock_alias_repo_cls.return_value.resolve = mock_resolve
+        mock_video_repo_cls.return_value.get_videos_by_actress_names = mock_get_videos
+
+        response = client.get(
+            "/api/actresses/alice/photo-candidates", params={"attempt": 2}
+        )
+        assert response.status_code == 200
+
+    # resolve() 至少被以請求 name "alice" 呼叫過（_resolve_query_names 與
+    # _get_random_videos_with_covers 各呼叫一次，皆以 "alice"）
+    assert call("alice") in mock_resolve.call_args_list
+
+    assert mock_get_videos.called
+    called_names = mock_get_videos.call_args[0][0]
+    assert set(called_names) == {"alice", "bob", "cody"}
+
+
+def test_cloud_attempt_boundary_invalid_returns_422(client):
+    """CD-8：attempt=-1 / attempt=abc → FastAPI 422。"""
+    with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+         patch('web.routers.actress.init_db'):
+        mock_actress_repo_cls.return_value.get_by_name.return_value = _make_mock_actress("alice")
+
+        response = client.get(
+            "/api/actresses/alice/photo-candidates", params={"attempt": -1}
+        )
+        assert response.status_code == 422
+
+        response = client.get(
+            "/api/actresses/alice/photo-candidates", params={"attempt": "abc"}
+        )
+        assert response.status_code == 422
+
+
+def test_cloud_attempt_boundary_large_int(client):
+    """
+    CD-8：attempt=10**9 → 200，modulo 正確算出。
+    names = ["alice", "bob", "cody"]（len=3）；10**9 % 3 == 1 → query_name == "bob"。
+    """
+    mock_actress = _make_mock_actress("alice")
+    mock_actress.photo_source = None
+
+    mock_resolve = MagicMock(return_value={"alice", "bob", "cody"})
+    mock_get_videos = MagicMock(return_value=[])
+    fetch_calls = []
+
+    def mock_fetch(name, src):
+        fetch_calls.append(name)
+        return None
+
+    with patch('web.routers.actress.ActressRepository') as mock_actress_repo_cls, \
+         patch('web.routers.actress.AliasRepository') as mock_alias_repo_cls, \
+         patch('web.routers.actress.VideoRepository') as mock_video_repo_cls, \
+         patch('web.routers.actress.init_db'), \
+         patch('web.routers.actress._fetch_single_source', side_effect=mock_fetch):
+
+        mock_actress_repo_cls.return_value.get_by_name.return_value = mock_actress
+        mock_alias_repo_cls.return_value.resolve = mock_resolve
+        mock_video_repo_cls.return_value.get_videos_by_actress_names = mock_get_videos
+
+        response = client.get(
+            "/api/actresses/alice/photo-candidates", params={"attempt": 10**9}
+        )
+        assert response.status_code == 200
+
+    assert fetch_calls, "應有雲端 fetch 呼叫"
+    assert all(n == "bob" for n in fetch_calls), (
+        f"attempt=10**9 modulo 應算出 'bob'，實際: {fetch_calls}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_api_actress.py
+++ b/tests/integration/test_api_actress.py
@@ -1413,6 +1413,121 @@ class TestSetActressPhoto:
         assert local_data["crop_mode"] == "auto"
         assert set(local_data.keys()) == {"photo_url", "photo_source", "auto_focal", "crop_mode"}
 
+    # ---- TASK-102a-T1: alias 展開對稱（RED→GREEN） ----
+
+    def test_set_actress_photo_local_crop_alias_video_success(self, client, tmp_db, tmp_path):
+        """別名片候選儲存：片子掛在別名（非主名）名下，POST 仍須成功（spec-102 §3.1-1）。
+
+        修碼前紅在 404 video_or_cover_not_found（_get_actress_videos 只用主名單查）；
+        修碼後 200，比照 test_set_actress_photo_local_crop_success 的斷言深度。
+        """
+        from core.database import AliasRepository, VideoRepository, Video
+
+        self._save_actress(client)
+        alias_name = "別名A"
+        # _save_actress → favorite 端點已透過 sync_from_favorite 建立 ACTRESS_NAME 的
+        # primary alias 群組（aliases=[]），因此這裡用 add_alias 掛新別名，而非 add()
+        # 新建群組（add() 對已存在的 primary_name 會拋 ValueError）。
+        ok, err = AliasRepository().add_alias(ACTRESS_NAME, alias_name)
+        assert ok, f"add_alias 失敗: {err}"
+
+        video_path = str(tmp_path / "alias_video.mp4")
+        cover_path = str(tmp_path / "alias_cover.jpg")
+        Path(cover_path).write_bytes(b"\xff\xd8\xff\xe0fake_alias_cover")
+        video = Video(
+            path=video_path,
+            title="Alias Video",
+            actresses=[alias_name],
+            cover_path=cover_path,
+        )
+        VideoRepository().upsert(video)
+        video_uri = f"file://{video_path}"
+        fake_jpeg = b"\xff\xd8\xff\xe0FAKE_ALIAS_CROP_JPEG"
+
+        gfriends = tmp_path / "gfriends"
+        gfriends.mkdir()
+        with patch("web.routers.actress.crop_video_cover", return_value=fake_jpeg), \
+             patch("web.routers.actress.GFRIENDS_DIR", gfriends), \
+             patch("core.actress_photo.GFRIENDS_DIR", gfriends):
+            resp = client.post(
+                f"/api/actresses/{ACTRESS_NAME}/photo",
+                json={"source": "local_crop", "video_path": video_uri},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["photo_source"] == "local_crop"
+        assert "?v=" in data["photo_url"]
+        written = list(gfriends.glob("*.jpg"))
+        assert len(written) == 1
+        assert written[0].read_bytes() == fake_jpeg
+
+    def test_set_actress_photo_local_crop_unrelated_actress_still_404(self, client, tmp_db, tmp_path):
+        """偽造路徑：片子掛在「無關女優」名下（不在目標 alias set 內），仍須 404
+        （spec-102 §3.1-2 安全邊界不動）。
+        """
+        from core.database import AliasRepository, VideoRepository, Video
+
+        self._save_actress(client)
+        ok, err = AliasRepository().add_alias(ACTRESS_NAME, "別名A")
+        assert ok, f"add_alias 失敗: {err}"
+
+        unrelated_video_path = str(tmp_path / "unrelated_video.mp4")
+        unrelated_cover_path = str(tmp_path / "unrelated_cover.jpg")
+        Path(unrelated_cover_path).write_bytes(b"\xff\xd8\xff\xe0fake_unrelated_cover")
+        video = Video(
+            path=unrelated_video_path,
+            title="Unrelated Video",
+            actresses=["無關女優XYZ"],
+            cover_path=unrelated_cover_path,
+        )
+        VideoRepository().upsert(video)
+        video_uri = f"file://{unrelated_video_path}"
+
+        resp = client.post(
+            f"/api/actresses/{ACTRESS_NAME}/photo",
+            json={"source": "local_crop", "video_path": video_uri},
+        )
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "video_or_cover_not_found"
+
+    def test_set_actress_photo_local_crop_uses_alias_resolve_symmetrically(self, client, tmp_db, tmp_path):
+        """對稱守衛：local_crop 儲存路徑必須呼叫 AliasRepository.resolve(name) 且
+        VideoRepository.get_videos_by_actress_names 收到展開後的多名 list（與候選端
+        _get_random_videos_with_covers 同一對 API，spec-102 §3.2 / plan-102a CD-3）。
+        """
+        from core.database import VideoRepository
+
+        self._save_actress(client)
+        video_path, cover_path = self._save_video_with_cover(tmp_path)
+        video_uri = f"file://{video_path}"
+        fake_jpeg = b"\xff\xd8\xff\xe0FAKE_SYMMETRY_JPEG"
+
+        gfriends = tmp_path / "gfriends"
+        gfriends.mkdir()
+
+        with patch("web.routers.actress.AliasRepository") as mock_alias_repo_cls, \
+             patch("web.routers.actress.VideoRepository") as mock_video_repo_cls, \
+             patch("web.routers.actress.crop_video_cover", return_value=fake_jpeg), \
+             patch("web.routers.actress.GFRIENDS_DIR", gfriends), \
+             patch("core.actress_photo.GFRIENDS_DIR", gfriends):
+            mock_alias_repo_cls.return_value.resolve.return_value = {ACTRESS_NAME, "別名A"}
+            real_video_repo = VideoRepository()
+            mock_video_repo_cls.return_value.get_videos_by_actress_names.side_effect = (
+                real_video_repo.get_videos_by_actress_names
+            )
+
+            resp = client.post(
+                f"/api/actresses/{ACTRESS_NAME}/photo",
+                json={"source": "local_crop", "video_path": video_uri},
+            )
+
+        assert resp.status_code == 200
+        mock_alias_repo_cls.return_value.resolve.assert_called_once_with(ACTRESS_NAME)
+        mock_video_repo_cls.return_value.get_videos_by_actress_names.assert_called_once()
+        called_names = mock_video_repo_cls.return_value.get_videos_by_actress_names.call_args[0][0]
+        assert set(called_names) == {ACTRESS_NAME, "別名A"}
+
 
 # ---------------------------------------------------------------------------
 # T2 (TASK-100a-T2): POST /api/actresses/{name}/photo/upload — 女優照片上傳

--- a/tests/integration/test_api_actress.py
+++ b/tests/integration/test_api_actress.py
@@ -1441,7 +1441,7 @@ class TestSetActressPhoto:
             cover_path=cover_path,
         )
         VideoRepository().upsert(video)
-        video_uri = f"file://{video_path}"
+        video_uri = to_file_uri(video_path)
         fake_jpeg = b"\xff\xd8\xff\xe0FAKE_ALIAS_CROP_JPEG"
 
         gfriends = tmp_path / "gfriends"
@@ -1482,7 +1482,7 @@ class TestSetActressPhoto:
             cover_path=unrelated_cover_path,
         )
         VideoRepository().upsert(video)
-        video_uri = f"file://{unrelated_video_path}"
+        video_uri = to_file_uri(unrelated_video_path)
 
         resp = client.post(
             f"/api/actresses/{ACTRESS_NAME}/photo",
@@ -1500,7 +1500,7 @@ class TestSetActressPhoto:
 
         self._save_actress(client)
         video_path, cover_path = self._save_video_with_cover(tmp_path)
-        video_uri = f"file://{video_path}"
+        video_uri = to_file_uri(video_path)
         fake_jpeg = b"\xff\xd8\xff\xe0FAKE_SYMMETRY_JPEG"
 
         gfriends = tmp_path / "gfriends"

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -505,8 +505,15 @@ def _load_actress(name: str):
 
 
 def _get_actress_videos(name: str) -> list:
-    """Threadpool helper: fetch videos for actress (init_db already ran in _load_actress)."""
-    return VideoRepository().get_videos_by_actress(name)
+    """Threadpool helper: fetch videos across the actress's alias set
+    (init_db already ran in _load_actress).
+
+    Part A（spec-102 §3）：與候選端 _get_random_videos_with_covers 同一對
+    API（resolve + get_videos_by_actress_names），兩端對稱——別名片候選
+    才通得過儲存驗證。無 alias 時 resolve 回 {name}，行為等價舊版單名查詢。
+    """
+    names = list(AliasRepository().resolve(name))
+    return VideoRepository().get_videos_by_actress_names(names)
 
 
 def _write_actress_photo(name: str, crop_bytes: bytes, ext: str = ".jpg") -> None:

--- a/web/routers/actress.py
+++ b/web/routers/actress.py
@@ -20,7 +20,7 @@ from io import BytesIO
 from typing import Optional, List
 from urllib.parse import quote
 
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, UploadFile, File, Query
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel
 from PIL import Image
@@ -397,11 +397,15 @@ def _get_random_videos_with_covers(actress_name: str, count: int) -> list:
 # ---------------------------------------------------------------------------
 
 @router.get("/{name}/photo-candidates")
-async def list_photo_candidates(name: str):
+async def list_photo_candidates(name: str, attempt: int = Query(0, ge=0)):
     """
     SSE 串流回傳女優候選照片（最多 6 張）。
     雲端 0–3 張並行抓取 + 本機影片封面 crop 補足至 6 張。
     actress 不存在 → JSONResponse 404。
+
+    attempt（TASK-102b-T1，spec-102 Part B）：optional 輪替序號，stateless。
+    0/省略＝請求 name；N>0＝依 alias 穩定排序輪替雲端查詢名，只影響雲端 4 源，
+    本機補位與 current_source 排除邏輯不受影響（CD-7）。
     """
     _, actress = await asyncio.to_thread(_load_actress, name)
     if actress is None:
@@ -413,6 +417,27 @@ async def list_photo_candidates(name: str):
     current_source = actress.photo_source
     cloud_sources = [s for s in ["graphis", "gfriends", "wiki", "minnano"] if s != current_source]
 
+    def _resolve_query_names(n: str) -> list:
+        # CD-2：序位 0 = 請求的 name（URL path param），不是 record.primary_name。
+        # resolve() 是雙向解析——若燈箱女優名恰是 alias-hit，取 record primary 當
+        # 序位 0 會讓 attempt=0 的查詢名與 0.12.3 不同，破壞「無 alias／既有路徑
+        # 逐位一致」的回歸底線。正常情境（請求名＝主名）下與 spec §4.2「主名固定
+        # 第一」等價。其餘名字用 sorted() 保穩定序（resolve() 回傳的是無序 set）。
+        resolved = AliasRepository().resolve(n)  # set；miss → {n}
+        return [n] + sorted(resolved - {n})
+
+    if attempt == 0:
+        # names[0] 恆為請求 name（見上方 CD-2 註解），attempt=0 不需要 resolve()
+        # 就能算出 query_name==name——省一次 DB 呼叫，也讓 attempt 省略/0 的路徑
+        # 與 0.12.3（未帶輪替邏輯前）resolve() 呼叫次數逐位一致，不動既有回歸測試。
+        query_name = name
+    else:
+        names = await asyncio.to_thread(_resolve_query_names, name)
+        query_name = names[attempt % len(names)]  # len(names) >= 1 恆成立
+    logger.info(
+        "[actress] photo-candidates attempt=%d query_name=%s", attempt, query_name
+    )  # CD-10(b)：不對此行寫斷言
+
     async def generate():
         total = 0
         max_cloud = 3
@@ -421,7 +446,7 @@ async def list_photo_candidates(name: str):
         async def fetch_source(src: str):
             try:
                 url = await asyncio.wait_for(
-                    asyncio.to_thread(_fetch_single_source, name, src),
+                    asyncio.to_thread(_fetch_single_source, query_name, src),
                     timeout=5.0,
                 )
                 return (src, url)

--- a/web/routers/capabilities.py
+++ b/web/routers/capabilities.py
@@ -950,6 +950,11 @@ _TOOLS: list[dict] = [
                     "type": "string",
                     "description": "女優名稱（URL path parameter，需 URL encode）",
                 },
+                "attempt": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "重抓輪替序號：0/省略=主名；N=依 alias 穩定排序輪替，無 alias 時任意 N 行為同 0",
+                },
             },
             "required": ["name"],
         },

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -148,6 +148,9 @@ export function stateLightbox() {
         _pickerCurrentSource: null,
         _pickerFloatTweens: [],
         _pickerRunId: 0,
+        // 102b T2: 🔄 輪替序號。歸零只在 openActressPicker 首開判別（CD-4），
+        // ⛔ 不進 _resetPicker——那也是 🔄 重抓路徑的一環，在 reset 清會抹掉剛 +1 的值。
+        _pickerAttempt: 0,
         _pickerSSE: null,
         _pickerBurstFired: false,       // SSE 收齊後一次 burst（防 done/error 重複觸發）
         _pickerReadyAbort: null,        // T3: _burstAllPickerCandidates waitForMount 的 per-run AbortController
@@ -1720,6 +1723,11 @@ export function stateLightbox() {
             // _onPickerSelect 皆同款 early-return，裁決 5）。
             if (this._pickerSelected) return;
 
+            // 102b T2 (CD-4)：🔴 必須在 _resetPicker()（下方會把 _pickerOpen 翻 false）
+            // 之前讀 _pickerOpen 判別首開/重抓——換女優必經關→開，歸零由結構保證。
+            if (this._pickerOpen) { this._pickerAttempt++; }   // 🔄 重抓（同一 picker session）
+            else { this._pickerAttempt = 0; }                  // 首開（含換女優後首開）→ 主名重來
+
             // Tear down any in-flight SSE before starting a new one
             if (this._pickerSSE) { this._pickerSSE.close(); this._pickerSSE = null; }
 
@@ -1787,7 +1795,10 @@ export function stateLightbox() {
          * 超過數秒，誤殺會讓用戶只看到雲端那張。連線中斷由 EventSource onerror 兜底。
          */
         _startPickerSSE(name, runId) {
-            const url = `/api/actresses/${encodeURIComponent(name)}/photo-candidates`;
+            // 102b T2 (CD-5)：0 不帶參數（首開 URL 與 0.12.3 逐位一致）；
+            // 顯式 > 0 而非 truthiness（0 是合法值，gotchas「|| 吞 numeric 0」）
+            const url = `/api/actresses/${encodeURIComponent(name)}/photo-candidates`
+                + (this._pickerAttempt > 0 ? `?attempt=${this._pickerAttempt}` : '');
             const sse = new EventSource(url);
             this._pickerSSE = sse;
             this._pickerBurstFired = false;
@@ -2124,6 +2135,8 @@ export function stateLightbox() {
          * 內部 reset：清空候選 + kill float tweens
          */
         _resetPicker() {
+            // 102b T2: ⛔ 不清 _pickerAttempt——本函式也是 🔄 重抓路徑的一環
+            // （openActressPicker :1727 會呼叫），在此清會抹掉剛 +1 的值。
             this._pickerOpen = false;
             this._pickerLoading = false;
             this._pickerSelected = false;

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -1753,9 +1753,13 @@ export function stateLightbox() {
          */
         async _burstAllPickerCandidates(runId) {
             if (this._pickerRunId !== runId) return;
-            if (this._candidates.length === 0) return;
             if (this._pickerBurstFired) return;     // 防 done/timeout/error 重複觸發
             this._pickerBurstFired = true;          // dedup latch 維持在等待前（位置不動）
+            // Codex PR#111 一審 P2：0 候選（改名女優主名 0 命中的典型情境）也要落 latch，
+            // 否則 🔄（x-show="_pickerBurstFired"，showcase.html:1064）永遠不出現，
+            // 用戶卡死在 attempt 0 無法換別名重抓。_pickerLoading 已在呼叫端（done/onerror
+            // handler）設為 false，此處不需重複處理。
+            if (this._candidates.length === 0) return;
 
             // T3（CD-3/CD-3a）：waitForMount 等候選卡 mount 取代 $nextTick。predicate 用
             // expected（burst 時 _candidates 已定，SSE 已 close 不再增）非硬編；observer root =


### PR DESCRIPTION
## Summary

feature/102-alias-photo（v0.12.4）修「改過名（有別名）的女優換照片特別難」的兩個問題：

- **Part A（fix）**：picker 本機 crop 候選只要來自別名片，一選必 404「抓取失敗」。根因＝候選端 alias 展開、儲存驗證端單名查詢的不對稱；修法＝`_get_actress_videos` 改用與候選端同一對 API（`AliasRepository.resolve` + `get_videos_by_actress_names`）。安全邊界不放寬（偽造路徑仍 404）、無 alias 女優零行為變更、offload 靜態守衛不動。
- **Part B（feat）**：picker 🔄 重抓時雲端查詢名 stateless 輪替（`attempt` query param、modulo 選名、`attempt=0` 與 0.12.3 逐位一致含 DB 呼叫序）；前端 `_pickerAttempt` 計數器（首開歸零／重抓 +1，UI 零改動）；capabilities input_schema 同步 optional `attempt`。

## Task → Commit 對照

| Task | Commit | 內容 |
|---|---|---|
| 102a-T1 | `121d5c54` | alias 展開對稱（3 行）+3 測試 + WSL/UNC mock 同步 |
| 102a-T2 | `47a11b7b` | mutation 驗證標記（3 紅 137 綠形狀正確）|
| 102b-T1 | `2bda6a01` | 後端輪替 + capabilities（+6 測試，RED 先行）|
| 102b-T2 | `b9a32e61` | 前端計數器 +14/-1（CDP 6/6 PASS）|
| Codex P0 | `23feda93` | 測試手刻 file:// URI → to_file_uri（二審通過）|

## 驗證

- 全套 pytest **5348 passed, 1 skipped**＋`ruff check .` 綠＋`npm run lint` 綠（static_guard_lint 1034）＋`npm test` 118 綠
- **8 源金絲雀全 PASS**（live）
- **CDP 真機實測**：輪替全序列（主名→川北メイサ→沢北みなみ→繞回）、換人歸零、無 alias 逐位一致、儲存身分 200（驗後資料還原）
- 每 task 獨立 Sonnet review；Gemini 整支 branch 第二意見 5 條 findings 全 triage 為既有設計已覆蓋（0 採納）

## Plan deviations（已裁決 ACCEPT）

- `attempt==0` 短路跳過 `resolve()`（與 plan 偽碼逐值等價；既有 Case 1 call-count 斷言的必要保護，attempt=0 含 DB 呼叫序與 0.12.3 逐位一致）

## Accepted residuals

- `sorted()` mutation 檢查因 str hash randomization 非確定性紅（偵測強度缺口，非出貨碼缺陷；production 確有 sorted()）
- picker 卡 GSAP idle-float 令 Playwright actionability wait 不收斂（CDP 測試用 page.mouse 座標真點擊 workaround；gotcha 候選已記 TASK card）

🤖 Generated with [Claude Code](https://claude.com/claude-code)