### PR TITLE
feature/105: 唯讀/非唯讀「判斷與回報層」單一化（v0.12.7）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.7] - 2026-07-22
+
+本版是一次「內部收斂＋順手修 bug」（feature/105）：把唯讀來源與一般來源在「刮完之後怎麼記帳、怎麼回報」這層——原本被抄成四份、每次改都漏抄一份的判斷邏輯——收斂成**單一實作、兩邊共用**，並替它上了機械守衛（債長不回來）。**絕大部分對使用者隱形**，實際會被感受到的是下面四個修復。
+
+### Fixed
+- **唯讀片不再誤顯示破圖**：唯讀來源的片在重刮／補缺時，若輸出夾的封面圖檔已被刪除、或跨機器路徑對不上（DB 還記著、磁碟其實沒有），以前會誤判「有封面」、讓介面拉出一張不存在的縮圖（破圖）。本版改為**實際檢查磁碟上封面在不在**，與一般來源完全一致。
+- **重刮不再清空原文標題**：一般來源的片重刮時，若這次線上刮不到原文標題（originaltitle），以前會把**既有的原文標題清空**（資料庫與 NFO 都被清）。本版改為刮不到就**保留既有值**（此修復唯讀側早已有、這次補回一般側）。
+- **某些片重刮不再失敗**：承上，在「既有原文標題本來就是空的 + 這次也刮不到」的特定組合下，重刮會在產生 NFO 時崩潰、該片補料失敗。本版一併修好（原文標題一律以空字串處理，不會變成無效值）。
+- **批次補料單片出錯不再拖垮整批**：批次補料時，若某一片在前置解析階段就出錯，以前會**整批掛掉**；本版改為**只有該片失敗、其餘照常完成**（與一般片的逐片錯誤隔離一致）。
+
+### Internal
+純內部工程，對使用者無感、零行為變更（除上述四個 bugfix）：
+- **第②層「寫後記帳＋回報」收斂**：把「有沒有可服務的封面／要不要保留既有封面／原文標題保留／回報 `hit`/`no_cover`/`not_found`/`error`」這四類判斷，從 enricher 一份＋唯讀三分支各一份（共四份手抄）收斂成單一實作。本該與一般來源相同的部分抽進新的中性模組 `core/enrich_contract.py`（兩邊都 import、無循環依賴）；唯讀限定的部分（not-found 樁列、失敗形狀）收進 `core/readonly_producer.py`；封面寫入後的焦點記帳三份拷貝收進 `core/focal_trigger.py`。刻意的唯讀／非唯讀差異（唯讀恆寫 NFO、`fields_filled` 語意）以**參數**表達、不開第二套實作。
+- **防漂移雙機械閘**：新增 AST 靜態結構守衛（鎖「每個判斷只有一份、呼叫端都改呼叫同一份、舊手抄指紋不得復生」）＋ 唯讀/非唯讀 contract-parity 測試（等價輸入下兩路徑可比欄位相等 + 全欄位歸類 fail-loud，未來新增欄位漏鏡射即報紅）。這是「一勞永逸」的核心——讓第②層不會再長出第五份拷貝。
+- 第①層（拿哪份 metadata／封面）與第③層（實際寫檔演算法）維持**刻意分歧、完全不動**（唯讀 local-first 零連網 vs 一般 DB→NFO→scraper merge；就地補寫 vs 整體 regenerate 進輸出夾）。
+
+### 測試
+- 全套 pytest **5603 passed, 1 skipped**（unit + integration，排除 smoke／e2e）＋ `ruff check .` 綠 ＋ `npm run lint` 綠（static_guard 1031／css-guard／cjk_guard；i18n 102 缺 key 為既往版本 milestone 同步項、非本版）。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live）。
+- 新增守衛：AST 結構守衛（`test_enrich_contract_structure.py`）＋ contract-parity（`test_readonly_enrich_contract_parity.py`）＋ 六支共用 helper/建構器 unit（`test_enrich_contract.py`）＋ focal 收斂 unit（`test_focal_trigger.py`）；兩支防漂移守衛皆做 mutation 自驗（拿掉呼叫／植入舊指紋／回退 helper → 對應守衛真的變紅）。
+- 每 task 獨立 Sonnet review（T7 抓到負向鎖指紋硬編變數名 `existing`、漏掉主 target 用的 `existing_record` 近空殼，已放寬為錨定 attribute shape）＋ grok 整支 branch 第二意見（**提 1／採納 1／假陽性 0／未查證 0／增量 1**）：抓到本 branch 引入、四層 review 皆漏的回歸——原文標題保留 helper 在「DB 既有值為 SQL NULL＋這次刮不到」時回傳 `None`（而非 `''`），會讓 NFO 產生崩潰；已修為回傳恆為字串。
+- 本版無新增 i18n key（純後端 + 守衛）。
+
 ## [0.12.6] - 2026-07-21
 
 本版讓「唯讀來源」（通常是雲端分享盤）變聰明了：如果那個盤本身已經是整理好的媒體庫（影片旁邊就附了 `.nfo` 和封面圖），OpenAver 會**直接讀用它現成的資料**，不再無視它、傻傻地重新上網刮一次——更快、更省流量、也更準（撞號抓錯的問題在已整理的庫直接消失）。同時，唯讀來源的片現在也能用放大鏡補料、齒輪重刮、補劇照，而且產物一律落在獨立輸出夾，**絕不會寫回你的唯讀盤**。

--- a/core/enrich_contract.py
+++ b/core/enrich_contract.py
@@ -37,6 +37,18 @@ def cover_uri_is_servable(cover_uri, path_mappings) -> bool:
     return bool(cover_uri) and os.path.exists(uri_to_local_fs_path(cover_uri, path_mappings))
 
 
+def should_preserve_cover(write_cover, overwrite_existing, cover_exists) -> bool:
+    """純政策：這次是否「不寫封面、保留既有」。cover_exists 由呼叫端各自算
+    （非唯讀 with_suffix('.jpg') 來源旁；唯讀 cover_uri_is_servable 走 DB
+    cover_path + path-mapping）——政策共用、封面定位各異（spec §5 末項）。"""
+    return (not write_cover) or (cover_exists and not overwrite_existing)
+
+
+def apply_cover_preserve(strategy, write_cover, overwrite_existing, cover_exists):
+    """gate→strategy 接線：命中保留 → ('none',)（不產出檔案）；否則原 strategy。"""
+    return ('none',) if should_preserve_cover(write_cover, overwrite_existing, cover_exists) else strategy
+
+
 def compute_has_servable_cover(repo, path_uri, path_mappings) -> bool:
     """寫完 + commit 後重讀 DB 最終 cover_path，再確認實體封面檔是否服務得到。
 

--- a/core/enrich_contract.py
+++ b/core/enrich_contract.py
@@ -27,6 +27,34 @@ class EnrichResult:
     reason: Optional[str] = None
 
 
+def enrich_success(*, nfo_written, cover_written, extrafanart_written,
+                   fields_filled, source_used,
+                   has_servable_cover=None, reason=None) -> EnrichResult:
+    """成功 EnrichResult 建構器（feature/105，CD-105-7）。
+
+    六個成功構造（enricher tail / fetch_samples_only / 唯讀 enrich-single /
+    唯讀 samples ×2 / batch 唯讀）物理共用此份，消除「成功回報 shape 漏鏡射」漂移。
+
+    reason 派生單一住此：`has_servable_cover is not None`（有封面站）→ 派生
+    'hit'/'no_cover'（覆蓋 reason 參數）；為 None（samples 站）→ 用顯式 reason 參數。
+    `success=True`／`error=None` 恆定。其餘欄位（nfo_written / extrafanart_written /
+    fields_filled / source_used）builder 不計算，原樣塞入——刻意差異全由呼叫端實參表達
+    （CD-105-6-4：不開第二套函式）。keyword-only 避免位置錯位。
+    """
+    if has_servable_cover is not None:
+        reason = "hit" if has_servable_cover else "no_cover"
+    return EnrichResult(
+        success=True,
+        error=None,
+        nfo_written=nfo_written,
+        cover_written=cover_written,
+        extrafanart_written=extrafanart_written,
+        fields_filled=fields_filled,
+        source_used=source_used,
+        reason=reason,
+    )
+
+
 def cover_uri_is_servable(cover_uri, path_mappings) -> bool:
     """封面 URI 是否「前端 /thumb 真的服務得到」的最小磁碟真相原子。
 

--- a/core/enrich_contract.py
+++ b/core/enrich_contract.py
@@ -49,6 +49,13 @@ def apply_cover_preserve(strategy, write_cover, overwrite_existing, cover_exists
     return ('none',) if should_preserve_cover(write_cover, overwrite_existing, cover_exists) else strategy
 
 
+def effective_original_title(meta, existing) -> str:
+    """重刮回空原文標題時保留 DB 既有值。meta 有非空 original_title → 用之；
+    否則回退 existing.original_title（existing 為 None → '')。唯一 preserve 邏輯，
+    非唯讀 enricher 與唯讀 producer 皆呼叫此份（方案 A：唯一 preserve 在 helper）。"""
+    return meta.get('original_title') or (existing.original_title if existing else '')
+
+
 def compute_has_servable_cover(repo, path_uri, path_mappings) -> bool:
     """寫完 + commit 後重讀 DB 最終 cover_path，再確認實體封面檔是否服務得到。
 

--- a/core/enrich_contract.py
+++ b/core/enrich_contract.py
@@ -1,0 +1,69 @@
+"""enrich_contract.py — enrich 記帳合約的中性原子（無 side-effect、無網路、無寫檔）。
+
+依賴僅 `core.database` / `core.path_utils` / `os` / `dataclasses`。
+**不 import** `core.enricher` / `core.readonly_producer`（避免循環依賴；本模組是被它們共用的底層）。
+
+存在理由（feature/105）：enrich「寫完後記帳 has_servable_cover」的判斷原本被手抄多份，
+enricher 那份含磁碟複驗（正確），唯讀那份漏了（Bug 1 破圖）。把單一原子收斂於此，
+三呼叫點物理共用同一份磁碟真相，消除鏡射漂移。
+"""
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+from core.path_utils import uri_to_local_fs_path
+
+
+@dataclass
+class EnrichResult:
+    success: bool
+    nfo_written: bool
+    cover_written: bool
+    extrafanart_written: int
+    fields_filled: List[str]
+    source_used: str
+    error: Optional[str]
+    reason: Optional[str] = None
+
+
+def cover_uri_is_servable(cover_uri, path_mappings) -> bool:
+    """封面 URI 是否「前端 /thumb 真的服務得到」的最小磁碟真相原子。
+
+    `bool(cover_uri)`（DB 有記 cover_path）**且** 該封面實體檔在磁碟上實際存在
+    （uri_to_local_fs_path 反解後 os.path.exists）。cover_uri 為空 → 短路 False，
+    不呼叫 os.path.exists。
+    """
+    return bool(cover_uri) and os.path.exists(uri_to_local_fs_path(cover_uri, path_mappings))
+
+
+def compute_has_servable_cover(repo, path_uri, path_mappings) -> bool:
+    """寫完 + commit 後重讀 DB 最終 cover_path，再確認實體封面檔是否服務得到。
+
+    reason=hit 必須是「前端 /thumb 真的服務得到」。/thumb（scanner.py get_thumb）
+    有兩道 gate，兩道都過才服務得到，reason=hit 必須同時鏡射：
+      gate 1（scanner.py:1276-1277）：DB cover_path 非空，否則 404。
+      gate 2（scanner.py:1290/1300/1332-1333）：cache miss 或 disabled 時要讀
+        實體封面檔（uri_to_local_fs_path 反解後 generate / fallback FileResponse），
+        檔不在 → 404。（cache hit 於 :1263 直接 serve WebP 不碰實體檔，見下方 false-negative）
+    故不能只查 DB cover_path 非空（只鏡射 gate 1，Codex PR #98 P2）：DB 有記
+    cover_path、但該實體封面檔已被刪/移／path_mapping 失效解不到時，/thumb 於
+    cache miss/disabled 會 404 → 飛入破圖，卻誤計 hit。
+    亦不能用磁碟 sidecar 真相（Path(fs_path).with_suffix('.jpg')）判：磁碟有 .jpg
+    但 DB cover_path 空（散落 sidecar 未入 DB／db·nfo-sourced 命中跳過 :514
+    _db_upsert）會漏 gate 1（Codex P1，v0.11.9）。故重讀 DB 最終 cover_path，
+    並用 /thumb 同一組解析（uri_to_local_fs_path + 同 path_mappings）確認實體檔存在。
+    此重讀應在所有寫檔 + _db_upsert + nfo_mtime UPDATE 之後（同步、已 commit），
+    故看到的是最終 DB 狀態。
+    已知並接受的 false-negative（安全方向）：cache hit（stale WebP 已快取）但實體
+    封面檔已刪時，/thumb 仍能從快取 serve（:1263），此處卻判 no_cover。代價是「服務
+    得到的封面不飛入」（不破圖）；反向 false-positive（判 hit 卻 404 破圖）代價更高，
+    故偏保守。
+
+    Args:
+        repo: VideoRepository（呼叫端建構、已完成寫入/upsert）。
+        path_uri: DB row 的 key（canonical file:/// URI），必須與 upsert 寫入時同一 key。
+        path_mappings: WSL 反解用；與 /thumb 同一組解析。
+    """
+    row = repo.get_by_path(path_uri)
+    return cover_uri_is_servable(row.cover_path if row else "", path_mappings)

--- a/core/enrich_contract.py
+++ b/core/enrich_contract.py
@@ -1,7 +1,8 @@
 """enrich_contract.py — enrich 記帳合約的中性原子（無 side-effect、無網路、無寫檔）。
 
-依賴僅 `core.database` / `core.path_utils` / `os` / `dataclasses`。
-**不 import** `core.enricher` / `core.readonly_producer`（避免循環依賴；本模組是被它們共用的底層）。
+依賴僅 `os` / `dataclasses` / `typing` / `core.path_utils`（repo 走 duck typing 由呼叫端傳入、
+不 import `core.database`）。**不 import** `core.enricher` / `core.readonly_producer`（避免循環依賴；
+本模組是被它們共用的底層）。
 
 存在理由（feature/105）：enrich「寫完後記帳 has_servable_cover」的判斷原本被手抄多份，
 enricher 那份含磁碟複驗（正確），唯讀那份漏了（Bug 1 破圖）。把單一原子收斂於此，

--- a/core/enrich_contract.py
+++ b/core/enrich_contract.py
@@ -81,8 +81,12 @@ def apply_cover_preserve(strategy, write_cover, overwrite_existing, cover_exists
 def effective_original_title(meta, existing) -> str:
     """重刮回空原文標題時保留 DB 既有值。meta 有非空 original_title → 用之；
     否則回退 existing.original_title（existing 為 None → '')。唯一 preserve 邏輯，
-    非唯讀 enricher 與唯讀 producer 皆呼叫此份（方案 A：唯一 preserve 在 helper）。"""
-    return meta.get('original_title') or (existing.original_title if existing else '')
+    非唯讀 enricher 與唯讀 producer 皆呼叫此份（方案 A：唯一 preserve 在 helper）。
+
+    回傳**恆為 str**：`original_title TEXT` 欄可為 SQL NULL、`Video.from_row` 原樣
+    傳 Python None，故尾端 `or ''` 把 None（與 '')正規化成 ''——否則 None 會被注入
+    meta['original_title']、下游 generate_nfo 的 html.escape(None) 拋 AttributeError。"""
+    return meta.get('original_title') or (existing.original_title if existing else '') or ''
 
 
 def compute_has_servable_cover(repo, path_uri, path_mappings) -> bool:

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -15,6 +15,7 @@ from core.enrich_contract import (
     EnrichResult,
     compute_has_servable_cover,
     effective_original_title,
+    enrich_success,
     should_preserve_cover,
 )
 from core.focal_trigger import maybe_submit_video_focal
@@ -576,15 +577,13 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         repo, to_file_uri(fs_path_for_db), path_mappings
     )
 
-    return EnrichResult(
-        success=True,
+    return enrich_success(
         nfo_written=nfo_written,
         cover_written=cover_written,
         extrafanart_written=extrafanart_written,
         fields_filled=fields_filled,
         source_used=source_used,
-        error=None,
-        reason=("hit" if has_servable_cover else "no_cover"),
+        has_servable_cover=has_servable_cover,
     )
 
 
@@ -710,14 +709,13 @@ def fetch_samples_only(
         _db_upsert_samples_only(repo, fs_path_for_db, written_uris)
 
     logger.info("[fetch_samples_only] %s: %d samples downloaded", number, len(written_uris))
-    return EnrichResult(
-        success=True,
+    return enrich_success(
         nfo_written=False,
         cover_written=False,
         extrafanart_written=len(written_uris),
         fields_filled=[],
         source_used=meta.get("source", ""),
-        error=None,
+        reason=None,
     )
 
 

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from core.config import _STEM_IMAGE_MODES
 from core.database import Video, VideoRepository, get_connection
-from core.enrich_contract import EnrichResult, compute_has_servable_cover
+from core.enrich_contract import EnrichResult, compute_has_servable_cover, should_preserve_cover
 from core.focal_trigger import maybe_submit_video_focal
 from core.logger import get_logger
 from core.nfo_updater import parse_nfo
@@ -219,13 +219,11 @@ def _write_cover(
     write_cover: bool,
     overwrite_existing: bool,
 ) -> bool:
-    if not write_cover:
-        return False
     if not cover_url:
         return False
 
     cover_path = str(Path(fs_path).with_suffix(".jpg"))
-    if os.path.exists(cover_path) and not overwrite_existing:
+    if should_preserve_cover(write_cover, overwrite_existing, os.path.exists(cover_path)):
         return False
 
     return download_image(cover_url, cover_path)

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -11,7 +11,12 @@ from typing import List, Optional
 
 from core.config import _STEM_IMAGE_MODES
 from core.database import Video, VideoRepository, get_connection
-from core.enrich_contract import EnrichResult, compute_has_servable_cover, should_preserve_cover
+from core.enrich_contract import (
+    EnrichResult,
+    compute_has_servable_cover,
+    effective_original_title,
+    should_preserve_cover,
+)
 from core.focal_trigger import maybe_submit_video_focal
 from core.logger import get_logger
 from core.nfo_updater import parse_nfo
@@ -430,6 +435,12 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
     path_uri = to_file_uri(fs_path_for_db)  # db-ns-ok: fs_path_for_db, DB round-trip value, no reverse mapping applied
     existing_record = repo.get_by_path(path_uri)
     preserved_user_tags = existing_record.user_tags if existing_record else []
+
+    # Bug 2 (feature/105): synthesize the EFFECTIVE original_title ONCE, before any
+    # write branch, so both _write_nfo (<originaltitle>) and _db_upsert consume the
+    # same preserved value. A refresh_full re-scrape returning an empty original_title
+    # must NOT clobber the existing DB/NFO value (mirrors user_tags/cover preserve).
+    meta['original_title'] = effective_original_title(meta, existing_record)
 
     cover_url = meta.get("cover_url", "")
 

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -6,12 +6,12 @@ import os
 import shutil
 import time
 import xml.etree.ElementTree as ET
-from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
 
 from core.config import _STEM_IMAGE_MODES
 from core.database import Video, VideoRepository, get_connection
+from core.enrich_contract import EnrichResult, compute_has_servable_cover
 from core.focal_trigger import maybe_submit_video_focal
 from core.logger import get_logger
 from core.nfo_updater import parse_nfo
@@ -27,16 +27,8 @@ VALID_MODES = {"fill_missing", "db_to_sidecar", "refresh_full"}
 _FILL_MISSING_REQUIRED = ["title", "actresses", "maker", "director", "series", "label", "tags", "release_date"]
 
 
-@dataclass
-class EnrichResult:
-    success: bool
-    nfo_written: bool
-    cover_written: bool
-    extrafanart_written: int
-    fields_filled: List[str]
-    source_used: str
-    error: Optional[str]
-    reason: Optional[str] = None
+# EnrichResult 定義已遷入 core.enrich_contract（中性合約模組），此處 re-export
+# 保持全庫既有 `from core.enricher import EnrichResult` 匯入零改動（feature/105）。
 
 
 def _nfo_to_meta(root: ET.Element) -> dict:
@@ -566,30 +558,13 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
             if conn:
                 conn.close()
 
-    # reason=hit 必須是「前端 /thumb 真的服務得到」。/thumb（scanner.py get_thumb）
-    # 有兩道 gate，兩道都過才服務得到，reason=hit 必須同時鏡射：
-    #   gate 1（scanner.py:1276-1277）：DB cover_path 非空，否則 404。
-    #   gate 2（scanner.py:1290/1300/1332-1333）：cache miss 或 disabled 時要讀
-    #     實體封面檔（uri_to_local_fs_path 反解後 generate / fallback FileResponse），
-    #     檔不在 → 404。（cache hit 於 :1263 直接 serve WebP 不碰實體檔，見下方 false-negative）
-    # 故不能只查 DB cover_path 非空（只鏡射 gate 1，Codex PR #98 P2）：DB 有記
-    # cover_path、但該實體封面檔已被刪/移／path_mapping 失效解不到時，/thumb 於
-    # cache miss/disabled 會 404 → 飛入破圖，卻誤計 hit。
-    # 亦不能用磁碟 sidecar 真相（Path(fs_path).with_suffix('.jpg')）判：磁碟有 .jpg
-    # 但 DB cover_path 空（散落 sidecar 未入 DB／db·nfo-sourced 命中跳過 :514
-    # _db_upsert）會漏 gate 1（Codex P1，v0.11.9）。故重讀 DB 最終 cover_path，
-    # 並用 /thumb 同一組解析（uri_to_local_fs_path + 同 path_mappings）確認實體檔存在。
-    # 此重讀在所有寫檔 + _db_upsert + nfo_mtime UPDATE 之後（同步、已 commit），
-    # 故看到的是最終 DB 狀態。
-    # 已知並接受的 false-negative（安全方向）：cache hit（stale WebP 已快取）但實體
-    # 封面檔已刪時，/thumb 仍能從快取 serve（:1263），此處卻判 no_cover。代價是「服務
-    # 得到的封面不飛入」（不破圖）；反向 false-positive（判 hit 卻 404 破圖）代價更高，
-    # 故偏保守。
+    # reason=hit 的「/thumb 兩道 gate + 磁碟複驗 + false-negative 取捨」完整理由已
+    # 遷入 core.enrich_contract.compute_has_servable_cover 的 docstring（feature/105，
+    # 三呼叫點共用同一份磁碟真相）。此重讀在所有寫檔 + _db_upsert + nfo_mtime UPDATE
+    # 之後（同步、已 commit），故看到的是最終 DB 狀態。
     # db-ns-ok: fs_path_for_db, DB round-trip key（同 :437 path_uri）
-    final_row = repo.get_by_path(to_file_uri(fs_path_for_db))
-    cover_uri = final_row.cover_path if final_row else ''
-    has_servable_cover = bool(cover_uri) and os.path.exists(
-        uri_to_local_fs_path(cover_uri, path_mappings)
+    has_servable_cover = compute_has_servable_cover(
+        repo, to_file_uri(fs_path_for_db), path_mappings
     )
 
     return EnrichResult(

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -18,7 +18,7 @@ from core.enrich_contract import (
     enrich_success,
     should_preserve_cover,
 )
-from core.focal_trigger import maybe_submit_video_focal
+from core.focal_trigger import schedule_focal_after_cover_write
 from core.logger import get_logger
 from core.nfo_updater import parse_nfo
 from core.organizer import crop_to_poster, download_image, find_subtitle_files, generate_nfo
@@ -538,18 +538,10 @@ def enrich_single(  # ranker-invalidate-ok: (only updates nfo_mtime, not a corpu
         # 不進此塊，manual 值原樣保留。video_path_uri 須與 _db_upsert 寫入的 key 一致
         # （:190 / :594 to_file_uri(fs_path_for_db)），複用上方已算過的 path_uri。
         if cover_written:
-            repo.reset_focal_to_auto(path_uri)
-            # db-ns-ok: fs_path_for_db, DB round-trip value, no reverse mapping applied
-            maybe_submit_video_focal(
-                number,
-                meta.get("maker"),
-                to_file_uri(fs_path_for_db if fs_path_for_db is not None else fs_path),
-                local_cover,
-                # 99b-T2 caller #4：與 _db_upsert:619-620 計算 cover_uri 同式
-                # （to_file_uri(local_cover_path, path_mappings)），local_cover
-                # 即該處的 local_cover_path。cover_written=True 時 local_cover
-                # 必非空，仍加 `if local_cover else ""` 防未來 gate 條件漂移。
-                cover_path_uri=to_file_uri(local_cover, path_mappings) if local_cover else "",
+            # TASK-105-T6: reset+submit 收斂至共用 helper（video_uri=path_uri，
+            # 與 reset 現用值同源、byte-identical，見 TASK-105-T6.md 等值證明）。
+            schedule_focal_after_cover_write(
+                repo, path_uri, number, meta.get("maker"), local_cover, path_mappings
             )
 
     # nfo_mtime 獨立更新：不論 mode/source，只要 NFO 存在就同步 DB

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -225,6 +225,10 @@ def _write_cover(
     write_cover: bool,
     overwrite_existing: bool,
 ) -> bool:
+    # write_cover=False 先短路，避免對「不寫封面」的片多做一次 os.path.exists
+    # （逐位元組對齊 T2 前行為）；exists/overwrite 保留判斷仍走共用 should_preserve_cover。
+    if not write_cover:
+        return False
     if not cover_url:
         return False
 

--- a/core/focal_trigger.py
+++ b/core/focal_trigger.py
@@ -14,6 +14,7 @@ import os
 from core.database import VideoRepository
 from core.focal import requires_face_detection, submit_focal
 from core.logger import get_logger
+from core.path_utils import to_file_uri
 
 logger = get_logger(__name__)
 
@@ -58,3 +59,24 @@ def maybe_submit_video_focal(number, maker, video_path_uri, cover_fs_path, *, co
     except Exception:
         logger.exception("maybe_submit_video_focal 排程失敗（不影響呼叫端流程）: %s", video_path_uri)
         return
+
+
+def schedule_focal_after_cover_write(repo, video_uri, number, maker, cover_fs, path_mappings):
+    """本次實際寫入新封面後的 focal 記帳（三站共用；98b/99a/113-R2 同形狀）。
+
+    helper 僅保證一條不變式：reset_focal_to_auto 必在 maybe_submit_video_focal
+    之前（先清舊 manual 值、再讓 gate 判是否排 worker，避免有碼片極端時序下短暫
+    殘留 manual）。以下**刻意留呼叫端**、helper 不介入：
+      - try/except（readonly 兩站有、enricher 無）；
+      - repo lifecycle（enricher 傳既有 repo、readonly 傳 fresh VideoRepository()，
+        「致命細節 1」——不可重用綁在 user_tags 分支內的 repo）；
+      - `if cover_written:` / `if assets.get('cover_fs'):` guard（只在寫了封面時呼叫）；
+      - batch 必須在 run_in_executor closure 內呼叫（reset/submit 皆阻塞 DB，不可搬回
+        event loop 裸呼叫，async-offload 守衛）。
+    helper 不建 repo、不包 try/except、不判 cover guard。
+    """
+    repo.reset_focal_to_auto(video_uri)
+    maybe_submit_video_focal(
+        number, maker, video_uri, cover_fs,
+        cover_path_uri=to_file_uri(cover_fs, path_mappings) if cover_fs else "",
+    )

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -26,7 +26,7 @@ from typing import Callable, Optional
 from core import thumbnail_cache
 from core.config import _STEM_IMAGE_MODES, iter_gallery_sources
 from core.database import Video, get_db_path
-from core.enrich_contract import effective_original_title
+from core.enrich_contract import EnrichResult, effective_original_title
 from core.focal import requires_face_detection
 from core.focal_trigger import maybe_submit_video_focal
 from core.gallery_scanner import IMAGE_EXTENSIONS, VideoScanner, fast_scan_directory
@@ -1475,6 +1475,36 @@ def _produce_one(
 
 
 # ---------------------------------------------------------------------------
+# TASK-105-T5 (T2-a/T2-b): readonly-only Tier-2 convergence helpers
+# ---------------------------------------------------------------------------
+
+def _readonly_stub_not_found(repo, uri: str, number, fs_path: str) -> None:
+    """唯讀 not-found 樁列（順序不可反）：先 insert_if_ignore 建樁 row、
+    再 update_scrape_attempted_at 記帳。update_scrape_attempted_at 是 bare
+    UPDATE...WHERE path=?，無 row 靜默 no-op，故必須先建樁（見 video.py:1144-1167）。
+
+    repo 由呼叫端傳（各站來源不同：S1/S2 現場新建、S3 呼叫端傳入共用實例）；
+    `if number:` guard（若有）留呼叫端 — helper body 無條件執行兩步。
+    """
+    repo.insert_if_ignore(Video(path=uri, number=number, title=os.path.basename(fs_path)))
+    repo.update_scrape_attempted_at(uri, time.time())
+
+
+def _readonly_enrich_failure(error, reason=None) -> EnrichResult:
+    """唯讀失敗回報固定形狀：success/nfo/cover 全 False、extrafanart=0、
+    fields_filled=[]、source_used=''；只 error/reason 由呼叫端定。
+
+    reason 預設 None（對齊 fetch-samples 路徑「無 top-level exception boundary」
+    的刻意語意）；需 'error'/'not_found' 的站顯式傳 reason=。
+    """
+    return EnrichResult(
+        success=False, nfo_written=False, cover_written=False,
+        extrafanart_written=0, fields_filled=[], source_used='',
+        error=error, reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
 # T-4: _emit helper + produce_source orchestrator (plan §7)
 # ---------------------------------------------------------------------------
 
@@ -1581,8 +1611,7 @@ def produce_source(source, config, repo, *, proxy_url="", on_progress=None, shou
             # no-number-no-NFO case — no DB row for a file we can't identify
             # at all).
             if number:
-                repo.insert_if_ignore(Video(path=src_uri, number=number, title=os.path.basename(fi["path"])))
-                repo.update_scrape_attempted_at(src_uri, time.time())
+                _readonly_stub_not_found(repo, src_uri, number, fi["path"])
             result.no_scrape += 1
             _emit(on_progress, result, src_uri, "no_scrape")
             continue

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -26,6 +26,7 @@ from typing import Callable, Optional
 from core import thumbnail_cache
 from core.config import _STEM_IMAGE_MODES, iter_gallery_sources
 from core.database import Video, get_db_path
+from core.enrich_contract import effective_original_title
 from core.focal import requires_face_detection
 from core.focal_trigger import maybe_submit_video_focal
 from core.gallery_scanner import IMAGE_EXTENSIONS, VideoScanner, fast_scan_directory
@@ -1088,7 +1089,7 @@ def _upsert_db(
         path=source_uri,
         number=meta['number'],
         title=meta['title'],
-        original_title=meta.get('original_title') or (existing.original_title if existing else ''),
+        original_title=effective_original_title(meta, existing),
         actresses=meta.get('actors', []),
         maker=meta.get('maker', ''),
         director=meta.get('director', ''),
@@ -1445,18 +1446,18 @@ def _produce_one(
         fd, config, allocated_this_run, path_mappings,
     )
     old_base = _build_old_base(existing, file_info["path"], config)  # '' when no prior row/title/number
-    # FIX P1 (Codex PR#113 round-6, 2026-07-21): synthesize the EFFECTIVE
-    # original_title ONCE, before writing any asset, so the output NFO
+    # FIX P1 (Codex PR#113 round-6, 2026-07-21; feature/105 T3: extracted to
+    # effective_original_title helper): synthesize the EFFECTIVE original_title
+    # ONCE, before writing any asset, so the output NFO
     # (_write_movie_assets→generate_nfo) and the DB row (_upsert_db) consume the
     # SAME value. A re-scrape whose source returns an empty original_title must
     # NOT clobber the on-disk NFO's <originaltitle> to '' while the DB keeps the
     # old value — that split (preserve in _upsert_db only) was on-disk data loss
     # + NFO/DB drift. Mirrors the cover_path/sample_images preserve-if-empty
     # contract. Full-mode only in effect (samples_only writes no NFO), but the
-    # mutation is harmless there. _upsert_db keeps its own preserve as a defensive
+    # mutation is harmless there. _upsert_db calls the same helper as a defensive
     # net for any direct caller, but after this line meta already carries the truth.
-    if not meta.get('original_title') and existing and existing.original_title:
-        meta['original_title'] = existing.original_title
+    meta['original_title'] = effective_original_title(meta, existing)
     # PR #93 五審四次 P2 (option C): media-server 模式下用注入的 getter 讓
     # _write_movie_assets 在真正落 .strm 那一刻才重讀 fresh strm_path_mappings
     # （見 _write_movie_assets 內部該段落的完整解釋）。strm_mappings_getter=None

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.12.6"
+__version__ = "0.12.7"
 VERSION = __version__
 
 # 版本資訊

--- a/tests/integration/test_api_batch_enrich.py
+++ b/tests/integration/test_api_batch_enrich.py
@@ -1096,6 +1096,45 @@ class TestBatchEnrichReadonlyCoverPreserveGate:
         mock_repo.return_value.reset_focal_to_auto.assert_not_called()
         mock_focal.assert_not_called()
 
+    # ── PR#114 P2: 唯讀成功項的 thumbnail_cache.invalidate 是 best-effort cleanup
+    # （檔案 unlink 可拋 OSError）。其失敗不得把成功項打成失敗、也不得讓外層 except
+    # 再 failed_count+=1 造成同一項 success+failed 雙記（done 匯總 success+failed >
+    # total）。故障注入型測試 ──
+    def test_thumbnail_invalidate_oserror_does_not_double_count_or_fail_item(
+        self, client, mocker,
+    ):
+        """唯讀成功項的縮圖失效拋 OSError → 不得雙記、不得誤報失敗。修前（invalidate
+        未包 best-effort try/except）：外層 except 捕獲 → failed_count+=1，同項既
+        success 又 failed → done 匯總 success=1, failed=1, total=1（success+failed=2
+        > total），且該項被 yield 成失敗。MUTATION LOCK：拿掉 ok 分支對 invalidate
+        外包的 best-effort try/except → 本測試 RED。"""
+        mocker.patch("web.routers.scraper.load_config", return_value=self._readonly_config())
+        # 既有 servable cover → refresh_full 仍寫（cover_written True），
+        # has_servable_cover=True → reason 'hit'（成功項的正常 reason）。
+        self._mock_routing(
+            mocker,
+            existing_cover_path="file:///out/ro_src-x/RO-001/RO-001.jpg",
+        )
+        inval_spy = mocker.patch(
+            "web.routers.scraper.thumbnail_cache.invalidate",
+            side_effect=OSError("disk gone"),
+        )
+
+        response = self._post(client, mode="refresh_full")
+
+        events = parse_sse(response.text)
+        inval_spy.assert_called_once()  # 確有觸發到（否則測試無效）
+        done = [e for e in events if e["type"] == "done"][0]["summary"]
+        # 無雙記：success + failed 精確等於 total（修前為 2 > 1）。
+        assert done["total"] == 1
+        assert done["success"] + done["failed"] == done["total"]
+        assert done["success"] == 1 and done["failed"] == 0
+        # 成功項不因 cleanup 失敗被誤報成失敗。
+        result_items = [e for e in events if e["type"] == "result-item"]
+        assert len(result_items) == 1
+        assert result_items[0]["success"] is True
+        assert result_items[0]["reason"] == "hit"
+
 
 # ── P2 review round 3 (FIX#4/FIX#5): readonly + mode='db_to_sidecar' clean
 # rejection, + canonical `reason` on the batch failure result-item ─────────────
@@ -1289,3 +1328,31 @@ class TestBatchEnrichThumbnailInvalidation:
         assert response.status_code == 200
         called = [c.args[0] for c in inval_spy.call_args_list]
         assert called == ["file:///nas/dup.mp4"]
+
+    def test_invalidate_oserror_does_not_double_count_or_fail_item(self, client, mocker):
+        """PR#114 P2（可寫路徑孿生）：enrich 成功後的 thumbnail_cache.invalidate
+        拋 OSError → best-effort try/except 吞掉；不得讓外層 except 再 failed_count+=1
+        造成同一成功項 success+failed 雙記、也不得誤報失敗。MUTATION LOCK：拿掉可寫
+        分支 invalidate 外包的 best-effort try/except → 本測試 RED（done 回 success=1,
+        failed=1, total=1，且該項 success=False）。"""
+        mocker.patch("web.routers.scraper.enrich_single", return_value=_ok_result())
+        inval_spy = mocker.patch(
+            "web.routers.scraper.thumbnail_cache.invalidate",
+            side_effect=OSError("disk gone"),
+        )
+
+        response = client.post("/api/batch-enrich", json={
+            "items": [{"file_path": "file:///nas/ok.mp4", "number": "IPZ-154"}],
+            "mode": "refresh_full",
+        })
+
+        assert response.status_code == 200
+        inval_spy.assert_called_once()
+        events = parse_sse(response.text)
+        done = [e for e in events if e["type"] == "done"][0]["summary"]
+        assert done["total"] == 1
+        assert done["success"] + done["failed"] == done["total"]
+        assert done["success"] == 1 and done["failed"] == 0
+        result_items = [e for e in events if e["type"] == "result-item"]
+        assert len(result_items) == 1
+        assert result_items[0]["success"] is True

--- a/tests/integration/test_api_batch_enrich.py
+++ b/tests/integration/test_api_batch_enrich.py
@@ -886,12 +886,15 @@ class TestBatchEnrichReadonlyCoverPreserveGate:
         assert mock_produce.call_args.kwargs["cover_strategy"] == ("none",)
 
     def test_refresh_full_writes_regardless_of_had_cover(self, client, mocker):
-        """batch 預設 mode=refresh_full（BatchEnrichRequest 預設值）→ 不 preserve，
-        即使既有 cover_path 存在（回歸鎖：不得被 P2#3 誤擋）。"""
+        """refresh_full + overwrite_existing=True → 寫（不 preserve），即使既有
+        cover_path 存在（回歸鎖：不得被 P2#3 誤擋）。feature/105 AC4 後 refresh_full
+        的保留政策綁 overwrite_existing（mode-agnostic）：refresh_full+overwrite=False
+        現改為「保留」（前端不可達——batch 恆送 fill_missing，見 state-batch.js:108），
+        故此回歸鎖須顯式送 overwrite_existing=True 走真實覆蓋路徑。"""
         mocker.patch("web.routers.scraper.load_config", return_value=self._readonly_config())
         mock_produce, _, _ = self._mock_routing(mocker, existing_cover_path="file:///out/old.jpg")
 
-        response = self._post(client, mode="refresh_full")
+        response = self._post(client, mode="refresh_full", overwrite_existing=True)
 
         result_items = [e for e in parse_sse(response.text) if e["type"] == "result-item"]
         assert result_items[0]["success"] is True
@@ -903,6 +906,31 @@ class TestBatchEnrichReadonlyCoverPreserveGate:
         mock_produce, _, _ = self._mock_routing(mocker, existing_cover_path="file:///out/old.jpg")
 
         response = self._post(client, mode="refresh_full", write_cover=False)
+
+        result_items = [e for e in parse_sse(response.text) if e["type"] == "result-item"]
+        assert result_items[0]["success"] is True
+        assert mock_produce.call_args.kwargs["cover_strategy"] == ("none",)
+
+    # ── feature/105 T2 AC4 delta（batch 側，鏡射 test_api_enrich.py 同名）：移除唯讀
+    # mode=='fill_missing' 顯式閘後，唯讀保留政策與非唯讀 core.enricher._write_cover
+    # 完全 mode-agnostic 對齊。refresh_full + overwrite=false + 既有可服務封面 → 保留
+    # （改前 mode 閘 False 會靜默覆蓋）。前端不可達（batch 恆送 fill_missing，見
+    # state-batch.js:108），latent-safety 對齊。MUTATION SELF-CHECK：把 mode 閘加回
+    # （preserve = (not write_cover) or (mode=='fill_missing' and not overwrite and
+    # had_cover)）會讓本測試 RED（cover_strategy 變回 ('download', ...)）。────────
+    def test_refresh_full_no_overwrite_existing_cover_preserves_mode_agnostic(
+        self, client, mocker,
+    ):
+        """AC4：batch refresh_full + overwrite=false + 既有封面（磁碟檔在）→ preserve
+        （('none',)），與 enricher _write_cover 同輸入
+        should_preserve_cover(write_cover=True, overwrite=False, cover_exists=True)
+        =True 一致。"""
+        mocker.patch("web.routers.scraper.load_config", return_value=self._readonly_config())
+        mock_produce, _, _ = self._mock_routing(
+            mocker, existing_cover_path="file:///out/old.jpg", cover_file_exists=True,
+        )
+
+        response = self._post(client, mode="refresh_full", overwrite_existing=False)
 
         result_items = [e for e in parse_sse(response.text) if e["type"] == "result-item"]
         assert result_items[0]["success"] is True

--- a/tests/integration/test_api_batch_enrich.py
+++ b/tests/integration/test_api_batch_enrich.py
@@ -810,7 +810,11 @@ class TestBatchEnrichReadonlyCoverPreserveGate:
         # singleton，機械上與上一行同物件，兩者一致即可）。cover_file_exists
         # 同時餵 had_cover（scraper）與 has_servable_cover（enrich_contract）兩道 gate。
         mocker.patch("core.enrich_contract.os.path.exists", return_value=cover_file_exists)
-        mock_focal = mocker.patch("web.routers.scraper.maybe_submit_video_focal")
+        # TASK-105-T6: reset+submit 收斂進 schedule_focal_after_cover_write（住
+        # core.focal_trigger）；maybe_submit_video_focal 的實際呼叫端隨之從
+        # web.routers.scraper 移到 core.focal_trigger（bare name 在該模組 global
+        # namespace 內解析），patch target 需對齊使用端（gotchas-backend.md §1）。
+        mock_focal = mocker.patch("core.focal_trigger.maybe_submit_video_focal")
         return mock_produce, mock_repo, mock_focal
 
     def _post(self, client, **overrides):

--- a/tests/integration/test_api_batch_enrich.py
+++ b/tests/integration/test_api_batch_enrich.py
@@ -804,6 +804,12 @@ class TestBatchEnrichReadonlyCoverPreserveGate:
         # 維持原 had_cover=True 行為；cover_file_exists=False 模擬 round-6
         # 回報的 bug 場景（DB row 殘留、輸出檔已被刪除/對應不到）。
         mocker.patch("web.routers.scraper.os.path.exists", return_value=cover_file_exists)
+        # feature/105 patch-target migration (CD-105-8): has_servable_cover 的磁碟
+        # 複驗隨 compute_has_servable_cover 從 web.routers.scraper 搬進
+        # core.enrich_contract；顯式 patch 該命名空間（os.path 為共享 module
+        # singleton，機械上與上一行同物件，兩者一致即可）。cover_file_exists
+        # 同時餵 had_cover（scraper）與 has_servable_cover（enrich_contract）兩道 gate。
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=cover_file_exists)
         mock_focal = mocker.patch("web.routers.scraper.maybe_submit_video_focal")
         return mock_produce, mock_repo, mock_focal
 
@@ -931,6 +937,29 @@ class TestBatchEnrichReadonlyCoverPreserveGate:
         assert mock_produce.call_args.kwargs["cover_strategy"] == ("none",)
         assert result_items[0]["cover_written"] is False
         assert result_items[0]["reason"] == "hit"
+
+    # ── feature/105 AC2 (Bug 1 fix), batch equivalence/regression guard: DB has
+    # residual cover_path but the physical cover file is gone → reason must be
+    # 'no_cover'. NOTE: batch never had Bug 1 — its pre-T1 form was
+    # `cover_written or had_cover`, and had_cover already carried a disk check, so
+    # this scenario returned 'no_cover' before T1 too. This test therefore LOCKS
+    # that the unification onto the shared compute_has_servable_cover atom
+    # PRESERVES that disk-verify guarantee (behavior-equivalent refactor). It goes
+    # RED if the shared atom's disk check is dropped (verified: reverting
+    # cover_uri_is_servable to `return bool(cover_uri)` flips this to 'hit'). ────
+    def test_residual_cover_path_but_file_deleted_reason_is_no_cover(self, client, mocker):
+        mocker.patch("web.routers.scraper.load_config", return_value=self._readonly_config())
+        mock_produce, _, _ = self._mock_routing(
+            mocker, existing_cover_path="file:///out/old.jpg",
+            produce_cover_fs="", cover_file_exists=False,
+        )
+
+        response = self._post(client, mode="fill_missing", overwrite_existing=False)
+
+        result_items = [e for e in parse_sse(response.text) if e["type"] == "result-item"]
+        assert result_items[0]["success"] is True
+        assert result_items[0]["cover_written"] is False
+        assert result_items[0]["reason"] == "no_cover"
 
     # ── P2#4: cover-written focal reset + re-submit ──────────────────────────
 

--- a/tests/integration/test_api_batch_enrich.py
+++ b/tests/integration/test_api_batch_enrich.py
@@ -747,6 +747,64 @@ class TestBatchEnrichReadonlyGuard:
         mock_produce.assert_called_once()
         assert "write_nfo" not in mock_produce.call_args.kwargs
 
+    # TASK-105-T9（BUG，PR#113 round 8 Codex thread `Sn2qv`）：唯讀分支的
+    # executor await（含 in-executor 前置如 resolve_ingest_plan）未被任何
+    # per-item try/except 隔離——單一唯讀項的例外會上傳批次層 try，`raise` 後
+    # SSE 生成器崩潰、整批掛掉（後續項與 done 全失）。故障注入：對其中一個唯讀
+    # 項的 resolve_ingest_plan 拋例外，斷言（a）該項回失敗結果項
+    # （success=False, reason='error'），（b）其後的可寫項與唯讀成功項仍完成
+    # （證明迴圈續跑，故障項故意不放最後一筆），（c）done 事件仍發出、計數正確。
+    # §7 mutation 自驗強制：見 task card。
+    def test_readonly_item_resolve_plan_raises_isolated_batch_continues(self, client, mocker):
+        """單一唯讀項 resolve_ingest_plan 拋例外 → 該項回失敗結果項（reason='error'），
+        同批其後的可寫項與唯讀成功項仍完成、done 仍發出（改前整批崩、無 done）。"""
+        mocker.patch(
+            "web.routers.scraper.load_config",
+            return_value=self._readonly_config(),
+        )
+        mocker.patch("web.routers.scraper.enrich_single", return_value=_ok_result())
+        # 唯讀路由基座（owning/_produce_one/VideoRepository 預設）；
+        # resolve_ingest_plan 另行以 side_effect 覆寫（依 number 分流成功/拋例外）。
+        self._mock_readonly_routing(mocker)
+
+        def _plan_side_effect(fs_path, number, *args, **kwargs):
+            if number == "RO-FAIL":
+                raise RuntimeError("boom in resolve_ingest_plan")
+            return ({"number": number, "title": "T", "cover": ""}, ("none",))
+
+        mocker.patch(
+            "web.routers.scraper.resolve_ingest_plan",
+            side_effect=_plan_side_effect,
+        )
+
+        response = client.post("/api/batch-enrich", json={
+            "items": [
+                # 故障唯讀項置批首（非批尾）——證明例外未中斷迴圈：若置批尾，
+                # 改前的 bug 恰好也會讓「無後續項」看起來像通過。
+                {"file_path": "/tmp/ro_src/RO-FAIL.mp4", "number": "RO-FAIL"},
+                {"file_path": "/tmp/rw/RW-OK.mp4", "number": "RW-OK"},
+                {"file_path": "/tmp/ro_src/RO-OK.mp4", "number": "RO-OK"},
+            ],
+            "mode": "refresh_full",
+        })
+
+        assert response.status_code == 200
+        events = parse_sse(response.text)
+        by_number = {e["number"]: e for e in events if e["type"] == "result-item"}
+
+        # 故障項：隔離成失敗結果項，非整批崩
+        assert by_number["RO-FAIL"]["success"] is False
+        assert by_number["RO-FAIL"]["reason"] == "error"
+
+        # 其後兩項仍完成（證明迴圈續跑）
+        assert by_number["RW-OK"]["success"] is True
+        assert by_number["RO-OK"]["success"] is True
+
+        # done 仍發出、計數對稱
+        done_events = [e for e in events if e["type"] == "done"]
+        assert len(done_events) == 1
+        assert done_events[0]["summary"] == {"total": 3, "success": 2, "failed": 1}
+
 
 class TestBatchEnrichReadonlyCoverPreserveGate:
     """Codex PR#113 P2#3/P2#4（round 2，owner-confirmed 全面對齊）：batch readonly

--- a/tests/integration/test_api_enrich.py
+++ b/tests/integration/test_api_enrich.py
@@ -720,6 +720,29 @@ class TestEnrichSingleReadonlyCoverPreserveGate:
         assert response.json()["success"] is True
         assert mock_produce.call_args.kwargs["cover_strategy"] == ("none",)
 
+    # ── feature/105 T2 AC4 delta：移除唯讀 mode=='fill_missing' 顯式閘後，唯讀保留
+    # 政策與非唯讀 core.enricher._write_cover 完全 mode-agnostic 對齊。refresh_full
+    # + overwrite=false + 既有可服務封面 → 保留（改前 mode 閘 False 會靜默覆蓋）。
+    # MUTATION SELF-CHECK：把 mode 閘加回（preserve = (not write_cover) or
+    # (request.mode == 'fill_missing' and not overwrite and had_cover)）會讓本測試
+    # RED（cover_strategy 變回 ('download', ...)）——已於實作時驗證。─────────────
+    def test_refresh_full_no_overwrite_existing_cover_preserves_mode_agnostic(
+        self, client, mocker,
+    ):
+        """AC4：refresh_full + overwrite=false + 既有封面（磁碟檔在）→ preserve
+        （('none',)），與 enricher _write_cover 同輸入
+        should_preserve_cover(write_cover=True, overwrite=False, cover_exists=True)
+        =True 一致。"""
+        mocker.patch("web.routers.scraper.load_config", return_value=_readonly_gallery_config("/tmp/ro_src"))
+        mock_produce, _, _ = self._mock_routing(
+            mocker, existing_cover_path="file:///out/old.jpg", cover_file_exists=True,
+        )
+
+        response = self._post(client, mode="refresh_full", overwrite_existing=False)
+
+        assert response.json()["success"] is True
+        assert mock_produce.call_args.kwargs["cover_strategy"] == ("none",)
+
     # ── P2 review round 3 (FIX#1): reason reflects a SERVABLE cover, not just
     # this-call cover_written ────────────────────────────────────────────────
 
@@ -2351,6 +2374,8 @@ class TestReadonlyRoutingE2E:
             "source": "javlibrary",
             "detail_url": "https://www.javlibrary.com/ja/?v=abcxyz",
             "mode": "refresh_full",
+            # overwrite_existing:True 對齊真實齒輪重刮（state-rescrape.js:404）；feature/105 AC4 後 refresh_full 保留政策綁 overwrite_existing
+            "overwrite_existing": True,
         })
         assert resp2.json()["success"] is True
 

--- a/tests/integration/test_api_enrich.py
+++ b/tests/integration/test_api_enrich.py
@@ -3161,3 +3161,78 @@ class TestReadonlyRoutingE2E:
                 f"round-trip 不變式破了: fs_path={fs_path!r} pm={pm!r} canonical={canonical!r} -> "
                 f"{round_tripped_fs!r} -> {to_file_uri(round_tripped_fs, pm)!r}"
             )
+
+
+# ── AC3 (feature/105 Bug 2): 非唯讀 refresh_full 重刮回空 → 保留既有原文標題 ─────
+
+class TestEnrichSinglePreservesOriginalTitle:
+    """AC3 (feature/105 T3, Bug 2): a non-readonly `refresh_full` re-scrape whose
+    source returned an EMPTY original_title must NOT clobber the existing value —
+    BOTH the written NFO <originaltitle> AND the DB row must preserve it.
+
+    Drives the REAL enrich_single with a REAL VideoRepository(temp db) + REAL
+    generate_nfo (only search_jav is mocked). Before the fix, both were cleared to
+    '' (the injection line `meta['original_title'] = effective_original_title(...)`
+    is the load-bearing preserve — remove it and this test goes RED)."""
+
+    def _scraper_data_without_original_title(self, number="TEST-001"):
+        # 重刮這次來源未回傳 original_title（key 缺 → _scraper_to_meta 落 ''）
+        return {
+            "number": number,
+            "title": "新しいタイトル",
+            "actors": ["女優A"],
+            "cover": "",
+            "date": "2024-01-01",
+            "maker": "SOD",
+            "director": "監督",
+            "series": "シリーズ",
+            "label": "LABEL",
+            "tags": ["タグ"],
+            "sample_images": [],
+            "duration": 120,
+            "url": "https://www.javbus.com/TEST-001",
+        }
+
+    def test_refresh_full_empty_rescrape_preserves_original_title_in_nfo_and_db(
+        self, tmp_path, mocker
+    ):
+        import xml.etree.ElementTree as ET
+        from core.database import init_db, VideoRepository, Video
+        from core.enricher import enrich_single
+        from core.path_utils import to_file_uri
+
+        db_path = tmp_path / "ac3.db"
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+
+        video_file = tmp_path / "TEST-001.mp4"
+        video_file.write_bytes(b"\x00")
+        path_uri = to_file_uri(str(video_file))
+
+        # 既有 DB row 帶非空 original_title（對應 NFO 也將被寫）
+        repo.upsert(Video(
+            path=path_uri, number="TEST-001", title="既存タイトル",
+            original_title="既存の原題",
+        ))
+
+        # enrich_single 內部 new VideoRepository() → 指向同一 temp DB
+        mocker.patch("core.enricher.VideoRepository", return_value=repo)
+        mocker.patch(
+            "core.enricher.search_jav",
+            return_value=self._scraper_data_without_original_title(),
+        )
+
+        result = enrich_single(
+            file_path=path_uri, number="TEST-001", mode="refresh_full",
+            write_nfo=True, write_cover=False, write_extrafanart=False,
+        )
+        assert result.success, result.error
+
+        # DB row 保留既有原文標題
+        assert repo.get_by_path(path_uri).original_title == "既存の原題"
+
+        # 寫出的 NFO <originaltitle> 保留既有原文標題（改前皆清成 ''）
+        nfo_file = video_file.with_suffix(".nfo")
+        assert nfo_file.exists(), "NFO 應被寫出"
+        root = ET.parse(nfo_file).getroot()
+        assert root.findtext("originaltitle") == "既存の原題"

--- a/tests/integration/test_api_enrich.py
+++ b/tests/integration/test_api_enrich.py
@@ -636,6 +636,13 @@ class TestEnrichSingleReadonlyCoverPreserveGate:
         # 的一般情境）維持原 had_cover=True 行為；cover_file_exists=False 用來
         # 模擬 round-6 回報的 bug 場景（DB row 殘留、輸出檔已被刪除/對應不到）。
         mocker.patch("web.routers.scraper.os.path.exists", return_value=cover_file_exists)
+        # feature/105 patch-target migration (CD-105-8): has_servable_cover 的磁碟
+        # 複驗隨 compute_has_servable_cover 從 web.routers.scraper 搬進
+        # core.enrich_contract；顯式 patch 該命名空間讓「哪個 mock 餵 has_servable_cover」
+        # 自我文件化（os.path 為共享 module singleton，機械上與上一行同物件，
+        # 兩者一致即可）。cover_file_exists 同時餵 had_cover（scraper）與
+        # has_servable_cover（enrich_contract）兩道 gate。
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=cover_file_exists)
         mock_focal = mocker.patch("web.routers.scraper.maybe_submit_video_focal")
         return mock_produce, mock_repo, mock_focal
 
@@ -742,6 +749,29 @@ class TestEnrichSingleReadonlyCoverPreserveGate:
         assert mock_produce.call_args.kwargs["cover_strategy"] == ("none",)
         assert data["cover_written"] is False
         assert data["reason"] == "hit"
+
+    # ── feature/105 AC2 (Bug 1 fix): reason must be 'no_cover' when the DB has a
+    # residual cover_path but the physical cover file is gone on disk. Before the
+    # fix enrich-single only checked the DB row → wrongly reported 'hit' → the
+    # frontend built a /api/gallery/thumb URL that 404s (broken fly-in image).
+    # MUTATION LOCK: revert enrich-single's has_servable_cover to the DB-only
+    # `bool(assets.get('cover_fs')) or bool(existing and existing.cover_path)` and
+    # this test goes RED (reason flips back to 'hit'). ────────────────────────
+    def test_residual_cover_path_but_file_deleted_reason_is_no_cover(self, client, mocker):
+        mocker.patch("web.routers.scraper.load_config", return_value=_readonly_gallery_config("/tmp/ro_src"))
+        # DB row still has cover_path, but the output cover file no longer exists on
+        # disk (cover_file_exists=False) and this call wrote nothing (produce_cover_fs="").
+        mock_produce, _, _ = self._mock_routing(
+            mocker, existing_cover_path="file:///out/old.jpg",
+            produce_cover_fs="", cover_file_exists=False,
+        )
+
+        response = self._post(client, mode="fill_missing", overwrite_existing=False)
+
+        data = response.json()
+        assert data["success"] is True
+        assert data["cover_written"] is False
+        assert data["reason"] == "no_cover"
 
     def test_gear_refresh_full_overwrite_true_writes_regardless_of_had_cover(self, client, mocker):
         """gear rescrape（refresh_full + overwrite=True，state-rescrape.js:404/408

--- a/tests/integration/test_api_enrich.py
+++ b/tests/integration/test_api_enrich.py
@@ -643,7 +643,11 @@ class TestEnrichSingleReadonlyCoverPreserveGate:
         # 兩者一致即可）。cover_file_exists 同時餵 had_cover（scraper）與
         # has_servable_cover（enrich_contract）兩道 gate。
         mocker.patch("core.enrich_contract.os.path.exists", return_value=cover_file_exists)
-        mock_focal = mocker.patch("web.routers.scraper.maybe_submit_video_focal")
+        # TASK-105-T6: reset+submit 收斂進 schedule_focal_after_cover_write（住
+        # core.focal_trigger）；maybe_submit_video_focal 的實際呼叫端隨之從
+        # web.routers.scraper 移到 core.focal_trigger（bare name 在該模組 global
+        # namespace 內解析），patch target 需對齊使用端（gotchas-backend.md §1）。
+        mock_focal = mocker.patch("core.focal_trigger.maybe_submit_video_focal")
         return mock_produce, mock_repo, mock_focal
 
     def _post(self, client, **overrides):

--- a/tests/integration/test_enrich_contract_structure.py
+++ b/tests/integration/test_enrich_contract_structure.py
@@ -1,0 +1,384 @@
+"""唯讀/非唯讀第②層「寫後記帳+回報」收斂終態的跨檔 AST 結構守衛（feature/105 T7）。
+
+[pytest-justified: cross-file Python AST contract, feature/91/66 先例]
+
+把 T1–T6 收斂後的「一份實作」最終狀態用機械閘鎖死，防止 enricher 未來一長新
+欄位就再手抄一份唯讀拷貝（PR#113 八輪 churn 的根因）：
+
+  1. **正向鎖**：對明列的 production target 函式（P1–P7），斷言其 named
+     FunctionDef body 內含對應 `core.enrich_contract` / `core.focal_trigger`
+     helper 的 `ast.Call`（消除手抄的第②層邏輯）。
+  2. **負向鎖**：對同一批 target body，以 AST 節點形狀（非字串 regex）斷言
+     四類舊 mirror 手抄指紋不復生。
+  3. **白名單防腐**：每個 named target 必須能 AST 定位，避免改名後恆綠假通過。
+
+掃描粒度＝named `FunctionDef`/`AsyncFunctionDef` 的「直接 body」（遞迴但**停在
+巢狀 def**，比照先例 `test_async_offload_guard.py::_collect_direct_calls`）：
+`event_generator` 收集 Call 時停在 nested `_do_readonly`，故 P6 的四支阻塞
+helper 不會污染 P7、P7 只鎖 event_generator 自身的 `enrich_success`。
+
+為何 pytest 不是 lint（CLAUDE.md「Lint 守衛規則」north-star）：本守衛驗的是
+「某個 Python 函式的源碼語意（AST 節點形狀）」——CLAUDE.md 判斷原則明列此類走
+pytest（C 類）。它 walk named FunctionDef 的 `ast.Call`/`ast.Assign`/`ast.BoolOp`
+節點形狀，非 `"name" in source` 字面掃描，故 eslint/static_guard 無法表達、
+亦不觸 SA-pre-6 的 html/js/css content-based 偵測。
+"""
+import ast
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parents[2]
+ENRICHER_PY = REPO_ROOT / "core" / "enricher.py"
+SCRAPER_PY = REPO_ROOT / "web" / "routers" / "scraper.py"
+
+
+# ============================================================
+# AST 工具（比照 test_async_offload_guard.py 骨架）
+# ============================================================
+
+def _parse(py_file: pathlib.Path) -> ast.Module:
+    return ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+
+
+def _find_func(tree: ast.Module, name: str):
+    """全樹遍歷找 node.name == name 的 FunctionDef/AsyncFunctionDef（名稱檔內唯一）。
+
+    涵蓋雙層巢狀（`event_generator` in `batch_enrich_endpoint`；`_do_readonly` in
+    `event_generator`）——`ast.walk` 遞迴命中即可。找不到回 None（白名單防腐用）。
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+def _direct_nodes(func_node) -> list:
+    """收集 func_node「直接 body」的所有子節點（遞迴，但**停在巢狀 def**）。
+
+    停在 nested `FunctionDef`/`AsyncFunctionDef`：故 `event_generator` 的收集不會
+    下潛到 `_do_readonly`，兩者各自獨立掃描、集合互不污染（比照先例
+    `_collect_direct_calls`「遇 nested def 就 continue 不下潛」）。
+    """
+    out = []
+
+    def _walk(nodes):
+        for node in nodes:
+            out.append(node)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            _walk(ast.iter_child_nodes(node))
+
+    _walk(ast.iter_child_nodes(func_node))
+    return out
+
+
+def _call_name(call: ast.Call):
+    """取 Call 的函式名：ast.Name → .id（裸名，如 enrich_success()）；
+    ast.Attribute → .attr（如 mod.enrich_success()）。
+
+    HEAD 實測六支 helper + schedule_focal_after_cover_write 全以裸名呼叫（各模組
+    `from … import`），故 `.id` 即命中；仍涵蓋 `.attr` 防未來改 import 風格
+    （比照先例 `test_async_offload_guard.py::_call_name`）。
+    """
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def _direct_call_names(func_node) -> set:
+    return {
+        _call_name(n)
+        for n in _direct_nodes(func_node)
+        if isinstance(n, ast.Call) and _call_name(n) is not None
+    }
+
+
+# ============================================================
+# 正向鎖清單（HEAD 51d33ca3 實測，權威見 TASK-105-T7 現況分析表）
+# ============================================================
+# (檔案, 函式名, {必含 helper Call})
+POSITIVE_LOCKS = [
+    # P1
+    (ENRICHER_PY, "enrich_single", {
+        "effective_original_title",
+        "compute_has_servable_cover",
+        "enrich_success",
+        "schedule_focal_after_cover_write",  # focal 站 A（AC7）
+    }),
+    # P2
+    (ENRICHER_PY, "_write_cover", {"should_preserve_cover"}),
+    # P3
+    (ENRICHER_PY, "fetch_samples_only", {"enrich_success"}),
+    # P4
+    (SCRAPER_PY, "enrich_single_endpoint", {
+        "cover_uri_is_servable",
+        "apply_cover_preserve",
+        "compute_has_servable_cover",
+        "enrich_success",
+        "schedule_focal_after_cover_write",  # focal 站 B（AC7）
+    }),
+    # P5
+    (SCRAPER_PY, "fetch_samples_endpoint", {"enrich_success"}),
+    # P6 — nested：只鎖自身 body 的四支阻塞 helper，**不含** enrich_success
+    #      （enrich_success 在 event_generator/P7，非 _do_readonly）
+    (SCRAPER_PY, "_do_readonly", {
+        "cover_uri_is_servable",
+        "apply_cover_preserve",
+        "compute_has_servable_cover",
+        "schedule_focal_after_cover_write",  # focal 站 C（AC7）
+    }),
+    # P7 — nested async：batch 唯讀成功 result dict 專屬（在 _do_readonly 返回後的
+    #      async context，收集停在 nested def 故不含 P6 四支）
+    (SCRAPER_PY, "event_generator", {"enrich_success"}),
+]
+
+# 白名單防腐：所有 named target（去重）
+ALL_TARGETS = [(f, n) for f, n, _ in POSITIVE_LOCKS]
+
+_TREE_CACHE: dict = {}
+
+
+def _tree(py_file: pathlib.Path) -> ast.Module:
+    key = str(py_file)
+    if key not in _TREE_CACHE:
+        _TREE_CACHE[key] = _parse(py_file)
+    return _TREE_CACHE[key]
+
+
+class TestPositiveContractLocks:
+    """正向鎖：每個 target body 必含指定共用 helper 的 Call（消除手抄第②層）。"""
+
+    @pytest.mark.parametrize("py_file, func_name, required", POSITIVE_LOCKS,
+                             ids=[n for _, n, _ in POSITIVE_LOCKS])
+    def test_target_calls_required_helpers(self, py_file, func_name, required):
+        func = _find_func(_tree(py_file), func_name)
+        assert func is not None, f"{py_file.name}:{func_name} 定位不到（白名單防腐應先報）"
+        present = _direct_call_names(func)
+        missing = required - present
+        assert not missing, (
+            f"{py_file.name}:{func_name}() 的 body 未呼叫共用 helper {sorted(missing)}"
+            f" —— 疑似手抄第②層邏輯而繞過 core.enrich_contract/core.focal_trigger。"
+            f" 現有直接呼叫: {sorted(present)}"
+        )
+
+
+# ============================================================
+# 負向鎖：四類舊 mirror 手抄指紋（AST 節點形狀，非字串 regex）
+# ============================================================
+
+def _is_mirror_cover_assign(node) -> bool:
+    """指紋1：`has_servable_cover = cover_written or had_cover`。
+
+    要求：(a) 單一 bare Name target（id=='has_servable_cover'）——**排除** 961 的
+    Tuple/List 解包；(b) value 為 BoolOp(Or) 且**兩 operand 皆 ast.Name**——961 的
+    `payload or ({}, {}, False)` 右 operand 是 Tuple 非 Name，天然排除；正確碼
+    `has_servable_cover = compute_has_servable_cover(...)` value 是 Call 非 BoolOp，
+    亦排除。
+    """
+    if not isinstance(node, ast.Assign):
+        return False
+    if len(node.targets) != 1:
+        return False
+    tgt = node.targets[0]
+    if not (isinstance(tgt, ast.Name) and tgt.id == "has_servable_cover"):
+        return False
+    val = node.value
+    if not (isinstance(val, ast.BoolOp) and isinstance(val.op, ast.Or)):
+        return False
+    return all(isinstance(v, ast.Name) for v in val.values)
+
+
+def _is_inline_reason_ifexp(node) -> bool:
+    """指紋2：inline `reason = 'hit' if … else 'no_cover'`（reason 派生已入
+    enrich_success builder，不得散落 target body）。IfExp body/orelse 為
+    Constant('hit')/Constant('no_cover')。
+    """
+    if not isinstance(node, ast.IfExp):
+        return False
+    body, orelse = node.body, node.orelse
+    if not (isinstance(body, ast.Constant) and isinstance(orelse, ast.Constant)):
+        return False
+    return {body.value, orelse.value} == {"hit", "no_cover"}
+
+
+def _is_fill_missing_had_cover_boolop(node) -> bool:
+    """指紋3：`mode == 'fill_missing' and not … and had_cover`（已被
+    apply_cover_preserve 取代、fill_missing 顯式閘移除）。BoolOp(And) 之子樹含
+    Compare(== Constant('fill_missing')) 且含 Name('had_cover')。
+    """
+    if not (isinstance(node, ast.BoolOp) and isinstance(node.op, ast.And)):
+        return False
+    subtree = list(ast.walk(node))
+    has_fill = any(
+        isinstance(c, ast.Compare)
+        and any(isinstance(cmp, ast.Constant) and cmp.value == "fill_missing"
+                for cmp in ([c.left] + list(c.comparators)))
+        for c in subtree
+    )
+    has_had_cover = any(isinstance(c, ast.Name) and c.id == "had_cover" for c in subtree)
+    return has_fill and has_had_cover
+
+
+def _is_second_original_title_preserve(node) -> bool:
+    """指紋4：第二套手寫 original_title preserve `… or <row>.original_title`
+    （唯一 preserve 只在 effective_original_title helper）。BoolOp(Or) 之子樹含
+    `Attribute(attr='original_title', value=Name(<任意>))`。
+
+    **錨定 attr shape、不錨定 receiver 變數名**（F1 修正）：主 target `enrich_single`
+    的 DB row 變數是 `existing_record`（非 `existing`），若硬編 `existing.` 會漏掉最
+    可能發生複製回退的那個站（AST 指紋硬編 receiver 名的經典假綠）。任意 `Name`
+    receiver 的 `.original_title` 屬性存取都算——因 `meta` 是 dict、走 `meta.get(...)`
+    不會有 `.original_title` 屬性存取，只有 DB row 物件（不論命名）才有此屬性；
+    全庫唯一的合法 `<x>.original_title`（`enricher.py:80` `video.original_title`）在
+    所有 named target 之外、且非 BoolOp，粒度天然不掃。
+
+    不誤傷 plain `meta.get("original_title","")`（那是純 Call、非 Attribute，且在
+    _write_nfo/_db_upsert/_write_movie_assets 等非-target 函式，粒度天然不掃）。
+    """
+    if not (isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or)):
+        return False
+    for c in ast.walk(node):
+        if (isinstance(c, ast.Attribute) and c.attr == "original_title"
+                and isinstance(c.value, ast.Name)):
+            return True
+    return False
+
+
+NEGATIVE_FINGERPRINTS = [
+    ("has_servable_cover = cover_written or had_cover", _is_mirror_cover_assign),
+    ("reason = 'hit' if … else 'no_cover'", _is_inline_reason_ifexp),
+    ("mode == 'fill_missing' and … and had_cover", _is_fill_missing_had_cover_boolop),
+    ("… or existing.original_title (2nd preserve)", _is_second_original_title_preserve),
+]
+
+
+class TestNegativeMirrorLocks:
+    """負向鎖：target body 內不得殘留四類舊 mirror 手抄指紋。"""
+
+    @pytest.mark.parametrize("py_file, func_name", ALL_TARGETS,
+                             ids=[n for _, n in ALL_TARGETS])
+    def test_no_mirror_fingerprints(self, py_file, func_name):
+        func = _find_func(_tree(py_file), func_name)
+        assert func is not None, f"{py_file.name}:{func_name} 定位不到"
+        nodes = _direct_nodes(func)
+        violations = []
+        for label, detector in NEGATIVE_FINGERPRINTS:
+            if any(detector(n) for n in nodes):
+                violations.append(label)
+        assert not violations, (
+            f"{py_file.name}:{func_name}() 復生舊 mirror 手抄指紋: {violations}"
+            f" —— 第②層邏輯應共用 core.enrich_contract helper，不得手抄。"
+        )
+
+
+class TestFalsePositiveGuards:
+    """反證：GREEN 狀態下守衛不誤傷 961 Tuple-target 與非-target plain meta.get。"""
+
+    def test_961_tuple_target_not_flagged(self):
+        """scraper.py:961 `assets, item_meta, has_servable_cover = payload or ({}, {}, False)`
+        是 Tuple-target 的正確碼（T2「用參數表達刻意差異」），負向鎖指紋1 不得命中。
+        """
+        eg = _find_func(_tree(SCRAPER_PY), "event_generator")
+        assert eg is not None
+        tuple_assigns = [
+            n for n in _direct_nodes(eg)
+            if isinstance(n, ast.Assign)
+            and len(n.targets) == 1 and isinstance(n.targets[0], ast.Tuple)
+            and any(isinstance(e, ast.Name) and e.id == "has_servable_cover"
+                    for e in n.targets[0].elts)
+        ]
+        assert tuple_assigns, (
+            "應能在 event_generator 定位到 961 的 Tuple-target has_servable_cover 解包"
+            "（找不到代表掃描函式錯或該碼已移除，需複查 T7 設計）"
+        )
+        for a in tuple_assigns:
+            assert not _is_mirror_cover_assign(a), (
+                "961 Tuple-target `payload or (…)` 被指紋1 誤報為 BLOCKER —— "
+                "指紋1 的『單一 bare Name target + 兩 Name operand』排除失效"
+            )
+
+    def test_plain_meta_get_original_title_not_in_targets(self):
+        """三處 plain `meta.get("original_title","")` 皆在非-target 函式
+        （_write_nfo/_db_upsert/_write_movie_assets）；且即便當作 Call 節點也非
+        指紋4（BoolOp 形狀）。確認負向鎖粒度天然不掃這些正確碼。
+        """
+        # 確認 target 清單不含這三個非-target 函式
+        target_names = {n for _, n in ALL_TARGETS}
+        assert target_names.isdisjoint({"_write_nfo", "_db_upsert", "_write_movie_assets"})
+        # 即使掃到 plain meta.get，指紋4（BoolOp Or）形狀不會命中它（它是純 Call）
+        tree = _tree(ENRICHER_PY)
+        wr = _find_func(tree, "_write_nfo")
+        assert wr is not None
+        assert not any(_is_second_original_title_preserve(n) for n in _direct_nodes(wr)), (
+            "plain meta.get('original_title') 被指紋4 誤報 —— 指紋4 應只命中 "
+            "BoolOp(Or) 含 existing.original_title"
+        )
+
+
+class TestNegativeDetectorSensitivity:
+    """負向鎖 detector 敏感度（防近空殼假綠）：直接餵 AST 片段，斷言四個 detector
+    對 canonical mirror 形狀**命中**、對正確碼**放行**。這把「守衛真的鎖得住」的
+    mutation 直覺固化成回歸測試（F1：指紋4 曾硬編 `existing` 漏掉主 target 的
+    `existing_record`）。"""
+
+    @staticmethod
+    def _first(src: str, node_type):
+        for n in ast.walk(ast.parse(src)):
+            if isinstance(n, node_type):
+                return n
+        raise AssertionError(f"片段內找不到 {node_type.__name__}")
+
+    def test_fp1_fires_on_canonical_mirror(self):
+        node = self._first("has_servable_cover = cover_written or had_cover", ast.Assign)
+        assert _is_mirror_cover_assign(node)
+
+    def test_fp1_passes_961_tuple_and_correct_call(self):
+        assert not _is_mirror_cover_assign(
+            self._first("a, b, has_servable_cover = payload or ({}, {}, False)", ast.Assign))
+        assert not _is_mirror_cover_assign(
+            self._first("has_servable_cover = compute_has_servable_cover(r, u, m)", ast.Assign))
+
+    def test_fp2_fires_on_inline_reason(self):
+        node = self._first("reason = 'hit' if hsc else 'no_cover'", ast.IfExp)
+        assert _is_inline_reason_ifexp(node)
+
+    def test_fp3_fires_on_fill_missing_gate(self):
+        node = self._first(
+            "x = mode == 'fill_missing' and not overwrite and had_cover", ast.BoolOp)
+        assert _is_fill_missing_had_cover_boolop(node)
+
+    def test_fp4_fires_on_both_receiver_names(self):
+        # F1：主 target enrich_single 用 existing_record（非 existing）——兩者都須命中
+        for recv in ("existing", "existing_record", "row"):
+            node = self._first(
+                f"t = meta.get('original_title') or ({recv}.original_title if {recv} else '')",
+                ast.BoolOp)
+            assert _is_second_original_title_preserve(node), f"指紋4 漏掉 receiver={recv}"
+
+    def test_fp4_passes_plain_meta_get(self):
+        # 純 Call、無 .original_title 屬性存取 → 不得命中
+        for n in ast.walk(ast.parse('t = meta.get("original_title", "")')):
+            if isinstance(n, ast.BoolOp):
+                raise AssertionError("片段不應含 BoolOp")
+        # 顯式：整棵樹無任一節點被指紋4 判為 True
+        assert not any(
+            _is_second_original_title_preserve(n)
+            for n in ast.walk(ast.parse('t = meta.get("original_title", "")')))
+
+
+class TestWhitelistAntiRot:
+    """白名單防腐（比照先例 test_whitelist_entries_exist）：
+    每個 named target 必須能在對應檔 AST 定位，否則守衛指向殭屍函式、恆綠假通過。
+    """
+
+    @pytest.mark.parametrize("py_file, func_name", ALL_TARGETS,
+                             ids=[n for _, n in ALL_TARGETS])
+    def test_target_function_exists(self, py_file, func_name):
+        func = _find_func(_tree(py_file), func_name)
+        assert func is not None, (
+            f"正向/負向鎖 target {py_file.name}:{func_name} 指向不存在的函式"
+            f"（改名？）—— 守衛失去意義，須更新清單或修復函式名"
+        )

--- a/tests/integration/test_enrich_contract_structure.py
+++ b/tests/integration/test_enrich_contract_structure.py
@@ -148,6 +148,10 @@ def _tree(py_file: pathlib.Path) -> ast.Module:
     return _TREE_CACHE[key]
 
 
+# [lint-guard: pytest-justified] Python-AST 源碼語意守衛（cross-file enrich_contract 契約）：
+# 斷言 AST 節點形狀 / detector 函式在 parsed Python 片段上的行為，非 html/js/css 靜態
+# 字串存在檢查，eslint/static_guard 無法表達（pre-merge SA-pre-6 例外清單「Python-AST
+# 源碼語意守衛」）。
 class TestPositiveContractLocks:
     """正向鎖：每個 target body 必含指定共用 helper 的 Call（消除手抄第②層）。"""
 
@@ -255,6 +259,10 @@ NEGATIVE_FINGERPRINTS = [
 ]
 
 
+# [lint-guard: pytest-justified] Python-AST 源碼語意守衛（cross-file enrich_contract 契約）：
+# 斷言 AST 節點形狀 / detector 函式在 parsed Python 片段上的行為，非 html/js/css 靜態
+# 字串存在檢查，eslint/static_guard 無法表達（pre-merge SA-pre-6 例外清單「Python-AST
+# 源碼語意守衛」）。
 class TestNegativeMirrorLocks:
     """負向鎖：target body 內不得殘留四類舊 mirror 手抄指紋。"""
 
@@ -274,6 +282,10 @@ class TestNegativeMirrorLocks:
         )
 
 
+# [lint-guard: pytest-justified] Python-AST 源碼語意守衛（cross-file enrich_contract 契約）：
+# 斷言 AST 節點形狀 / detector 函式在 parsed Python 片段上的行為，非 html/js/css 靜態
+# 字串存在檢查，eslint/static_guard 無法表達（pre-merge SA-pre-6 例外清單「Python-AST
+# 源碼語意守衛」）。
 class TestFalsePositiveGuards:
     """反證：GREEN 狀態下守衛不誤傷 961 Tuple-target 與非-target plain meta.get。"""
 
@@ -318,6 +330,10 @@ class TestFalsePositiveGuards:
         )
 
 
+# [lint-guard: pytest-justified] Python-AST 源碼語意守衛（cross-file enrich_contract 契約）：
+# 斷言 AST 節點形狀 / detector 函式在 parsed Python 片段上的行為，非 html/js/css 靜態
+# 字串存在檢查，eslint/static_guard 無法表達（pre-merge SA-pre-6 例外清單「Python-AST
+# 源碼語意守衛」）。
 class TestNegativeDetectorSensitivity:
     """負向鎖 detector 敏感度（防近空殼假綠）：直接餵 AST 片段，斷言四個 detector
     對 canonical mirror 形狀**命中**、對正確碼**放行**。這把「守衛真的鎖得住」的
@@ -369,6 +385,10 @@ class TestNegativeDetectorSensitivity:
             for n in ast.walk(ast.parse('t = meta.get("original_title", "")')))
 
 
+# [lint-guard: pytest-justified] Python-AST 源碼語意守衛（cross-file enrich_contract 契約）：
+# 斷言 AST 節點形狀 / detector 函式在 parsed Python 片段上的行為，非 html/js/css 靜態
+# 字串存在檢查，eslint/static_guard 無法表達（pre-merge SA-pre-6 例外清單「Python-AST
+# 源碼語意守衛」）。
 class TestWhitelistAntiRot:
     """白名單防腐（比照先例 test_whitelist_entries_exist）：
     每個 named target 必須能在對應檔 AST 定位，否則守衛指向殭屍函式、恆綠假通過。

--- a/tests/integration/test_readonly_enrich_contract_parity.py
+++ b/tests/integration/test_readonly_enrich_contract_parity.py
@@ -1,0 +1,372 @@
+"""test_readonly_enrich_contract_parity.py — 唯讀／非唯讀 enrich 行為 contract-parity（TASK-105-T8）
+
+[pytest-justified: cross-file readonly/non-readonly API behaviour contract, runtime 兩路徑回傳值
+比對，非 static-string guard]
+
+本檔驗的是「`web/routers/scraper.py` 唯讀分支」與「`core/enricher.py` 對應函式」**兩個檔案之間的
+runtime API 行為 contract**（CLAUDE.md 判斷原則：兩檔之間的 API contract → pytest C/E 類）：
+對 6 個等價邊界輸入情境，各跑一次唯讀分支（TestClient/SSE）與一次非唯讀函式（直接 call），把兩邊
+回傳的 `EnrichResult` **可比欄位**（success/reason/cover_written/extrafanart_written）斷言相等，並
+**明列刻意豁免欄位**（nfo_written/source_used/fields_filled/error）不比。eslint/static_guard_lint
+（靜態字面掃描）無法表達「實際跑兩條 code path 比對 runtime dict」。
+
+定位（T7 的第二道防線）：T7「一份 helper + AST 守衛」偵測「有沒有呼叫同一份 helper」；本 parity
+偵測「呼叫的那份 helper 行為對不對」——同一份 helper 餵等價輸入，兩路徑吐出的可比欄位真的相等。
+未來 `EnrichResult` 長新欄 / helper 換簽章導致兩路徑悄悄漂移時 fail-loud（CD-105-6-3 全歸類）。
+
+Non-Goal（spec §3，守住）：不斷言任何時序/併發（不碰 PR#93 殘留競態）；不合併/不動兩
+CoverPreserveGate 類（本檔獨立新增）；不比 `EnrichResult` 以外的 fs 路徑值。
+"""
+
+import dataclasses
+from contextlib import ExitStack
+from dataclasses import asdict
+from pathlib import Path
+
+from unittest.mock import MagicMock, patch
+
+from core.enrich_contract import EnrichResult
+
+
+# ── 全欄位歸類常數（防「只比三欄」退化的靈魂，CD-105-6-3）────────────────────────
+
+# 動態取，不硬編：未來 EnrichResult 加欄且未歸類 → _assert_parity 的全歸類 assert RED。
+ALL_ENRICHRESULT_FIELDS = {f.name for f in dataclasses.fields(EnrichResult)}
+
+# 可比欄位（4，斷言相等）——兩路徑本該相同：
+#   success               成功/失敗語意兩路徑一致（第②層記帳結果）
+#   reason                hit/no_cover/not_found/None，派生自共用 enrich_success / 共用失敗形狀（parity 核心）
+#   cover_written         本次是否實際寫出封面（共用 apply_cover_preserve/should_preserve_cover 結果）
+#   extrafanart_written   本次實際寫出劇照數（int）
+COMPARED_FIELDS = {"success", "reason", "cover_written", "extrafanart_written"}
+
+# 豁免欄位（4，明列理由、刻意不比）：
+EXEMPT_FIELDS = {
+    # nfo_written：唯讀恆 True（write_nfo=false 已在 router 上游拒絕、holistic produce 一律寫 NFO，
+    #   spec §2.3）；非唯讀反映 _write_nfo 實際結果。結構性刻意差異。
+    "nfo_written",
+    # source_used：落地來源標籤不同（唯讀＝ingest/rescrape 來源；非唯讀＝db/nfo/scraper meta source）。
+    #   spec §4 AC9「檔案路徑/來源」豁免的具現（EnrichResult 無 path 欄，路徑差異體現在此）。
+    "source_used",
+    # fields_filled：presence-list vs merge-diff（唯讀＝全 meta 非空 key 列 _readonly_fields_filled；
+    #   非唯讀＝merge diff 列）。唯讀 ingest 無 base 可 diff，spec §2.3 刻意不同。
+    "fields_filled",
+    # error：失敗文案兩邊本就不同（唯讀「找不到可用的番號資料」vs 非唯讀「找不到 {number} 的資料」）
+    #   ——只比 success/reason，不比 error 字面。
+    "error",
+}
+
+# 註：spec §4 AC9 亦列「檔案路徑」豁免——EnrichResult dataclass 無任何 path 型欄位，故那是預防性
+# 條款：本 parity 本就只碰這 8 欄、不觸及 _produce_one 的 cover_fs/movie_dir 等 fs-layout 值
+# （第③層 write-layer 刻意差異，spec §5）。
+
+
+def _assert_parity(readonly: dict, nonreadonly: dict):
+    """契約核心：全歸類 fail-loud + 逐可比欄相等 + 豁免欄 shape 完整（不比值）。"""
+    # (1) 全歸類：COMPARED ∪ EXEMPT 必須恰為 EnrichResult 全欄。未來新欄未歸類 → RED
+    #     （backstop 的核心防漂移點，CD-105-6-3）。
+    assert COMPARED_FIELDS | EXEMPT_FIELDS == ALL_ENRICHRESULT_FIELDS, (
+        "EnrichResult 欄位未全數歸類（COMPARED ∪ EXEMPT ≠ dataclass fields）——"
+        f"未歸類: {ALL_ENRICHRESULT_FIELDS - (COMPARED_FIELDS | EXEMPT_FIELDS)}；"
+        f"多餘: {(COMPARED_FIELDS | EXEMPT_FIELDS) - ALL_ENRICHRESULT_FIELDS}"
+    )
+    # (2) 逐可比欄相等（失敗訊息帶欄名 + 兩值，便於定位哪路徑漂移）。
+    for f in sorted(COMPARED_FIELDS):
+        assert readonly[f] == nonreadonly[f], (
+            f"parity 漂移 @ {f!r}: readonly={readonly[f]!r} != nonreadonly={nonreadonly[f]!r}"
+        )
+    # (3) 豁免欄不斷值，但兩邊 key 都在（證明 shape 完整、未來 rename 露餡）。
+    for f in EXEMPT_FIELDS:
+        assert f in readonly and f in nonreadonly, f"豁免欄 {f!r} 缺 key（shape 不完整）"
+
+
+# ── 共用常數 / SSE helper ─────────────────────────────────────────────────────
+
+NUMBER = "ABC-001"
+NR_FILE = "/video/ABC-001.mp4"          # 非唯讀影片路徑（全 mock，實體不需存在）
+RO_DIR = "/tmp/ro_src"                   # 唯讀來源目錄（E batch 走真 is_path_readonly，需真前綴）
+RO_FILE = "/tmp/ro_src/ABC-001.mp4"
+COVER_URL = "http://x/new.jpg"
+
+
+def parse_sse(text: str) -> list:
+    """解析 SSE 文字回傳事件 dict 列表（複製自 test_api_batch_enrich.py:16）。"""
+    events = []
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            import json
+            events.append(json.loads(line[6:]))
+    return events
+
+
+def _strip_sse_wrapper(item: dict) -> dict:
+    """去掉 result-item 的 SSE 包裝欄（type/number/file_path），剩 EnrichResult 8 欄。"""
+    return {k: v for k, v in item.items() if k not in ("type", "number", "file_path")}
+
+
+def _video_exists_only(path):
+    """情境⑤ path-keyed os.path.exists side_effect：影片路徑→True、封面/其餘→False。
+
+    🔴 非唯讀若用 blanket False 會在 enricher.py:376 top-level
+    `if not os.path.exists(fs_path): return reason='error'` 提早 bail 成 error，與唯讀
+    no_cover 假發散。故影片檔存在（通過 top-level 檢查）、封面檔不存在（→ no_cover）。
+    """
+    return str(path).endswith((".mp4", ".mkv"))
+
+
+# ── 唯讀側 config / owning stub（複製精神自 test_api_enrich.py:274/285，本檔自成 fixture）──
+
+def _readonly_gallery_config(path):
+    return {
+        "gallery": {"directories": [{"path": path, "readonly": True}], "path_mappings": {}},
+        "search": {},
+        "scraper": {},
+    }
+
+
+def _owning_stub(path):
+    source = MagicMock()
+    source.path = path
+    return (source, "/out/ro", "file:///out/ro")
+
+
+def _patch_os_exists(mocker, targets, os_exists):
+    """os_exists 為 callable → side_effect（path-keyed）；否則 → return_value（blanket bool）。
+    CD-105-8：唯讀兩處（web.routers.scraper.os.path.exists + core.enrich_contract.os.path.exists）
+    機械上同 module singleton，一致即可。"""
+    for t in targets:
+        if callable(os_exists):
+            mocker.patch(t, side_effect=os_exists)
+        else:
+            mocker.patch(t, return_value=os_exists)
+
+
+# ── 非唯讀路徑 runner（A/B，直接 import + call，asdict 正規化）──────────────────
+
+def _scraper_meta(cover=COVER_URL, sample_images=None):
+    return {
+        "number": NUMBER, "title": "T", "maker": "M",
+        "cover": cover, "source": "javbus",
+        "sample_images": sample_images or [],
+    }
+
+
+def _run_nonreadonly_enrich(*, search_result, os_exists, row_cover_path="",
+                            download_image_ret=True, mode="refresh_full",
+                            write_cover=True, overwrite_existing=False):
+    """A：core.enricher.enrich_single 直呼。patch 落 core.enricher.* 使用端 binding +
+    全域 os.path.exists（同時覆蓋 top-level 檔案檢查 / _write_cover / cover_uri_is_servable
+    磁碟複驗，三者共享 module singleton）。刻意不 mock 契約 helper（enrich_success /
+    compute_has_servable_cover / cover_uri_is_servable / apply_cover_preserve），只 mock
+    其輸入依賴（DB row via VideoRepository / os.path.exists / download_image / search_jav）。"""
+    from core.enricher import enrich_single
+    row = MagicMock(cover_path=row_cover_path, user_tags=[], original_title="",
+                    size_bytes=1000, mtime=1.0)
+    with ExitStack() as es:
+        if callable(os_exists):
+            es.enter_context(patch("os.path.exists", side_effect=os_exists))
+        else:
+            es.enter_context(patch("os.path.exists", return_value=os_exists))
+        mock_repo_cls = es.enter_context(patch("core.enricher.VideoRepository"))
+        mock_repo_cls.return_value.get_by_path.return_value = row
+        es.enter_context(patch("core.enricher.search_jav", return_value=search_result))
+        es.enter_context(patch("core.enricher.generate_nfo", return_value=True))
+        es.enter_context(patch("core.enricher.download_image", return_value=download_image_ret))
+        es.enter_context(patch("core.enricher.find_subtitle_files", return_value=[]))
+        es.enter_context(patch("core.focal_trigger.maybe_submit_video_focal"))
+        result = enrich_single(
+            file_path=NR_FILE, number=NUMBER, mode=mode,
+            write_nfo=True, write_cover=write_cover, write_extrafanart=False,
+            overwrite_existing=overwrite_existing,
+        )
+    return asdict(result)
+
+
+def _run_nonreadonly_samples(*, search_meta, sample_uris):
+    """B：core.enricher.fetch_samples_only 直呼。"""
+    from core.enricher import fetch_samples_only
+    with ExitStack() as es:
+        es.enter_context(patch("os.path.exists", return_value=True))
+        es.enter_context(patch("core.enricher.VideoRepository"))
+        es.enter_context(patch("core.enricher.search_jav", return_value=search_meta))
+        es.enter_context(patch("core.enricher._write_extrafanart", return_value=sample_uris))
+        es.enter_context(patch("core.enricher._db_upsert_samples_only"))
+        result = fetch_samples_only(file_path=NR_FILE, number=NUMBER)
+    return asdict(result)
+
+
+# ── 唯讀路徑 runner（C/D/E，TestClient，response.json()/SSE-parse 正規化）─────────
+
+_RO_OS_EXISTS_TARGETS = ["web.routers.scraper.os.path.exists", "core.enrich_contract.os.path.exists"]
+
+
+def _run_readonly_enrich(client, mocker, *, plan_meta, os_exists, existing_cover_path="",
+                         produce_cover_fs="", mode="fill_missing", write_cover=True,
+                         overwrite_existing=False, readonly_action="ingest"):
+    """C：POST /api/enrich-single 唯讀分支。patch 落 web.routers.scraper.* 使用端 binding +
+    兩處 os.path.exists（CD-105-8）。契約 helper 不 mock（跑真 helper 才測得出 parity）。"""
+    mocker.patch("web.routers.scraper.load_config", return_value=_readonly_gallery_config(RO_DIR))
+    mocker.patch("web.routers.scraper.resolve_owning_output_root", return_value=_owning_stub(RO_DIR))
+    mocker.patch("web.routers.scraper.resolve_ingest_plan",
+                 return_value=(plan_meta, ("download", COVER_URL)))
+    mocker.patch("web.routers.scraper._produce_one",
+                 return_value=(Path("/out/ro/ABC-001"),
+                               {"cover_fs": produce_cover_fs, "sample_fs": [], "nfo_mtime": 1.0}))
+    mock_repo = mocker.patch("web.routers.scraper.VideoRepository")
+    mock_repo.return_value.get_by_path.return_value = MagicMock(
+        size_bytes=1000, mtime=1.0, cover_path=existing_cover_path)
+    _patch_os_exists(mocker, _RO_OS_EXISTS_TARGETS, os_exists)
+    mocker.patch("core.focal_trigger.maybe_submit_video_focal")
+    resp = client.post("/api/enrich-single", json={
+        "file_path": RO_FILE, "number": NUMBER, "readonly_action": readonly_action,
+        "mode": mode, "write_cover": write_cover, "overwrite_existing": overwrite_existing,
+    })
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def _run_readonly_batch(client, mocker, *, plan_meta, os_exists, existing_cover_path="",
+                        produce_cover_fs="", mode="refresh_full", write_cover=True,
+                        overwrite_existing=False):
+    """E：POST /api/batch-enrich 唯讀分支（SSE）。同 C 的決策碼，另多跑 run_in_executor +
+    SSE reason 正規化（:987 'no_scrape'→'not_found'）。is_path_readonly 不 mock（走真前綴），
+    故 item 檔須在 RO_DIR 下。"""
+    mocker.patch("web.routers.scraper.load_config", return_value=_readonly_gallery_config(RO_DIR))
+    mocker.patch("web.routers.scraper.resolve_owning_output_root", return_value=_owning_stub(RO_DIR))
+    mocker.patch("web.routers.scraper.resolve_ingest_plan",
+                 return_value=(plan_meta, ("download", COVER_URL)))
+    mocker.patch("web.routers.scraper._produce_one",
+                 return_value=(Path("/out/ro/ABC-001"),
+                               {"cover_fs": produce_cover_fs, "sample_fs": [], "nfo_mtime": 1.0}))
+    mock_repo = mocker.patch("web.routers.scraper.VideoRepository")
+    mock_repo.return_value.get_by_path.return_value = MagicMock(
+        size_bytes=1000, mtime=1.0, cover_path=existing_cover_path)
+    _patch_os_exists(mocker, _RO_OS_EXISTS_TARGETS, os_exists)
+    mocker.patch("core.focal_trigger.maybe_submit_video_focal")
+    resp = client.post("/api/batch-enrich", json={
+        "items": [{"file_path": RO_FILE, "number": NUMBER}],
+        "mode": mode, "write_cover": write_cover, "overwrite_existing": overwrite_existing,
+    })
+    assert resp.status_code == 200
+    items = [e for e in parse_sse(resp.text) if e["type"] == "result-item"]
+    assert len(items) == 1
+    return _strip_sse_wrapper(items[0])
+
+
+def _run_readonly_samples(client, mocker, *, search_meta, produce_sample_fs):
+    """D：POST /api/scraper/fetch-samples 唯讀分支。"""
+    mocker.patch("web.routers.scraper.load_config", return_value=_readonly_gallery_config(RO_DIR))
+    mocker.patch("web.routers.scraper.resolve_owning_output_root", return_value=_owning_stub(RO_DIR))
+    mocker.patch("web.routers.scraper.search_jav", return_value=search_meta)
+    mocker.patch("web.routers.scraper._produce_one",
+                 return_value=(Path("/out/ro/ABC-001"),
+                               {"cover_fs": "", "sample_fs": produce_sample_fs, "nfo_mtime": 1.0}))
+    mocker.patch("web.routers.scraper.VideoRepository")
+    mocker.patch("web.routers.scraper.os.path.exists", return_value=True)
+    resp = client.post("/api/scraper/fetch-samples", json={"file_path": RO_FILE, "number": NUMBER})
+    assert resp.status_code == 200
+    return resp.json()
+
+
+# ── 6 情境 parity（各跑唯讀分支 + 非唯讀 core.enricher 對應函式）──────────────────
+
+class TestReadonlyEnrichContractParity:
+
+    def test_scenario_1_no_hit_not_found(self, client, mocker):
+        """①全無命中：唯讀 C（resolve_ingest_plan→None）+ E（batch）vs 非唯讀 A
+        （search_jav→None）。reason=not_found、cover_written=False、extrafanart=0。"""
+        nr = _run_nonreadonly_enrich(search_result=None, os_exists=True, mode="refresh_full")
+        assert nr["success"] is False and nr["reason"] == "not_found"
+
+        ro_c = _run_readonly_enrich(client, mocker, plan_meta=None, os_exists=True, mode="refresh_full")
+        _assert_parity(ro_c, nr)
+
+        ro_e = _run_readonly_batch(client, mocker, plan_meta=None, os_exists=True)
+        _assert_parity(ro_e, nr)  # E 覆蓋 SSE reason 正規化 'no_scrape'→'not_found'
+
+    def test_scenario_2_meta_no_cover(self, client, mocker):
+        """②有 meta 無封面：唯讀 C（cover_fs=''）+ E vs 非唯讀 A（meta 無 servable cover）。
+        reason=no_cover、cover_written=False。"""
+        nr = _run_nonreadonly_enrich(
+            search_result=_scraper_meta(cover=""), os_exists=True, row_cover_path="",
+            mode="refresh_full")
+        assert nr["success"] is True and nr["reason"] == "no_cover" and nr["cover_written"] is False
+
+        ro_c = _run_readonly_enrich(
+            client, mocker, plan_meta=_scraper_meta(cover=""), os_exists=True,
+            existing_cover_path="", produce_cover_fs="", mode="refresh_full")
+        _assert_parity(ro_c, nr)
+
+        ro_e = _run_readonly_batch(
+            client, mocker, plan_meta=_scraper_meta(cover=""), os_exists=True,
+            existing_cover_path="", produce_cover_fs="")
+        _assert_parity(ro_e, nr)
+
+    def test_scenario_3_meta_cover_written(self, client, mocker):
+        """③有 meta＋封面成功寫（overwrite=True 排除 preserve）：唯讀 C（cover_fs 有值、
+        servable）vs 非唯讀 A（download_image→True、DB cover 在）。reason=hit、cover_written=True。"""
+        nr = _run_nonreadonly_enrich(
+            search_result=_scraper_meta(), os_exists=True,
+            row_cover_path="file:///video/ABC-001.jpg", download_image_ret=True,
+            mode="refresh_full", overwrite_existing=True)
+        assert nr["success"] is True and nr["reason"] == "hit" and nr["cover_written"] is True
+
+        ro_c = _run_readonly_enrich(
+            client, mocker, plan_meta=_scraper_meta(), os_exists=True,
+            existing_cover_path="file:///out/cover.jpg",
+            produce_cover_fs="/out/ro/ABC-001/ABC-001.jpg",
+            mode="refresh_full", overwrite_existing=True, readonly_action="rescrape")
+        _assert_parity(ro_c, nr)
+
+    def test_scenario_4_fill_missing_existing_cover_preserved(self, client, mocker):
+        """④fill_missing+overwrite=False+既有 servable 封面（保留）：唯讀 C（had_cover=True →
+        cover_strategy ('none',)）vs 非唯讀 A（_write_cover should_preserve→True）。
+        cover_written=False 但 reason=hit（has_servable_cover 解耦）。"""
+        nr = _run_nonreadonly_enrich(
+            search_result=_scraper_meta(), os_exists=True,
+            row_cover_path="file:///video/ABC-001.jpg",
+            mode="fill_missing", overwrite_existing=False)
+        assert nr["success"] is True and nr["reason"] == "hit" and nr["cover_written"] is False
+
+        ro_c = _run_readonly_enrich(
+            client, mocker, plan_meta=_scraper_meta(), os_exists=True,
+            existing_cover_path="file:///out/cover.jpg", produce_cover_fs="",
+            mode="fill_missing", overwrite_existing=False)
+        _assert_parity(ro_c, nr)
+
+    def test_scenario_5_residual_cover_deleted_on_disk(self, client, mocker):
+        """⑤既有封面磁碟已刪（residual cover_path、檔不在）：唯讀 C vs 非唯讀 A。
+        🔴 兩路徑皆用 path-keyed os.path.exists（影片→True、封面→False），非唯讀不可用
+        blanket False（會 top-level bail 成 reason='error' 假發散）。reason=no_cover、
+        cover_written=False。"""
+        nr = _run_nonreadonly_enrich(
+            search_result=_scraper_meta(), os_exists=_video_exists_only,
+            row_cover_path="file:///out/old.jpg", download_image_ret=False,
+            mode="refresh_full", overwrite_existing=False)
+        assert nr["success"] is True and nr["reason"] == "no_cover" and nr["cover_written"] is False
+
+        ro_c = _run_readonly_enrich(
+            client, mocker, plan_meta=_scraper_meta(), os_exists=_video_exists_only,
+            existing_cover_path="file:///out/old.jpg", produce_cover_fs="",
+            mode="fill_missing", overwrite_existing=False)
+        _assert_parity(ro_c, nr)
+
+    def test_scenario_6_samples(self, client, mocker):
+        """⑥補劇照：唯讀 D（fetch-samples readonly）vs 非唯讀 B（fetch_samples_only）。
+        兩子例：成功（extrafanart=N、reason=None）＋找不到（success=False、reason=None）。"""
+        # ⑥a 成功：N=2 samples 寫出
+        nr_ok = _run_nonreadonly_samples(
+            search_meta=_scraper_meta(sample_images=["s1", "s2"]), sample_uris=["u1", "u2"])
+        assert nr_ok["success"] is True and nr_ok["reason"] is None and nr_ok["extrafanart_written"] == 2
+
+        ro_ok = _run_readonly_samples(
+            client, mocker, search_meta=_scraper_meta(sample_images=["s1", "s2"]),
+            produce_sample_fs=["f1", "f2"])
+        _assert_parity(ro_ok, nr_ok)
+
+        # ⑥b 找不到：search_jav→None，兩路徑 reason=None（samples 站不設 reason）
+        nr_miss = _run_nonreadonly_samples(search_meta=None, sample_uris=[])
+        assert nr_miss["success"] is False and nr_miss["reason"] is None
+
+        ro_miss = _run_readonly_samples(client, mocker, search_meta=None, produce_sample_fs=[])
+        _assert_parity(ro_miss, nr_miss)

--- a/tests/unit/test_enrich_contract.py
+++ b/tests/unit/test_enrich_contract.py
@@ -14,6 +14,7 @@ from core.enrich_contract import (
     apply_cover_preserve,
     compute_has_servable_cover,
     cover_uri_is_servable,
+    effective_original_title,
     should_preserve_cover,
 )
 
@@ -88,6 +89,34 @@ class TestComputeHasServableCover:
         repo = self._repo("file:///out/x.jpg")
         compute_has_servable_cover(repo, "file:///the/canonical/key.mp4", {})
         repo.get_by_path.assert_called_once_with("file:///the/canonical/key.mp4")
+
+
+# ── effective_original_title ─────────────────────────────────────────────────
+
+class TestEffectiveOriginalTitle:
+    """重刮回空原文標題時保留 DB 既有值（唯一 preserve 邏輯，方案 A）。3 邊界：
+    1. meta 有非空值 → 用 meta（新值仍覆蓋既有）
+    2. meta 空/缺 key + existing 有值 → 保留 existing（Bug 2 修正）
+    3. meta 空/缺 key + existing=None → ''
+    """
+
+    def test_meta_has_value_uses_meta(self):
+        """meta 有非空 original_title → 用之（即使 existing 也有值仍覆蓋）。"""
+        existing = SimpleNamespace(original_title='既存')
+        assert effective_original_title({'original_title': '新原題'}, existing) == '新原題'
+        assert effective_original_title({'original_title': '新原題'}, None) == '新原題'
+
+    def test_meta_empty_or_missing_falls_back_to_existing(self):
+        """meta 空 '' 或缺 key + existing 有值 → 保留 existing（Bug 2 修正）。"""
+        existing = SimpleNamespace(original_title='既存')
+        assert effective_original_title({'original_title': ''}, existing) == '既存'
+        assert effective_original_title({}, existing) == '既存'
+
+    def test_both_empty_or_no_existing_returns_empty(self):
+        """meta 空/缺 + existing=None（或 existing 也空）→ ''。"""
+        assert effective_original_title({'original_title': ''}, None) == ''
+        assert effective_original_title({}, None) == ''
+        assert effective_original_title({'original_title': ''}, SimpleNamespace(original_title='')) == ''
 
 
 # ── should_preserve_cover ────────────────────────────────────────────────────

--- a/tests/unit/test_enrich_contract.py
+++ b/tests/unit/test_enrich_contract.py
@@ -11,10 +11,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from core.enrich_contract import (
+    EnrichResult,
     apply_cover_preserve,
     compute_has_servable_cover,
     cover_uri_is_servable,
     effective_original_title,
+    enrich_success,
     should_preserve_cover,
 )
 
@@ -145,6 +147,69 @@ class TestShouldPreserveCover:
         """無封面 → 寫（不保留，不論 overwrite）。"""
         assert should_preserve_cover(True, False, False) is False
         assert should_preserve_cover(True, True, False) is False
+
+
+# ── enrich_success ───────────────────────────────────────────────────────────
+
+class TestEnrichSuccess:
+    """成功建構器（feature/105 T4，CD-105-7）：reason 派生單一住 builder 內。
+    has_servable_cover（None/True/False）× reason（None/顯式）正交三態；
+    has_servable_cover is not None 時派生值覆蓋 reason 參數（派生優先）。
+    """
+
+    def _base_kwargs(self):
+        return dict(
+            nfo_written=True,
+            cover_written=False,
+            extrafanart_written=3,
+            fields_filled=['title', 'actors'],
+            source_used='javdb',
+        )
+
+    def test_has_servable_cover_true_derives_hit(self):
+        r = enrich_success(**self._base_kwargs(), has_servable_cover=True)
+        assert r.reason == 'hit'
+
+    def test_has_servable_cover_false_derives_no_cover(self):
+        r = enrich_success(**self._base_kwargs(), has_servable_cover=False)
+        assert r.reason == 'no_cover'
+
+    def test_no_cover_arg_and_reason_none_stays_none(self):
+        """samples 站：不傳 has_servable_cover + reason=None（顯式）→ None。"""
+        r = enrich_success(**self._base_kwargs(), reason=None)
+        assert r.reason is None
+
+    def test_no_cover_arg_reason_passthrough(self):
+        """has_servable_cover=None + 顯式 reason → 原樣穿透（走 else 分支）。"""
+        r = enrich_success(**self._base_kwargs(), reason='foo')
+        assert r.reason == 'foo'
+
+    def test_derivation_overrides_reason_param(self):
+        """衝突優先：has_servable_cover=True + reason='no_cover' → 'hit'（派生覆蓋參數）。"""
+        r = enrich_success(**self._base_kwargs(), has_servable_cover=True, reason='no_cover')
+        assert r.reason == 'hit'
+
+    def test_eight_fields_correct(self):
+        """success/error 恆定，其餘 6 欄位原樣塞入（含 fields_filled 原樣）。"""
+        fields = ['title', 'actors']
+        r = enrich_success(
+            nfo_written=False,
+            cover_written=True,
+            extrafanart_written=5,
+            fields_filled=fields,
+            source_used='avsox',
+            has_servable_cover=None,
+            reason=None,
+        )
+        assert isinstance(r, EnrichResult)
+        assert r.success is True
+        assert r.error is None
+        assert r.nfo_written is False
+        assert r.cover_written is True
+        assert r.extrafanart_written == 5
+        assert r.fields_filled == fields
+        assert r.source_used == 'avsox'
+        assert r.reason is None
 
 
 # ── apply_cover_preserve ─────────────────────────────────────────────────────

--- a/tests/unit/test_enrich_contract.py
+++ b/tests/unit/test_enrich_contract.py
@@ -10,7 +10,12 @@ Bug 1 (feature/105) 四組正交邊界：
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from core.enrich_contract import cover_uri_is_servable, compute_has_servable_cover
+from core.enrich_contract import (
+    apply_cover_preserve,
+    compute_has_servable_cover,
+    cover_uri_is_servable,
+    should_preserve_cover,
+)
 
 
 # ── cover_uri_is_servable ────────────────────────────────────────────────────
@@ -83,3 +88,53 @@ class TestComputeHasServableCover:
         repo = self._repo("file:///out/x.jpg")
         compute_has_servable_cover(repo, "file:///the/canonical/key.mp4", {})
         repo.get_by_path.assert_called_once_with("file:///the/canonical/key.mp4")
+
+
+# ── should_preserve_cover ────────────────────────────────────────────────────
+
+class TestShouldPreserveCover:
+    """純政策 predicate：write_cover × overwrite_existing × cover_exists 三布林正交。
+    mode 維度已移除（AC4 mode-agnostic）。4 組有效組合（write_cover=False 吸收
+    overwrite/exists 兩維，故 4 組非 8 組）。"""
+
+    def test_not_write_cover_always_preserves(self):
+        """write_cover=False → 恆保留（吸收 overwrite/exists 兩維）。"""
+        assert should_preserve_cover(False, False, False) is True
+        assert should_preserve_cover(False, False, True) is True
+        assert should_preserve_cover(False, True, False) is True
+        assert should_preserve_cover(False, True, True) is True
+
+    def test_write_cover_existing_no_overwrite_preserves(self):
+        """有封面 + 不覆蓋 → 保留。"""
+        assert should_preserve_cover(True, False, True) is True
+
+    def test_write_cover_existing_overwrite_writes(self):
+        """有封面 + 覆蓋 → 寫（不保留）。"""
+        assert should_preserve_cover(True, True, True) is False
+
+    def test_write_cover_no_existing_writes(self):
+        """無封面 → 寫（不保留，不論 overwrite）。"""
+        assert should_preserve_cover(True, False, False) is False
+        assert should_preserve_cover(True, True, False) is False
+
+
+# ── apply_cover_preserve ─────────────────────────────────────────────────────
+
+class TestApplyCoverPreserve:
+    def test_preserve_returns_none_strategy(self):
+        """命中保留 → ('none',)，覆蓋掉原 strategy。"""
+        assert apply_cover_preserve(
+            ("download", "http://x/new.jpg"), False, False, False
+        ) == ("none",)
+        assert apply_cover_preserve(
+            ("download", "http://x/new.jpg"), True, False, True
+        ) == ("none",)
+
+    def test_not_preserve_passes_strategy_through(self):
+        """不保留 → 原 strategy 原樣穿透。"""
+        assert apply_cover_preserve(
+            ("download", "http://x/new.jpg"), True, True, True
+        ) == ("download", "http://x/new.jpg")
+        assert apply_cover_preserve(
+            ("download", "http://x/new.jpg"), True, False, False
+        ) == ("download", "http://x/new.jpg")

--- a/tests/unit/test_enrich_contract.py
+++ b/tests/unit/test_enrich_contract.py
@@ -1,0 +1,85 @@
+"""Unit tests for core.enrich_contract — cover_uri_is_servable / compute_has_servable_cover.
+
+Bug 1 (feature/105) 四組正交邊界：
+1. DB 有 cover_path + 檔在磁碟 → True
+2. DB 有 cover_path + 檔已刪 → False（Bug 1 核心）
+3. 無 row / cover_path 空 → False（短路，不呼叫 os.path.exists）
+4. path-mapping 解不到（uri_to_local_fs_path 回不存在路徑）→ False
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.enrich_contract import cover_uri_is_servable, compute_has_servable_cover
+
+
+# ── cover_uri_is_servable ────────────────────────────────────────────────────
+
+class TestCoverUriIsServable:
+    def test_cover_present_and_file_exists_true(self, mocker):
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=True)
+        assert cover_uri_is_servable("file:///out/ABC-001/ABC-001.jpg", {}) is True
+
+    def test_cover_present_but_file_deleted_false(self, mocker):
+        """Bug 1 核心：DB 有 cover_path 但實體檔已被刪 → False。"""
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=False)
+        assert cover_uri_is_servable("file:///out/ABC-001/ABC-001.jpg", {}) is False
+
+    def test_empty_cover_short_circuits_without_disk_check(self, mocker):
+        """cover_uri 空 → 短路 False，os.path.exists 不得被呼叫。"""
+        m_exists = mocker.patch("core.enrich_contract.os.path.exists", return_value=True)
+        assert cover_uri_is_servable("", {}) is False
+        m_exists.assert_not_called()
+
+    def test_path_mapping_unresolvable_false(self, mocker):
+        """path-mapping 解不到 → uri_to_local_fs_path 回不存在路徑 → os.path.exists False。"""
+        # 不 mock os.path.exists；用一個保證不存在的路徑，讓真實磁碟檢查回 False。
+        assert cover_uri_is_servable(
+            "file:///nonexistent-drive/definitely/not/here-xyz.jpg", {}
+        ) is False
+
+
+# ── compute_has_servable_cover ───────────────────────────────────────────────
+
+class TestComputeHasServableCover:
+    def _repo(self, cover_path):
+        repo = MagicMock()
+        repo.get_by_path.return_value = SimpleNamespace(cover_path=cover_path)
+        return repo
+
+    def test_db_has_cover_and_file_exists_true(self, mocker):
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=True)
+        repo = self._repo("file:///out/ABC-001/ABC-001.jpg")
+        assert compute_has_servable_cover(repo, "file:///src/ABC-001.mp4", {}) is True
+
+    def test_db_has_cover_but_file_deleted_false(self, mocker):
+        """Bug 1 核心：DB row 殘留 cover_path、磁碟檔已刪 → False。"""
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=False)
+        repo = self._repo("file:///out/ABC-001/ABC-001.jpg")
+        assert compute_has_servable_cover(repo, "file:///src/ABC-001.mp4", {}) is False
+
+    def test_no_row_false_short_circuits(self, mocker):
+        """無 row → cover_path '' → False，os.path.exists 不得被呼叫。"""
+        m_exists = mocker.patch("core.enrich_contract.os.path.exists", return_value=True)
+        repo = MagicMock()
+        repo.get_by_path.return_value = None
+        assert compute_has_servable_cover(repo, "file:///src/ABC-001.mp4", {}) is False
+        m_exists.assert_not_called()
+
+    def test_empty_cover_path_false_short_circuits(self, mocker):
+        m_exists = mocker.patch("core.enrich_contract.os.path.exists", return_value=True)
+        repo = self._repo("")
+        assert compute_has_servable_cover(repo, "file:///src/ABC-001.mp4", {}) is False
+        m_exists.assert_not_called()
+
+    def test_path_mapping_unresolvable_false(self):
+        """path-mapping 解不到 → 真實磁碟檢查回 False（不 mock os.path.exists）。"""
+        repo = self._repo("file:///nonexistent-drive/definitely/not/here-xyz.jpg")
+        assert compute_has_servable_cover(repo, "file:///src/ABC-001.mp4", {}) is False
+
+    def test_uses_given_path_uri_key(self, mocker):
+        """compute 必須用傳入的 path_uri 當 get_by_path 的 key（upsert 寫入同 key）。"""
+        mocker.patch("core.enrich_contract.os.path.exists", return_value=True)
+        repo = self._repo("file:///out/x.jpg")
+        compute_has_servable_cover(repo, "file:///the/canonical/key.mp4", {})
+        repo.get_by_path.assert_called_once_with("file:///the/canonical/key.mp4")

--- a/tests/unit/test_enrich_contract.py
+++ b/tests/unit/test_enrich_contract.py
@@ -120,6 +120,16 @@ class TestEffectiveOriginalTitle:
         assert effective_original_title({}, None) == ''
         assert effective_original_title({'original_title': ''}, SimpleNamespace(original_title='')) == ''
 
+    def test_existing_original_title_none_returns_empty_str_not_none(self):
+        """meta 空 + existing.original_title 為 SQL NULL（Video.from_row → Python None）→ 回 ''
+        而非 None（grok pre-merge P2 回歸修正）。DB `original_title TEXT` 可為 NULL、
+        `from_row` 原樣傳 None；若回 None 會被注入 meta['original_title']，下游
+        `generate_nfo` 的 `html.escape(None)` 拋 AttributeError。回傳恆為 str。"""
+        assert effective_original_title({}, SimpleNamespace(original_title=None)) == ''
+        assert effective_original_title({'original_title': ''}, SimpleNamespace(original_title=None)) == ''
+        # 型別鎖：任何輸入組合回傳皆為 str（不得回 None）
+        assert isinstance(effective_original_title({}, SimpleNamespace(original_title=None)), str)
+
 
 # ── should_preserve_cover ────────────────────────────────────────────────────
 

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -2410,7 +2410,7 @@ class TestEnrichFocalTrigger:
             patch("core.enricher.generate_nfo", return_value=True),
             patch("core.enricher.download_image", return_value=True),
             patch("core.enricher.find_subtitle_files", return_value=[]),
-            patch("core.enricher.maybe_submit_video_focal") as mock_submit,
+            patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit,
         ):
             mock_repo = MagicMock()
             mock_existing = MagicMock()
@@ -2492,7 +2492,7 @@ class TestEnrichPreserveCropModeE2E:
             patch("core.enricher.generate_nfo", return_value=True),
             patch("core.enricher.download_image", return_value=True),
             patch("core.enricher.find_subtitle_files", return_value=[]),
-            patch("core.enricher.maybe_submit_video_focal"),
+            patch("core.focal_trigger.maybe_submit_video_focal"),
             patch("core.similar.ranker_cache.SimilarRankerCache"),
         ):
             from core.enricher import enrich_single
@@ -2566,7 +2566,7 @@ class TestEnrichFocalReset:
             patch("core.enricher.generate_nfo", return_value=True),
             patch("core.enricher.download_image", return_value=True),
             patch("core.enricher.find_subtitle_files", return_value=[]),
-            patch("core.enricher.maybe_submit_video_focal", side_effect=_capture_submit),
+            patch("core.focal_trigger.maybe_submit_video_focal", side_effect=_capture_submit),
             patch("core.similar.ranker_cache.SimilarRankerCache"),
         ):
             from core.enricher import enrich_single
@@ -2599,7 +2599,7 @@ class TestEnrichFocalReset:
             patch("core.enricher.generate_nfo", return_value=True),
             patch("core.enricher.download_image", return_value=True),
             patch("core.enricher.find_subtitle_files", return_value=[]),
-            patch("core.enricher.maybe_submit_video_focal") as mock_submit,
+            patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit,
             patch("core.similar.ranker_cache.SimilarRankerCache"),
         ):
             from core.enricher import enrich_single
@@ -2672,7 +2672,7 @@ class TestEnrichFocalCoverPathUriNamespace:
             patch("core.enricher.generate_nfo", return_value=True),
             patch("core.enricher.download_image", side_effect=self._write_fake_cover),
             patch("core.enricher.find_subtitle_files", return_value=[]),
-            patch("core.enricher.maybe_submit_video_focal", side_effect=_capture_submit),
+            patch("core.focal_trigger.maybe_submit_video_focal", side_effect=_capture_submit),
             patch("core.similar.ranker_cache.SimilarRankerCache"),
         ):
             from core.enricher import enrich_single
@@ -2732,7 +2732,7 @@ class TestEnrichFocalCoverPathUriNamespace:
             patch("core.enricher.generate_nfo", return_value=True),
             patch("core.enricher.download_image", side_effect=self._write_fake_cover),
             patch("core.enricher.find_subtitle_files", return_value=[]),
-            patch("core.enricher.maybe_submit_video_focal", side_effect=_capture_submit),
+            patch("core.focal_trigger.maybe_submit_video_focal", side_effect=_capture_submit),
             patch("core.similar.ranker_cache.SimilarRankerCache"),
         ):
             from core.enricher import enrich_single

--- a/tests/unit/test_focal_trigger.py
+++ b/tests/unit/test_focal_trigger.py
@@ -1,5 +1,6 @@
 """
 test_focal_trigger.py — TASK-98b-T2 / 99b-T2: maybe_submit_video_focal helper 契約
+                         + TASK-105-T6: schedule_focal_after_cover_write 收斂 helper
 
 TDD-lite（注入假 submit_focal / 假 repo / 假 gate，不真跑 pigo、不碰真 DB）：
 - gate：有碼 → 不 submit；無碼 → submit
@@ -8,6 +9,13 @@ TDD-lite（注入假 submit_focal / 假 repo / 假 gate，不真跑 pigo、不�
 - commit lambda：呼叫 update_auto_focal(video_path_uri, focal_str, cover_path_uri)（fp 忽略）
 - 防禦：helper 內任何例外都吞掉（不冒泡打斷 scrape/scan）
 - 99b-T2 CD-99b-9：cover_path_uri 為 keyword-only 必填，省略即 TypeError（fail-closed）
+
+TASK-105-T6 schedule_focal_after_cover_write：
+- 順序鎖：reset_focal_to_auto 必早於 maybe_submit_video_focal
+- args passthrough：reset 單一 video_uri；submit 位置 (number, maker, video_uri, cover_fs)
+  + keyword-only cover_path_uri
+- cover_path_uri 派生：truthy → to_file_uri(cover_fs, path_mappings)；falsy → ""
+- db_path 不傳
 """
 
 from unittest.mock import patch, MagicMock
@@ -248,3 +256,137 @@ def test_cover_path_uri_cannot_be_passed_positionally():
             "SIRO-1234", "", "file:///x/SIRO-1234.mp4", "/x/SIRO-1234.jpg",
             "file:///x/SIRO-1234.jpg",
         )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# TASK-105-T6: schedule_focal_after_cover_write（三站收斂 helper）
+# ══════════════════════════════════════════════════════════════════════════
+
+def test_schedule_focal_reset_called_before_submit():
+    """順序鎖（最核心不變式）：reset_focal_to_auto 必早於 maybe_submit_video_focal。
+
+    mutation 鎖：把 helper body 反過來（submit 先、reset 後）→ 本測 RED（parent
+    mock 的 mock_calls 順序會變成 submit 先出現）。
+    """
+    repo = MagicMock()
+    manager = MagicMock()
+    manager.attach_mock(repo.reset_focal_to_auto, "reset")
+
+    with patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit:
+        manager.attach_mock(mock_submit, "submit")
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, "file:///x/SIRO-1234.mp4", "SIRO-1234", "SOD",
+            "/x/SIRO-1234.jpg", {},
+        )
+
+    call_names = [c[0] for c in manager.mock_calls]
+    assert call_names.index("reset") < call_names.index("submit")
+
+
+def test_schedule_focal_reset_passthrough():
+    """reset_focal_to_auto 以單一 video_uri 呼叫一次。"""
+    repo = MagicMock()
+    video_uri = "file:///x/SIRO-1234.mp4"
+
+    with patch("core.focal_trigger.maybe_submit_video_focal"):
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, video_uri, "SIRO-1234", "SOD", "/x/SIRO-1234.jpg", {},
+        )
+
+    repo.reset_focal_to_auto.assert_called_once_with(video_uri)
+
+
+def test_schedule_focal_submit_passthrough():
+    """maybe_submit_video_focal 收到 (number, maker, video_uri, cover_fs) 位置參
+    + cover_path_uri= keyword；第三位置參與 reset 同一個 video_uri（防未來誤拆兩 URI）。
+    """
+    repo = MagicMock()
+    video_uri = "file:///x/SIRO-1234.mp4"
+    cover_fs = "/x/SIRO-1234.jpg"
+
+    with patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit:
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, video_uri, "SIRO-1234", "SOD", cover_fs, {},
+        )
+
+    mock_submit.assert_called_once()
+    args, kwargs = mock_submit.call_args
+    assert args[0] == "SIRO-1234"
+    assert args[1] == "SOD"
+    assert args[2] == video_uri
+    assert args[3] == cover_fs
+    assert "cover_path_uri" in kwargs
+
+
+def test_schedule_focal_cover_path_uri_truthy_derives_via_to_file_uri():
+    """cover_fs 非空 → cover_path_uri == to_file_uri(cover_fs, path_mappings)
+    （patch to_file_uri 回 sentinel，斷言穿透）。"""
+    repo = MagicMock()
+    path_mappings = {"a": "b"}
+    sentinel = "file:///sentinel/cover.jpg"
+
+    with (
+        patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit,
+        patch("core.focal_trigger.to_file_uri", return_value=sentinel) as mock_to_uri,
+    ):
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, "file:///x/SIRO-1234.mp4", "SIRO-1234", "SOD",
+            "/x/SIRO-1234.jpg", path_mappings,
+        )
+
+    mock_to_uri.assert_called_once_with("/x/SIRO-1234.jpg", path_mappings)
+    _, kwargs = mock_submit.call_args
+    assert kwargs["cover_path_uri"] == sentinel
+
+
+def test_schedule_focal_cover_path_uri_falsy_empty_string():
+    """cover_fs == "" → cover_path_uri == ""（to_file_uri 不決定此分支的最終值）。"""
+    repo = MagicMock()
+
+    with (
+        patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit,
+        patch("core.focal_trigger.to_file_uri", return_value="should-not-be-used"),
+    ):
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, "file:///x/SIRO-1234.mp4", "SIRO-1234", "SOD", "", {},
+        )
+
+    _, kwargs = mock_submit.call_args
+    assert kwargs["cover_path_uri"] == ""
+
+
+def test_schedule_focal_cover_path_uri_falsy_none():
+    """cover_fs is None → cover_path_uri == ""。"""
+    repo = MagicMock()
+
+    with (
+        patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit,
+        patch("core.focal_trigger.to_file_uri", return_value="should-not-be-used"),
+    ):
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, "file:///x/SIRO-1234.mp4", "SIRO-1234", "SOD", None, {},
+        )
+
+    _, kwargs = mock_submit.call_args
+    assert kwargs["cover_path_uri"] == ""
+
+
+def test_schedule_focal_does_not_pass_db_path():
+    """maybe_submit_video_focal 呼叫不含 db_path kwarg（走預設 DB，三站現況一致）。"""
+    repo = MagicMock()
+
+    with patch("core.focal_trigger.maybe_submit_video_focal") as mock_submit:
+        from core.focal_trigger import schedule_focal_after_cover_write
+        schedule_focal_after_cover_write(
+            repo, "file:///x/SIRO-1234.mp4", "SIRO-1234", "SOD",
+            "/x/SIRO-1234.jpg", {},
+        )
+
+    _, kwargs = mock_submit.call_args
+    assert "db_path" not in kwargs

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -5775,3 +5775,108 @@ class TestResolveOwningOutputRoot:
         result = resolve_owning_output_root(canonical, config)
         assert result is not None
         assert result[0].path == str(good)
+
+
+class TestReadonlyStubNotFound:
+    """TASK-105-T5 (T2-a): _readonly_stub_not_found(repo, uri, number, fs_path)
+    collapses the 3 not-found stub call sites (S1 scraper.py enrich-single,
+    S2 scraper.py batch, S3 readonly_producer.py bulk produce_source) into one
+    helper. Core invariant: insert_if_ignore MUST run before
+    update_scrape_attempted_at (the latter is a bare UPDATE...WHERE path=?
+    that silently no-ops without a row — see video.py:1144-1167)."""
+
+    def test_insert_before_update_ordering(self):
+        """MUTATION LOCK: insert_if_ignore call index must be < update_scrape_attempted_at
+        call index in repo.mock_calls. Reversing the two calls in the helper body
+        must turn this RED."""
+        from core.readonly_producer import _readonly_stub_not_found
+
+        repo = MagicMock()
+        _readonly_stub_not_found(repo, "file:///src/videos/X-001.mp4", "X-001", "/src/videos/X-001.mp4")
+
+        call_names = [c[0] for c in repo.mock_calls]
+        insert_idx = call_names.index("insert_if_ignore")
+        update_idx = call_names.index("update_scrape_attempted_at")
+        assert insert_idx < update_idx
+
+    def test_video_three_field_lock(self):
+        """Video(path=uri, number=number, title=basename(fs_path)) — other
+        fields fall back to dataclass defaults (cover_path='', output_dir='',
+        sample_images=[])."""
+        from core.database import Video
+        from core.readonly_producer import _readonly_stub_not_found
+
+        repo = MagicMock()
+        _readonly_stub_not_found(
+            repo, "file:///src/videos/NOTFOUND-001.mp4", "NOTFOUND-001", "/src/videos/NOTFOUND-001.mp4",
+        )
+
+        repo.insert_if_ignore.assert_called_once()
+        inserted = repo.insert_if_ignore.call_args[0][0]
+        assert isinstance(inserted, Video)
+        assert inserted.path == "file:///src/videos/NOTFOUND-001.mp4"
+        assert inserted.number == "NOTFOUND-001"
+        assert inserted.title == "NOTFOUND-001.mp4"  # basename, WITH extension
+        assert inserted.cover_path == ''
+        assert inserted.output_dir == ''
+        assert inserted.sample_images == []
+
+    def test_uri_consistency_between_insert_and_update(self):
+        """The uri passed to insert_if_ignore's Video.path must be the exact
+        same value passed as update_scrape_attempted_at's first positional
+        arg — guards against a future accidental fs_path/canonical mismatch."""
+        from core.readonly_producer import _readonly_stub_not_found
+
+        repo = MagicMock()
+        uri = "file:///src/videos/X-001.mp4"
+        _readonly_stub_not_found(repo, uri, "X-001", "/src/videos/X-001.mp4")
+
+        inserted = repo.insert_if_ignore.call_args[0][0]
+        update_call_args = repo.update_scrape_attempted_at.call_args[0]
+        assert inserted.path == uri
+        assert update_call_args[0] == uri
+
+    def test_update_scrape_attempted_at_uses_current_time(self):
+        repo = MagicMock()
+        from core.readonly_producer import _readonly_stub_not_found
+
+        before = time.time()
+        _readonly_stub_not_found(repo, "file:///x.mp4", "X-001", "/x.mp4")
+        after = time.time()
+
+        ts = repo.update_scrape_attempted_at.call_args[0][1]
+        assert before <= ts <= after
+
+
+class TestReadonlyEnrichFailure:
+    """TASK-105-T5 (T2-b): _readonly_enrich_failure(error, reason=None) -> EnrichResult
+    collapses scraper.py's 9 failure EnrichResult constructions (F1-F9) into one
+    shape builder. All 6 constant fields are fixed; only error/reason vary."""
+
+    def test_shape_lock_default_reason_none(self):
+        from core.enrich_contract import EnrichResult
+        from core.readonly_producer import _readonly_enrich_failure
+
+        result = _readonly_enrich_failure("msg")
+
+        assert isinstance(result, EnrichResult)
+        assert result.success is False
+        assert result.nfo_written is False
+        assert result.cover_written is False
+        assert result.extrafanart_written == 0
+        assert result.fields_filled == []
+        assert result.source_used == ''
+        assert result.error == "msg"
+        assert result.reason is None
+
+    def test_reason_passthrough_not_found(self):
+        from core.readonly_producer import _readonly_enrich_failure
+
+        result = _readonly_enrich_failure("m", "not_found")
+        assert result.reason == "not_found"
+
+    def test_reason_passthrough_error(self):
+        from core.readonly_producer import _readonly_enrich_failure
+
+        result = _readonly_enrich_failure("m", "error")
+        assert result.reason == "error"

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -1830,10 +1830,10 @@ class TestUpsertDbFullModeExistingPreservation:
         as '' → on-disk data loss + NFO/DB drift. This drives the FULL _produce_one
         path with REAL generate_nfo and asserts the written file itself.
 
-        MUTATION LOCK: removing the `meta['original_title'] = existing.original_title`
-        synthesis in _produce_one turns the NFO assertion below RED (DB stays green
-        via _upsert_db's own preserve — which is exactly why the NFO assertion is
-        the load-bearing one here)."""
+        MUTATION LOCK: removing the `meta['original_title'] = effective_original_title(...)`
+        helper call (the synthesis in _produce_one) turns the NFO assertion below RED
+        (DB stays green via _upsert_db's own effective_original_title call — which is
+        exactly why the NFO assertion is the load-bearing one here)."""
         import xml.etree.ElementTree as ET
         from core.readonly_producer import _produce_one
         from core.database import Video

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -9,7 +9,6 @@ Scraper API 路由 - 單檔刮削
 import asyncio
 import json
 import os
-import time
 from dataclasses import asdict
 from urllib.parse import urlparse
 
@@ -18,10 +17,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from typing import List, Literal, Optional
 
-from core.database import Video, VideoRepository
+from core.database import VideoRepository
 from core.db_inflow import try_inflow_upsert
 from core.focal_trigger import maybe_submit_video_focal
-from core.enricher import EnrichResult, enrich_single, fetch_samples_only, resolve_nfo_cover_paths
+from core.enricher import enrich_single, fetch_samples_only, resolve_nfo_cover_paths
 from core.enrich_contract import apply_cover_preserve, compute_has_servable_cover, cover_uri_is_servable, enrich_success
 from core.organizer import organize_file
 from core.path_utils import to_file_uri, uri_to_fs_path, uri_to_local_fs_path, coerce_to_file_uri
@@ -35,7 +34,10 @@ from core.scrapers.javlibrary import JAVLIBRARY_ORIGIN
 from core.logger import get_logger
 from core.config import load_config
 from core.readonly_source import is_path_readonly, readonly_source_prefixes, writable_source_prefixes
-from core.readonly_producer import resolve_owning_output_root, resolve_ingest_plan, _produce_one
+from core.readonly_producer import (
+    resolve_owning_output_root, resolve_ingest_plan, _produce_one,
+    _readonly_stub_not_found, _readonly_enrich_failure,
+)
 from core import thumbnail_cache
 from web.routers.notifications import emit_notification as _emit_notif
 
@@ -449,12 +451,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
         # EnrichResult rather than silently doing a full ingest/rescrape instead
         # (this branch otherwise ignores request.mode entirely).
         if request.mode == 'db_to_sidecar':
-            return asdict(EnrichResult(
-                success=False, nfo_written=False, cover_written=False,
-                extrafanart_written=0, fields_filled=[], source_used='',
-                error=_READONLY_DB_TO_SIDECAR_ERROR_MSG,
-                reason='error',
-            ))
+            return asdict(_readonly_enrich_failure(_READONLY_DB_TO_SIDECAR_ERROR_MSG, 'error'))
         # P1 revert + reject (round-3 review 2026-07-21): readonly produce is
         # holistic (a library entry always has an NFO) — write_nfo=false is
         # rejected the same way db_to_sidecar is above, rather than threading
@@ -462,18 +459,9 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
         # _READONLY_NO_NFO_ERROR_MSG). The frontend never sends
         # write_nfo=false, so this is zero UI impact.
         if not request.write_nfo:
-            return asdict(EnrichResult(
-                success=False, nfo_written=False, cover_written=False,
-                extrafanart_written=0, fields_filled=[], source_used='',
-                error=_READONLY_NO_NFO_ERROR_MSG,
-                reason='error',
-            ))
+            return asdict(_readonly_enrich_failure(_READONLY_NO_NFO_ERROR_MSG, 'error'))
         if not output_root:
-            return asdict(EnrichResult(
-                success=False, nfo_written=False, cover_written=False,
-                extrafanart_written=0, fields_filled=[], source_used="",
-                error="未設定媒體庫輸出路徑", reason="error",
-            ))
+            return asdict(_readonly_enrich_failure("未設定媒體庫輸出路徑", "error"))
         try:
             action = request.readonly_action or 'ingest'
             scraper_data = None
@@ -498,16 +486,8 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
                 # reason='not_found' (not 'error') matches the batch sibling
                 # (:1003) and non-readonly enricher.py:393/431.
                 repo = VideoRepository()
-                repo.insert_if_ignore(Video(
-                    path=canonical, number=request.number,
-                    title=os.path.basename(fs_path),
-                ))
-                repo.update_scrape_attempted_at(canonical, time.time())
-                return asdict(EnrichResult(
-                    success=False, nfo_written=False, cover_written=False,
-                    extrafanart_written=0, fields_filled=[], source_used="",
-                    error="找不到可用的番號資料", reason="not_found",
-                ))
+                _readonly_stub_not_found(repo, canonical, request.number, fs_path)
+                return asdict(_readonly_enrich_failure("找不到可用的番號資料", "not_found"))
             repo = VideoRepository()
             existing = repo.get_by_path(canonical)
             # Codex PR#113 P2#3（round 2，owner-confirmed 全面對齊；round 6 修正）：
@@ -587,11 +567,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             ))
         except Exception:
             logger.exception("enrich_single_endpoint readonly 改道失敗")
-            return asdict(EnrichResult(
-                success=False, nfo_written=False, cover_written=False,
-                extrafanart_written=0, fields_filled=[], source_used="",
-                error="enrich 處理失敗，請查閱日誌", reason="error",
-            ))
+            return asdict(_readonly_enrich_failure("enrich 處理失敗，請查閱日誌", "error"))
 
     # CD-62-4 分裂陷阱智慧防呆：refresh_full + overwrite=false 時，若這組設定不會寫出任何
     # sidecar（NFO/cover）卻仍 _db_upsert，就是純分裂。一個 sidecar「會寫」需 write 旗標開 + 檔案缺
@@ -706,11 +682,7 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
         # cover_written are always False here (samples-only never touches NFO or
         # cover), fields_filled is always [] (no metadata merge happens).
         if not output_root:
-            return asdict(EnrichResult(
-                success=False, nfo_written=False, cover_written=False,
-                extrafanart_written=0, fields_filled=[], source_used="",
-                error="未設定媒體庫輸出路徑", reason="error",
-            ))
+            return asdict(_readonly_enrich_failure("未設定媒體庫輸出路徑", "error"))
         try:
             meta = search_jav(req.number, source="auto", proxy_url=proxy_url)
             # P2 review round 3 (FIX#2/FIX#3): mirror core.enricher.fetch_samples_only
@@ -724,11 +696,7 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
             # The old `not meta or not meta.get(...)` conflated both into one
             # success=True branch, silently swallowing total search failures.
             if not meta:
-                return asdict(EnrichResult(
-                    success=False, nfo_written=False, cover_written=False,
-                    extrafanart_written=0, fields_filled=[], source_used="",
-                    error=f"找不到 {req.number} 的資料", reason=None,
-                ))
+                return asdict(_readonly_enrich_failure(f"找不到 {req.number} 的資料"))
             if not meta.get("sample_images"):
                 return asdict(enrich_success(
                     nfo_written=False, cover_written=False,
@@ -771,11 +739,7 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
             # top-level exception boundary of its own — stays the dataclass
             # default None on every path), so this router-level catch-all
             # matches with reason=None too (FIX#2 field-for-field parity).
-            return asdict(EnrichResult(
-                success=False, nfo_written=False, cover_written=False,
-                extrafanart_written=0, fields_filled=[], source_used="",
-                error="fetch_samples 處理失敗，請查閱日誌", reason=None,
-            ))
+            return asdict(_readonly_enrich_failure("fetch_samples 處理失敗，請查閱日誌"))
 
     # uri-no-reverse: comparison-only (DB LIKE prefix), inner kept bare per TASK-91-T3 inner/outer analysis
     folder_uri_prefix = to_file_uri(os.path.dirname(uri_to_fs_path(req.file_path)), path_mappings) + "/"
@@ -904,11 +868,7 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                             # trap). This branch already canonicalizes 'no_scrape'
                             # → reason='not_found' below (:1003) — no change there.
                             stub_repo = VideoRepository()
-                            stub_repo.insert_if_ignore(Video(
-                                path=uri, number=itm.number,
-                                title=os.path.basename(fs_path),
-                            ))
-                            stub_repo.update_scrape_attempted_at(uri, time.time())
+                            _readonly_stub_not_found(stub_repo, uri, itm.number, fs_path)
                             return ('no_scrape', "找不到可用的番號資料")
                         repo = VideoRepository()
                         existing = repo.get_by_path(uri)
@@ -1032,11 +992,7 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         reason = 'not_found' if status == 'no_scrape' else 'error'
                         result_item = {
                             'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
-                            **asdict(EnrichResult(
-                                success=False, nfo_written=False, cover_written=False,
-                                extrafanart_written=0, fields_filled=[], source_used='',
-                                error=payload or '生成失敗', reason=reason,
-                            )),
+                            **asdict(_readonly_enrich_failure(payload or '生成失敗', reason)),
                         }
                         yield f"data: {json.dumps(result_item)}\n\n"
                     continue

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -22,7 +22,7 @@ from core.database import Video, VideoRepository
 from core.db_inflow import try_inflow_upsert
 from core.focal_trigger import maybe_submit_video_focal
 from core.enricher import EnrichResult, enrich_single, fetch_samples_only, resolve_nfo_cover_paths
-from core.enrich_contract import compute_has_servable_cover
+from core.enrich_contract import apply_cover_preserve, compute_has_servable_cover, cover_uri_is_servable
 from core.organizer import organize_file
 from core.path_utils import to_file_uri, uri_to_fs_path, uri_to_local_fs_path, coerce_to_file_uri
 from core.scraper import (
@@ -523,14 +523,12 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             # 封面檔已被刪除或路徑對應後在磁碟上不存在，這樣仍會誤判「已有封面」
             # 而跳過重建，留下一張壞掉/消失的圖。改為額外要求檔案實際存在於磁碟，
             # 與 _write_cover 的 os.path.exists(cover_path) 判斷真正一致。
-            had_cover = bool(existing and existing.cover_path) and os.path.exists(
-                uri_to_local_fs_path(existing.cover_path, path_mappings)
+            had_cover = cover_uri_is_servable(
+                existing.cover_path if existing else "", path_mappings
             )
-            preserve_cover = (not request.write_cover) or (
-                request.mode == 'fill_missing' and not request.overwrite_existing and had_cover
+            cover_strategy = apply_cover_preserve(
+                cover_strategy, request.write_cover, request.overwrite_existing, had_cover
             )
-            if preserve_cover:
-                cover_strategy = ('none',)
             file_info = {
                 "path": fs_path,
                 "size": existing.size_bytes if existing else os.path.getsize(fs_path),
@@ -922,14 +920,12 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         # BatchEnrichRequest 沒有 per-item mode/write_cover/
                         # overwrite_existing 覆寫欄位（BatchEnrichItem 只帶 file_path/
                         # number/source/javbus_lang），一律用整批 request 的值。
-                        had_cover = bool(existing and existing.cover_path) and os.path.exists(
-                            uri_to_local_fs_path(existing.cover_path, _ro_mappings)
+                        had_cover = cover_uri_is_servable(
+                            existing.cover_path if existing else "", _ro_mappings
                         )
-                        preserve_cover = (not request.write_cover) or (
-                            request.mode == 'fill_missing' and not request.overwrite_existing and had_cover
+                        cs = apply_cover_preserve(
+                            cs, request.write_cover, request.overwrite_existing, had_cover
                         )
-                        if preserve_cover:
-                            cs = ('none',)
                         file_info = {
                             "path": fs_path,
                             "size": existing.size_bytes if existing else os.path.getsize(fs_path),

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -942,7 +942,17 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         status, payload = await loop.run_in_executor(None, _do_readonly)
                         if status == 'ok':
                             success_count += 1
-                            thumbnail_cache.invalidate(canonical)
+                            # PR#114 P2: 縮圖失效是 best-effort cleanup（檔案 unlink 可拋
+                            # OSError）——比照上方 focal 排程各自 try/except 吞掉，不可讓其
+                            # 失敗被外層 except 捕獲，否則同一成功項會 success+failed 雙記
+                            # 且被誤報成失敗（done 匯總 success+failed > total）。
+                            try:
+                                thumbnail_cache.invalidate(canonical)
+                            except Exception:
+                                logger.warning(
+                                    "batch_enrich item %s 縮圖失效失敗（不影響結果）",
+                                    item.number, exc_info=True,
+                                )
                             # nfo_written=True unconditionally: assets_mode='full' reaching
                             # here means _write_movie_assets ran to completion (it raises
                             # otherwise, caught above as 'error'), and the NFO write is
@@ -1055,7 +1065,15 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         # feature/71 T8: 換封面成功 → 失效舊縮圖（廉價同步 unlink，不需 offload）。
                         # item.file_path 已是 DB file:/// URI → 冪等 coerce，不可 double-encode
                         # （同 enrich-single，PR #60 Codex P2）。
-                        thumbnail_cache.invalidate(coerce_to_file_uri(item.file_path))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
+                        # PR#114 P2: unlink 可拋 OSError → best-effort try/except 吞掉，避免被
+                        # 外層 except 捕獲導致同一成功項 success+failed 雙記 + 誤報失敗。
+                        try:
+                            thumbnail_cache.invalidate(coerce_to_file_uri(item.file_path))  # uri-no-reverse: coerce_to_file_uri forward URI build, D2 complement
+                        except Exception:
+                            logger.warning(
+                                "batch_enrich item %s 縮圖失效失敗（不影響結果）",
+                                item.number, exc_info=True,
+                            )
                     else:
                         failed_count += 1
                     yield f"data: {json.dumps({'type': 'result-item', 'number': item.number, 'file_path': item.file_path, **result_dict})}\n\n"

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -22,7 +22,7 @@ from core.database import Video, VideoRepository
 from core.db_inflow import try_inflow_upsert
 from core.focal_trigger import maybe_submit_video_focal
 from core.enricher import EnrichResult, enrich_single, fetch_samples_only, resolve_nfo_cover_paths
-from core.enrich_contract import apply_cover_preserve, compute_has_servable_cover, cover_uri_is_servable
+from core.enrich_contract import apply_cover_preserve, compute_has_servable_cover, cover_uri_is_servable, enrich_success
 from core.organizer import organize_file
 from core.path_utils import to_file_uri, uri_to_fs_path, uri_to_local_fs_path, coerce_to_file_uri
 from core.scraper import (
@@ -574,8 +574,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
                     )
                 except Exception:
                     logger.warning("readonly enrich focal 排程失敗（不影響改道結果）", exc_info=True)
-            return asdict(EnrichResult(
-                success=True,
+            return asdict(enrich_success(
                 # NFO is always written on a successful readonly produce (P1
                 # revert, round-3 review 2026-07-21) — write_nfo=false never
                 # reaches here (rejected above).
@@ -584,8 +583,7 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
                 extrafanart_written=len(assets.get('sample_fs', [])),
                 fields_filled=_readonly_fields_filled(meta),
                 source_used=meta.get('source', ''),
-                error=None,
-                reason='hit' if has_servable_cover else 'no_cover',
+                has_servable_cover=has_servable_cover,
             ))
         except Exception:
             logger.exception("enrich_single_endpoint readonly 改道失敗")
@@ -732,11 +730,11 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
                     error=f"找不到 {req.number} 的資料", reason=None,
                 ))
             if not meta.get("sample_images"):
-                return asdict(EnrichResult(
-                    success=True, nfo_written=False, cover_written=False,
+                return asdict(enrich_success(
+                    nfo_written=False, cover_written=False,
                     extrafanart_written=0, fields_filled=[],
                     source_used=meta.get('source', ''),
-                    error=None, reason=None,
+                    reason=None,
                 ))
             fs_path = uri_to_local_fs_path(req.file_path, path_mappings)
             repo = VideoRepository()
@@ -761,10 +759,10 @@ def fetch_samples_endpoint(req: FetchSamplesRequest) -> dict:
                 allocated_this_run=set(), path_mappings=path_mappings,
             )
             written = len(assets.get('sample_fs', []))
-            return asdict(EnrichResult(
-                success=True, nfo_written=False, cover_written=False,
+            return asdict(enrich_success(
+                nfo_written=False, cover_written=False,
                 extrafanart_written=written, fields_filled=[],
-                source_used=meta.get('source', ''), error=None,
+                source_used=meta.get('source', ''),
                 reason=None,
             ))
         except Exception:
@@ -1009,15 +1007,13 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         cover_written = bool(assets.get('cover_fs'))
                         result_item = {
                             'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
-                            **asdict(EnrichResult(
-                                success=True,
+                            **asdict(enrich_success(
                                 nfo_written=True,
                                 cover_written=cover_written,
                                 extrafanart_written=len(assets.get('sample_fs', [])),
                                 fields_filled=_readonly_fields_filled(item_meta),
                                 source_used=item_meta.get('source', ''),
-                                error=None,
-                                reason='hit' if has_servable_cover else 'no_cover',
+                                has_servable_cover=has_servable_cover,
                             )),
                         }
                         yield f"data: {json.dumps(result_item)}\n\n"

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -22,6 +22,7 @@ from core.database import Video, VideoRepository
 from core.db_inflow import try_inflow_upsert
 from core.focal_trigger import maybe_submit_video_focal
 from core.enricher import EnrichResult, enrich_single, fetch_samples_only, resolve_nfo_cover_paths
+from core.enrich_contract import compute_has_servable_cover
 from core.organizer import organize_file
 from core.path_utils import to_file_uri, uri_to_fs_path, uri_to_local_fs_path, coerce_to_file_uri
 from core.scraper import (
@@ -548,17 +549,15 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             )
             thumbnail_cache.invalidate(canonical)
             cover_written = bool(assets.get('cover_fs'))
-            # Codex PR#113 P2 review round 3: `reason` must reflect whether a
-            # SERVABLE cover exists, not just whether THIS call wrote one —
-            # mirrors core.enricher.enrich_single's own decoupling (enricher.py
-            # :589-604, has_servable_cover based on a final DB+disk re-check).
-            # A fill_missing/overwrite=false pass on a video that already has a
-            # cover hits preserve_cover=True → cover_strategy=('none',) →
-            # cover_written=False, but the EXISTING cover (DB row, re-read
-            # above into `existing`) is still fully servable — reason must stay
-            # 'hit' or the scanner fly-in/badge (state-batch.js keys off
-            # status==='hit') wrongly suppresses for a preserve-cover pass.
-            has_servable_cover = bool(assets.get('cover_fs')) or bool(existing and existing.cover_path)
+            # Bug 1 fix (feature/105): `reason` must reflect whether a SERVABLE
+            # cover exists — DB has cover_path AND the physical file is on disk —
+            # not just whether the DB row has a cover_path. _produce_one已同步
+            # upsert（寫檔+_db_upsert）於上，故此處重讀 DB 最終 cover_path + 磁碟
+            # 複驗，與 core.enricher.enrich_single 共用同一個 compute_has_servable_cover
+            # 原子（消除唯讀漏磁碟複驗的破圖 false-positive）。key=canonical，與
+            # 上方 existing = repo.get_by_path(canonical) 及 _produce_one 的 upsert
+            # key 同一命名空間。
+            has_servable_cover = compute_has_servable_cover(repo, canonical, path_mappings)
             # Codex PR#113 P2#4（round 2）：對齊 core.enricher.enrich_single:528-547
             # ——只在「本次實際寫入新封面內容」時才作廢舊手動焦點、再排新的背景偵測。
             # preserve_cover=True 時 cover_strategy=('none',) 不產出檔案，
@@ -976,12 +975,19 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                                     "batch_enrich readonly item %s focal 排程失敗（不影響結果）",
                                     itm.number, exc_info=True,
                                 )
-                        # had_cover carried out in payload (not just used for the
-                        # preserve_cover gate above) — the 'ok' branch outside this
-                        # closure needs it to compute has_servable_cover for `reason`
-                        # (P2 review round 3), and `existing` itself is local to this
-                        # executor closure / not accessible after run_in_executor returns.
-                        return ('ok', (assets, meta, had_cover))
+                        # Bug 1 fix (feature/105): has_servable_cover MUST re-read
+                        # the final DB row + disk-verify (shared compute_has_servable_cover
+                        # atom, same as core.enricher.enrich_single). The DB read
+                        # (repo.get_by_path) is a BLOCKING sqlite call — it MUST stay
+                        # inside this executor closure (already off the event loop);
+                        # doing it in the async 'ok' branch below would block the loop.
+                        # _produce_one already upserted synchronously above, so this
+                        # reads the produced/preserved cover_path. key=uri (=canonical),
+                        # same namespace as existing = repo.get_by_path(uri) and
+                        # _produce_one's upsert key. Carried out via payload since
+                        # `repo`/`existing` are local to this closure.
+                        has_servable_cover = compute_has_servable_cover(repo, uri, _ro_mappings)
+                        return ('ok', (assets, meta, has_servable_cover))
 
                     loop = asyncio.get_running_loop()
                     status, payload = await loop.run_in_executor(None, _do_readonly)
@@ -993,25 +999,18 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         # otherwise, caught above as 'error'), and the NFO write is
                         # always attempted now (P1 revert, round-3 review 2026-07-21 —
                         # write_nfo=false is rejected above, before this point).
-                        assets, item_meta, had_cover = payload or ({}, {}, False)
+                        # has_servable_cover was computed INSIDE the executor closure
+                        # (compute_has_servable_cover: final DB re-read + disk verify,
+                        # Bug 1 fix feature/105) and carried out via payload — the DB
+                        # read is blocking and must not run in this async context.
+                        # reason mirrors non-readonly EnrichResult semantics
+                        # (core/enricher.py) so state-batch.js _resolveCardStatus
+                        # doesn't fall back to its success-implies-'hit' default —
+                        # an NFO-only ingest (no servable cover) reports 'no_cover',
+                        # so the frontend never builds a /api/gallery/thumb URL for a
+                        # cover that isn't servable.
+                        assets, item_meta, has_servable_cover = payload or ({}, {}, False)
                         cover_written = bool(assets.get('cover_fs'))
-                        # Codex PR#113 P2 #2: mirror non-readonly EnrichResult.reason
-                        # semantics (core/enricher.py:603) so state-batch.js
-                        # _resolveCardStatus doesn't fall back to its
-                        # success-implies-'hit' default (:300) — an NFO-only
-                        # ingest (no cover) would otherwise be misreported as
-                        # 'hit', causing the frontend to build a /api/gallery/thumb
-                        # URL for a cover that was never written.
-                        # P2 review round 3: `reason` must reflect a SERVABLE cover
-                        # (this-call write OR an existing DB row cover_path), not
-                        # just this-call cover_written — same has_servable_cover
-                        # decoupling as enrich-single (see that branch's comment) /
-                        # core.enricher.enrich_single (enricher.py:589-604). had_cover
-                        # was computed inside the executor closure (before _produce_one
-                        # ran) from the pre-write DB row and carried out via payload
-                        # (preserve-cover means that row's cover_path is untouched by
-                        # this call, so it's still what's servable now).
-                        has_servable_cover = cover_written or had_cover
                         result_item = {
                             'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
                             **asdict(EnrichResult(

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -19,7 +19,7 @@ from typing import List, Literal, Optional
 
 from core.database import VideoRepository
 from core.db_inflow import try_inflow_upsert
-from core.focal_trigger import maybe_submit_video_focal
+from core.focal_trigger import maybe_submit_video_focal, schedule_focal_after_cover_write
 from core.enricher import enrich_single, fetch_samples_only, resolve_nfo_cover_paths
 from core.enrich_contract import apply_cover_preserve, compute_has_servable_cover, cover_uri_is_servable, enrich_success
 from core.organizer import organize_file
@@ -544,13 +544,10 @@ def enrich_single_endpoint(request: EnrichRequest) -> dict:
             if cover_written:
                 try:
                     focal_repo = VideoRepository()  # 致命細節 1：不可重用上面的 repo 變數
-                    focal_repo.reset_focal_to_auto(canonical)
-                    maybe_submit_video_focal(
-                        meta['number'],
-                        meta.get('maker'),
-                        canonical,
-                        assets['cover_fs'],
-                        cover_path_uri=to_file_uri(assets['cover_fs'], path_mappings),
+                    # TASK-105-T6: reset+submit 收斂至共用 helper。
+                    schedule_focal_after_cover_write(
+                        focal_repo, canonical, meta['number'], meta.get('maker'),
+                        assets['cover_fs'], path_mappings,
                     )
                 except Exception:
                     logger.warning("readonly enrich focal 排程失敗（不影響改道結果）", exc_info=True)
@@ -916,13 +913,10 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         if assets.get('cover_fs'):
                             try:
                                 focal_repo = VideoRepository()  # 致命細節 1：不可重用上面的 repo
-                                focal_repo.reset_focal_to_auto(uri)
-                                maybe_submit_video_focal(
-                                    meta['number'],
-                                    meta.get('maker'),
-                                    uri,
-                                    assets['cover_fs'],
-                                    cover_path_uri=to_file_uri(assets['cover_fs'], _ro_mappings),
+                                # TASK-105-T6: reset+submit 收斂至共用 helper。
+                                schedule_focal_after_cover_write(
+                                    focal_repo, uri, meta['number'], meta.get('maker'),
+                                    assets['cover_fs'], _ro_mappings,
                                 )
                             except Exception:
                                 logger.warning(

--- a/web/routers/scraper.py
+++ b/web/routers/scraper.py
@@ -937,56 +937,73 @@ async def batch_enrich_endpoint(request: BatchEnrichRequest):
                         has_servable_cover = compute_has_servable_cover(repo, uri, _ro_mappings)
                         return ('ok', (assets, meta, has_servable_cover))
 
-                    loop = asyncio.get_running_loop()
-                    status, payload = await loop.run_in_executor(None, _do_readonly)
-                    if status == 'ok':
-                        success_count += 1
-                        thumbnail_cache.invalidate(canonical)
-                        # nfo_written=True unconditionally: assets_mode='full' reaching
-                        # here means _write_movie_assets ran to completion (it raises
-                        # otherwise, caught above as 'error'), and the NFO write is
-                        # always attempted now (P1 revert, round-3 review 2026-07-21 —
-                        # write_nfo=false is rejected above, before this point).
-                        # has_servable_cover was computed INSIDE the executor closure
-                        # (compute_has_servable_cover: final DB re-read + disk verify,
-                        # Bug 1 fix feature/105) and carried out via payload — the DB
-                        # read is blocking and must not run in this async context.
-                        # reason mirrors non-readonly EnrichResult semantics
-                        # (core/enricher.py) so state-batch.js _resolveCardStatus
-                        # doesn't fall back to its success-implies-'hit' default —
-                        # an NFO-only ingest (no servable cover) reports 'no_cover',
-                        # so the frontend never builds a /api/gallery/thumb URL for a
-                        # cover that isn't servable.
-                        assets, item_meta, has_servable_cover = payload or ({}, {}, False)
-                        cover_written = bool(assets.get('cover_fs'))
-                        result_item = {
-                            'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
-                            **asdict(enrich_success(
-                                nfo_written=True,
-                                cover_written=cover_written,
-                                extrafanart_written=len(assets.get('sample_fs', [])),
-                                fields_filled=_readonly_fields_filled(item_meta),
-                                source_used=item_meta.get('source', ''),
-                                has_servable_cover=has_servable_cover,
-                            )),
-                        }
-                        yield f"data: {json.dumps(result_item)}\n\n"
-                    else:
+                    try:
+                        loop = asyncio.get_running_loop()
+                        status, payload = await loop.run_in_executor(None, _do_readonly)
+                        if status == 'ok':
+                            success_count += 1
+                            thumbnail_cache.invalidate(canonical)
+                            # nfo_written=True unconditionally: assets_mode='full' reaching
+                            # here means _write_movie_assets ran to completion (it raises
+                            # otherwise, caught above as 'error'), and the NFO write is
+                            # always attempted now (P1 revert, round-3 review 2026-07-21 —
+                            # write_nfo=false is rejected above, before this point).
+                            # has_servable_cover was computed INSIDE the executor closure
+                            # (compute_has_servable_cover: final DB re-read + disk verify,
+                            # Bug 1 fix feature/105) and carried out via payload — the DB
+                            # read is blocking and must not run in this async context.
+                            # reason mirrors non-readonly EnrichResult semantics
+                            # (core/enricher.py) so state-batch.js _resolveCardStatus
+                            # doesn't fall back to its success-implies-'hit' default —
+                            # an NFO-only ingest (no servable cover) reports 'no_cover',
+                            # so the frontend never builds a /api/gallery/thumb URL for a
+                            # cover that isn't servable.
+                            assets, item_meta, has_servable_cover = payload or ({}, {}, False)
+                            cover_written = bool(assets.get('cover_fs'))
+                            result_item = {
+                                'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
+                                **asdict(enrich_success(
+                                    nfo_written=True,
+                                    cover_written=cover_written,
+                                    extrafanart_written=len(assets.get('sample_fs', [])),
+                                    fields_filled=_readonly_fields_filled(item_meta),
+                                    source_used=item_meta.get('source', ''),
+                                    has_servable_cover=has_servable_cover,
+                                )),
+                            }
+                            yield f"data: {json.dumps(result_item)}\n\n"
+                        else:
+                            failed_count += 1
+                            # P2 review round 3 (FIX#5): canonicalize `reason` — only
+                            # 'hit'/'no_cover'/'not_found'/'error' are ever emitted, never
+                            # a raw internal status string. 'no_scrape' → 'not_found'
+                            # (mirrors core.enricher's own not_found reason value for the
+                            # same "couldn't find any data" condition — Codex PR#113
+                            # one-pass alignment); every other non-'ok' status ('error',
+                            # 'db_to_sidecar' [FIX#4], and the theoretically-unreachable
+                            # 'skip') collapses to 'error' — previously `reason = status`
+                            # would have leaked 'skip' verbatim if that dead path were
+                            # ever somehow hit.
+                            reason = 'not_found' if status == 'no_scrape' else 'error'
+                            result_item = {
+                                'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
+                                **asdict(_readonly_enrich_failure(payload or '生成失敗', reason)),
+                            }
+                            yield f"data: {json.dumps(result_item)}\n\n"
+                    except Exception:
+                        # TASK-105-T9（BUG，PR#113 round 8 Codex thread `Sn2qv`）：唯讀分支
+                        # 補齊與可寫路徑（:1045 對應 except）同層的 per-item 隔離。narrow
+                        # try（:889，護 _produce_one）與 focal try（:914）之外的任何
+                        # in-executor 例外（如 resolve_ingest_plan）改前會經 await（原
+                        # :941）重拋、直上批次層 try（:803）→ raise → 整批 SSE 崩潰。此
+                        # except 把該唯讀項隔離成一筆失敗結果項，同批其他項照常完成。
+                        # except Exception（非 BaseException）：asyncio.CancelledError
+                        # 需正確上傳，不得被吞成假失敗項。
+                        logger.exception("batch_enrich readonly item %s 失敗", item.number)
                         failed_count += 1
-                        # P2 review round 3 (FIX#5): canonicalize `reason` — only
-                        # 'hit'/'no_cover'/'not_found'/'error' are ever emitted, never
-                        # a raw internal status string. 'no_scrape' → 'not_found'
-                        # (mirrors core.enricher's own not_found reason value for the
-                        # same "couldn't find any data" condition — Codex PR#113
-                        # one-pass alignment); every other non-'ok' status ('error',
-                        # 'db_to_sidecar' [FIX#4], and the theoretically-unreachable
-                        # 'skip') collapses to 'error' — previously `reason = status`
-                        # would have leaked 'skip' verbatim if that dead path were
-                        # ever somehow hit.
-                        reason = 'not_found' if status == 'no_scrape' else 'error'
                         result_item = {
                             'type': 'result-item', 'number': item.number, 'file_path': item.file_path,
-                            **asdict(_readonly_enrich_failure(payload or '生成失敗', reason)),
+                            **asdict(_readonly_enrich_failure("enrich 處理失敗，請查閱日誌", 'error')),
                         }
                         yield f"data: {json.dumps(result_item)}\n\n"
                     continue


### PR DESCRIPTION
## 摘要

把唯讀來源與一般來源（enricher）在「刮完之後怎麼記帳、怎麼回報」這層——原本被抄成四份、每次改都漏抄一份的第②層判斷邏輯——收斂成**單一實作、兩邊共用**，並上 AST 結構守衛 + contract-parity 雙機械閘防漂移。順修四個因複製而生的 bug。第①③層（拿哪份 metadata／實際寫檔）維持刻意分歧、完全不動。

**性質**：內部工程為主 + 四個 bugfix。薄抽取（純函式/建構器），非重寫。

## Task → Commit 對照

| Task | Commit | 內容 |
|---|---|---|
| T1 | `aa430fa4` | 建 `core/enrich_contract.py` 中性模組（EnrichResult 遷移 + has_servable_cover 單一化，關 Bug 1 唯讀破圖）|
| T2 | `d73d9fd9` | should_preserve_cover + apply_cover_preserve（封面保留 mode-agnostic 對齊）|
| T3 | `2c000933` | effective_original_title 原文標題保留單一化（關 Bug 2 非唯讀 data-loss）|
| T4 | `80853e17` | enrich_success 成功建構器收斂五路徑（reason 派生入 builder）|
| — | `e9a3a96c` | review nits（docstring 依賴清單 + _write_cover 短路對齊）|
| T5 | `36f3be14` | Tier 2 唯讀側收斂（_readonly_stub_not_found + _readonly_enrich_failure）|
| T6 | `84b55747` | schedule_focal_after_cover_write 收斂 focal reset 三份拷貝（落 focal_trigger.py）|
| T9 | `51d33ca3` | batch 唯讀項 per-item 錯誤隔離（控制流 bug）|
| T7 | `9a16517b` | AST 靜態結構守衛（正/負向鎖 + 白名單防腐）|
| T8 | `7b1da43a` | contract-parity backstop（全可比欄位 + 豁免表）|
| pre-merge | `90904a97` | grok P2 修：effective_original_title 回傳恆為 str（防 NULL→None 破 NFO）|
| docs | (this) | 版號 0.12.7 + CHANGELOG |

## 四個 bugfix（使用者可感知）

1. **唯讀片破圖**：輸出封面已刪/跨機器路徑對不上時，不再誤標「有封面」拉破圖（改實查磁碟，與一般片一致）。
2. **重刮清空原文標題**：一般片重刮刮不到原文標題時保留既有值（唯讀早已修、補回一般側）。
3. **NULL 破 NFO**（grok pre-merge 增量）：既有原文標題為 SQL NULL + 這次刮不到 → 舊碼回 None → `html.escape(None)` 崩潰；已修為恆回字串。
4. **批次單片拖垮整批**：批次補料某片前置解析出錯不再整批掛，只該片失敗。

## 測試

- 全套 pytest **5604 passed, 1 skipped**（unit + integration，排除 smoke/e2e）＋ `ruff check .` 綠 ＋ `npm run lint` 綠。
- 來源金絲雀 **8 源全 PASS**（pre-merge live）。
- 新增守衛：AST 結構守衛 + contract-parity + 六支共用 helper unit + focal unit；兩支防漂移守衛皆 mutation 自驗。
- 每 task 獨立 Sonnet review（T7 抓負向鎖硬編變數名近空殼、已修）＋ grok 整支 branch 第二意見（提1/採納1/假陽1=0/未查證0/**增量1**：抓到四層 review 皆漏、本 branch 引入的 NULL→None 回歸）。

## Plan deviations（已修正 plan 字面）

- T7：batch `enrich_success` 實際落在 `event_generator`（非 plan 字面的 `_do_readonly`）——`_do_readonly` 是 executor 阻塞 closure、enrich_success 在其返回後的 async context 組 SSE dict。正向鎖已定位到正確函式。

## Accepted residuals

- 兩個 CoverPreserveGate 整合測試類**刻意不合併**（spec §3 Non-Goal，各驗 router 接線）。
- i18n 102 缺 key 為既往版本 zh_TW-only 累積、milestone 同步項——本 branch 零 i18n 改動。
- CHANGELOG 現 8 個 0.12.x 全文條目（345 行）——0.12.x 為進行中系列，壓縮待 0.13 開啟或 milestone。

🤖 Generated with [Claude Code](https://claude.com/claude-code)