### PR TITLE
v0.12.9 — 啟動檢查更新 + 深色 token + 候選汙染修復 + 拖檔存取判讀（feature/107）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.9] - 2026-07-24
+
+0.12 系列 released 前的優化版（feature/107），一次收四件性質不同的小事：桌面版開機會自動幫你看一下有沒有新版、深色主題幾顆看不清的按鈕修清楚、修好一個整理可能送出空資料的隱性 bug，以及一個只有開發者會遇到的拖檔訊息誤導。
+
+### Added
+#### 🔔 啟動時自動檢查更新（桌面版）
+- **桌面 App 開機後會在背景靜靜地去 GitHub 看一次有沒有新版本**，真的有才在側邊欄鈴鐺推一則「OpenAver 有新版本 vX.Y.Z」通知（已是最新就完全安靜、不打擾）。通知不附下載連結——看到後到 Help 頁按既有的「更新」鈕走 App 內建更新即可。
+- **Help 頁版本標題右側多一個「啟動時檢查更新」開關**（預設開）。開著時打開 Help 頁會自動幫你按一次「檢查更新」，直接顯示「有新版本」或「已是最新版本」，不用再手動點。關掉後開機與 Help 頁都不自動查，行為與以前完全一致。
+- 離線／逾時／查詢失敗一律安靜略過，不會拖慢開機、也不會冒錯誤通知。只在桌面版生效（LAN／瀏覽器端看的是別人的桌面、自己無從更新，不給無法行動的噪音）。
+
+### Changed
+#### 🌙 深色主題幾顆按鈕看清楚了
+- 深色（dim）主題下，Help「檢查更新」、設定頁選資料夾、搜尋錯誤態的上一個／下一個等幾顆邊框式按鈕，原本邊框與文字幾乎與卡片同色、不移上去看不見。本版補上深色主題缺的顏色定義，一次修好整類「深色描邊按鈕太暗」的問題。
+
+### Fixed
+- **修好「整理前移除當前檔案可能送出空資料」的隱性 bug**：在多候選的檔案上看著較後面的候選、然後把當前這個檔從清單移除，鄰近檔案的候選選擇會被汙染，之後直接整理可能送出空的或錯的資料（寫進空 NFO／資料庫、無提示）。本版從源頭杜絕這個汙染。（目前的整理流程其實會在送出前重新同步、把這個汙染遮蔽掉，屬隱性問題；本修讓資料狀態永遠正確，不再依賴那層遮蔽。）
+- **關掉「啟動時檢查更新」開關若儲存失敗，畫面不再與實際設定不符**：開關切換若因寫入失敗沒存進去，以前畫面顯示已關、實際卻仍開著（下次開機仍會自動查）。本版改為儲存失敗時把開關還原、並明確提示，畫面與實際設定一致。
+
+#### 🛠️ 開發者專用
+- **拖入存取不到的檔案改顯示正確原因**：開發者在 WSL2 環境把「無權限／未掛載的 Windows 網路檔」拖進搜尋頁時，以前誤顯示「無法識別番號」（讓人以為是番號解析壞了）。本版改顯示「無法存取此檔案路徑（權限不足或未掛載）」，一眼看出是環境問題。可正常存取但檔名真的沒番號的檔，維持顯示「無法識別番號」不變。一般使用者（Windows 原生部署）不會遇到這個情況。
+
+### 測試
+- 全套 pytest **5640 passed, 1 skipped**（unit + integration，排除 smoke／e2e）＋ `ruff check .` 綠 ＋ `npm run lint` 綠（static_guard 1037／css-guard 44／cjk clean）＋ `npm test`（node:test **285**，含候選汙染守衛〔跑真 switchToFile、三向 mutation〕／filter-files inaccessible 前端分流／toggle 儲存失敗還原 等，皆 mutation 實測殺 mutant）。
+- 來源金絲雀：**8 源全 PASS**（javbus／jav321／heyzo／d2pass／avsox／fc2／javdb／dmm，pre-merge live）。
+- 每 task 獨立 Sonnet review（皆 APPROVE，subagent mutation 後工作樹經 Opus 核對完整）＋ Codex P2 修（auto_check_update PUT 擋非布林字串 truthy 反轉）＋ **pre-merge Phase 1 跨廠牌 holistic 第二意見**（Opus subagent high：**LGTM**、逐一查證 A/B/C/D 交互〔尤其 file-list.js 兩處獨立編輯不衝突〕；Codex：**提 3〔P1×1 P2×1 P3×1〕採納 1 假陽性 0**——P1＝版號待 bump〔本步驟處理〕、**P2＝toggle PUT 失敗未檢查 success 已修**、P3＝filter-files inaccessible 桶為全域加法〔by-design〕；grok 依 `reference_grok_cli` 增量持續為 0 之計分卡準則本輪略過）。
+- 功能 D 的 AC-D1 以 node/python 執行式 repro 坐實例外型別（未掛載＝FileNotFoundError、無權限＝PermissionError），owner 拍板走路徑外觀啟發式。功能 A/B/D 的桌面顯示與真拖檔留 owner 真機 hard-gate。
+- 本版新增 i18n key 只寫 zh_TW（其餘三語留空靠回退）。
+
 ## [0.12.8] - 2026-07-22
 
 本版把搜尋頁的 detail（詳情卡）做成「把這個檔案整理進庫之前，最後看一眼並手動修正」的地方（feature/106）。以前 scraper 抓錯／漏抓演員、或無碼片沒有發售日只能將就；現在拖檔進搜尋頁後，可在整理前直接改標題、改演員、補發售日，修正會隨整理一起寫進 NFO＋資料庫。純關鍵字搜尋（只是查資料、沒有要整理）維持唯讀、不出現任何編輯鈕。

--- a/core/config.py
+++ b/core/config.py
@@ -176,6 +176,7 @@ class GeneralConfig(BaseModel):
     locale: Literal["zh-TW", "zh-CN", "ja", "en"] = "zh-TW"  # 介面語系
     server_mode: bool = False  # LAN 伺服器模式開關（feature/80）
     close_action: Literal["ask", "tray", "exit"] = "ask"  # 視窗關閉行為（feature/82）
+    auto_check_update: bool = True  # 啟動時檢查更新（feature/107）
 
     @field_validator("close_action", mode="before")
     @classmethod
@@ -485,6 +486,14 @@ def _load_config_unlocked() -> dict:
             raw_config['general'] = gen
         if gen.get('close_action') not in _CLOSE_ACTIONS:
             gen['close_action'] = 'ask'
+            need_save = True
+
+        # Additive migration（feature/107 P1-T1）：general.auto_check_update 補預設。
+        # load_config() return raw dict（不 model_validate），舊 config 缺此 key 時 Pydantic default
+        # 不 backfill → 顯式補 True。gen 已由上方 close_action 段保證是 dict，直接複用。
+        # 用 not in（非 falsy）：既存 False（使用者曾關閉）為合法值，不可被 True 覆寫。
+        if 'auto_check_update' not in gen:
+            gen['auto_check_update'] = True
             need_save = True
 
         # Save migrated config（已持鎖 → 用 unlocked 版避免自我死鎖）

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.12.8"
+__version__ = "0.12.9"
 VERSION = __version__
 
 # 版本資訊

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -1081,6 +1081,7 @@
       "update_available_suffix": "可用",
       "up_to_date": "已是最新版本",
       "auto_check_toggle": "啟動時檢查更新",
+      "auto_check_save_failed": "設定儲存失敗，請稍後再試",
       "ai_instruction": "貼給 AI agent 就能操作 OpenAver",
       "ai_hint_unsupported": "不適用網頁版聊天",
       "ai_tools": "支援：Claude Code · Cursor · Codex 等 AI agent"

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -1079,6 +1079,7 @@
       "update_available_prefix": "新版本",
       "update_available_suffix": "可用",
       "up_to_date": "已是最新版本",
+      "auto_check_toggle": "啟動時檢查更新",
       "ai_instruction": "貼給 AI agent 就能操作 OpenAver",
       "ai_hint_unsupported": "不適用網頁版聊天",
       "ai_tools": "支援：Claude Code · Cursor · Codex 等 AI agent"

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -107,7 +107,8 @@
       "translate_failed_generic": "翻譯失敗",
       "no_japanese_title": "無需翻譯的日文標題",
       "number_not_recognized": "無法從檔名識別番號",
-      "number_parse_unavailable": "無法連線，請手動輸入番號"
+      "number_parse_unavailable": "無法連線，請手動輸入番號",
+      "path_inaccessible": "無法存取此檔案路徑（權限不足或未掛載）"
     },
     "nav": {
       "prev": "上一個 (←)",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -833,7 +833,8 @@
     "batch_enrich_failed": "批次補完中斷",
     "jl_cf_timeout": "JavLibrary CF 驗證逾時",
     "thumb_prewarm_start": "開始建立封面縮圖快取",
-    "thumb_prewarm_done": "封面縮圖快取已完成"
+    "thumb_prewarm_done": "封面縮圖快取已完成",
+    "update_available": "OpenAver 有新版本"
   },
   "similar_mode": {
     "button_aria_label": "探索相似影片",

--- a/scripts/static_guard_lint.mjs
+++ b/scripts/static_guard_lint.mjs
@@ -3346,6 +3346,26 @@ const RULES = [
     scope: { anchor: /<button class="lightbox-nav lightbox-nav-next"/, window: 400 },
     note: '[nit-1 nav-arrow-picker] PR#108：picker 開啟時隱藏女優「下一位」箭頭（防死點擊）；影片分支 hasVisibleNext() 維持零改動',
   },
+
+  // ---- [TestHelpAutoCheckToggle] help.html：107-P1-T3 啟動時檢查更新 toggle ----
+  { file: 'web/templates/help.html', kind: 'required-string', pattern: 'data-is-desktop=', note: '[lint-guard 107-P1-T3] .help-container 注入 is_desktop 訊號（init gate 輸入）' },
+  { file: 'web/templates/help.html', kind: 'required-string', pattern: 'data-auto-check-update=', note: '[lint-guard 107-P1-T3] .help-container 注入 auto_check_update 初值（SSR，無 fetch race）' },
+  { file: 'web/templates/help.html', kind: 'required-string', pattern: 'x-model="autoCheckUpdate"', note: '[lint-guard 107-P1-T3] toggle 綁 autoCheckUpdate state（AC-A1）' },
+  { file: 'web/templates/help.html', kind: 'required-string', pattern: '@change="saveAutoCheckUpdate()"', note: '[lint-guard 107-P1-T3] toggle 切換即時 PUT 持久化（AC-A1）' },
+  { file: 'web/templates/help.html', kind: 'required-string', pattern: "t('help.hero.auto_check_toggle')", note: '[lint-guard 107-P1-T3] toggle 文案走 i18n key（不硬編碼）' },
+  // help.js 必須落在 pre_alpine_module block（Alpine Core defer 之前）——ES module 隱式 defer，
+  // 放 extra_js（Alpine 之後）會讓 alpine:init listener 註冊太晚、helpPage 靜默不 hydrate（no error，
+  // CDP-only 才抓得到；107-P1-T3 CDP 實測踩過）。scope 視窗鎖 module script 緊接 block 內，防移回 extra_js。
+  // 參 gotchas-frontend §「ESM type=module 與 Alpine CDN defer 的初始化時序」。
+  {
+    file: 'web/templates/help.html', kind: 'required-string',
+    pattern: 'pages/help.js',
+    // scope = pre_alpine_module block BODY（capture group）。若 help.js 移出此 block（如移回
+    // extra_js），block body 不再含它 → RED。用 block body 而非 char-window：緊鄰的 extra_js
+    // block 落在固定字元窗內會讓 window 版假綠（Codex/Sonnet mutation 抓到，見 feedback_mutation_anchor_precision）。
+    scope: /\{%\s*block pre_alpine_module\s*%\}([\s\S]*?)\{%\s*endblock\s*%\}/,
+    note: '[lint-guard 107-P1-T3] help.js module script 須在 pre_alpine_module block body 內（早於 Alpine Core，防 hydrate 時序 bug 回歸）',
+  },
 ];
 
 // ---- helpers ----

--- a/scripts/static_guard_lint.mjs
+++ b/scripts/static_guard_lint.mjs
@@ -3366,6 +3366,19 @@ const RULES = [
     scope: /\{%\s*block pre_alpine_module\s*%\}([\s\S]*?)\{%\s*endblock\s*%\}/,
     note: '[lint-guard 107-P1-T3] help.js module script 須在 pre_alpine_module block body 內（早於 Alpine Core，防 hydrate 時序 bug 回歸）',
   },
+  // 遷自 tests/unit/test_frontend_lint.py TestHelpPage.test_help_html_contains（SA-pre-6：
+  // 該 class 無 [lint-guard] 標記，兩條純 HTML 屬性存在性字面斷言應走 lint 而非 pytest）。
+  {
+    file: 'web/templates/help.html', kind: 'required-string',
+    pattern: 'type="module" src="/static/js/pages/help.js"',
+    note: '[lint-guard 107-P1-T3] help.js 以 ES module 載入（隱式 defer；alpine:init 註冊 helpPage，時序安全）— 遷自 test_frontend_lint.py TestHelpPage',
+  },
+  {
+    file: 'web/templates/help.html', kind: 'forbidden-string',
+    pattern: 'defer',
+    scope: /<script[^>]*help\.js[^>]*>/,
+    note: '[lint-guard 107-P1-T3] help.js script tag 禁顯式 defer（module 已隱式 defer）— 遷自 test_frontend_lint.py',
+  },
 ];
 
 // ---- helpers ----

--- a/tests/integration/test_api_config_endpoints.py
+++ b/tests/integration/test_api_config_endpoints.py
@@ -317,6 +317,68 @@ class TestServerModeEndpoint:
         assert resp.json()["success"] is True
 
 
+class TestAutoCheckUpdateEndpoint:
+    """PUT /api/config/general/auto_check_update 端點測試（Codex P2：布林語意欄位擋字串反轉）
+
+    auto_check_update 是布林語意欄位，下游 lifespan(_startup_update_check) 與 help.html
+    data-attr 都當布林讀。字串 "false" 是 truthy，若落盤會被當「開啟」→ 語意反轉。
+    比照 server_mode，非 bool 一律 400。"""
+
+    @pytest.fixture
+    def mock_config_path(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.json"
+        default_path = tmp_path / "config.default.json"
+
+        config_data = {
+            "general": {"locale": "zh-TW", "theme": "light", "sidebar_collapsed": False,
+                        "tutorial_completed": False, "font_size": "md", "default_page": "search"},
+        }
+        config_path.write_text(json.dumps(config_data))
+        default_path.write_text(json.dumps(config_data))
+
+        monkeypatch.setattr("core.config.CONFIG_PATH", config_path)
+        monkeypatch.setattr("core.config.CONFIG_DEFAULT_PATH", default_path)
+        monkeypatch.setattr("web.routers.config._reset_translate_service", lambda: None)
+
+        return config_path
+
+    def test_string_false_returns_400_not_stored(self, client, mock_config_path):
+        """安全性關鍵：字串 "false" 是 truthy，必須 400 且不得寫入 config
+        （否則 lifespan `not "false"` = False → gate 誤過、help data-attr 誤算 true）。"""
+        resp = client.put("/api/config/general/auto_check_update", json={"value": "false"})
+
+        assert resp.status_code == 400
+        saved = json.loads(mock_config_path.read_text())
+        assert "auto_check_update" not in saved.get("general", {})
+
+    def test_bool_false_returns_200_persisted_as_bool(self, client, mock_config_path):
+        """PUT {value: false} 真 bool → 200 且落盤為 bool False（非字串 "false"）"""
+        resp = client.put("/api/config/general/auto_check_update", json={"value": False})
+
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        saved = json.loads(mock_config_path.read_text())
+        stored = saved.get("general", {}).get("auto_check_update")
+        assert stored is False  # 嚴格：bool False，非 truthy 字串 "false"
+
+    def test_bool_true_returns_200_persisted_as_bool(self, client, mock_config_path):
+        """PUT {value: true} 真 bool → 200 且落盤為 bool True"""
+        resp = client.put("/api/config/general/auto_check_update", json={"value": True})
+
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+        saved = json.loads(mock_config_path.read_text())
+        assert saved.get("general", {}).get("auto_check_update") is True
+
+    def test_int_one_rejected(self, client, mock_config_path):
+        """PUT {value: 1} (int) → 422（StrictBool|StrictStr schema 層擋整數，非本次新增，補一條確認）"""
+        resp = client.put("/api/config/general/auto_check_update", json={"value": 1})
+
+        assert resp.status_code == 422
+        saved = json.loads(mock_config_path.read_text())
+        assert "auto_check_update" not in saved.get("general", {})
+
+
 class TestFullConfigSavePreservesServerMode:
     """P2-1: PUT /api/config（全量儲存）不得改寫 server_mode（toggle-lifecycle 所有權）
 

--- a/tests/integration/test_filter_files_inaccessible.py
+++ b/tests/integration/test_filter_files_inaccessible.py
@@ -1,0 +1,136 @@
+"""
+test_filter_files_inaccessible.py — P2-T6（spec-107 功能 D）
+
+filter-files 的 `rejected.inaccessible` 桶：把「無讀權限（PermissionError）＋未掛載/UNC
+（啟發式）」與「檔案真的不存在（not_found）」分流，讓桌面拖入存取不到的 Windows 檔時能顯示
+正確訊息（前端 path_inaccessible）而非誤導的「無法識別番號」。
+
+涵蓋：
+- `_looks_unmounted_drive` 純函式全分支（mock is_mount 決定性）。
+- 端點 stat-early：PermissionError→inaccessible、FileNotFoundError+未掛載→inaccessible、
+  FileNotFoundError+已掛載/非 mnt→not_found、SMB ValueError→inaccessible。
+- **min_size_mb=0 預設下仍 stat**（原 bug：預設不 stat 則權限/未掛載無從判別）。
+- 既有 filter-files 零回歸。
+- 故障注入 mutation 自驗（見各測試 docstring）。
+"""
+import pytest
+from pathlib import Path
+
+from web.routers.search import _looks_unmounted_drive, _filter_files_sync
+
+
+class TestLooksUnmountedDrive:
+    """純函式：路徑外觀啟發式（mock is_mount 決定性，不依賴真實 /mnt 狀態）"""
+
+    def test_mnt_letter_unmounted_true(self, monkeypatch):
+        """/mnt/<letter>/… 且該碟未掛載（is_mount=False）→ True（存取不到）"""
+        monkeypatch.setattr(Path, "is_mount", lambda self: False)
+        assert _looks_unmounted_drive("/mnt/z/lan/video.mp4") is True
+
+    def test_mnt_letter_mounted_false(self, monkeypatch):
+        """/mnt/<letter>/… 但該碟已掛載（is_mount=True）→ False（檔案真缺 = not_found，不誤報）"""
+        monkeypatch.setattr(Path, "is_mount", lambda self: True)
+        assert _looks_unmounted_drive("/mnt/c/foo/missing.mp4") is False
+
+    def test_local_unix_path_false(self, monkeypatch):
+        """一般本地 Unix 路徑（非 /mnt/<letter>）→ False（真的不存在歸 not_found）"""
+        # is_mount 不該被呼叫（regex 先短路），但仍 mock 防萬一
+        monkeypatch.setattr(Path, "is_mount", lambda self: True)
+        assert _looks_unmounted_drive("/home/me/no_number.mp4") is False
+
+    def test_windows_native_drive_false(self, monkeypatch):
+        """Windows 原生 `Z:\\…`（非 /mnt/<letter> 形狀）→ False（dev-only 不涵蓋 Windows 原生）"""
+        monkeypatch.setattr(Path, "is_mount", lambda self: False)
+        assert _looks_unmounted_drive("Z:\\lan\\video.mp4") is False
+
+    def test_mnt_multichar_not_matched(self, monkeypatch):
+        """/mnt/wsl、/mnt/nas 等多字元掛載名不符 `/mnt/<單字母>` → False（不誤判系統掛載）"""
+        monkeypatch.setattr(Path, "is_mount", lambda self: False)
+        assert _looks_unmounted_drive("/mnt/nas/share/video.mp4") is False
+
+
+class TestFilterFilesInaccessible:
+    """端點層：rejected.inaccessible 分流（透過 _filter_files_sync 直呼，繞過 asyncio）"""
+
+    def _mock_stat_raise(self, monkeypatch, target: str, exc):
+        """只對 target 路徑的 Path.stat 拋 exc，其餘走原生（is_file/is_mount 內部 stat 不受影響）"""
+        original_stat = Path.stat
+
+        def fake_stat(self_path, *args, **kwargs):
+            if str(self_path) == target:
+                raise exc
+            return original_stat(self_path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+
+    def test_permission_error_to_inaccessible(self, tmp_path, monkeypatch):
+        """stat PermissionError → inaccessible（非 not_found）。
+        mutation：把 `except PermissionError` 分支拿掉 → 落 OSError→not_found，本測試轉紅。
+        min_size_mb 為 config 預設（0），本測試同時證明**預設下仍 stat**（否則永不觸發權限例外）。"""
+        mp4 = tmp_path / "PERM-001.mp4"
+        mp4.write_bytes(b"x")
+        self._mock_stat_raise(monkeypatch, str(mp4), PermissionError("denied"))
+
+        result = _filter_files_sync([str(mp4)])
+        assert result["rejected"]["inaccessible"] == 1
+        assert result["rejected"]["not_found"] == 0
+        assert result["files"] == []
+
+    def test_unmounted_drive_to_inaccessible(self, tmp_path, monkeypatch):
+        """stat FileNotFoundError + 路徑像未掛載碟（/mnt/z、is_mount=False）→ inaccessible。
+        mutation：把 `_looks_unmounted_drive(path)` 換成常數 False → 落 not_found，本測試轉紅。"""
+        target = "/mnt/z/lan/UNMOUNTED-001.mp4"
+        self._mock_stat_raise(monkeypatch, target, FileNotFoundError("no such"))
+        monkeypatch.setattr(Path, "is_mount", lambda self: False)  # /mnt/z 未掛載
+
+        result = _filter_files_sync([target])
+        assert result["rejected"]["inaccessible"] == 1
+        assert result["rejected"]["not_found"] == 0
+
+    def test_genuinely_missing_local_to_not_found(self, tmp_path, monkeypatch):
+        """stat FileNotFoundError + 一般本地路徑（非 /mnt/<letter>）→ not_found（不誤報存取問題）。"""
+        target = str(tmp_path / "genuinely_missing.mp4")  # 不建立
+        # is_mount 任意（regex 先短路），確保決定性
+        monkeypatch.setattr(Path, "is_mount", lambda self: True)
+
+        result = _filter_files_sync([target])
+        assert result["rejected"]["not_found"] == 1
+        assert result["rejected"]["inaccessible"] == 0
+
+    def test_mounted_missing_file_to_not_found(self, tmp_path, monkeypatch):
+        """已掛載碟上檔案真缺（/mnt/c/…、is_mount=True）→ not_found（啟發式不誤報）。"""
+        target = "/mnt/c/foo/MOUNTED-MISSING.mp4"
+        self._mock_stat_raise(monkeypatch, target, FileNotFoundError("no such"))
+        monkeypatch.setattr(Path, "is_mount", lambda self: True)  # /mnt/c 已掛載
+
+        result = _filter_files_sync([target])
+        assert result["rejected"]["not_found"] == 1
+        assert result["rejected"]["inaccessible"] == 0
+
+    def test_smb_unc_value_error_to_inaccessible(self):
+        """SMB/UNC 路徑 → normalize_path 拋 ValueError → inaccessible（WSL 與純 Linux 皆拋 ValueError）。
+        mutation：把 `except ValueError` 改回記 not_found → 本測試轉紅。"""
+        result = _filter_files_sync(["\\\\server\\share\\video.mp4"])
+        assert result["rejected"]["inaccessible"] == 1
+        assert result["rejected"]["not_found"] == 0
+
+    def test_valid_file_passes_no_regression(self, tmp_path):
+        """既有行為零回歸：可存取的 mp4 → 進 files、inaccessible=0。"""
+        mp4 = tmp_path / "ABC-001.mp4"
+        mp4.write_bytes(b"fake video")
+
+        result = _filter_files_sync([str(mp4)])
+        assert len(result["files"]) == 1
+        assert result["files"][0]["path"] == str(mp4)
+        assert result["rejected"]["inaccessible"] == 0
+        assert result["rejected"]["not_found"] == 0
+
+    def test_total_rejected_includes_inaccessible(self, tmp_path, monkeypatch):
+        """total_rejected = sum(rejected.values()) 自動含 inaccessible（前端計數依賴）。"""
+        mp4 = tmp_path / "PERM.mp4"
+        mp4.write_bytes(b"x")
+        self._mock_stat_raise(monkeypatch, str(mp4), PermissionError("denied"))
+
+        result = _filter_files_sync([str(mp4)])
+        assert result["total_rejected"] == 1
+        assert result["total_rejected"] == sum(result["rejected"].values())

--- a/tests/unit/test_core_config.py
+++ b/tests/unit/test_core_config.py
@@ -1411,6 +1411,88 @@ class TestMigrationCloseAction:
         assert written.get("general", {}).get("close_action") == "ask"
 
 
+# ============ TASK-107-P1-T1：GeneralConfig.auto_check_update schema ============
+
+class TestAutoCheckUpdateSchema:
+    """auto_check_update: bool = True 欄位 schema 測試（TASK-107-P1-T1）"""
+
+    def test_auto_check_update_default_true(self):
+        """GeneralConfig() 預設 auto_check_update is True"""
+        from core.config import GeneralConfig
+        cfg = GeneralConfig()
+        assert cfg.auto_check_update is True
+
+    def test_appconfig_auto_check_update_default_true(self):
+        """AppConfig().general.auto_check_update 預設 True"""
+        cfg = AppConfig()
+        assert cfg.general.auto_check_update is True
+
+
+# ============ TASK-107-P1-T1：additive migration general.auto_check_update ============
+
+class TestMigrationAutoCheckUpdate:
+    """general.auto_check_update additive migration（feature/107 P1-T1）"""
+
+    def test_auto_check_update_added_when_missing(self, tmp_path, monkeypatch):
+        """舊 config 缺 general.auto_check_update → migration 自動補 True 並寫回檔案"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {"general": {"theme": "dark", "locale": "zh-TW"}})
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert result.get("general", {}).get("auto_check_update") is True
+        # migration 命中 → 已寫回 config.json（斷言檔案 dict 內容，非只 Pydantic 物件）
+        written = _read_config(config_path)
+        assert written.get("general", {}).get("auto_check_update") is True
+
+    def test_auto_check_update_not_overwritten_when_false(self, tmp_path, monkeypatch):
+        """既存 auto_check_update=False（使用者曾關閉）不被覆寫（用 not in 判斷）"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {"general": {"auto_check_update": False}})
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert result.get("general", {}).get("auto_check_update") is False
+        # 回讀檔案仍為 False
+        written = _read_config(config_path)
+        assert written.get("general", {}).get("auto_check_update") is False
+
+    def test_auto_check_update_added_when_general_absent(self, tmp_path, monkeypatch):
+        """general 段完全缺失 → migration 安全建立並補 True"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {"scraper": {"create_folder": True}})
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert result.get("general", {}).get("auto_check_update") is True
+
+    def test_auto_check_update_added_when_general_not_dict(self, tmp_path, monkeypatch):
+        """general 段非 dict（如 null）→ migration 安全建立並補 True"""
+        config_path = tmp_path / "config.json"
+        _write_config(config_path, {"general": None})
+        monkeypatch.setattr(core_config, "CONFIG_PATH", config_path)
+        monkeypatch.setattr(core_config, "CONFIG_DEFAULT_PATH", tmp_path / "config.default.json")
+
+        result = load_config()
+
+        assert result.get("general", {}).get("auto_check_update") is True
+
+    def test_config_default_json_has_auto_check_update(self):
+        """web/config.default.json general 區塊含 auto_check_update（fresh-install GET 正確）"""
+        import json as _json
+        default_path = Path(__file__).parents[2] / "web" / "config.default.json"
+        data = _json.loads(default_path.read_text(encoding="utf-8"))
+        assert "auto_check_update" in data.get("general", {}), \
+            "config.default.json general 缺 auto_check_update 鍵"
+        assert data["general"]["auto_check_update"] is True
+
+
 # ============ TASK-88a-T3：gallery.directories str → DirectoryConfig object migration ============
 
 class TestMigrationDirectoriesToObject:

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -1539,7 +1539,10 @@ class TestHelpPage:
     """T4b 守衛 — Help 頁必要元素"""
 
     def test_help_html_contains(self):
-        """help.html 含 helpPage / checkUpdate / hero-terminal / help.hero.ai_instruction；help.js script 無 defer"""
+        """help.html 含 helpPage / checkUpdate / hero-terminal / help.hero.ai_instruction；
+        help.js 以 type="module" 載入（107-P1-T3 Option A：page-module + alpine:init 註冊，
+        比照 scanner/main.js；module 隱式 defer 但 helpPage() 經 `alpine:init` listener 註冊
+        Alpine.data，時序安全）。禁 defer 屬性（module 已隱式 defer，顯式 defer 無意義且混淆）。"""
         html = (PROJECT_ROOT / 'web/templates/help.html').read_text(encoding='utf-8')
         for expected in ['helpPage', 'checkUpdate', 'hero-terminal', 'help.hero.ai_instruction']:
             assert expected in html, f"help.html missing: {expected!r}"
@@ -1548,8 +1551,10 @@ class TestHelpPage:
         matches = re.findall(r'<script[^>]*help\.js[^>]*>', html)
         assert len(matches) == 1, \
             f"help.html 應恰好有 1 個 help.js script tag，找到 {len(matches)} 個"
+        assert 'type="module"' in matches[0], \
+            "help.js 應以 type=\"module\" 載入（107-P1-T3 Option A：export function helpPage + alpine:init 註冊）"
         assert 'defer' not in matches[0], \
-            "help.js script tag 帶有 defer — Alpine 會在 helpPage() 定義前初始化"
+            "help.js script tag 帶有 defer — module 已隱式 defer，顯式 defer 冗餘且混淆"
 
     def test_help_js_contains(self):
         """help.js 含 copyCurlCommand / execCommand"""

--- a/tests/unit/test_frontend_lint.py
+++ b/tests/unit/test_frontend_lint.py
@@ -1551,10 +1551,6 @@ class TestHelpPage:
         matches = re.findall(r'<script[^>]*help\.js[^>]*>', html)
         assert len(matches) == 1, \
             f"help.html 應恰好有 1 個 help.js script tag，找到 {len(matches)} 個"
-        assert 'type="module"' in matches[0], \
-            "help.js 應以 type=\"module\" 載入（107-P1-T3 Option A：export function helpPage + alpine:init 註冊）"
-        assert 'defer' not in matches[0], \
-            "help.js script tag 帶有 defer — module 已隱式 defer，顯式 defer 冗餘且混淆"
 
     def test_help_js_contains(self):
         """help.js 含 copyCurlCommand / execCommand"""

--- a/tests/unit/test_startup_update_check.py
+++ b/tests/unit/test_startup_update_check.py
@@ -1,0 +1,144 @@
+"""TASK-107-P1-T2: lifespan 啟動更新檢查 orchestration 單元測試。
+
+測試入口＝直接 `await web.app._startup_update_check()`，patch 四個 use-site 依賴：
+  - `web.app.check_update`（AsyncMock）
+  - `web.app.emit_notification`（Mock）
+  - `web.app.load_config`（回 raw dict）
+  - `web.app._is_windows_desktop` / `web.app._is_mac_desktop`（回 bool）
+
+pytest.ini asyncio_mode = auto → async def test_* 無需 @pytest.mark.asyncio 裝飾。
+
+繞開背景 task 競態（AC-A6 lifespan 不 await 其完成）：把 orchestration 收成
+module-level async 函式後可直接 await、確定性斷言 emit 有無與參數。
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import web.app as webapp
+
+
+def _patches(*, check_update_result=None, check_update_exc=None,
+             config=None, is_win=True, is_mac=False):
+    """回傳 (check_update_mock, emit_mock) 並套用 patch 的 context manager helper。
+
+    以 ExitStack 風格手動組合較繁瑣，這裡改用一個 patch 集合的 contextmanager。
+    """
+    cu = AsyncMock()
+    if check_update_exc is not None:
+        cu.side_effect = check_update_exc
+    else:
+        cu.return_value = check_update_result
+    emit = Mock()
+    load = Mock(return_value=config if config is not None else {"general": {"auto_check_update": True}})
+    return cu, emit, load, is_win, is_mac
+
+
+def _apply(cu, emit, load, is_win, is_mac):
+    return [
+        patch.object(webapp, "check_update", cu),
+        patch.object(webapp, "emit_notification", emit),
+        patch.object(webapp, "load_config", load),
+        patch.object(webapp, "_is_windows_desktop", Mock(return_value=is_win)),
+        patch.object(webapp, "_is_mac_desktop", Mock(return_value=is_mac)),
+    ]
+
+
+async def _run(cu, emit, load, is_win, is_mac):
+    ctxs = _apply(cu, emit, load, is_win, is_mac)
+    for c in ctxs:
+        c.start()
+    try:
+        await webapp._startup_update_check()
+    finally:
+        for c in ctxs:
+            c.stop()
+
+
+async def test_has_update_emits_once():
+    """桌面 + flag on + 有新版 → emit 恰一次，args=("info","notif.update_available")、message="v9.9.9"。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={
+            "success": True, "has_update": True,
+            "current_version": "1.0.0", "latest_version": "9.9.9",
+            "download_url": "https://example.com",
+        }
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_awaited_once()
+    emit.assert_called_once_with("info", "notif.update_available", message="v9.9.9")
+
+
+async def test_up_to_date_no_emit():
+    """桌面 + flag on + 已最新（has_update False）→ 無 emit。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={
+            "success": True, "has_update": False,
+            "current_version": "9.9.9", "latest_version": "9.9.9",
+        }
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_awaited_once()
+    emit.assert_not_called()
+
+
+async def test_404_no_latest_version_no_emit():
+    """404 分支（has_update False、無 latest_version）→ 無 emit、不 KeyError。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={"success": True, "has_update": False, "current_version": "1.0.0"}
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_awaited_once()
+    emit.assert_not_called()
+
+
+async def test_flag_off_check_update_not_called():
+    """開關關（auto_check_update False）→ check_update 未被呼叫、無 emit。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={"success": True, "has_update": True, "latest_version": "9.9.9"},
+        config={"general": {"auto_check_update": False}},
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_not_awaited()
+    cu.assert_not_called()
+    emit.assert_not_called()
+
+
+async def test_non_desktop_check_update_not_called():
+    """非桌面（両 is_desktop False）→ check_update 未被呼叫、無 emit。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={"success": True, "has_update": True, "latest_version": "9.9.9"},
+        is_win=False, is_mac=False,
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_not_awaited()
+    cu.assert_not_called()
+    emit.assert_not_called()
+
+
+async def test_check_update_raises_does_not_propagate():
+    """check_update 拋例外 → _startup_update_check 不外拋（正常返回）、無 emit。"""
+    cu, emit, load, is_win, is_mac = _patches(check_update_exc=RuntimeError("boom"))
+    # 不應拋出 —— 若外拋，await 這行會 raise，測試 fail。
+    await _run(cu, emit, load, is_win, is_mac)
+    emit.assert_not_called()
+
+
+async def test_error_dict_no_emit():
+    """check_update 回 error dict（success False）→ 不 emit、不 crash。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={"success": False, "error": "連線逾時"}
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_awaited_once()
+    emit.assert_not_called()
+
+
+async def test_missing_flag_key_defaults_true():
+    """config general 缺 auto_check_update → .get(..., True) 落預設 True → 桌面下照常查。"""
+    cu, emit, load, is_win, is_mac = _patches(
+        check_update_result={"success": True, "has_update": True, "latest_version": "9.9.9"},
+        config={},
+    )
+    await _run(cu, emit, load, is_win, is_mac)
+    cu.assert_awaited_once()
+    emit.assert_called_once_with("info", "notif.update_available", message="v9.9.9")

--- a/web/app.py
+++ b/web/app.py
@@ -3,6 +3,7 @@ OpenAver Web GUI - FastAPI Application
 """
 from contextlib import asynccontextmanager
 from pathlib import Path
+import asyncio
 import os
 import re
 import subprocess
@@ -39,6 +40,30 @@ from core.metatube.state import metatube_state as _mt_startup_state
 BASE_DIR = Path(__file__).parent
 TEMPLATES_DIR = BASE_DIR / "templates"
 STATIC_DIR = BASE_DIR / "static"
+
+
+async def _startup_update_check() -> None:
+    """TASK-107-P1-T2: 桌面 App 啟動時背景復用 check_update() 查一次 GitHub，
+    只有真的有新版時 emit 一則 info 通知。失敗全靜默、絕不外拋（不 crash 啟動）。
+
+    gate 順序（AC-A4）：desktop gate 與 flag gate 都在 await check_update() 之前，
+    任一 gate 不過即 return，check_update() 完全不被呼叫、零網路請求。
+    config 一律 dict 存取（CD-107-4，禁 _cfg.general.xxx，否則 AttributeError 被吞）。
+    """
+    try:
+        _cfg = load_config()  # raw dict
+        if not (_is_windows_desktop() or _is_mac_desktop()):
+            return  # gate 1：非桌面 → 零網路
+        if not _cfg.get("general", {}).get("auto_check_update", True):
+            return  # gate 2：開關關 → 零網路
+        result = await check_update()  # 復用端點函式，check_update() 本體不動
+        if result.get("has_update") and result.get("latest_version"):
+            emit_notification(
+                "info", "notif.update_available",
+                message=f"v{result['latest_version']}",
+            )
+    except Exception:
+        logger.warning("lifespan: startup update check failed", exc_info=True)
 
 
 @asynccontextmanager
@@ -83,6 +108,12 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.warning("lifespan: startup_reconnect failed unexpectedly", exc_info=True)
 
+    # TASK-107-P1-T2: 背景（非阻塞）啟動更新檢查。lifespan 不 await 此 task，
+    # yield 立刻放行，App 啟動不被 GitHub 網路往返拖慢（AC-A6）。
+    # create_task 回傳值須保留強引用（event loop 只持 weak ref），否則 task 可能
+    # 執行中途被 GC 回收 —— 存 app.state（app 已建立、比 module global 乾淨，無需 global）。
+    app.state.startup_check_task = asyncio.create_task(_startup_update_check())
+
     yield
     # ── shutdown ──────────────────────────────────────────────
     # 目前無 shutdown 邏輯（setup_logging 是 module-level，不需 teardown）
@@ -120,6 +151,9 @@ from web.routers import actress_alias as actress_alias_router
 from web.routers import tag_alias as tag_alias_router
 from web.routers import tags as tags_router
 from web.routers import notifications as notifications_router
+# TASK-107-P1-T2: import emit_notification at module level so lifespan can call
+# it directly and tests can patch("web.app.emit_notification") at the use-site.
+from web.routers.notifications import emit_notification
 from web.routers import similar as similar_router
 from web.routers import settings_link as settings_link_router
 from web.routers import scraper_sources as scraper_sources_router

--- a/web/config.default.json
+++ b/web/config.default.json
@@ -75,7 +75,8 @@
     "tutorial_completed": false,
     "font_size": "md",
     "locale": "zh-TW",
-    "close_action": "ask"
+    "close_action": "ask",
+    "auto_check_update": true
   },
   "sources": [
     {

--- a/web/routers/config.py
+++ b/web/routers/config.py
@@ -206,6 +206,12 @@ def update_general_field(field: str, request: GeneralFieldRequest, raw_request: 
         if field == "server_mode" and not isinstance(request.value, bool):
             raise HTTPException(status_code=400, detail="server_mode 必須為布林值")
 
+        # auto_check_update 布林語意欄位擋字串 truthy 反轉（Codex P2），比照 server_mode：
+        # 字串 "false" 是 truthy，若落盤 lifespan `not "false"`=False 會誤判 gate 通過、
+        # help data-attr 也誤算 true → 使用者關閉卻被當開啟。非 bool → 400。
+        if field == "auto_check_update" and not isinstance(request.value, bool):
+            raise HTTPException(status_code=400, detail="auto_check_update 必須為布林值")
+
         # server_mode 是主機決定，遠端連入的客人不得切換（spec「遠端自鎖不防護」的更乾淨版本）。
         # 僅允許 loopback 來源切換；fail-closed：client None → 視為非 loopback → 拒絕。
         # 不信任 X-Forwarded-For，純用 TCP 對端 raw_request.client.host。

--- a/web/routers/config.py
+++ b/web/routers/config.py
@@ -196,7 +196,7 @@ def update_general_field(field: str, request: GeneralFieldRequest, raw_request: 
     註：保持同步 def —— body 內 mutate_config 走檔案 I/O，依 async-offload 守衛
     （feature/71）須在 Starlette threadpool 執行，不可改 async def 卡 event loop。
     """
-    allowed = {"sidebar_collapsed", "theme", "font_size", "locale", "server_mode"}
+    allowed = {"sidebar_collapsed", "theme", "font_size", "locale", "server_mode", "auto_check_update"}
     if field not in allowed:
         return {"success": False, "error": f"不允許更新欄位: {field}"}
     try:

--- a/web/routers/search.py
+++ b/web/routers/search.py
@@ -783,8 +783,25 @@ def get_favorite_files() -> dict:
     }
 
 
+def _looks_unmounted_drive(path: str) -> bool:
+    """P2-T6 啟發式：路徑形如 WSL 掛載點 `/mnt/<letter>/…` 但該碟未掛載 → 存取不到（非「檔案不存在」）。
+
+    owner 拍板（spec-107 功能 D）：WSL2 開發者拖入未掛載的 Windows 碟時 stat 拋 FileNotFoundError，
+    與「真的不存在的本地檔」同例外，只能靠路徑外觀區分。`/mnt/<letter>` 已掛載但檔案真缺 → is_mount()
+    為 True → 回 False（歸 not_found，正確）。非 `/mnt/<letter>` 形狀（Windows 原生 Z: 碟、本地 `/home/…`）
+    一律 False，不誤判。SMB/UNC 由 normalize_path ValueError 另行歸類、不經此函式。
+    """
+    m = re.match(r'^/mnt/([a-z])(?:/|$)', path)
+    if not m:
+        return False
+    try:
+        return not Path(f'/mnt/{m.group(1)}').is_mount()
+    except OSError:
+        return False
+
+
 def _filter_files_sync(paths: list) -> dict:
-    """Threadpool helper（CD-66-3 外層）：load_config + 檔案走訪（exists/stat/iterdir）。
+    """Threadpool helper（CD-66-3 外層）：load_config + 檔案走訪（stat/iterdir）。
 
     整段同步阻塞 I/O，由 filter_files 經 await asyncio.to_thread 移出 event loop。
     """
@@ -798,7 +815,8 @@ def _filter_files_sync(paths: list) -> dict:
     min_size_bytes = min_size_mb * 1024 * 1024
 
     filtered = []
-    rejected = {"extension": 0, "size": 0, "not_found": 0}
+    # P2-T6: inaccessible 桶＝無讀權限（PermissionError）＋未掛載/UNC（啟發式），與 not_found 分流
+    rejected = {"extension": 0, "size": 0, "not_found": 0, "inaccessible": 0}
     nfo_stem_cache: dict = {}
 
     for original_path in paths:
@@ -806,12 +824,20 @@ def _filter_files_sync(paths: list) -> dict:
         try:
             path = normalize_path(original_path)
         except ValueError:
-            rejected["not_found"] += 1
+            # WSL 不支援的 SMB/UNC 網路路徑＝存取不到的網路碟（非「檔案不存在」）
+            rejected["inaccessible"] += 1
             continue
 
         p = Path(path)
-        if not p.exists():
-            rejected["not_found"] += 1
+        # P2-T6 stat-early：取代 p.exists()（會把權限吞成 False→not_found），且預設 min_size_mb=0
+        # 時原本根本不 stat、permission/未掛載無從判別。一次 stat 供權限判別 + 後續 size 重用。
+        try:
+            stat_result = p.stat()
+        except PermissionError:
+            rejected["inaccessible"] += 1
+            continue
+        except (FileNotFoundError, OSError):
+            rejected["inaccessible" if _looks_unmounted_drive(path) else "not_found"] += 1
             continue
 
         suffix = p.suffix.lower()
@@ -820,12 +846,8 @@ def _filter_files_sync(paths: list) -> dict:
             continue
 
         if min_size_bytes > 0 and suffix not in ZERO_SIZE_EXTENSIONS:
-            try:
-                if p.stat().st_size < min_size_bytes:
-                    rejected["size"] += 1
-                    continue
-            except OSError:
-                rejected["not_found"] += 1
+            if stat_result.st_size < min_size_bytes:
+                rejected["size"] += 1
                 continue
 
         # NFO 同 stem 偵測（case-insensitive，父目錄 listing cache）
@@ -863,7 +885,7 @@ async def filter_files(request: Request) -> dict:
         {
             "success": True,
             "files": ["filtered paths"],
-            "rejected": {"extension": 0, "size": 0, "not_found": 0},
+            "rejected": {"extension": 0, "size": 0, "not_found": 0, "inaccessible": 0},
             "total_rejected": 0
         }
     """

--- a/web/static/css/input.css
+++ b/web/static/css/input.css
@@ -103,6 +103,10 @@
 
   --fluent-smoke: rgba(0, 0, 0, 0.6);
 
+  /* neutral 覆寫（dim 補齊，鏡射 light；提亮至可視對比，修 btn-outline btn-neutral 深色隱形）*/
+  /* L=60%：對 base-100/200 卡面均 ≥3:1（WCAG 非文字門檻，清楚可見）、又低於 base-content 83% 維持次級克制 */
+  --color-neutral: oklch(60% 0.02 250);
+
   /* Constellation Lab star tokens - dim theme overrides (bright gold on dark) */
   --star-line-bright: oklch(0.86 0.11 80);
   --star-line-fade:   oklch(0.70 0.08 80);

--- a/web/static/css/tailwind.css
+++ b/web/static/css/tailwind.css
@@ -2951,6 +2951,9 @@
       border-width: var(--border, 1px) 0 var(--border, 1px) var(--border, 1px);
     }
   }
+  .ms-auto {
+    margin-inline-start: auto;
+  }
   .modal-action {
     @layer daisyui.l1.l2.l3 {
       margin-top: calc(0.25rem * 6);
@@ -6137,6 +6140,7 @@ html.theme-transition-active #sidebar, html.theme-transition-active #main-conten
   --fluent-shadow-28: 0px 0px 2px rgba(0, 0, 0, 0.24), 0px 14px 28px rgba(0, 0, 0, 0.28);
   --fluent-shadow-64: 0px 0px 2px rgba(0, 0, 0, 0.24), 0px 32px 64px rgba(0, 0, 0, 0.28);
   --fluent-smoke: rgba(0, 0, 0, 0.6);
+  --color-neutral: oklch(60% 0.02 250);
   --star-line-bright: oklch(0.86 0.11 80);
   --star-line-fade: oklch(0.70 0.08 80);
   --star-glow: oklch(0.88 0.14 78);

--- a/web/static/js/pages/__tests__/help-page.test.mjs
+++ b/web/static/js/pages/__tests__/help-page.test.mjs
@@ -105,3 +105,27 @@ test('saveAutoCheckUpdate: off → body {"value":false}', async () => {
   assert.equal(put.method, 'PUT');
   assert.equal(put.body, JSON.stringify({ value: false }));
 });
+
+// Codex Phase-1 P2：PUT 失敗（success:false 或 throw）不得讓 UI 與 config 背離。
+// x-model 已把 autoCheckUpdate 翻到 desired；失敗須還原 + 顯示 toast，否則使用者關掉
+// 開關卻沒存進去，下次啟動仍自動查 GitHub（違反 opt-out AC-A4）。
+test('saveAutoCheckUpdate: PUT 回 success:false → 還原本地狀態 + 顯示 toast', async () => {
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({ success: false }) });
+  const toasts = [];
+  // 使用者原本 on，x-model 翻成 off（desired=false）；PUT 失敗應還原回 on
+  const fakeThis = { ...helpPage(), autoCheckUpdate: false, showToast: (m, t) => toasts.push({ m, t }) };
+  await fakeThis.saveAutoCheckUpdate();
+  assert.equal(fakeThis.autoCheckUpdate, true, 'PUT 失敗應還原 autoCheckUpdate（!desired），UI 不與持久化背離');
+  assert.equal(toasts.length, 1, '應顯示一則失敗 toast');
+  assert.equal(toasts[0].t, 'error');
+});
+
+test('saveAutoCheckUpdate: PUT throw（離線）→ 還原本地狀態 + 顯示 toast', async () => {
+  globalThis.fetch = async () => { throw new Error('offline'); };
+  const toasts = [];
+  const fakeThis = { ...helpPage(), autoCheckUpdate: true, showToast: (m, t) => toasts.push({ m, t }) };
+  await fakeThis.saveAutoCheckUpdate();
+  assert.equal(fakeThis.autoCheckUpdate, false, 'throw 亦應還原（!desired）');
+  assert.equal(toasts.length, 1);
+  assert.equal(toasts[0].t, 'error');
+});

--- a/web/static/js/pages/__tests__/help-page.test.mjs
+++ b/web/static/js/pages/__tests__/help-page.test.mjs
@@ -1,0 +1,107 @@
+// TASK-107-P1-T3: helpPage init() gate 矩陣 + saveAutoCheckUpdate PUT wiring
+//
+// 核心不變式（spec-107 D-A1）：非桌面 → init() 一律不呼叫 checkUpdate()
+// （對 /api/check-update 零請求 = 零 GitHub 連線）。此為 behavioral 不變式，
+// 必須真的執行 init() 用 fetch spy 斷言「有沒有呼叫」，源碼字串比對證不了。
+//
+// help.js 是 exported page-module（Option A：export function helpPage + 保留
+// alpine:init 註冊，比照 scanner/main.js:23）。模組頂層有
+// `document.addEventListener('alpine:init', ...)`，node 無 document，故 import
+// 前先 stub document（callback 只註冊、import 時不執行，不需真 Alpine）。
+//
+// 範本：search/__tests__/confirm-edit-actors-fetch-spy.test.mjs
+// （globalThis.window = globalThis + fetch spy + fakeThis 展開 mixin）。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.window = globalThis;
+globalThis.document = { addEventListener() {} };
+globalThis.t = (key) => key;
+
+const { helpPage } = await import('../help.js');
+
+// fetch spy：記錄每次呼叫的 url/method/body，回傳成功殼
+function installFetchSpy() {
+  const calls = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    calls.push({ url, method: opts.method || 'GET', body: opts.body });
+    return { ok: true, json: async () => ({ success: true, has_update: false }) };
+  };
+  return calls;
+}
+
+function makeFakeThis(isDesktop, autoCheckUpdate) {
+  return {
+    ...helpPage(),
+    $el: { dataset: { isDesktop, autoCheckUpdate } },
+  };
+}
+
+// init() 內 loadVersion()/checkUpdate() 皆 async 但同步呼到第一個 await（fetch）
+// 前，故 init.call() 返回後 fetch spy 已記錄；斷言 /api/check-update 有無即可。
+function checkUpdateHit(calls) {
+  return calls.some((c) => c.url === '/api/check-update');
+}
+
+test('init gate: (桌面, on) → checkUpdate 觸發（打 /api/check-update）', () => {
+  const calls = installFetchSpy();
+  const fakeThis = makeFakeThis('true', 'true');
+  fakeThis.init();
+  assert.equal(checkUpdateHit(calls), true, '桌面+開 應自動查更新');
+  assert.equal(calls.some((c) => c.url === '/api/version'), true, 'init 仍呼 loadVersion');
+});
+
+test('init gate: (桌面, off) → 不打 /api/check-update（idle，與現況一致）', () => {
+  const calls = installFetchSpy();
+  const fakeThis = makeFakeThis('true', 'false');
+  fakeThis.init();
+  assert.equal(checkUpdateHit(calls), false, '桌面+關 不應自動查更新');
+});
+
+test('init gate: (非桌面, on) → 不打 /api/check-update（核心不變式：非桌面零 GitHub）', () => {
+  const calls = installFetchSpy();
+  const fakeThis = makeFakeThis('false', 'true');
+  fakeThis.init();
+  assert.equal(checkUpdateHit(calls), false, '非桌面 即使 on 也不得連 GitHub（spec D-A1）');
+});
+
+test('init gate: (非桌面, off) → 不打 /api/check-update', () => {
+  const calls = installFetchSpy();
+  const fakeThis = makeFakeThis('false', 'false');
+  fakeThis.init();
+  assert.equal(checkUpdateHit(calls), false, '非桌面+關 不查');
+});
+
+test('init 初值讀取：dataset → autoCheckUpdate / _isDesktop 正確反映', () => {
+  installFetchSpy();
+  const on = makeFakeThis('true', 'true');
+  on.init();
+  assert.equal(on._isDesktop, true);
+  assert.equal(on.autoCheckUpdate, true);
+
+  const off = makeFakeThis('false', 'false');
+  off.init();
+  assert.equal(off._isDesktop, false);
+  assert.equal(off.autoCheckUpdate, false);
+});
+
+test('saveAutoCheckUpdate: on → PUT /api/config/general/auto_check_update body {"value":true}', async () => {
+  const calls = installFetchSpy();
+  const fakeThis = { ...helpPage(), autoCheckUpdate: true };
+  await fakeThis.saveAutoCheckUpdate();
+  const put = calls.find((c) => c.url === '/api/config/general/auto_check_update');
+  assert.ok(put, '應打 auto_check_update 端點');
+  assert.equal(put.method, 'PUT');
+  assert.equal(put.body, JSON.stringify({ value: true }));
+});
+
+test('saveAutoCheckUpdate: off → body {"value":false}', async () => {
+  const calls = installFetchSpy();
+  const fakeThis = { ...helpPage(), autoCheckUpdate: false };
+  await fakeThis.saveAutoCheckUpdate();
+  const put = calls.find((c) => c.url === '/api/config/general/auto_check_update');
+  assert.ok(put);
+  assert.equal(put.method, 'PUT');
+  assert.equal(put.body, JSON.stringify({ value: false }));
+});

--- a/web/static/js/pages/__tests__/help-page.test.mjs
+++ b/web/static/js/pages/__tests__/help-page.test.mjs
@@ -129,3 +129,28 @@ test('saveAutoCheckUpdate: PUT throw（離線）→ 還原本地狀態 + 顯示 
   assert.equal(toasts.length, 1);
   assert.equal(toasts[0].t, 'error');
 });
+
+// Codex 107 P2：兩次快速切換可能各發一個 PUT，server 寫入順序若被打亂，config 會與
+// 最後可見的 toggle 狀態相反（兩次都 success:true，既有 revert-on-failure 抓不到）。
+// 修法：disable-while-saving——_autoCheckSaving 在 PUT in-flight 期間為 true（checkbox
+// :disabled 綁它），resolve 後（無論成功/失敗/throw）清為 false，讓同一時間只可能有一個
+// PUT in-flight。用手動控制的 pending promise 斷言「in-flight 期間 true、resolve 後 false」。
+test('saveAutoCheckUpdate: PUT in-flight 期間 _autoCheckSaving=true，resolve 後清回 false', async () => {
+  let resolveFetch;
+  globalThis.fetch = () => new Promise((resolve) => { resolveFetch = resolve; });
+  const fakeThis = { ...helpPage(), autoCheckUpdate: true };
+
+  const savePromise = fakeThis.saveAutoCheckUpdate();
+  assert.equal(fakeThis._autoCheckSaving, true, 'PUT in-flight 期間應為 true（擋 checkbox 二次觸發）');
+
+  resolveFetch({ ok: true, json: async () => ({ success: true }) });
+  await savePromise;
+  assert.equal(fakeThis._autoCheckSaving, false, 'resolve 後應清回 false');
+});
+
+test('saveAutoCheckUpdate: PUT throw 亦清回 _autoCheckSaving=false（finally 保證）', async () => {
+  globalThis.fetch = async () => { throw new Error('offline'); };
+  const fakeThis = { ...helpPage(), autoCheckUpdate: true, showToast: () => {} };
+  await fakeThis.saveAutoCheckUpdate();
+  assert.equal(fakeThis._autoCheckSaving, false, 'throw 路徑也必須經 finally 清旗標，否則 checkbox 永久 disabled');
+});

--- a/web/static/js/pages/help.js
+++ b/web/static/js/pages/help.js
@@ -26,13 +26,25 @@ export function helpPage() {
         },
 
         async saveAutoCheckUpdate() {
+            // x-model 已先把 autoCheckUpdate 翻到 desired；PUT 失敗必須還原本地狀態，
+            // 否則 UI 顯示「關」但 config 仍「開」→ 下次啟動仍自動查 GitHub，違反 opt-out
+            // （比照 settings state-config.js setServerMode 的 success-then-commit / fail-revert）。
+            const desired = this.autoCheckUpdate;
             try {
-                await fetch('/api/config/general/auto_check_update', {
+                const resp = await fetch('/api/config/general/auto_check_update', {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ value: this.autoCheckUpdate }),
+                    body: JSON.stringify({ value: desired }),
                 });
-            } catch (e) { /* 靜默；toggle 已即時反映本地狀態 */ }
+                const result = await resp.json();
+                if (!result.success) {
+                    this.autoCheckUpdate = !desired;  // 還原，UI 不與持久化背離
+                    this.showToast(window.t('help.hero.auto_check_save_failed'), 'error');
+                }
+            } catch (e) {
+                this.autoCheckUpdate = !desired;  // 還原（離線/HTTP 錯）
+                this.showToast(window.t('help.hero.auto_check_save_failed'), 'error');
+            }
         },
 
         async loadVersion() {

--- a/web/static/js/pages/help.js
+++ b/web/static/js/pages/help.js
@@ -1,5 +1,5 @@
 // Help 頁面 Alpine.js 元件
-function helpPage() {
+export function helpPage() {
     return {
         // State
         appVersion: '',
@@ -13,11 +13,26 @@ function helpPage() {
         showUpdateModal: false,
         isDefaultPath: true,
         updateLoading: false,
+        autoCheckUpdate: false,
+        _isDesktop: false,
         _toast: { message: '', type: 'info', visible: false },
         _toastTimer: null,
 
         init() {
             this.loadVersion();
+            this._isDesktop = this.$el.dataset.isDesktop === 'true';
+            this.autoCheckUpdate = this.$el.dataset.autoCheckUpdate === 'true';
+            if (this._isDesktop && this.autoCheckUpdate) this.checkUpdate();
+        },
+
+        async saveAutoCheckUpdate() {
+            try {
+                await fetch('/api/config/general/auto_check_update', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ value: this.autoCheckUpdate }),
+                });
+            } catch (e) { /* 靜默；toggle 已即時反映本地狀態 */ }
         },
 
         async loadVersion() {

--- a/web/static/js/pages/help.js
+++ b/web/static/js/pages/help.js
@@ -14,6 +14,7 @@ export function helpPage() {
         isDefaultPath: true,
         updateLoading: false,
         autoCheckUpdate: false,
+        _autoCheckSaving: false,
         _isDesktop: false,
         _toast: { message: '', type: 'info', visible: false },
         _toastTimer: null,
@@ -30,6 +31,9 @@ export function helpPage() {
             // 否則 UI 顯示「關」但 config 仍「開」→ 下次啟動仍自動查 GitHub，違反 opt-out
             // （比照 settings state-config.js setServerMode 的 success-then-commit / fail-revert）。
             const desired = this.autoCheckUpdate;
+            this._autoCheckSaving = true;  // 擋 checkbox，防兩次快速切換同時有 PUT in-flight
+            // （server 寫入順序若被打亂，config 會與最後可見的 toggle 狀態相反——兩次 PUT 都
+            // success:true，既有 revert-on-failure 邏輯抓不到，見 107 P2 Codex review）
             try {
                 const resp = await fetch('/api/config/general/auto_check_update', {
                     method: 'PUT',
@@ -44,6 +48,8 @@ export function helpPage() {
             } catch (e) {
                 this.autoCheckUpdate = !desired;  // 還原（離線/HTTP 錯）
                 this.showToast(window.t('help.hero.auto_check_save_failed'), 'error');
+            } finally {
+                this._autoCheckSaving = false;
             }
         },
 

--- a/web/static/js/pages/search/__tests__/remove-file-candidate-pollution.test.mjs
+++ b/web/static/js/pages/search/__tests__/remove-file-candidate-pollution.test.mjs
@@ -1,0 +1,100 @@
+// TASK-107-P2-T5（spec-107 功能 C / plan P2-T5，CD-106-5 漏網路徑）
+//
+// removeFile 移除「當前檔」時，先把 currentFileIndex 重指鄰檔（file-list.js:287-291）
+// 才呼叫 switchToFile（:298）；而 switchToFile 頂部（:12-13）會做
+//   fileList[currentFileIndex].selectedCandidateIndex = this.currentIndex
+// 此時 currentFileIndex 已是鄰檔、currentIndex 仍是外出檔的候選值 → 把外出檔的
+// 候選 index 寫進鄰檔（汙染）。鄰檔候選數 ≤ 該值時 selectedCandidateIndex 越界。
+//
+// 定版修法（D-C1）：switchToFile 加 skipPersist 參數，removeFile 移除當前檔那條傳
+// skipPersist=true（外出檔已 splice、其候選 index 無須也不該被保存）。正常左右導航
+// skipPersist 預設 false、行為零變化。
+//
+// 本檔跑「真的 switchToFile」（非 spy）以驗證頂部持久化的實際寫入對象——這是
+// remove-file-edit-preserve.test.mjs（stub switchToFile）看不到的層。
+// 註：現行碼中此汙染於「整理」時被 batch.js:363/501 的 re-sync（同步 current 檔）
+// 遮蔽，故屬 latent（stored state 短暫錯誤）；skipPersist 從源頭消除汙染，使正確性
+// 不再依賴每條整理入口都記得 re-sync（defense-in-depth）。守衛鎖 stored 不變式本身。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { searchStateFileList } from '../state/file-list.js';
+
+// switchToFile 走「searched 鄰檔」分支（file-list.js:36）會碰的最小 DOM/動畫依賴
+globalThis.window = globalThis;
+globalThis.document = globalThis.document || { querySelector: () => null };
+globalThis.window.t = globalThis.window.t || ((k) => k);
+// gsap 保持 undefined（typeof gsap !== 'undefined' 分支跳過）
+
+function makeFile(name, nCands, { searched = true, selectedCandidateIndex = 0 } = {}) {
+    return {
+        filename: name,
+        number: name,
+        searched,
+        scraped: false,
+        searchResults: Array.from({ length: nCands }, (_, i) => ({ title: `${name}-c${i}`, __idx: i })),
+        hasMoreResults: false,
+        selectedCandidateIndex,
+    };
+}
+
+function makeState(files, currentFileIndex, currentIndex) {
+    return {
+        ...searchStateFileList(),
+        fileList: files,
+        currentFileIndex,
+        currentIndex,
+        listMode: 'file',
+        displayMode: 'detail',
+        searchResults: [],
+        hasMoreResults: false,
+        pageState: 'result',
+        clearAll() { this.fileList = []; },
+        saveState() {},
+        _resetCoverState() {},
+        $nextTick() {},
+        fetchUserTagsForCurrent() {},
+    };
+}
+
+test('removeFile 移除當前檔：鄰檔 selectedCandidateIndex 不被外出檔 currentIndex 汙染 (AC-C3)', () => {
+    // A = 當前檔（3 候選、正在看候選 #2），B = 鄰檔（1 候選、自己的 selectedCandidateIndex=0）
+    const state = makeState(
+        [makeFile('A', 3), makeFile('B', 1, { selectedCandidateIndex: 0 })],
+        0,   // currentFileIndex → A
+        2,   // currentIndex → 正在看 A 的候選 #2
+    );
+
+    state.removeFile(0);  // 移除當前檔 A → B 成為當前檔
+
+    const B = state.fileList[0];
+    assert.equal(state.currentFileIndex, 0, 'B 應成為當前檔');
+    // 核心不變式：B 保留自己的候選 index 0，不被外出檔 A 的 currentIndex(2) 汙染
+    assert.equal(
+        B.selectedCandidateIndex, 0,
+        '鄰檔 selectedCandidateIndex 應仍為自己的 0，不得被外出檔 currentIndex(2) 覆蓋（越界會讓整理送空 metadata）',
+    );
+    // 越界防線：即使假設整理直接讀 stored（不 re-sync），也不得越界
+    assert.ok(
+        B.selectedCandidateIndex < B.searchResults.length,
+        '鄰檔 selectedCandidateIndex 不得越界其候選數',
+    );
+});
+
+test('反向守衛：正常左右導航（switchToFile 預設 skipPersist=false）仍持久化外出檔候選', () => {
+    // 從 A（正在看候選 #2）切到 B —— 外出檔 A 的候選應被保存為 2（正常行為零變化）
+    const state = makeState(
+        [makeFile('A', 3), makeFile('B', 2)],
+        0,   // 當前 A
+        2,   // 正在看 A 候選 #2
+    );
+
+    // 預設呼叫（不傳 skipPersist）＝正常導航
+    state.switchToFile(1, 'first', false);
+
+    assert.equal(
+        state.fileList[0].selectedCandidateIndex, 2,
+        '正常導航離開 A 時，A 的候選 index(2) 必須被持久化（skipPersist 預設 false，行為不得回歸）',
+    );
+    assert.equal(state.currentFileIndex, 1, '已切到 B');
+});

--- a/web/static/js/pages/search/__tests__/set-file-list-inaccessible.test.mjs
+++ b/web/static/js/pages/search/__tests__/set-file-list-inaccessible.test.mjs
@@ -1,0 +1,124 @@
+// TASK-107-P2-T6（spec-107 功能 D）: setFileList 桌面拖檔 path_inaccessible 表面化守衛
+//
+// 桌面 pywebview 拖入未掛載/UNC/無權限檔 → filter-files 回 rejected.inaccessible。
+// setFileList 應：
+//   (1) inaccessible-only → 只顯示 path_inaccessible（error），不出通用「已過濾」toast、
+//       不出 no_valid_files、明確中止（fileList 空）。
+//   (2) 無 inaccessible、全員抽不出番號 → 正常顯示 no_valid_files，不誤出 path_inaccessible。
+//   (3) mixed（inaccessible + 其他桶如副檔名）→ 通用 toast 涵蓋其他桶 + path_inaccessible 皆出。
+//
+// 組裝方式沿用 set-file-list-fallback.test.mjs：真 setFileList 本體，只 mock 外部依賴。
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { searchStateFileList } from '../state/file-list.js';
+import { searchStateSearchFlow } from '../state/search-flow.js';
+import { searchStateBase } from '../state/base.js';
+
+globalThis.window = globalThis;
+
+function makeFakeThis(overrides = {}) {
+  return Object.assign(
+    {},
+    searchStateBase(),
+    searchStateSearchFlow(),
+    searchStateFileList(),
+    { _resetCoverState() {} },
+    overrides,
+  );
+}
+
+// filter-files 回指定 result；其餘 URL 回 success:false（本檔不觸發）
+function stubFilterFiles(result) {
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('/api/search/filter-files')) {
+      return { ok: true, json: async () => result };
+    }
+    return { ok: true, json: async () => ({ success: false }) };
+  };
+}
+
+test('D(1) inaccessible-only：只顯示 path_inaccessible、無通用 toast、無 no_valid_files、中止', async () => {
+  window.t = (key) => key;
+  window.SearchFile = {
+    parseFilenames: async (fs) => fs.map((f) => ({ filename: f, number: null, has_subtitle: false })),
+    detectSuffixes: () => [],
+    extractChineseTitle: () => null,
+  };
+  // 桌面拖單一未掛載檔 → filter-files 全濾（files 空）、只有 inaccessible
+  stubFilterFiles({
+    success: true,
+    files: [],
+    rejected: { extension: 0, size: 0, not_found: 0, inaccessible: 1 },
+    total_rejected: 1,
+  });
+
+  const toasts = [];
+  const fakeThis = makeFakeThis({ showToast(msg, type) { toasts.push({ msg, type }); } });
+
+  await searchStateFileList().setFileList.call(fakeThis, ['/mnt/z/lan/vid.mp4']);
+
+  const keys = toasts.map((t) => t.msg);
+  assert.deepEqual(fakeThis.fileList, [], 'inaccessible-only 應中止、不建 fileList');
+  assert.ok(keys.includes('search.error.path_inaccessible'), '應顯示 path_inaccessible');
+  assert.equal(
+    toasts.find((t) => t.msg === 'search.error.path_inaccessible').type, 'error',
+    'path_inaccessible 為 error 類型',
+  );
+  assert.ok(!keys.includes('search.filelist.filtered_count'), 'inaccessible-only 不應出通用「已過濾」toast');
+  assert.ok(!keys.includes('search.toast.no_valid_files'), 'inaccessible-only 不應補 no_valid_files（已 path_inaccessible 中止）');
+});
+
+test('D(2) 反向：無 inaccessible、全員抽不出番號 → 正常 no_valid_files、不誤出 path_inaccessible', async () => {
+  window.t = (key) => key;
+  window.SearchFile = {
+    parseFilenames: async (fs) => fs.map((f) => ({ filename: f, number: null, has_subtitle: false })),
+    detectSuffixes: () => [],
+    extractChineseTitle: () => null,
+  };
+  stubFilterFiles({
+    success: true,
+    files: [{ path: '/a/no_number.mp4', has_nfo: false }],
+    rejected: { extension: 0, size: 0, not_found: 0, inaccessible: 0 },
+    total_rejected: 0,
+  });
+
+  const toasts = [];
+  const fakeThis = makeFakeThis({ showToast(msg, type) { toasts.push({ msg, type }); } });
+
+  await searchStateFileList().setFileList.call(fakeThis, ['/a/no_number.mp4']);
+
+  const keys = toasts.map((t) => t.msg);
+  assert.ok(!keys.includes('search.error.path_inaccessible'), '無 inaccessible 不得誤出 path_inaccessible');
+  assert.ok(keys.includes('search.toast.no_valid_files'), '全員無番號應正常顯示 no_valid_files');
+});
+
+test('D(3) mixed：inaccessible + 副檔名 → 通用 toast（涵蓋副檔名）與 path_inaccessible 皆出、有效檔仍建', async () => {
+  window.t = (key) => key;
+  window.SearchFile = {
+    parseFilenames: async (fs) => fs.map((f) => ({ filename: f, number: 'ABC-123', has_subtitle: false })),
+    detectSuffixes: () => [],
+    extractChineseTitle: () => null,
+  };
+  // 一個有效檔 + 一個副檔名被濾 + 一個 inaccessible
+  stubFilterFiles({
+    success: true,
+    files: [{ path: '/a/ABC-123.mp4', has_nfo: false }],
+    rejected: { extension: 1, size: 0, not_found: 0, inaccessible: 1 },
+    total_rejected: 2,
+  });
+
+  const toasts = [];
+  const fakeThis = makeFakeThis({
+    showToast(msg, type) { toasts.push({ msg, type }); },
+    switchToFile: async () => {},
+  });
+
+  await searchStateFileList().setFileList.call(fakeThis, ['/a/ABC-123.mp4', '/a/note.txt', '/mnt/z/lan/x.mp4']);
+
+  const keys = toasts.map((t) => t.msg);
+  assert.equal(fakeThis.fileList.length, 1, 'mixed：有效檔仍建入 fileList');
+  // 通用 toast 的 msg 會把細項附在後面（filtered_count（副檔名 1）），故用 startsWith
+  assert.ok(keys.some((k) => k.startsWith('search.filelist.filtered_count')), 'mixed：通用 toast 應出（涵蓋副檔名等非-inaccessible 桶）');
+  assert.ok(keys.includes('search.error.path_inaccessible'), 'mixed：path_inaccessible 亦應出');
+});

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -6,10 +6,14 @@ export function searchStateFileList() {
     return {
     // ===== T1d: File Methods =====
 
-    async switchToFile(index, position = 'first', showFullLoading = false) {
+    async switchToFile(index, position = 'first', showFullLoading = false, skipPersist = false) {
         if (index < 0 || index >= this.fileList.length) return;
 
-        if (this.listMode === 'file' && this.fileList[this.currentFileIndex]) {
+        // skipPersist（P2-T5，spec 功能 C）：removeFile 移除當前檔後 currentFileIndex 已被重指
+        // 鄰檔、但 currentIndex 仍是外出檔的值——此時持久化會把外出檔候選 index 寫進鄰檔（汙染）。
+        // 外出檔已 splice、無須也不該保存其候選 index，故該路徑傳 skipPersist=true 跳過此寫入。
+        // 正常左右導航維持預設 false（照常持久化外出檔候選），行為零變化。
+        if (!skipPersist && this.listMode === 'file' && this.fileList[this.currentFileIndex]) {
             this.fileList[this.currentFileIndex].selectedCandidateIndex = this.currentIndex;
         }
 
@@ -295,7 +299,8 @@ export function searchStateFileList() {
             // 檔/候選不變，跳過 switchToFile 以免無謂把顯示跳回候選 0（純顯示最佳化，
             // 見上方 removingCurrent 註解——編輯安全已由 identity guard 結構性保證，
             // 與這個分支是否執行無關）。
-            this.switchToFile(this.currentFileIndex, 'first', false);
+            // skipPersist=true：外出檔已 splice，不得把其 currentIndex 汙染進鄰檔（P2-T5）
+            this.switchToFile(this.currentFileIndex, 'first', false, true);
         }
         this.saveState();
     },

--- a/web/static/js/pages/search/state/file-list.js
+++ b/web/static/js/pages/search/state/file-list.js
@@ -316,6 +316,10 @@ export function searchStateFileList() {
         // requestId-mismatch 早退，卻不清理 _searchSnapshot/activeEventSource，見 Codex 第3輪 P2）
         this._abortControllers['handleFileDrop']?.abort();
         var hasNfoMap = {};
+        // P2-T6（功能 D）：宣告在 try 外——空列表檢查（下方）在同 try 內須看得到（Codex 三審#1）。
+        // 桌面 pywebview 拖入未掛載/UNC/無權限檔時，filter-files 回 rejected.inaccessible，
+        // 表面化為 path_inaccessible 並中止，取代誤導的「無法識別番號」。
+        let hadInaccessible = false;
         try {
             try {
                 const resp = await fetch('/api/search/filter-files', {
@@ -327,17 +331,24 @@ export function searchStateFileList() {
                 const result = await resp.json();
 
                 if (result.success) {
-                    if (result.total_rejected > 0) {
-                        const { extension, size, not_found } = result.rejected;
-                        let msg = window.t('search.filelist.filtered_count', { count: result.total_rejected });
+                    const { extension = 0, size = 0, not_found = 0, inaccessible = 0 } = result.rejected || {};
+                    hadInaccessible = inaccessible > 0;
+                    // 通用「已過濾」toast 只計非-inaccessible 桶：inaccessible-only 時 genericCount=0
+                    // 自然不冒（避免與 path_inaccessible 雙 toast）；mixed 時通用涵蓋其他桶、
+                    // path_inaccessible 另出（P2-T6 Codex 四審；改 genericCount 一併修正原以
+                    // total_rejected 當計數會含 inaccessible 造成「count 含未解釋桶」的落差）。
+                    const genericCount = extension + size + not_found;
+                    if (genericCount > 0) {
+                        let msg = window.t('search.filelist.filtered_count', { count: genericCount });
                         const details = [];
                         if (extension > 0) details.push(window.t('search.filelist.rejected_extension', { count: extension }));
                         if (size > 0) details.push(window.t('search.filelist.rejected_size', { count: size }));
                         if (not_found > 0) details.push(window.t('search.filelist.rejected_not_found', { count: not_found }));
                         if (details.length > 0) msg += `（${details.join('、')}）`;
-
-                        // T6b: 後端過濾提示（info 類型）
                         this.showToast(msg, 'info');
+                    }
+                    if (hadInaccessible) {
+                        this.showToast(window.t('search.error.path_inaccessible'), 'error');
                     }
                     paths = result.files.map(f => f.path);
                     result.files.forEach(f => { hasNfoMap[f.path] = !!f.has_nfo; });
@@ -393,6 +404,9 @@ export function searchStateFileList() {
             // validIndices 恆為全量，只有 paths 本身就空（filter-files 已全數濾掉）時才會落到這裡，
             // 此時 number_parse_unavailable toast 已顯示過，不再補 no_valid_files（避免雙 toast）。
             if (validIndices.length === 0) {
+                // P2-T6：已因 inaccessible 顯示 path_inaccessible，優先中止、不補通用 no_valid_files
+                // （桌面拖單一未掛載檔被全濾 → 只出 path_inaccessible 一則、明確中止）。
+                if (hadInaccessible) return;
                 if (!parseFailed) {
                     this.showToast(window.t('search.toast.no_valid_files'), 'warning');
                 }

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -7,15 +7,26 @@
 {% endblock %}
 
 {% block content %}
-<div class="help-container container mx-auto px-4 max-w-screen-2xl" x-data="helpPage">
+<div class="help-container container mx-auto px-4 max-w-screen-2xl" x-data="helpPage"
+     data-is-desktop="{{ 'true' if is_desktop else 'false' }}"
+     data-auto-check-update="{{ 'true' if config.get('general', {}).get('auto_check_update', True) else 'false' }}">
     <!-- Hero Card — 置頂區 -->
     <div class="card help-card fluent-rounded-xl mb-4">
         <div class="card-body flex flex-col lg:flex-row">
             <!-- 左欄：現有內容不動 -->
             <div class="flex-1">
-                <h2 class="card-title text-lg">
-                    <i class="bi bi-info-circle"></i>
-                    <span>OpenAver <span x-text="appVersion || 'v{{ version }}'">v{{ version }}</span></span>
+                <h2 class="card-title text-lg flex items-center justify-between">
+                    <span class="flex items-center gap-2">
+                        <i class="bi bi-info-circle"></i>
+                        <span>OpenAver <span x-text="appVersion || 'v{{ version }}'">v{{ version }}</span></span>
+                    </span>
+                    {% if is_desktop %}
+                    <label class="flex items-center gap-2 text-sm font-normal ms-auto">
+                        <span>{{ t('help.hero.auto_check_toggle') }}</span>
+                        <input type="checkbox" class="toggle toggle-primary toggle-sm"
+                               x-model="autoCheckUpdate" @change="saveAutoCheckUpdate()">
+                    </label>
+                    {% endif %}
                 </h2>
                 <p class="text-base-content/60 text-sm mb-1">{{ t('help.hero.subtitle') }}</p>
                 <p class="text-base-content/60 text-sm mb-3">
@@ -757,6 +768,9 @@
 </div>
 
 {% endblock %}
-{% block extra_js %}
-<script src="/static/js/pages/help.js"></script>
+{# help.js 走 pre_alpine_module（Alpine Core 之前）：ES module 隱式 defer，須早於 Alpine
+   start 掛上 alpine:init listener 才註冊得到 Alpine.data('helpPage')，比照 scanner/main.js、
+   search/main.js。放 extra_js（Alpine Core 之後）會導致 helpPage 註冊太晚、頁面不 hydrate。 #}
+{% block pre_alpine_module %}
+<script type="module" src="/static/js/pages/help.js"></script>
 {% endblock %}

--- a/web/templates/help.html
+++ b/web/templates/help.html
@@ -24,7 +24,8 @@
                     <label class="flex items-center gap-2 text-sm font-normal ms-auto">
                         <span>{{ t('help.hero.auto_check_toggle') }}</span>
                         <input type="checkbox" class="toggle toggle-primary toggle-sm"
-                               x-model="autoCheckUpdate" @change="saveAutoCheckUpdate()">
+                               x-model="autoCheckUpdate" @change="saveAutoCheckUpdate()"
+                               :disabled="_autoCheckSaving">
                     </label>
                     {% endif %}
                 </h2>


### PR DESCRIPTION
0.12 系列 released 前的優化 branch（feature/107），四功能 A/B/C/D + Phase 1 修復。

## 功能
- **A 啟動時自動檢查更新（桌面）**：lifespan 背景 `await check_update()` + emit info 通知（desktop gate + flag gate + 失敗靜默）；Help 頁「啟動時檢查更新」toggle（預設開、桌面限定、opt-out）+ 開頁自動反映結果。
- **B 深色 neutral token**：dim 主題補 `--color-neutral: oklch(60% 0.02 250)`，一次修好 8 顆 `btn-outline btn-neutral` 深色隱形（量化：舊 1.11:1 → 新 3.36–3.70:1）。
- **C removeFile 候選汙染（106 遺留 P2）**：`switchToFile` 加 `skipPersist`，移除當前檔不再把外出檔 `currentIndex` 汙染進鄰檔 `selectedCandidateIndex`（源頭杜絕，不再依賴整理時 re-sync 遮蔽）。
- **D 拖檔存取不到判讀（dev-only）**：`filter-files` stat-early 重構 + `rejected.inaccessible` 桶（PermissionError／`/mnt/<letter>` 未掛載啟發式／SMB ValueError），前端 `setFileList` 顯示 path_inaccessible；瀏覽器 drop 路徑零動。

## task → commit
| task | commit |
|---|---|
| P1-T1 config auto_check_update + migration | a5b4a5e5 |
| P1-T2 lifespan 啟動檢查 + emit | 73828cf7 |
| P1-T3 Help toggle + 開頁反映 | 2f196aa5 |
| P1 Codex PUT StrictBool | e373c9f0 |
| P2-T4 dim neutral token | c98a5ccf |
| P2-T5 removeFile 候選汙染 | 72a505fb |
| P2-T6 拖檔存取判讀 | 0e1149e9 |
| Phase1-P2 toggle 失敗還原 | 1e86f23f |
| 版號 + CHANGELOG | 8595e9fb |

## 測試
- 全套 pytest **5640 passed, 1 skipped**；`ruff check .` 綠；`npm run lint` 綠（static_guard 1037／css-guard 44／cjk clean）；`npm test` **285**（含候選汙染守衛跑真 switchToFile 三向 mutation、filter-files inaccessible 前端分流、toggle 失敗還原，皆 mutation 殺 mutant）。
- 8 源金絲雀全 PASS（javbus/jav321/heyzo/d2pass/avsox/fc2/javdb/dmm，live）。
- 每 task 獨立 Sonnet review 全 APPROVE + pre-merge Phase 1 跨廠牌 holistic（Opus subagent **LGTM**；Codex **提 3 採納 1**：P2 toggle 失敗還原已修、P1 版號已 bump、P3 filter-files 全域桶 by-design）。

## plan 偏離（已回報、in-scope）
- D：`rejected.permission`（plan）→ `rejected.inaccessible`（owner 選啟發式後桶涵蓋權限＋未掛載，改名求準）；通用 toast 計數 `total_rejected`→`genericCount`（修「count 含未解釋桶」）。

## accepted residuals
- A/B/D 桌面顯示與真拖檔留 owner 真機 hard-gate（本機無 pywebview 桌面環境）。
- C 為 latent 加固（現行碼被整理時 re-sync 遮蔽、非 live data-loss；源頭修更穩健）。
- Opus P3（startup task 無 shutdown cancel／sync load_config／PUT 無 loopback guard）判 negligible，不動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)