### PR TITLE
fix(0.14.6): metatube 來源的圖片改走單一取回路徑（劇照 403 破圖 ＋ 被牆抓不到圖）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.6] - 2026-08-23
+
+> 這一版只影響**把 metatube 設成來源**的人。沒接 metatube 的話，圖片路徑一個位元組都沒動。
+
+### Fixed
+#### 🖼 metatube 來源的劇照，終於不再整排破圖
+- metatube 接了 30 幾家網站，但 OpenAver 顯示圖片時有一份自己的網域白名單——**冷門那幾家的圖床沒收錄，劇照就整排 403 破圖**。畫面上看起來像「這片沒有劇照」，不會知道是被自己人擋下來的。現在這些圖改走你自己那台 metatube 取回，白名單再也不用追著新站台跑。
+- 封面在 v0.13.6 已經修過，這次補上劇照。
+
+#### 🌏 連不到圖床的時候，會自動改走 metatube 那條路
+- 過去 OpenAver 是**用你自己這台電腦的網路**去抓圖，而 metatube 讀網頁用的是它自己的網路。於是會出現「資料抓得到、圖抓不到」的狀況。
+- 現在**整理／改名、補齊資料、唯讀來源產出**這三條路都一樣：先試原始網址，取不到才改用 metatube 幫你取回。封面和劇照都適用。
+- **存檔一律優先原始網址**——metatube 那條會把圖重新壓一次（實測體積 +3%、尺寸不變），所以只在原址真的取不到時才用它。
+
+#### 🛟 metatube 掛掉的時候，封面還是出得來
+- 原始網址從頭到尾保留著，沒有被代理網址取代。這讓既有的破圖救援機制（代理載不出來就換原始網址重試）繼續有效——**metatube 正在重開機或更新時，搜尋頁的封面不會整排變空白**。
+
+### 已知限制
+- 這條備援**只對「圖片網址是 metatube 給的」那些片有效**。如果你的來源順序讓 javdb／javbus 之類的自家來源贏得封面，那張圖沒有代理副本可退——自家 9 個來源的圖片路徑本次完全沒動。
+- 偶發的網路抖動會讓同一個圖床接下來 5 分鐘內的圖直接走 metatube 存檔（也就是存成重新壓過的副本）。肉眼幾乎看不出來，但如果你很在意原始檔，重刮一次即可。
+
+### 致謝
+- 起點是外部貢獻者 [@sheepzacks](https://github.com/sheepzacks) 的 [PR #151](https://github.com/slive777/OpenAver/pull/151)，他的 commit 是這支分支的第一顆。劇照代理的做法照收；「存檔要用哪一份」則翻成原址優先（理由見上）。
+
+測試數 6991 → 7048（pytest；npm test 1187 → 1189）。
+
 ## [0.14.5] - 2026-08-22
 
 ### Changed

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -72,6 +72,10 @@ def _nfo_to_meta(root: ET.Element) -> dict:
         "release_date": nfo_first_text(root, ("release", "premiered", "year")),
         "duration": nfo_runtime_minutes(root),
         "cover_url": "",
+        # CD-126-2：preview_* 是 metatube 取回路徑的暫態。本地 NFO 沒有代理可言，
+        # 但**鍵必須存在**——否則下游 `.get()` 的預設值會散落在四個地方。
+        "preview_cover_url": "",
+        "preview_sample_images": [],
         "url": nfo_text(root, "website"),
     }
 
@@ -139,6 +143,9 @@ def _video_to_meta(video: Video) -> dict:
         "release_date": video.release_date,
         "duration": video.duration,
         "cover_url": video.cover_path,
+        # CD-126-2：DB 來源沒有代理（preview_* 不入庫，見 T4b card 類別 Y）。鍵在值空。
+        "preview_cover_url": "",
+        "preview_sample_images": [],
         "url": "",
         "sample_images": video.sample_images or [],
     }
@@ -157,6 +164,10 @@ def _scraper_to_meta(data: dict) -> dict:
         "release_date": data.get("date", ""),
         "duration": data.get("duration"),
         "cover_url": data.get("cover", ""),
+        # CD-126-2：代理 URL 走平行欄位，與 cover/sample 同時進 meta。
+        # 這是整條 enrich 管線**唯一**有值的產生端——丟在這裡，下游全部是死的。
+        "preview_cover_url": data.get("preview_cover_url", ""),
+        "preview_sample_images": data.get("preview_sample_images", []),
         "url": data.get("url", ""),
         "sample_images": data.get("sample_images", []),
         # 63c-5（CD-63c-5）：唯一 summary/rating 流入 meta 的 crossing point。
@@ -195,12 +206,18 @@ def _merge_meta(base: dict, supplement: dict) -> tuple:
         if not merged.get(key) and supplement.get(key):
             merged[key] = supplement[key]
             filled.append(key)
+    # CD-126-2：preview_* 必須跟 cover/sample **在同一個分支裡**搬——分開搬＝封面來自
+    # 候選 A、代理來自候選 B（CD-113c-12 同一種病，畫面上看不出來）。
+    # sample_images 有 if 與 elif **兩條路**，兩條都要搬，漏一條就是上面那個病。
     if merged.get("cover_url") == "" and supplement.get("cover_url"):
         merged["cover_url"] = supplement["cover_url"]
+        merged["preview_cover_url"] = supplement.get("preview_cover_url", "")
     if merged.get("sample_images") is None and supplement.get("sample_images"):
         merged["sample_images"] = supplement["sample_images"]
+        merged["preview_sample_images"] = supplement.get("preview_sample_images", [])
     elif not merged.get("sample_images") and supplement.get("sample_images"):
         merged["sample_images"] = supplement["sample_images"]
+        merged["preview_sample_images"] = supplement.get("preview_sample_images", [])
     # 63c-5：summary/rating 從 supplement（scraper meta）透傳。base 通常是 DB/NFO meta
     # 無此欄（intentionally NOT carried），fill-if-empty 語意：base 有值不覆蓋。
     if not merged.get("summary") and supplement.get("summary"):
@@ -277,6 +294,7 @@ def _write_cover(
     write_cover: bool,
     overwrite_existing: bool,
     external_manager: str = "off",
+    preview_cover_url: str = "",
 ) -> bool:
     # write_cover=False 先短路，避免對「不寫封面」的片多做一次 os.path.exists
     # （逐位元組對齊 T2 前行為）；exists/overwrite 保留判斷仍走共用 should_preserve_cover。
@@ -289,6 +307,14 @@ def _write_cover(
     if should_preserve_cover(write_cover, overwrite_existing, os.path.exists(cover_path)):
         return False
 
+    # CD-126-3／10：原址優先，取不到才退代理。gate **只看 preview 非空**，
+    # 不得改用 meta["source"] 判斷——混源時「文字走 javbus、封面走 metatube」是合法狀態。
+    #
+    # **preview 為空時連 kwarg 都不傳**（不是傳 fallback_url=""）：AC-5 要求非 metatube
+    # 來源「逐字元相同」，而既有測試的 stub 簽名就是 (url, dest)——多一個 kwarg 會讓
+    # 它們 TypeError。這不是為了配合測試，是那些測試正確地把 AC-5 焊死了。
+    if preview_cover_url:
+        return download_image(cover_url, cover_path, fallback_url=preview_cover_url)
     return download_image(cover_url, cover_path)
 
 
@@ -376,6 +402,7 @@ def _write_extrafanart(
     sample_images: List[str],
     write_extrafanart: bool,
     path_mappings: dict = None,
+    preview_sample_images: List[str] = None,
 ) -> List[str]:
     if not write_extrafanart or not sample_images:
         return []
@@ -384,11 +411,21 @@ def _write_extrafanart(
     extrafanart_dir = parent / "extrafanart"
     os.makedirs(str(extrafanart_dir), exist_ok=True)
 
+    # CD-126-2：逐張配對用 index，**不用裸 zip()**——zip 在長度不等時會靜默截斷，
+    # 等於少下載幾張圖。長度不等的正確語意是「那幾格沒有代理」，不是「少下載」。
+    previews = preview_sample_images or []
     written_uris: List[str] = []
     for i, url in enumerate(sample_images):
         dest = str(extrafanart_dir / f"fanart{i+1}.jpg")
+        fallback = previews[i] if i < len(previews) else ""
         try:
-            if download_image(url, dest):
+            # 同 _write_cover：preview 為空時不傳 kwarg（AC-5 逐字元相同）
+            ok = (
+                download_image(url, dest, fallback_url=fallback)
+                if fallback
+                else download_image(url, dest)
+            )
+            if ok:
                 written_uris.append(to_file_uri(dest, path_mappings))
         except Exception as e:
             logger.warning("extrafanart %d 下載失敗: %s", i + 1, e)
@@ -524,6 +561,7 @@ def enrich_single(  # ranker-invalidate-ok: (no literal SQL here; corpus writes 
             fs_path=fs_path,
             cover_url=cover_url,
             write_cover=write_cover,
+            preview_cover_url=meta.get("preview_cover_url", ""),
             overwrite_existing=overwrite_existing, external_manager=external_manager,  # 兩個 kwarg 刻意併行：enrich_single 的規模閘 baseline(249) 零頭寸，拆成兩行會直接超標（CD-112-13）
         )
         imgs = _write_external_images(
@@ -574,6 +612,7 @@ def enrich_single(  # ranker-invalidate-ok: (no literal SQL here; corpus writes 
             cover_url=cover_url,
             write_cover=write_cover,
             overwrite_existing=overwrite_existing,
+            preview_cover_url=meta.get("preview_cover_url", ""),
         )
 
     written_uris = _write_extrafanart(
@@ -581,6 +620,7 @@ def enrich_single(  # ranker-invalidate-ok: (no literal SQL here; corpus writes 
         sample_images=meta.get("sample_images", []),
         write_extrafanart=write_extrafanart,
         path_mappings=path_mappings,
+        preview_sample_images=meta.get("preview_sample_images", []),
     )
     extrafanart_written = len(written_uris)
 
@@ -797,7 +837,10 @@ def fetch_samples_only(
         return _empty
 
     sample_images = meta.get("sample_images", [])
-    written_uris = _write_extrafanart(fs_path, sample_images, write_extrafanart=True, path_mappings=path_mappings)
+    written_uris = _write_extrafanart(
+        fs_path, sample_images, write_extrafanart=True, path_mappings=path_mappings,
+        preview_sample_images=meta.get("preview_sample_images", []),
+    )
 
     if written_uris:
         repo = VideoRepository()

--- a/core/metatube/mapper.py
+++ b/core/metatube/mapper.py
@@ -16,18 +16,25 @@ _FC2_NOISE_RE = re.compile(
 )
 
 
-def _build_preview_cover_url(base_url: str, provider: str, number: str, cover_url: str) -> str:
-    """metatube 預覽端點 URL（CD-113c-4／12／13）。
+def _build_proxy_image_url(base_url: str, provider: str, number: str, image_url: str) -> str:
+    """metatube 圖片代理端點 URL（泛化建構器，形狀同 CD-113c-4／12／13）。
 
-    base_url 或 cover_url 任一空 → ''（沒有可預覽的東西）。
+    metatube 伺服器的 `/v1/images/primary/{provider}/{number}?url=<image>&ratio=0&quality=100`
+    是**通用伺服器端圖片代理**：`?url=` 存在時伺服器會用該 provider 的 Fetcher
+    在境外取回**任何**圖片 URL（封面、劇照 preview_images、thumb…）並原圖回傳
+    （`ratio=0`＝不裁切，`quality=100`＝原品質；實測 200 回真實 JPEG 原尺寸）。
+    本地 OpenAver 不直連被牆的源站 CDN——所有從 metatube 刮到的圖片走同一條路
+    取回（來源一致性，feature/metatube-image-proxy）。
+
+    base_url 或 image_url 任一空 → ''（沒有可代理的東西）。
     provider／number 若含 `quote(safe="")` 需要轉義的字元（非 ASCII／保留字）
-    → ''，不組出一個上線會被 T3a `_SAFE_PATH_SEGMENT` 擋下的 URL——讓前端
-    `preview_cover_url || cover` 的 fallback 自然接手，而不是讓使用者看到
-    一張穩定 403 的圖。T3a 的允許字元集與 `quote()` 的預設 safe 集合定義
-    相同（RFC 3986 unreserved），故「轉義前後是否相等」是判斷「會不會被
-    T3a 擋下」的精確 predicate，不是近似值（Opus 審核裁決 4）。
+    → ''，不組出一個上線會被 T3a `_SAFE_PATH_SEGMENT` 擋下的 URL——讓呼叫端
+    的 fallback 自然接手，而不是讓使用者看到一張穩定 403 的圖。T3a 的允許字元集
+    與 `quote()` 的預設 safe 集合定義相同（RFC 3986 unreserved），故「轉義前後
+    是否相等」是判斷「會不會被 T3a 擋下」的精確 predicate，不是近似值
+    （Opus 審核裁決 4）。
     """
-    if not base_url or not cover_url:
+    if not base_url or not image_url:
         return ""
 
     # ---- Codex PR review P1（2026-08-07）：base_url 的 userinfo 不得外流 ----
@@ -41,8 +48,8 @@ def _build_preview_cover_url(base_url: str, provider: str, number: str, cover_ur
     # 自動轉成 `Authorization: Basic` header）。
     #
     # 因此**不在這裡靜默剝掉帳密**：那會讓「預覽打不通」變成難以診斷的失敗。
-    # 一律回 ''，讓既有的 `preview_cover_url || cover` fallback 接手。真正的
-    # 連線路徑（`MetatubeHttpClient`）拿到的仍是完整 base_url，Basic Auth 不受影響。
+    # 一律回 ''，讓既有 fallback 接手。真正的連線路徑（`MetatubeHttpClient`）
+    # 拿到的仍是完整 base_url，Basic Auth 不受影響。
     #
     # query／fragment 一起擋是**同一個 guard 順手修掉的功能 bug**：下面是字串
     # 內插，`http://h:9/?x=1` 會組出 `http://h:9/?x=1/v1/images/...`——路徑掉進
@@ -50,13 +57,13 @@ def _build_preview_cover_url(base_url: str, provider: str, number: str, cover_ur
     parsed_base = urlparse(base_url)
     if parsed_base.username or parsed_base.password:
         logger.debug(
-            "preview URL 略過：metatube base_url 帶 userinfo（host=%s）",
+            "proxy URL 略過：metatube base_url 帶 userinfo（host=%s）",
             parsed_base.hostname,
         )
         return ""
     if parsed_base.query or parsed_base.fragment:
         logger.debug(
-            "preview URL 略過：metatube base_url 帶 query/fragment（host=%s）",
+            "proxy URL 略過：metatube base_url 帶 query/fragment（host=%s）",
             parsed_base.hostname,
         )
         return ""
@@ -65,8 +72,18 @@ def _build_preview_cover_url(base_url: str, provider: str, number: str, cover_ur
     number_enc = quote(number, safe="")
     if provider_enc != provider or number_enc != number:
         return ""
-    query = urlencode({"url": cover_url, "ratio": 0, "quality": 100})
+    query = urlencode({"url": image_url, "ratio": 0, "quality": 100})
     return f"{base_url.rstrip('/')}/v1/images/primary/{provider_enc}/{number_enc}?{query}"
+
+
+def _build_preview_cover_url(base_url: str, provider: str, number: str, cover_url: str) -> str:
+    """metatube 預覽端點 URL（封面特化 wrapper，CD-113c-4／12／13）。
+
+    cover_url 空時回 ''（沒有可預覽的東西），讓前端 `preview_cover_url || cover`
+    的 fallback 接手。建構與防護邏輯全在 `_build_proxy_image_url`（形狀相同），
+    這裡只負責綁定語義上的「預覽封面」參數位置。
+    """
+    return _build_proxy_image_url(base_url, provider, number, cover_url)
 
 
 def map_movie_info(info: dict, base_url: str = "") -> Video:
@@ -101,6 +118,22 @@ def map_movie_info(info: dict, base_url: str = "") -> Video:
     cover_url = info.get("cover_url", "")
     preview_cover_url = _build_preview_cover_url(base_url, provider, number, cover_url)
 
+    # 來源一致性：從 metatube 刮到的影片，封面也應走 metatube 取回，避免本地
+    # 直連被牆的源站圖片 URL 超時。preview_cover_url 是 metatube 伺服器的
+    # `/v1/images/primary/...` 代理端點；base_url 帶 userinfo/query 等無法組出
+    # 代理 URL 時 _build_preview_cover_url 返回 ''，此時回退原始 cover_url，
+    # 行為與修改前一致。
+    effective_cover_url = preview_cover_url or cover_url
+
+    # 來源一致性（續，feature/metatube-image-proxy）：劇照 preview_images →
+    # sample_images 同樣逐張改寫成 metatube 代理端點 URL，取回路徑與封面一致。
+    # 逐張獨立降級：某張組不出代理 URL（base_url 異常／provider 需轉義）時
+    # 該張回退原始 URL，不影響其他張。
+    raw_samples = info.get("preview_images") or []
+    sample_images = [
+        _build_proxy_image_url(base_url, provider, number, u) or u for u in raw_samples
+    ]
+
     return Video(
         number=number,
         title=info.get("title", ""),
@@ -110,16 +143,17 @@ def map_movie_info(info: dict, base_url: str = "") -> Video:
         series=info.get("series", ""),
         actresses=actresses,
         date=date,
-        cover_url=cover_url,
+        cover_url=effective_cover_url,
         preview_cover_url=preview_cover_url,
         tags=info.get("genres") or [],
         detail_url=info.get("homepage", ""),
         duration=runtime,
-        sample_images=info.get("preview_images") or [],
+        sample_images=sample_images,
         rating=score,
         summary=summary,
         source=f"metatube:{provider}",
-        # thumb_url / big_thumb_url / preview_video_url / preview_video_hls_url 不吸（defer，spec §6）
+        # thumb_url / big_thumb_url / preview_video_url / preview_video_hls_url 不吸（defer，spec §6）；
+        # actors 只映射名字（Actress model 無頭像欄位、nfo 只寫名字）——演員圖不在本改動範圍
     )
 
 

--- a/core/metatube/mapper.py
+++ b/core/metatube/mapper.py
@@ -118,20 +118,13 @@ def map_movie_info(info: dict, base_url: str = "") -> Video:
     cover_url = info.get("cover_url", "")
     preview_cover_url = _build_preview_cover_url(base_url, provider, number, cover_url)
 
-    # 來源一致性：從 metatube 刮到的影片，封面也應走 metatube 取回，避免本地
-    # 直連被牆的源站圖片 URL 超時。preview_cover_url 是 metatube 伺服器的
-    # `/v1/images/primary/...` 代理端點；base_url 帶 userinfo/query 等無法組出
-    # 代理 URL 時 _build_preview_cover_url 返回 ''，此時回退原始 cover_url，
-    # 行為與修改前一致。
-    effective_cover_url = preview_cover_url or cover_url
-
-    # 來源一致性（續，feature/metatube-image-proxy）：劇照 preview_images →
-    # sample_images 同樣逐張改寫成 metatube 代理端點 URL，取回路徑與封面一致。
-    # 逐張獨立降級：某張組不出代理 URL（base_url 異常／provider 需轉義）時
-    # 該張回退原始 URL，不影響其他張。
+    # CD-126-1／2：cover_url / sample_images 恆為原始網址；代理 URL 住在平行的
+    # preview_* 欄位。組不出代理的劇照格填 ''（不是填原始——同 preview_cover_url
+    # 形狀），讓消費端沿用 `preview || raw`。
     raw_samples = info.get("preview_images") or []
-    sample_images = [
-        _build_proxy_image_url(base_url, provider, number, u) or u for u in raw_samples
+    sample_images = list(raw_samples)
+    preview_sample_images = [
+        _build_proxy_image_url(base_url, provider, number, u) or "" for u in raw_samples
     ]
 
     return Video(
@@ -143,12 +136,13 @@ def map_movie_info(info: dict, base_url: str = "") -> Video:
         series=info.get("series", ""),
         actresses=actresses,
         date=date,
-        cover_url=effective_cover_url,
+        cover_url=cover_url,
         preview_cover_url=preview_cover_url,
         tags=info.get("genres") or [],
         detail_url=info.get("homepage", ""),
         duration=runtime,
         sample_images=sample_images,
+        preview_sample_images=preview_sample_images,
         rating=score,
         summary=summary,
         source=f"metatube:{provider}",

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -640,13 +640,25 @@ def generate_jellyfin_images(cover_path: str, base_stem: str, number: str = '', 
 
 
 def _host_key(url: str) -> Optional[Tuple[str, str, int]]:
-    """Failure-memory key: (scheme, hostname, effective_port)."""
-    parsed = urlparse(url)
-    scheme = (parsed.scheme or "").lower()
-    hostname = (parsed.hostname or "").lower()
-    if not scheme or not hostname:
+    """Failure-memory key: (scheme, hostname, effective_port)。組不出就回 None。
+
+    Stage 2 review P3-1：`urlparse(...).port` 對非數字 port（`http://h:abc/x.jpg`）
+    **拋 ValueError**，而唯一的呼叫點 `download_image()` 的 `skip_primary = ...`
+    那行不在任何 try 內——例外會一路穿出 `organize_file()`，而那時
+    `shutil.move()`（:1219）**已經把影片檔搬到新資料夾了**，NFO 卻還沒寫。
+    使用者看到「整理失敗」，但檔案在新位置、資料夾是半成品，得自己收拾。
+    改動前這種髒網址只會讓封面抓不到，整理照樣完成——所以這是本 branch 引入的回歸。
+    回 None 即代表「這個網址沒有可記憶的 host」，兩個消費端都已經吃 None。
+    """
+    try:
+        parsed = urlparse(url)
+        scheme = (parsed.scheme or "").lower()
+        hostname = (parsed.hostname or "").lower()
+        if not scheme or not hostname:
+            return None
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError:
         return None
-    port = parsed.port or (443 if scheme == "https" else 80)
     return (scheme, hostname, port)
 
 

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -7,11 +7,14 @@ import os
 import re
 import sys
 import shutil
+import threading
+import time
 import requests
 import html
 from pathlib import Path
 from PIL import Image
 from typing import Optional, Dict, Any, List, Tuple
+from urllib.parse import urlparse
 
 from core.config import STEM_IMAGE_MODES
 from core.cover_attributes import effective_tags
@@ -26,9 +29,16 @@ logger = get_logger(__name__)
 
 # HTTP 請求設定
 REQUEST_TIMEOUT = 30
+CONNECT_TIMEOUT = 5  # CD-126-5c：只縮 connect；可達 host 的 handshake ≪ 5s
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
 }
+
+# Process-level failed-host memory (CD-126-5 / 5b / 5c). Key = (scheme, hostname, port).
+_HOST_FAILURE_TTL = 300
+_failed_hosts: Dict[Tuple[str, str, int], float] = {}
+_failed_hosts_lock = threading.Lock()
+_now = time.monotonic  # injectable clock for TTL tests (no sleep)
 
 
 def sanitize_filename(name: str) -> str:
@@ -629,35 +639,96 @@ def generate_jellyfin_images(cover_path: str, base_stem: str, number: str = '', 
     return result
 
 
-def download_image(url: str, save_path: str, referer: str = '') -> bool:
-    """下載圖片"""
-    if not url:
+def _host_key(url: str) -> Optional[Tuple[str, str, int]]:
+    """Failure-memory key: (scheme, hostname, effective_port)."""
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    hostname = (parsed.hostname or "").lower()
+    if not scheme or not hostname:
+        return None
+    port = parsed.port or (443 if scheme == "https" else 80)
+    return (scheme, hostname, port)
+
+
+def _host_recently_failed(key: Optional[Tuple[str, str, int]]) -> bool:
+    if key is None:
         return False
+    now = _now()
+    with _failed_hosts_lock:
+        expiry = _failed_hosts.get(key)
+        if expiry is None:
+            return False
+        if now >= expiry:
+            _failed_hosts.pop(key, None)
+            return False
+        return True
+
+
+def _record_host_failure(key: Optional[Tuple[str, str, int]]) -> None:
+    if key is None:
+        return
+    expiry = _now() + _HOST_FAILURE_TTL
+    with _failed_hosts_lock:
+        _failed_hosts[key] = expiry
+    logger.debug("image host connect failure recorded: %s (ttl=%ss)", key, _HOST_FAILURE_TTL)
+
+
+def _build_download_headers(url: str, referer: str = "") -> dict:
+    headers = HEADERS.copy()
+    effective_referer = referer
+    if not effective_referer:
+        if "javbus.com" in url:
+            effective_referer = "https://www.javbus.com/"
+        elif "dmm.co.jp" in url:
+            effective_referer = "https://www.dmm.co.jp/"
+        elif "jav321.com" in url:
+            effective_referer = "https://www.jav321.com/"
+    if effective_referer:
+        headers["Referer"] = effective_referer
+    return headers
+
+
+def _attempt_download_image(url: str, save_path: str, referer: str = "") -> bool:
+    """Try one URL. Record host only on connect-stage failures."""
+    headers = _build_download_headers(url, referer)
     try:
-        headers = HEADERS.copy()
-
-        # 根據 URL 設置對應的 Referer
-        if not referer:
-            if "javbus.com" in url:
-                referer = "https://www.javbus.com/"
-            elif "dmm.co.jp" in url:
-                referer = "https://www.dmm.co.jp/"
-            elif "jav321.com" in url:
-                referer = "https://www.jav321.com/"
-
-        if referer:
-            headers['Referer'] = referer
-
-        resp = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        resp = requests.get(
+            url, headers=headers, timeout=(CONNECT_TIMEOUT, REQUEST_TIMEOUT)
+        )
         if resp.status_code == 200 and len(resp.content) > 1000:
-            with open(save_path, 'wb') as f:
+            with open(save_path, "wb") as f:
                 f.write(resp.content)
             return True
+    except requests.exceptions.ConnectionError as e:
+        # ConnectTimeout is a ConnectionError subclass; ReadTimeout is not.
+        _record_host_failure(_host_key(url))
+        logger.warning(f"[!] 下載圖片失敗: {e}")
     except Exception as e:
         logger.warning(f"[!] 下載圖片失敗: {e}")
     return False
 
 
+def download_image(
+    url: str, save_path: str, referer: str = "", fallback_url: str = ""
+) -> bool:
+    """下載圖片。
+
+    metatube 的 `/v1/images/` 會重新編碼 JPEG（實測 +3% 體積、尺寸不變），所以先試原址，取不到才用代理副本。
+    """
+    if not url:
+        return False
+
+    # CD-126-8: original-first; proxy is a re-encoded JPEG rescue copy.
+    skip_primary = bool(fallback_url) and _host_recently_failed(_host_key(url))
+
+    if not skip_primary:
+        if _attempt_download_image(url, save_path, referer):
+            return True
+        if not fallback_url:
+            return False
+        return _attempt_download_image(fallback_url, save_path, referer)
+
+    return _attempt_download_image(fallback_url, save_path, referer)
 
 
 def generate_nfo(

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -688,13 +688,22 @@ def _build_download_headers(url: str, referer: str = "") -> dict:
     return headers
 
 
-def _attempt_download_image(url: str, save_path: str, referer: str = "") -> bool:
-    """Try one URL. Record host only on connect-stage failures."""
+def _attempt_download_image(
+    url: str, save_path: str, referer: str = "", *, short_connect: bool = False
+) -> bool:
+    """Try one URL. Record host only on connect-stage failures.
+
+    `short_connect` 只在「這次嘗試有代理可退」時為 True（CD-126-6 ＋ Codex PR review P2）。
+
+    **為什麼不無條件縮**：AC-5 要求非 metatube 來源「逐字元相同」。沒有 fallback 的
+    呼叫端（自家 9 源）縮成 5 秒 connect **等於改變結果**——連線慢但 TCP 接得起來的
+    使用者會從「30 秒後成功」變成「5 秒失敗」，而且**沒有代理可以救**。
+    短逾時的收益只存在於「失敗了還有第二條路」的情境，成本卻落在沒有第二條路的人身上。
+    """
     headers = _build_download_headers(url, referer)
+    timeout = (CONNECT_TIMEOUT, REQUEST_TIMEOUT) if short_connect else REQUEST_TIMEOUT
     try:
-        resp = requests.get(
-            url, headers=headers, timeout=(CONNECT_TIMEOUT, REQUEST_TIMEOUT)
-        )
+        resp = requests.get(url, headers=headers, timeout=timeout)
         if resp.status_code == 200 and len(resp.content) > 1000:
             with open(save_path, "wb") as f:
                 f.write(resp.content)
@@ -722,10 +731,15 @@ def download_image(
     skip_primary = bool(fallback_url) and _host_recently_failed(_host_key(url))
 
     if not skip_primary:
-        if _attempt_download_image(url, save_path, referer):
+        # 只有「有代理可退」的那一次原址嘗試才用短 connect（見 _attempt_download_image
+        # 的 docstring）。沒有 fallback 時逐字元維持改動前的 timeout=REQUEST_TIMEOUT。
+        if _attempt_download_image(
+            url, save_path, referer, short_connect=bool(fallback_url)
+        ):
             return True
         if not fallback_url:
             return False
+        # 代理那一次用正常 timeout（plan §2.3）——它通常在區網內，且已經是最後一條路。
         return _attempt_download_image(fallback_url, save_path, referer)
 
     return _attempt_download_image(fallback_url, save_path, referer)
@@ -1223,10 +1237,11 @@ def organize_file(  # noqa: C901 — 整理主流程；Phase 2（110b）會在�
         if img_url:
             cover_path = resolve_cover_target(os.path.join(target_dir, filename_base), ext_mode)
             # CD-126-3（owner 2026-08-23 裁決納入）：原址優先，取不到才退 metatube 代理。
-            # ⚠ **只有後端重刮那條會有值**——前端送來的 metadata 已被
-            # `buildOrganizeMetadata()` 剝除兩個 preview 欄位（TASK-126-T3 / 113c-T3b：
-            # 那是只對顯示有意義、會隨 metatube 連線狀態失效的網址，不能落磁碟）。
-            # 讀不到就跟今天完全一樣，不需要任何 if-else 去分辨來源。
+            # 後端重刮與前端整理（`buildOrganizeMetadata()`）**兩條都有值**——Codex PR
+            # review P2-1 之後前端不再剝除 preview 欄位。113c-T3b 的不變式是「代理網址
+            # 不落磁碟」，剝除只是當時採用的手段；改由 TestT6PreviewNotPersisted 直接
+            # 斷言 NFO／new_folder 下所有文字檔都不含代理 URL 來守。
+            # 讀不到（非 metatube 來源）就跟今天完全一樣，不需要 if-else 去分辨來源。
             preview_cover = metadata.get('preview_cover_url') or ''
             cover_ok = (
                 download_image(img_url, cover_path, fallback_url=preview_cover)

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -1222,7 +1222,18 @@ def organize_file(  # noqa: C901 — 整理主流程；Phase 2（110b）會在�
         img_url = metadata.get('cover', '')
         if img_url:
             cover_path = resolve_cover_target(os.path.join(target_dir, filename_base), ext_mode)
-            if download_image(img_url, cover_path):
+            # CD-126-3（owner 2026-08-23 裁決納入）：原址優先，取不到才退 metatube 代理。
+            # ⚠ **只有後端重刮那條會有值**——前端送來的 metadata 已被
+            # `buildOrganizeMetadata()` 剝除兩個 preview 欄位（TASK-126-T3 / 113c-T3b：
+            # 那是只對顯示有意義、會隨 metatube 連線狀態失效的網址，不能落磁碟）。
+            # 讀不到就跟今天完全一樣，不需要任何 if-else 去分辨來源。
+            preview_cover = metadata.get('preview_cover_url') or ''
+            cover_ok = (
+                download_image(img_url, cover_path, fallback_url=preview_cover)
+                if preview_cover
+                else download_image(img_url, cover_path)
+            )
+            if cover_ok:
                 result['cover_path'] = cover_path
 
         # 外部管理器模式：依 ext_mode 決定 poster/fanart 命名規則（ext_mode 已在早偵測層定義）
@@ -1245,12 +1256,18 @@ def organize_file(  # noqa: C901 — 整理主流程；Phase 2（110b）會在�
             sample_images = metadata.get('sample_images', [])
             if sample_images:
                 extrafanart_dir = os.path.join(target_dir, 'extrafanart')
+                # 同上：逐張 index 配對（不用裸 zip，長度不等不得截斷下載張數）
+                sample_previews = metadata.get('preview_sample_images') or []
                 try:
                     os.makedirs(extrafanart_dir, exist_ok=True)
                     for i, url in enumerate(sample_images, 1):
                         try:
                             dest = os.path.join(extrafanart_dir, f'fanart{i}.jpg')
-                            download_image(url, dest)
+                            pv = sample_previews[i - 1] if i - 1 < len(sample_previews) else ''
+                            if pv:
+                                download_image(url, dest, fallback_url=pv)
+                            else:
+                                download_image(url, dest)
                         except Exception as e:
                             logger.warning(f"extrafanart {i} 下載失敗: {e}")
                 except Exception as e:

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -977,6 +977,19 @@ def _reraise_nfo_stat_error(e: OSError) -> None:
     raise e
 
 
+def _download_sample(url: str, dest: str, previews: list, idx: int) -> bool:
+    """逐張取劇照：原址優先，該格有代理才退代理（CD-126-3）。
+
+    **用 index 取值，不用裸 `zip()`**——zip 在長度不等時會靜默截斷，等於少下載幾張圖；
+    長度不等的正確語意是「那幾格沒有代理」，不是「少下載」。
+    preview 為空時**連 kwarg 都不傳**（AC-5：非 metatube 來源逐字元相同）。
+    """
+    fallback = previews[idx] if idx < len(previews) else ''
+    if fallback:
+        return download_image(url, dest, fallback_url=fallback)
+    return download_image(url, dest)
+
+
 def _write_movie_assets(
     movie_dir: str,
     meta: dict,
@@ -1067,9 +1080,10 @@ def _write_movie_assets(
         ef_dir = Path(movie_dir) / 'extrafanart'
         os.makedirs(ef_dir, exist_ok=True)
         sample_fs: list = []
+        previews = meta.get('preview_sample_images') or []
         for i, url in enumerate(meta.get('sample_images', []), 1):
             dest = str(ef_dir / f'fanart{i}.jpg')
-            if download_image(url, dest):
+            if _download_sample(url, dest, previews, i - 1):
                 sample_fs.append(dest)
         return {'sample_fs': sample_fs}
 
@@ -1086,7 +1100,15 @@ def _write_movie_assets(
         has_cover = False
     else:  # 'download' — byte-identical to the pre-T1 unconditional branch (C6)
         remote_url = cover_strategy[1]
-        has_cover = bool(remote_url) and download_image(remote_url, cover_fs)
+        # CD-126-9：fallback 從 `meta` 取，**不動 cover_strategy tuple 的形狀**——
+        # `cover_strategy[2]` 在 'copy' 種類下已經是 raw_source_media，同一個索引在不同
+        # kind 下代表不同東西，那正是本 branch 要消滅的形狀。
+        preview_cover = meta.get('preview_cover_url') or ''
+        has_cover = bool(remote_url) and (
+            download_image(remote_url, cover_fs, fallback_url=preview_cover)
+            if preview_cover
+            else download_image(remote_url, cover_fs)
+        )
 
     # 2) poster/fanart — media-server flavours only (CD-111-2 fail-closed whitelist); off produces none, matching non-readonly parity.
     if has_cover and external_manager in STEM_IMAGE_MODES:
@@ -1126,9 +1148,10 @@ def _write_movie_assets(
     if config.get('download_sample_images'):
         ef_dir = Path(movie_dir) / 'extrafanart'
         os.makedirs(ef_dir, exist_ok=True)
+        previews = meta.get('preview_sample_images') or []
         for i, url in enumerate(meta.get('sample_images', []), 1):
             dest = str(ef_dir / f'fanart{i}.jpg')
-            if download_image(url, dest):
+            if _download_sample(url, dest, previews, i - 1):
                 sample_fs.append(dest)
 
     # 4) NFO — title/fields use full meta (not truncated format_data).
@@ -1398,6 +1421,9 @@ def _nfo_to_producer_meta(root: ET.Element, fallback_number: str) -> dict:
         '_rating': rating_val,
         'cover': '',
         'sample_images': [],
+        # CD-126-2：本地 NFO 沒有代理可言，但鍵必須存在（同 enricher._nfo_to_meta）。
+        'preview_cover_url': '',
+        'preview_sample_images': [],
     }
 
 
@@ -1591,6 +1617,9 @@ def resolve_ingest_plan(
     if meta is None:
         return None, ('none',)
     meta['sample_images'] = []
+    # CD-126-2 等長契約：清空 sample_images 就必須連帶清空 preview——長度不等是**靜默錯位**
+    # （圖片對到別張），比破圖難查。
+    meta['preview_sample_images'] = []
     return meta, cover_strategy
 
 

--- a/core/readonly_producer.py
+++ b/core/readonly_producer.py
@@ -1103,6 +1103,15 @@ def _write_movie_assets(
         # CD-126-9：fallback 從 `meta` 取，**不動 cover_strategy tuple 的形狀**——
         # `cover_strategy[2]` 在 'copy' 種類下已經是 raw_source_media，同一個索引在不同
         # kind 下代表不同東西，那正是本 branch 要消滅的形狀。
+        #
+        # ⚠️ 隱含耦合（Stage 2 review P3-5）：primary 來自 `cover_strategy[1]`、fallback
+        # 來自 `meta['preview_cover_url']`，**兩個值住在不同容器**。今天成立是因為
+        # `('download', ...)` 只在 `resolve_ingest_plan()` 的兩處產生，兩處都是
+        # `('download', meta['cover'])`。若日後有人讓 'download' 的網址不再等於
+        # `meta['cover']`（例如改吃 NFO 的 <thumb>），直連失敗時會拿**另一張圖**的
+        # 代理網址存成封面——使用者拿到錯的封面且看不出來。下面的 assert 是那條的絆線。
+        # 不加 runtime assert：它會在唯讀產出跑到一半時崩掉，而這條耦合的破裂後果
+        # （封面錯一張）比崩掉輕。真正的防線是「動 resolve_ingest_plan 的人讀到這段」。
         preview_cover = meta.get('preview_cover_url') or ''
         has_cover = bool(remote_url) and (
             download_image(remote_url, cover_fs, fallback_url=preview_cover)

--- a/core/scrapers/models.py
+++ b/core/scrapers/models.py
@@ -29,6 +29,10 @@ class Video(BaseModel):
     label: str = Field(default="", description="發行商/レーベル")
     series: str = Field(default="", description="系列/シリーズ")
     sample_images: list[str] = Field(default_factory=list, description="樣品圖像 URL")
+    preview_sample_images: list[str] = Field(
+        default_factory=list,
+        description="metatube 預覽用劇照 URL（與 sample_images 等長同序；組不出填 ''；CD-126-2）",
+    )
 
     # 選用欄位（Task 5 會加入）
     rating: Optional[float] = None
@@ -56,6 +60,7 @@ class Video(BaseModel):
             'label': self.label,
             'series': self.series,
             'sample_images': self.sample_images,
+            'preview_sample_images': self.preview_sample_images,
         }
 
 

--- a/core/source_merger.py
+++ b/core/source_merger.py
@@ -129,9 +129,17 @@ def merge_results(
         # 不變式，merger 不該隱性依賴它（那正是 CD-113c-12 要消滅的形狀）。
         updates['preview_cover_url'] = ''
 
-    # sample_images 維持獨立 _first_non_empty（CD-113c-12 不適用於此欄，各自獨立解析）
-    sample_images_value = _first_non_empty(cover_ordered, 'sample_images', none_sentinel=False)
-    if sample_images_value is not None:
-        updates['sample_images'] = sample_images_value
+    # 劇照欄位：sample_images 依 user_order 找第一個該欄非空的候選（=「勝出候選」）。
+    # preview_sample_images 必須從**同一個**勝出候選複製，不可各自 _first_non_empty
+    # （CD-126-2／CD-113c-12 同源綁定；否則 sample 取候選 A、preview 取候選 B＝燈箱顯示別片劇照）。
+    # 勝出候選沒有 preview 時明確覆寫為空 list，不得沿用 text_source 或其他候選的值。
+    sample_winner = _first_non_empty_video(cover_ordered, 'sample_images', none_sentinel=False)
+    if sample_winner is not None:
+        updates['sample_images'] = sample_winner.sample_images
+        updates['preview_sample_images'] = sample_winner.preview_sample_images
+    elif text_source.preview_sample_images:
+        # 沒有任何候選有 sample_images ⇒ 沒有劇照可預覽。**明確清空**，不讓 preview
+        # 從 text_source 漏過來（同封面分支的防漏形狀）。
+        updates['preview_sample_images'] = []
 
     return text_source.model_copy(update=updates) if updates else text_source

--- a/core/version.py
+++ b/core/version.py
@@ -2,7 +2,7 @@
 OpenAver 版本資訊
 """
 
-__version__ = "0.14.5"
+__version__ = "0.14.6"
 VERSION = __version__
 
 # 版本資訊

--- a/scripts/py_function_size_lint.py
+++ b/scripts/py_function_size_lint.py
@@ -131,9 +131,16 @@ EXEMPTIONS: dict[tuple[str, str], tuple[int, str]] = {
         "target 焊死該函式，拆分成本由測試面而非邏輯面決定，與既有 C901 noqa 理由一致）。",
     ),
     ("core/organizer.py", "organize_file"): (
-        359,
+        366,
         "整理主流程；Phase 2（110b）會在其中加 containment 防線，加的是「呼叫一個新的小函式」，"
-        "不得讓本函式本身更複雜（見 plan-110b，與既有 C901 noqa 理由一致）。",
+        "不得讓本函式本身更複雜（見 plan-110b，與既有 C901 noqa 理由一致）。"
+        " ── 359→366（v0.14.6 / TASK-126-T4b，owner 2026-08-23 裁決把 organize 路徑納入）："
+        "封面與 extrafanart 兩處各多一段「有代理備胎才傳 fallback_url」的分支。"
+        "**backlog（不在本 branch 做）**：這個 4 行形狀在 organizer×2 / enricher×2 / "
+        "readonly_producer×3 共 7 處重複，抽成單一 helper 可同時消掉本條與 _write_movie_assets "
+        "的增量——但會讓既有測試的 `patch('core.enricher.download_image')` 攔不到"
+        "（BE-TEST-01 是 patch 消費端綁定），屬於「要連測試策略一起改」的動作，"
+        "不該在 pre-merge 尾聲順手做。",
     ),
     ("core/config.py", "_load_config_unlocked"): (
         304,
@@ -177,9 +184,14 @@ EXEMPTIONS: dict[tuple[str, str], tuple[int, str]] = {
         "難以追蹤資源釋放順序。",
     ),
     ("core/readonly_producer.py", "_write_movie_assets"): (
-        218,
+        235,
         "109 剛落地的唯讀單片產出主流程，寫入 nfo/cover/poster/fanart 等多個資產，需要維持"
-        "同一次 I/O 序列的可推理性（部分失敗時的處置順序）；剛穩定，暫不再拆避免二次擾動。",
+        "同一次 I/O 序列的可推理性（部分失敗時的處置順序）；剛穩定，暫不再拆避免二次擾動。"
+        " ── 218→235（v0.14.6 / TASK-126-T4b）：封面與 extrafanart 各接上代理備胎，"
+        "外加 CD-126-9 那條「primary 來自 cover_strategy[1]、fallback 來自 meta」隱含耦合的"
+        "說明註解（pre-merge Stage 2 P3-5；刻意用註解不用 runtime assert，"
+        "因為那會在唯讀產出跑到一半時崩掉，比它要防的「封面錯一張」更糟）。"
+        "同 organize_file 條的 helper backlog。",
     ),
     ("build.py", "download_and_install_packages"): (
         204,

--- a/scripts/static_guard_lint.mjs
+++ b/scripts/static_guard_lint.mjs
@@ -4248,6 +4248,32 @@ const RULES = [
     pattern: '.lightbox-cover:hover .cover-badges-part',
     note: '[122-T3] AC-17：燈箱 .cover-badges-part 不得掛 :hover 淡出',
   },
+
+  // ---- [lint-guard 126-T3] search.html 劇照三處 proxy-image 綁定必須吃 preview 優先 ----
+  // **三條獨立規則，各釘一個位置**——刻意不用單一條 `count: 3`。
+  // 理由（T3 Sonnet review MAJOR，已在 /tmp 沙盒實證）：`required-string` 的 count 是**下限**
+  // （`if (n < rule.count) err(...)`）且不剝註解，所以「刪掉三處之一 ＋ 別處多出兩次同樣指紋
+  // （含註解裡）」會靜默維持綠燈。**使用者流程**：日後有人動這支模板漏改一處 → CI 綠 →
+  // 那一格劇照又變回 403 破圖，而且沒人會去查，因為守衛回報過關。
+  // 指紋各自帶「誰的 index」，所以三處不會互相冒充。
+  {
+    file: 'web/templates/search.html',
+    kind: 'required-string',
+    pattern: 'currentLightboxVideo()?.preview_sample_images?.[i]',
+    note: '[lint-guard 126-T3a] 燈箱劇照按鈕的 /api/proxy-image 必須吃 preview_sample_images?.[i] || raw（CD-126-3；FE-JS-01 用 || 不用 ??）',
+  },
+  {
+    file: 'web/templates/search.html',
+    kind: 'required-string',
+    pattern: 'current().preview_sample_images?.[i]',
+    note: '[lint-guard 126-T3b] detail 縮圖點擊開燈箱的 map 必須吃 preview_sample_images?.[i] || raw（CD-126-3）',
+  },
+  {
+    file: 'web/templates/search.html',
+    kind: 'required-string',
+    pattern: 'current().preview_sample_images?.[idx]',
+    note: '[lint-guard 126-T3c] detail 縮圖 :src 必須吃 preview_sample_images?.[idx] || raw（CD-126-3）',
+  },
 ];
 
 // ---- helpers ----

--- a/tests/integration/test_capabilities_auth.py
+++ b/tests/integration/test_capabilities_auth.py
@@ -125,16 +125,25 @@ class TestCapabilitiesCurlAuthProperty:
         ps = data["agent_instructions"]["shell_compat"]["alternative_windows"]
         assert '-Headers @{Authorization = "Bearer $OPENAVER_TOKEN"}' in ps
 
-    def test_image_display_step_1_has_auth_header(self):
+    def test_image_display_curl_step_has_auth_header(self):
         """盲區 2（TASK-114b-T5 驗證階段新發現，plan-114b.md CD-114b-8 原文
         只列了 PowerShell 那一格）：這一格字面值是 "2. curl -H \"...\" -o
         ..."，因為前面帶步驟編號 "2. "，不是以 "curl " 開頭 —— `_iter_strings`
         的 `.startswith("curl ")` 過濾器天然看不到它，必須跟
-        alternative_windows 一樣單獨蓋一條。"""
+        alternative_windows 一樣單獨蓋一條。
+
+        v0.14.6：改成**按內容找**而不是按 `steps[1]` 找。原本寫死索引，結果
+        126 在前面插一格 metatube preview_* 的說明時，這支測試就紅了——而它
+        要守的東西（curl 那格帶不帶 auth header）根本沒變。位置不是它的不變式。
+        """
         data = _enabled_capabilities_json()
-        step = data["image_display"]["steps"][1]
-        assert step.startswith("2. curl ")
-        assert "Authorization: Bearer" in step
+        steps = data["image_display"]["steps"]
+        curl_steps = [s for s in steps if "curl " in s]
+        assert len(curl_steps) == 1, (
+            f"image_display.steps 裡的 curl 指令應恰好一條，實際 {len(curl_steps)} 條："
+            f"{curl_steps}——找不到就代表這支測試什麼都沒驗到"
+        )
+        assert "Authorization: Bearer" in curl_steps[0]
 
 
     def test_scenario_cover_download_step_has_auth_header(self):

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -3991,6 +3991,61 @@ class TestT4bEnrichCallerFallback(_T4bFailedHostsMixin):
         assert (ef / "fanart2.jpg").read_bytes() == _T4B_PROXY
 
 
+class TestT4bEnrichExternalManagerBranch(_T4bFailedHostsMixin):
+    """SA-pre-6 缺口：`external_manager != "off"` 的那個 _write_cover 呼叫點沒被驗過。
+
+    T4b 系列全部走 `external_manager` 預設值 "off"，只打到 enricher.py:610 那個
+    call site；:558 那條（Jellyfin / Emby / Kodi 使用者走的路）的
+    `preview_cover_url=` wiring 是「有寫但沒人驗過真的會退代理」。
+
+    使用者流程：使用者的外部管理器設成 Jellyfin、按「補齊資料」→ 封面原址連不到 →
+    這條 wiring 若被改壞，封面就抓不到，而測試全綠不會有人發現。
+    """
+
+    def test_external_manager_branch_uses_preview_fallback(self, tmp_path):
+        video = tmp_path / "SONE-205.mp4"
+        video.write_bytes(b"fake-video")
+        scraper = _t4b_scraper()
+
+        def fake_get(url, **kwargs):
+            if "cdn.example" in url:
+                raise requests.exceptions.ConnectTimeout("connect timed out")
+            return _t4b_ok(_T4B_PROXY)
+
+        with (
+            patch("core.organizer.requests.get", side_effect=fake_get),
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.find_subtitle_files", return_value=[]),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=str(video),
+                number="SONE-205",
+                mode="refresh_full",
+                scraper_data=scraper,
+                write_nfo=False,
+                write_cover=True,
+                write_extrafanart=False,
+                overwrite_existing=True,
+                external_manager="jellyfin",
+            )
+
+        assert result.success is True
+        assert result.cover_written is True, (
+            "external_manager 分支的 _write_cover 沒有把 preview_cover_url 傳下去"
+        )
+        # jellyfin flavour 下封面落點不是 <stem>.jpg（走 stem 長格式 -poster/-fanart），
+        # 所以掃「實際寫出了哪些 .jpg」而不是猜檔名。原址是 ConnectTimeout，
+        # 磁碟上只可能出現代理副本的位元組——這正是本測試要鎖的東西。
+        written = sorted(f.name for f in tmp_path.iterdir() if f.suffix == ".jpg")
+        assert written, f"jellyfin 分支沒有寫出任何圖片：{sorted(p.name for p in tmp_path.iterdir())}"
+        assert all(
+            (tmp_path / name).read_bytes() == _T4B_PROXY for name in written
+        ), f"寫出的圖片不是代理副本（原址是 ConnectTimeout，只可能來自代理）：{written}"
+
+
 class TestT4bEnrichMixedSource(_T4bFailedHostsMixin):
     """邊界 5 / CD-126-10：source=javbus 但 preview 非空 → fallback 仍傳入。"""
 

--- a/tests/unit/test_enricher.py
+++ b/tests/unit/test_enricher.py
@@ -3888,3 +3888,400 @@ class TestResolveNfoCoverPathsFlavourCoverage:
             f"nfo_path 必須在所有 flavour 下逐字相同，實際: {nfo_paths}"
         )
         assert next(iter(nfo_paths.values())) == str(video_path.with_suffix(".nfo"))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TASK-126-T4b：preview_* 管線接通 enricher（caller 層級）
+# ══════════════════════════════════════════════════════════════════════════════
+
+import hashlib
+import requests
+
+
+_T4B_BIG = b"P" * 1001
+_T4B_PROXY = b"F" * 1001
+
+
+def _t4b_ok(content=_T4B_BIG):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = content
+    return resp
+
+
+class _T4bFailedHostsMixin:
+    @pytest.fixture(autouse=True)
+    def _clear_failed_hosts(self):
+        import core.organizer as org
+        with org._failed_hosts_lock:
+            org._failed_hosts.clear()
+        yield
+        with org._failed_hosts_lock:
+            org._failed_hosts.clear()
+
+
+def _t4b_scraper(**overrides):
+    data = {
+        "number": "SONE-205",
+        "title": "テストタイトル",
+        "actors": ["女優A"],
+        "cover": "https://cdn.example/cover.jpg",
+        "preview_cover_url": "https://mt.example/v1/images/?url=cover",
+        "date": "2024-01-01",
+        "maker": "SOD",
+        "director": "監督",
+        "series": "シリーズ",
+        "label": "LABEL",
+        "tags": ["タグ"],
+        "sample_images": [
+            "https://cdn.example/s1.jpg",
+            "https://cdn.example/s2.jpg",
+        ],
+        "preview_sample_images": [
+            "https://mt.example/v1/images/?url=s1",
+            "https://mt.example/v1/images/?url=s2",
+        ],
+        "duration": 120,
+        "url": "https://example.com/SONE-205",
+        "source": "metatube:MGS",
+    }
+    data.update(overrides)
+    return data
+
+
+class TestT4bEnrichCallerFallback(_T4bFailedHostsMixin):
+    """邊界 1：enrich_single 入口，原址 ConnectTimeout → 代理成功存檔。"""
+
+    def test_enrich_single_connect_timeout_uses_preview_fallback(self, tmp_path):
+        video = tmp_path / "SONE-205.mp4"
+        video.write_bytes(b"fake-video")
+        scraper = _t4b_scraper()
+
+        def fake_get(url, **kwargs):
+            if "cdn.example" in url:
+                raise requests.exceptions.ConnectTimeout("connect timed out")
+            return _t4b_ok(_T4B_PROXY)
+
+        with (
+            patch("core.organizer.requests.get", side_effect=fake_get),
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.find_subtitle_files", return_value=[]),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=str(video),
+                number="SONE-205",
+                mode="refresh_full",
+                scraper_data=scraper,
+                write_nfo=False,
+                write_cover=True,
+                write_extrafanart=True,
+                overwrite_existing=True,
+            )
+
+        assert result.success is True
+        assert result.cover_written is True
+        cover = tmp_path / "SONE-205.jpg"
+        assert cover.exists()
+        assert cover.read_bytes() == _T4B_PROXY
+        ef = tmp_path / "extrafanart"
+        assert (ef / "fanart1.jpg").read_bytes() == _T4B_PROXY
+        assert (ef / "fanart2.jpg").read_bytes() == _T4B_PROXY
+
+
+class TestT4bEnrichMixedSource(_T4bFailedHostsMixin):
+    """邊界 5 / CD-126-10：source=javbus 但 preview 非空 → fallback 仍傳入。"""
+
+    def test_mixed_source_javbus_still_passes_fallback_url(self, tmp_path):
+        video = tmp_path / "SONE-205.mp4"
+        video.write_bytes(b"fake-video")
+        scraper = _t4b_scraper(source="javbus")
+
+        with (
+            patch("core.enricher.download_image", return_value=True) as mock_dl,
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.find_subtitle_files", return_value=[]),
+            patch("os.makedirs"),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=str(video),
+                number="SONE-205",
+                mode="refresh_full",
+                scraper_data=scraper,
+                write_nfo=False,
+                write_cover=True,
+                write_extrafanart=True,
+                overwrite_existing=True,
+            )
+
+        assert result.success is True
+        fallbacks = [
+            c.kwargs.get("fallback_url", "")
+            for c in mock_dl.call_args_list
+            if c.kwargs.get("fallback_url")
+        ]
+        assert "https://mt.example/v1/images/?url=cover" in fallbacks
+        assert "https://mt.example/v1/images/?url=s1" in fallbacks
+        assert "https://mt.example/v1/images/?url=s2" in fallbacks
+
+
+class TestT4bEnrichAc4cHash(_T4bFailedHostsMixin):
+    """邊界 6 / AC-4c：原址可達時存檔 hash 等於直連位元組，不是代理副本。"""
+
+    def test_enrich_single_primary_reachable_keeps_direct_bytes(self, tmp_path):
+        video = tmp_path / "SONE-205.mp4"
+        video.write_bytes(b"fake-video")
+        scraper = _t4b_scraper()
+        primary_bytes = b"DIRECT-BYTES" + (b"A" * 1000)
+        proxy_bytes = b"PROXY-BYTES" + (b"B" * 1000)
+
+        def fake_get(url, **kwargs):
+            if "cdn.example" in url:
+                return _t4b_ok(primary_bytes)
+            return _t4b_ok(proxy_bytes)
+
+        with (
+            patch("core.organizer.requests.get", side_effect=fake_get),
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.find_subtitle_files", return_value=[]),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import enrich_single
+            result = enrich_single(
+                file_path=str(video),
+                number="SONE-205",
+                mode="refresh_full",
+                scraper_data=scraper,
+                write_nfo=False,
+                write_cover=True,
+                write_extrafanart=False,
+                overwrite_existing=True,
+            )
+
+        assert result.success is True
+        cover = tmp_path / "SONE-205.jpg"
+        assert cover.exists()
+        assert hashlib.sha256(cover.read_bytes()).digest() == hashlib.sha256(primary_bytes).digest()
+        assert cover.read_bytes() != proxy_bytes
+
+
+class TestT4bEnrichPreviewShorter(_T4bFailedHostsMixin):
+    """邊界 8：preview 比 sample 短 → 缺格當 ''，不得截斷下載張數。"""
+
+    def test_short_preview_does_not_truncate_downloads(self, tmp_path):
+        video = tmp_path / "SONE-205.mp4"
+        video.write_bytes(b"fake-video")
+        scraper = _t4b_scraper(
+            sample_images=[
+                "https://cdn.example/s1.jpg",
+                "https://cdn.example/s2.jpg",
+                "https://cdn.example/s3.jpg",
+            ],
+            preview_sample_images=["https://mt.example/v1/images/?url=s1"],
+        )
+
+        with (
+            patch("core.enricher.download_image", return_value=True) as mock_dl,
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.find_subtitle_files", return_value=[]),
+            patch("os.makedirs"),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import enrich_single
+            enrich_single(
+                file_path=str(video),
+                number="SONE-205",
+                mode="refresh_full",
+                scraper_data=scraper,
+                write_nfo=False,
+                write_cover=False,
+                write_extrafanart=True,
+                overwrite_existing=True,
+            )
+
+        sample_calls = [
+            c for c in mock_dl.call_args_list
+            if c.args and "cdn.example/s" in str(c.args[0])
+        ]
+        assert len(sample_calls) == 3
+        assert sample_calls[0].kwargs.get("fallback_url") == "https://mt.example/v1/images/?url=s1"
+        assert sample_calls[1].kwargs.get("fallback_url", "") == ""
+        assert sample_calls[2].kwargs.get("fallback_url", "") == ""
+
+
+class TestT4bEnrichNonMetatube(_T4bFailedHostsMixin):
+    """邊界 9 / AC-5：preview 全空 → 不傳 fallback_url，行為與 branch 前相同。"""
+
+    def test_empty_preview_omits_fallback_url_kwarg(self, tmp_path):
+        video = tmp_path / "SONE-205.mp4"
+        video.write_bytes(b"fake-video")
+        scraper = _t4b_scraper(
+            preview_cover_url="",
+            preview_sample_images=["", ""],
+            source="javbus",
+        )
+
+        with (
+            patch("core.enricher.download_image", return_value=True) as mock_dl,
+            patch("core.enricher.generate_nfo", return_value=True),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher.find_subtitle_files", return_value=[]),
+            patch("os.makedirs"),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import enrich_single
+            enrich_single(
+                file_path=str(video),
+                number="SONE-205",
+                mode="refresh_full",
+                scraper_data=scraper,
+                write_nfo=False,
+                write_cover=True,
+                write_extrafanart=True,
+                overwrite_existing=True,
+            )
+
+        for c in mock_dl.call_args_list:
+            assert "fallback_url" not in c.kwargs
+            assert len(c.args) <= 2 or (len(c.args) >= 4 and c.args[3] == "")
+
+
+class TestT4bMergeMetaPreviewPair:
+    """邊界 10：_merge_meta 的 if 與 elif 兩條路都搬 preview。"""
+
+    def test_merge_meta_if_branch_moves_preview_samples(self):
+        from core.enricher import _merge_meta
+        base = {"cover_url": "http://a/c.jpg", "sample_images": None}
+        supplement = {
+            "cover_url": "http://b/c.jpg",
+            "preview_cover_url": "http://proxy/c",
+            "sample_images": ["http://b/s1.jpg"],
+            "preview_sample_images": ["http://proxy/s1"],
+        }
+        merged, _ = _merge_meta(base, supplement)
+        assert merged["sample_images"] == ["http://b/s1.jpg"]
+        assert merged["preview_sample_images"] == ["http://proxy/s1"]
+
+    def test_merge_meta_elif_branch_moves_preview_samples(self):
+        from core.enricher import _merge_meta
+        base = {"cover_url": "", "sample_images": []}
+        supplement = {
+            "cover_url": "http://b/c.jpg",
+            "preview_cover_url": "http://proxy/c",
+            "sample_images": ["http://b/s1.jpg"],
+            "preview_sample_images": ["http://proxy/s1"],
+        }
+        merged, _ = _merge_meta(base, supplement)
+        assert merged["cover_url"] == "http://b/c.jpg"
+        assert merged["preview_cover_url"] == "http://proxy/c"
+        assert merged["sample_images"] == ["http://b/s1.jpg"]
+        assert merged["preview_sample_images"] == ["http://proxy/s1"]
+
+
+class TestT4bNfoToMetaPreviewKeys:
+    """邊界 11：_nfo_to_meta / _video_to_meta 兩鍵存在且為空。"""
+
+    def test_nfo_to_meta_has_empty_preview_keys(self):
+        import xml.etree.ElementTree as ET
+        from core.enricher import _nfo_to_meta
+        root = ET.fromstring("<movie><title>T</title></movie>")
+        meta = _nfo_to_meta(root)
+        assert meta["preview_cover_url"] == ""
+        assert meta["preview_sample_images"] == []
+
+    def test_video_to_meta_has_empty_preview_keys(self):
+        from core.enricher import _video_to_meta
+        meta = _video_to_meta(_make_video())
+        assert meta["preview_cover_url"] == ""
+        assert meta["preview_sample_images"] == []
+
+    def test_scraper_to_meta_carries_preview_keys(self):
+        from core.enricher import _scraper_to_meta
+        meta = _scraper_to_meta(_t4b_scraper())
+        assert meta["preview_cover_url"] == "https://mt.example/v1/images/?url=cover"
+        assert meta["preview_sample_images"] == [
+            "https://mt.example/v1/images/?url=s1",
+            "https://mt.example/v1/images/?url=s2",
+        ]
+
+
+# ============ TASK-126-T4b review MAJOR-1：fetch_samples_only 這條下載路徑 ============
+#
+# spec §3.2 末條要求「**每條下載路徑**都要有 caller 層級的驗證」，不是「四個入口函式」。
+# T4b 的初版只守住 enrich_single，**fetch_samples_only（片庫頁按「補劇照」走的正是這條）
+# 完全沒有測試碰到**——review 在沙盒把那行 wiring 拔掉，127 條照樣全綠。
+
+class TestT4bFetchSamplesOnlyFallback(_T4bFailedHostsMixin):
+
+    def test_fetch_samples_only_uses_preview_fallback(self, tmp_path):
+        """被牆的使用者按「補劇照」→ 原址 ConnectTimeout → 代理接手，劇照落地。"""
+        import requests as _rq
+        fs = tmp_path / "ABC-999.mp4"
+        fs.write_bytes(b"v" * 100)
+        meta = {
+            "number": "ABC-999",
+            "sample_images": ["https://cdn.blocked/s1.jpg", "https://cdn.blocked/s2.jpg"],
+            "preview_sample_images": [
+                "http://mt.example/v1/images/primary/MGS/ABC-999?url=s1",
+                "http://mt.example/v1/images/primary/MGS/ABC-999?url=s2",
+            ],
+        }
+
+        def _side(url, **kwargs):
+            if "mt.example" in url:
+                return _t4b_ok(b"PROXY" + b"\x00" * 2000)
+            raise _rq.exceptions.ConnectTimeout("blocked")
+
+        with (
+            patch("core.enricher.search_jav", return_value=meta),
+            patch("core.organizer.requests.get", side_effect=_side),
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher._db_upsert_samples_only"),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import fetch_samples_only
+            result = fetch_samples_only(str(fs), "ABC-999")
+
+        assert result.extrafanart_written == 2, (
+            "兩張劇照都應該經由代理落地——這條 wiring 若被帶壞，使用者按「補劇照」"
+            "會拿到 0 張且沒有任何錯誤訊息"
+        )
+        written = sorted((tmp_path / "extrafanart").glob("fanart*.jpg"))
+        assert len(written) == 2
+        for p in written:
+            assert p.read_bytes().startswith(b"PROXY")
+
+    def test_fetch_samples_only_without_preview_keeps_todays_behaviour(self, tmp_path):
+        """AC-5：沒有 preview → 原址失敗即失敗，且不得出現 fallback_url kwarg。"""
+        import requests as _rq
+        fs = tmp_path / "ABC-998.mp4"
+        fs.write_bytes(b"v" * 100)
+        meta = {
+            "number": "ABC-998",
+            "sample_images": ["https://cdn.blocked/s1.jpg"],
+            "preview_sample_images": [],
+        }
+
+        def _side(url, **kwargs):
+            raise _rq.exceptions.ConnectTimeout("blocked")
+
+        with (
+            patch("core.enricher.search_jav", return_value=meta),
+            patch("core.organizer.requests.get", side_effect=_side) as mg,
+            patch("core.enricher.VideoRepository") as mock_repo_cls,
+            patch("core.enricher._db_upsert_samples_only"),
+        ):
+            mock_repo_cls.return_value = MagicMock()
+            from core.enricher import fetch_samples_only
+            result = fetch_samples_only(str(fs), "ABC-998")
+
+        assert result.extrafanart_written == 0
+        assert mg.call_count == 1, "不得有第二次嘗試"
+        assert "fallback_url" not in mg.call_args.kwargs

--- a/tests/unit/test_metatube_mapper.py
+++ b/tests/unit/test_metatube_mapper.py
@@ -205,13 +205,18 @@ def test_map_actors_none():
 # ============ TASK-113c-T3b: preview_cover_url（CD-113c-4／12／13） ============
 
 def test_map_movie_info_binds_preview_cover_url_from_base_url():
-    """base_url 顯式傳入 → preview_cover_url 出生時就綁定（DoD-1）"""
+    """base_url 顯式傳入 → preview_cover_url 出生時就綁定（DoD-1）
+
+    來源一致性（feature/metatube-image-proxy）：從 metatube 刮到的影片，
+    cover_url 也走 metatube 的 `/v1/images/primary/...` 代理端點取回，
+    避免本地直連被牆的源站圖片 URL。
+    """
     from core.metatube.mapper import map_movie_info
     info = _full_info()
     video = map_movie_info(info, base_url="http://192.168.1.100:8080")
     assert video.preview_cover_url != ""
     assert video.preview_cover_url.startswith("http://192.168.1.100:8080/v1/images/primary/FANZA/SONE-205?")
-    assert video.cover_url == "https://img.fanza.com/cover.jpg"
+    assert video.cover_url == video.preview_cover_url
 
 
 def test_map_movie_info_no_base_url_yields_empty_preview():
@@ -324,6 +329,65 @@ def test_preview_cover_url_implies_cover_url_nonempty():
                     f"preview_cover_url 非空但 cover_url 為空（違反不變式）："
                     f"info={info!r} base_url={base_url!r}"
                 )
+
+
+# ============ feature/metatube-image-proxy：劇照 sample_images 也走同一條路 ============
+
+def test_map_sample_images_proxied_with_base_url():
+    """base_url 顯式傳入 → sample_images 逐張改寫成 metatube 代理端點 URL（來源一致性）"""
+    from urllib.parse import urlparse, parse_qs
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    video = map_movie_info(info, base_url="http://192.168.1.100:8080")
+    assert len(video.sample_images) == 2
+    for proxied, original in zip(video.sample_images, info["preview_images"]):
+        parsed = urlparse(proxied)
+        assert parsed.path == "/v1/images/primary/FANZA/SONE-205"
+        qs = parse_qs(parsed.query)
+        assert qs["url"] == [original]
+        assert qs["ratio"] == ["0"]
+        assert qs["quality"] == ["100"]
+
+
+def test_map_sample_images_raw_without_base_url():
+    """未傳 base_url → sample_images 維持原始 URL（行為與修改前一致）"""
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    video = map_movie_info(info)
+    assert video.sample_images == ["https://img.fanza.com/s1.jpg", "https://img.fanza.com/s2.jpg"]
+
+
+def test_map_sample_images_per_item_fallback_to_raw():
+    """base_url 組不出代理（provider 需轉義）→ 逐張回退原始 URL，不整體空白"""
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    info["provider"] = "FAN ZA"
+    video = map_movie_info(info, base_url="http://192.168.1.100:8080")
+    assert video.sample_images == ["https://img.fanza.com/s1.jpg", "https://img.fanza.com/s2.jpg"]
+
+
+def test_map_sample_images_proxy_query_encoding_no_pollution():
+    """preview image 本身帶 ?token=...&expires=... → 代理 URL 的 url 參數逐字元等於原始
+    （CD-113c-13 同款防護延伸到劇照），且 ratio／quality 各恰好一次"""
+    from urllib.parse import urlparse, parse_qs
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    original = "https://img.fanza.com/s1.jpg?token=abc&expires=123"
+    info["preview_images"] = [original]
+    video = map_movie_info(info, base_url="http://192.168.1.100:8080")
+    qs = parse_qs(urlparse(video.sample_images[0]).query)
+    assert qs["url"] == [original]
+    assert len(qs["ratio"]) == 1
+    assert len(qs["quality"]) == 1
+
+
+def test_map_sample_images_empty_with_base_url():
+    """preview_images 缺失 + base_url → sample_images 為 []，不炸"""
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    info.pop("preview_images", None)
+    video = map_movie_info(info, base_url="http://192.168.1.100:8080")
+    assert video.sample_images == []
 
 
 # ============ clean_metatube_summary 邊界測試 ============

--- a/tests/unit/test_metatube_mapper.py
+++ b/tests/unit/test_metatube_mapper.py
@@ -207,16 +207,26 @@ def test_map_actors_none():
 def test_map_movie_info_binds_preview_cover_url_from_base_url():
     """base_url 顯式傳入 → preview_cover_url 出生時就綁定（DoD-1）
 
-    來源一致性（feature/metatube-image-proxy）：從 metatube 刮到的影片，
-    cover_url 也走 metatube 的 `/v1/images/primary/...` 代理端點取回，
-    避免本地直連被牆的源站圖片 URL。
+    CD-126-1：cover_url 恆為原始網址；代理 URL 只住在 preview_cover_url。
+    兩者皆非空時必須不相等（否則 shouldFallbackToCover 永遠為偽）。
     """
     from core.metatube.mapper import map_movie_info
     info = _full_info()
     video = map_movie_info(info, base_url="http://192.168.1.100:8080")
     assert video.preview_cover_url != ""
     assert video.preview_cover_url.startswith("http://192.168.1.100:8080/v1/images/primary/FANZA/SONE-205?")
-    assert video.cover_url == video.preview_cover_url
+    assert video.cover_url == info["cover_url"]
+    assert video.cover_url != video.preview_cover_url
+
+
+def test_map_movie_info_keeps_cover_url_raw():
+    """D1／mutation：cover_url 逐字元等於 info['cover_url']，不得被代理 URL 覆蓋。"""
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    video = map_movie_info(info, base_url="http://192.168.1.100:8080")
+    assert video.cover_url == info["cover_url"]
+    assert video.preview_cover_url != ""
+    assert video.cover_url != video.preview_cover_url
 
 
 def test_map_movie_info_no_base_url_yields_empty_preview():
@@ -331,16 +341,23 @@ def test_preview_cover_url_implies_cover_url_nonempty():
                 )
 
 
-# ============ feature/metatube-image-proxy：劇照 sample_images 也走同一條路 ============
+# ============ feature/metatube-image-proxy：劇照平行欄位 preview_sample_images ============
 
 def test_map_sample_images_proxied_with_base_url():
-    """base_url 顯式傳入 → sample_images 逐張改寫成 metatube 代理端點 URL（來源一致性）"""
+    """邊界 1：有 base_url、provider/number 正常、3 張劇照 →
+    sample_images 全原始；preview_sample_images 全代理；等長同序。"""
     from urllib.parse import urlparse, parse_qs
     from core.metatube.mapper import map_movie_info
     info = _full_info()
+    info["preview_images"] = [
+        "https://img.fanza.com/s1.jpg",
+        "https://img.fanza.com/s2.jpg",
+        "https://img.fanza.com/s3.jpg",
+    ]
     video = map_movie_info(info, base_url="http://192.168.1.100:8080")
-    assert len(video.sample_images) == 2
-    for proxied, original in zip(video.sample_images, info["preview_images"]):
+    assert video.sample_images == info["preview_images"]
+    assert len(video.preview_sample_images) == len(video.sample_images) == 3
+    for proxied, original in zip(video.preview_sample_images, info["preview_images"], strict=True):
         parsed = urlparse(proxied)
         assert parsed.path == "/v1/images/primary/FANZA/SONE-205"
         qs = parse_qs(parsed.query)
@@ -350,44 +367,88 @@ def test_map_sample_images_proxied_with_base_url():
 
 
 def test_map_sample_images_raw_without_base_url():
-    """未傳 base_url → sample_images 維持原始 URL（行為與修改前一致）"""
+    """邊界 2：無 base_url → preview_sample_images 等長全 ''；sample_images 逐字元不變。"""
     from core.metatube.mapper import map_movie_info
     info = _full_info()
     video = map_movie_info(info)
     assert video.sample_images == ["https://img.fanza.com/s1.jpg", "https://img.fanza.com/s2.jpg"]
+    assert video.preview_sample_images == ["", ""]
+    assert len(video.preview_sample_images) == len(video.sample_images)
 
 
 def test_map_sample_images_per_item_fallback_to_raw():
-    """base_url 組不出代理（provider 需轉義）→ 逐張回退原始 URL，不整體空白"""
+    """邊界 3：provider 需轉義（FAN ZA）→ sample_images 維持原始；
+    preview_sample_images 等長全 ''（組不出填 ''，不是填原始）。"""
     from core.metatube.mapper import map_movie_info
     info = _full_info()
     info["provider"] = "FAN ZA"
     video = map_movie_info(info, base_url="http://192.168.1.100:8080")
     assert video.sample_images == ["https://img.fanza.com/s1.jpg", "https://img.fanza.com/s2.jpg"]
+    assert video.preview_sample_images == ["", ""]
+    assert len(video.preview_sample_images) == len(video.sample_images)
+
+
+def test_map_preview_sample_images_empty_when_base_url_unsafe():
+    """邊界 4：base_url 帶 userinfo／query／fragment → preview 等長全 ''；sample 不變。"""
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    raw = list(info["preview_images"])
+    for unsafe in (
+        "http://user:pass@192.168.1.100:8080",
+        "http://192.168.1.100:8080/?x=1",
+        "http://192.168.1.100:8080/#frag",
+    ):
+        video = map_movie_info(info, base_url=unsafe)
+        assert video.sample_images == raw
+        assert video.preview_sample_images == ["", ""]
+        assert len(video.preview_sample_images) == len(video.sample_images)
 
 
 def test_map_sample_images_proxy_query_encoding_no_pollution():
-    """preview image 本身帶 ?token=...&expires=... → 代理 URL 的 url 參數逐字元等於原始
-    （CD-113c-13 同款防護延伸到劇照），且 ratio／quality 各恰好一次"""
+    """邊界 7：劇照 URL 自帶 ?token=…&expires=… →
+    代理 URL（preview_sample_images）的 url 參數逐字元等於原始；
+    ratio／quality 各恰好一次；sample_images 維持原始。"""
     from urllib.parse import urlparse, parse_qs
     from core.metatube.mapper import map_movie_info
     info = _full_info()
     original = "https://img.fanza.com/s1.jpg?token=abc&expires=123"
     info["preview_images"] = [original]
     video = map_movie_info(info, base_url="http://192.168.1.100:8080")
-    qs = parse_qs(urlparse(video.sample_images[0]).query)
+    assert video.sample_images == [original]
+    qs = parse_qs(urlparse(video.preview_sample_images[0]).query)
     assert qs["url"] == [original]
     assert len(qs["ratio"]) == 1
     assert len(qs["quality"]) == 1
 
 
 def test_map_sample_images_empty_with_base_url():
-    """preview_images 缺失 + base_url → sample_images 為 []，不炸"""
+    """邊界 5：preview_images 缺失或為 [] → 兩欄皆 []，不拋例外。"""
     from core.metatube.mapper import map_movie_info
     info = _full_info()
     info.pop("preview_images", None)
     video = map_movie_info(info, base_url="http://192.168.1.100:8080")
     assert video.sample_images == []
+    assert video.preview_sample_images == []
+
+    info2 = _full_info()
+    info2["preview_images"] = []
+    video2 = map_movie_info(info2, base_url="http://192.168.1.100:8080")
+    assert video2.sample_images == []
+    assert video2.preview_sample_images == []
+
+
+def test_map_preview_sample_images_empty_slot_when_raw_empty_string():
+    """邊界 6：某張 preview_images 是空字串 → 該格 preview 為 ''；
+    sample_images 保留該空字串原值 → 仍等長。"""
+    from core.metatube.mapper import map_movie_info
+    info = _full_info()
+    info["preview_images"] = ["https://img.fanza.com/s1.jpg", "", "https://img.fanza.com/s3.jpg"]
+    video = map_movie_info(info, base_url="http://192.168.1.100:8080")
+    assert video.sample_images == ["https://img.fanza.com/s1.jpg", "", "https://img.fanza.com/s3.jpg"]
+    assert len(video.preview_sample_images) == len(video.sample_images) == 3
+    assert video.preview_sample_images[1] == ""
+    assert video.preview_sample_images[0].startswith("http://192.168.1.100:8080/v1/images/primary/")
+    assert video.preview_sample_images[2].startswith("http://192.168.1.100:8080/v1/images/primary/")
 
 
 # ============ clean_metatube_summary 邊界測試 ============

--- a/tests/unit/test_metatube_mapper.py
+++ b/tests/unit/test_metatube_mapper.py
@@ -626,3 +626,73 @@ def test_to_legacy_dict_preview_never_carries_userinfo():
     blob = json.dumps(legacy, ensure_ascii=False)
     for secret in ("leakuser", "leakpass", "@127.0.0.1"):
         assert secret not in blob, f"序列化輸出洩漏 {secret!r}"
+
+
+def test_proxy_and_raw_urls_stay_distinct():
+    """不變式：代理 URL 與原始網址是兩個不同的值（備胎不准拆）。
+
+    cover-fallback.js::shouldFallbackToCover() 的 `preview !== cover` 是這條的唯一消費者。
+
+    **這支鎖的是「原址被代理 URL 就地覆蓋」這一種破壞**（＝ PR #151 原版的做法，
+    也就是本 task card 的兩個 mutation 點）。在那種破壞下，`preview !== cover` 恆為偽，
+    那套 error-time 救援變成死碼——而在本測試存在之前，**沒有任何一條測試會因此變紅**。
+
+    **它不涵蓋另一種性質的回歸**（T5 review 實測指出）：若 `_build_preview_cover_url()`
+    整個失效、`preview_cover_url` 恆為空字串，本測試的 implication 前提不成立 ⇒ **維持全綠**。
+    那種回歸由 TASK-113c-T3b 遺留的 6 支既有測試攔住（實測會同步變紅），不是這支的責任。
+
+    若這條不變式被打破（例如把 cover_url 覆蓋成代理 URL，或把 sample_images
+    就地改寫成代理 URL），前者在 metatube 重開機／更新中會讓搜尋頁封面整排破圖
+    且不會自己好（得重新載入頁面），後者會讓下載端拿不到原始網址、原址優先無從執行。
+
+    本測試窮舉：正常／cover_url 空／preview_images 空／provider 需轉義／
+    number 需轉義／base_url 帶 userinfo／base_url 帶 query × 有無 base_url，
+    逐一驗證 implication（兩者皆非空時才要求不等），不是單一案例的巧合。
+    同時斷言 len(sample_images) == len(preview_sample_images)。
+    """
+    from core.metatube.mapper import map_movie_info
+
+    scenarios = [
+        dict(_full_info()),
+        {**_full_info(), "cover_url": ""},
+        {**_full_info(), "preview_images": []},
+        {**_full_info(), "provider": "FAN ZA"},
+        {**_full_info(), "number": "SONE/205"},
+        # T5 review：這兩格原本是 `dict(_full_info())` 的重複——在 base_url="" 那條腿上
+        # 與 idx 0 逐字相同，14 組裡有 2 組沒有新增任何覆蓋。改成兩個真正不同的形狀，
+        # 讓兩條腿都有效（獨立組合數 12 → 14）。
+        {**_full_info(), "preview_images": ["https://img.fanza.com/s1.jpg", ""]},
+        {**_full_info(), "cover_url": "", "preview_images": []},
+    ]
+    unsafe_for_idx = {
+        5: "http://user:pass@192.168.1.100:8080",
+        6: "http://192.168.1.100:8080/?x=1",
+    }
+    for idx, info in enumerate(scenarios):
+        for base_url in ("", "http://192.168.1.100:8080"):
+            if idx in unsafe_for_idx:
+                actual_base = "" if base_url == "" else unsafe_for_idx[idx]
+            else:
+                actual_base = base_url
+            video = map_movie_info(info, base_url=actual_base)
+            if video.preview_cover_url and video.cover_url:
+                assert video.preview_cover_url != video.cover_url, (
+                    f"cover 與 preview 必須不同（違反不變式）："
+                    f"info={info!r} base_url={actual_base!r} "
+                    f"cover={video.cover_url!r} preview={video.preview_cover_url!r}"
+                )
+            assert len(video.sample_images) == len(video.preview_sample_images), (
+                f"sample_images 與 preview_sample_images 必須等長："
+                f"info={info!r} base_url={actual_base!r} "
+                f"len(raw)={len(video.sample_images)} len(prev)={len(video.preview_sample_images)}"
+            )
+            # strict=True：等長是硬契約（上一行已 assert），這裡再焊一次——
+            # 長度不等時當場 ValueError，而不是靜默截斷成少比對幾對。
+            for raw, prev in zip(
+                video.sample_images, video.preview_sample_images, strict=True
+            ):
+                if prev:
+                    assert prev != raw, (
+                        f"劇照代理與原始必須不同（違反不變式）："
+                        f"info={info!r} base_url={actual_base!r} raw={raw!r} prev={prev!r}"
+                    )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -13,6 +13,7 @@ def test_video_new_fields_defaults():
     assert v.label == ""
     assert v.series == ""
     assert v.sample_images == []
+    assert v.preview_sample_images == []
 
 
 def test_video_new_fields_with_values():
@@ -24,12 +25,14 @@ def test_video_new_fields_with_values():
         label='S1',
         series='NTR',
         sample_images=['http://a.jpg'],
+        preview_sample_images=['http://proxy/a.jpg'],
     )
     assert v.director == '山田'
     assert v.duration == 119
     assert v.label == 'S1'
     assert v.series == 'NTR'
     assert v.sample_images == ['http://a.jpg']
+    assert v.preview_sample_images == ['http://proxy/a.jpg']
 
 
 def test_to_legacy_dict_new_keys():
@@ -41,6 +44,7 @@ def test_to_legacy_dict_new_keys():
         label='S1',
         series='NTR',
         sample_images=['http://a.jpg'],
+        preview_sample_images=['http://proxy/a.jpg'],
     )
     d = v.to_legacy_dict()
     assert d['director'] == '山田'
@@ -48,6 +52,7 @@ def test_to_legacy_dict_new_keys():
     assert d['label'] == 'S1'
     assert d['series'] == 'NTR'
     assert d['sample_images'] == ['http://a.jpg']
+    assert d['preview_sample_images'] == ['http://proxy/a.jpg']
 
 
 def test_to_legacy_dict_new_keys_defaults():
@@ -59,6 +64,16 @@ def test_to_legacy_dict_new_keys_defaults():
     assert d['label'] == ""
     assert d['series'] == ""
     assert d['sample_images'] == []
+    assert d['preview_sample_images'] == []
+
+
+def test_to_legacy_dict_preview_sample_images_default_empty():
+    """邊界 10／D6／AC-5：非 metatube 來源恆 []；to_legacy_dict 輸出同名 key 為 []。"""
+    v = Video(number='TEST-001', source='javbus', sample_images=['http://a.jpg'])
+    assert v.preview_sample_images == []
+    d = v.to_legacy_dict()
+    assert 'preview_sample_images' in d
+    assert d['preview_sample_images'] == []
 
 
 # ============ Merge policy 測試 ============
@@ -174,11 +189,11 @@ def test_to_legacy_dict_excludes_summary():
 
 
 def test_to_legacy_dict_key_set_unchanged():
-    """15 鍵固定集合（TASK-113c-T3b 新增 preview_cover_url，授權來源 spec §5.4 v7-2）"""
+    """16 鍵固定集合（TASK-126-T2 新增 preview_sample_images）"""
     v = Video(number="TEST-001")
     expected_keys = {
         "number", "title", "actors", "date", "maker", "cover",
         "preview_cover_url", "tags", "source", "url", "director", "duration",
-        "label", "series", "sample_images",
+        "label", "series", "sample_images", "preview_sample_images",
     }
     assert set(v.to_legacy_dict().keys()) == expected_keys

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -5224,3 +5224,133 @@ class TestOrganizeContainment:
         target = tmp_path / "[SONE-205] Test Title.mp4"
         assert target.exists()
         assert not src.exists()
+
+
+# ============ TASK-126-T4b：代理網址走到 organize 的下載點 ============
+#
+# owner 2026-08-23 裁決把 organize 這條也納入。**但只有「後端重刮」那條會有值**——
+# 前端送來的 metadata 已被 buildOrganizeMetadata() 剝除兩個 preview 欄位
+# （TASK-126-T3 / 113c-T3b：那是只對顯示有意義、會隨 metatube 連線狀態失效的網址）。
+# 所以下面兩支測的是「metadata 帶得動就用得到」與「帶不動就跟今天一樣」。
+
+class TestT4bOrganizeFallback:
+
+    def _clear_failed_hosts(self):
+        import core.organizer as org
+        with org._failed_hosts_lock:
+            org._failed_hosts.clear()
+
+    def _resp(self, content):
+        m = MagicMock()
+        m.status_code = 200
+        m.content = content
+        return m
+
+    def _blocked_unless_proxy(self):
+        import requests as _rq
+
+        def _side(url, **kwargs):
+            if 'mt.example' in url:
+                return self._resp(b'PROXY' + b'\x00' * 2000)
+            raise _rq.exceptions.ConnectTimeout('blocked')
+        return _side
+
+    def test_organize_cover_uses_preview_fallback(self, tmp_path):
+        """邊界 4：organize 入口，原址 ConnectTimeout ＋ metadata 帶得動 preview → 走代理落地。"""
+        self._clear_failed_hosts()
+        try:
+            src = tmp_path / 'ABC-123.mp4'
+            src.write_bytes(b'v' * 100)
+            metadata = {
+                'number': 'ABC-123', 'title': 'T', 'actors': [], 'tags': [],
+                'cover': 'https://cdn.blocked/cover.jpg',
+                'preview_cover_url': 'http://mt.example/v1/images/primary/MGS/ABC-123?url=cover',
+            }
+            config = {'output_dir': str(tmp_path / 'out'), 'create_folder': True,
+                      'download_cover': True, 'create_nfo': False}
+            with patch('core.organizer.requests.get', side_effect=self._blocked_unless_proxy()):
+                result = organize_file(str(src), metadata, config)
+            assert result.get('cover_path'), '封面應經由代理落地'
+            assert open(result['cover_path'], 'rb').read().startswith(b'PROXY')
+        finally:
+            self._clear_failed_hosts()
+
+    def test_organize_without_preview_keeps_todays_behaviour(self, tmp_path):
+        """邊界 9（AC-5）：前端剝除後的 metadata（無 preview）→ 逐字元維持今天的行為。"""
+        self._clear_failed_hosts()
+        try:
+            src = tmp_path / 'ABC-124.mp4'
+            src.write_bytes(b'v' * 100)
+            metadata = {
+                'number': 'ABC-124', 'title': 'T', 'actors': [], 'tags': [],
+                'cover': 'https://cdn.blocked/cover.jpg',
+            }
+            config = {'output_dir': str(tmp_path / 'out'), 'create_folder': True,
+                      'download_cover': True, 'create_nfo': False}
+            with patch('core.organizer.requests.get',
+                       side_effect=self._blocked_unless_proxy()) as mg:
+                result = organize_file(str(src), metadata, config)
+            assert not result.get('cover_path'), '沒有 preview 就沒有退路，原址失敗即失敗'
+            assert mg.call_count == 1, '不得有第二次嘗試'
+            assert 'fallback_url' not in mg.call_args.kwargs
+        finally:
+            self._clear_failed_hosts()
+
+    def test_organize_extrafanart_uses_preview_fallback(self, tmp_path):
+        """TASK-126-T4b review MAJOR-3：organize 的**劇照**分支也要有 caller 測試。
+
+        初版兩支測試都只帶封面、沒帶 sample_images ⇒ 劇照那段迴圈根本沒跑到。
+        review 在沙盒把 `_previews` / `_pv_i` 整段拔掉，285 條照樣全綠。
+        """
+        self._clear_failed_hosts()
+        try:
+            src = tmp_path / 'ABC-125.mp4'
+            src.write_bytes(b'v' * 100)
+            metadata = {
+                'number': 'ABC-125', 'title': 'T', 'actors': [], 'tags': [],
+                'cover': '',
+                'sample_images': ['https://cdn.blocked/s1.jpg', 'https://cdn.blocked/s2.jpg'],
+                'preview_sample_images': [
+                    'http://mt.example/v1/images/primary/MGS/ABC-125?url=s1',
+                    'http://mt.example/v1/images/primary/MGS/ABC-125?url=s2',
+                ],
+            }
+            config = {'output_dir': str(tmp_path / 'out'), 'create_folder': True,
+                      'download_cover': False, 'create_nfo': False,
+                      'download_sample_images': True}
+            with patch('core.organizer.requests.get', side_effect=self._blocked_unless_proxy()):
+                result = organize_file(str(src), metadata, config)
+            ef = Path(result['new_folder']) / 'extrafanart'
+            written = sorted(ef.glob('fanart*.jpg'))
+            assert len(written) == 2, (
+                '劇照那半若沒接上 preview，被牆的使用者整理入庫會拿不到任何劇照，'
+                '而且沒有錯誤訊息'
+            )
+            for p in written:
+                assert p.read_bytes().startswith(b'PROXY')
+        finally:
+            self._clear_failed_hosts()
+
+    def test_organize_extrafanart_short_preview_does_not_truncate(self, tmp_path):
+        """邊界 8 在 organize 也成立：preview 比 sample 短，不得少下載。"""
+        self._clear_failed_hosts()
+        try:
+            src = tmp_path / 'ABC-126.mp4'
+            src.write_bytes(b'v' * 100)
+            metadata = {
+                'number': 'ABC-126', 'title': 'T', 'actors': [], 'tags': [],
+                'cover': '',
+                'sample_images': ['https://cdn.ok/s1.jpg', 'https://cdn.ok/s2.jpg', 'https://cdn.ok/s3.jpg'],
+                'preview_sample_images': ['http://mt.example/v1/images/primary/MGS/ABC-126?url=s1'],
+            }
+            config = {'output_dir': str(tmp_path / 'out'), 'create_folder': True,
+                      'download_cover': False, 'create_nfo': False,
+                      'download_sample_images': True}
+            with patch('core.organizer.requests.get',
+                       return_value=self._resp(b'DIRECT' + b'\x00' * 2000)) as mg:
+                result = organize_file(str(src), metadata, config)
+            ef = Path(result['new_folder']) / 'extrafanart'
+            assert len(sorted(ef.glob('fanart*.jpg'))) == 3, 'zip 截斷會讓這裡變成 1'
+            assert mg.call_count == 3
+        finally:
+            self._clear_failed_hosts()

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -2499,6 +2499,30 @@ class TestDownloadImageFallback:
         ]
 
     @patch("core.organizer.requests.get")
+    def test_download_image_malformed_port_does_not_raise(self, mock_get, tmp_path):
+        """Stage 2 review P3-1：非數字 port 的髒網址不得讓整個 organize 崩掉。
+
+        `urlparse('http://h:abc/x').port` 拋 ValueError，而 `download_image()` 的
+        `skip_primary = bool(fallback_url) and _host_recently_failed(_host_key(url))`
+        不在 try 內。它穿出去的時候 `organize_file()` 的 `shutil.move()` 已經跑完，
+        使用者拿到的是「整理失敗」＋一個影片已經被搬走的半成品資料夾。
+        正確行為：組不出 host key 就當作「沒有記憶」，照常走原址→代理兩次嘗試。
+        """
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("t"),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://h.example:abc/x.jpg",
+            str(tmp_path / "m.jpg"),
+            fallback_url="http://proxy.example/x",
+        ) is True
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == ["http://h.example:abc/x.jpg", "http://proxy.example/x"], (
+            "髒 port 應照常先試原址再退代理，不是跳過或炸掉"
+        )
+
+    @patch("core.organizer.requests.get")
     def test_download_image_port_differs_keeps_primary(self, mock_get, tmp_path):
         """邊界 10：:8080 失敗後預設 port 仍先試原址。"""
         mock_get.side_effect = [

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -2269,7 +2269,12 @@ class TestDownloadImageFallback:
 
     @patch("core.organizer.requests.get")
     def test_download_image_no_fallback_success_preserves_args(self, mock_get, tmp_path):
-        """邊界 1：無 fallback、原址成功；除 timeout 外參數與改動前相同。"""
+        """邊界 1：無 fallback、原址成功；**參數與改動前逐字元相同，timeout 也包含在內**。
+
+        Codex PR review P2：初版讓所有呼叫端（含自家 9 源）都吃 (5, 30)，
+        等於把「連線慢但接得起來」的使用者從「30 秒後成功」改成「5 秒失敗」，
+        而且他們沒有代理可退。AC-5 的「逐字元相同」把 timeout 也算在內。
+        """
         from core.organizer import HEADERS, REQUEST_TIMEOUT
 
         mock_get.return_value = _ok_resp()
@@ -2282,19 +2287,45 @@ class TestDownloadImageFallback:
         args, kwargs = mock_get.call_args
         assert args[0] == "http://example.com/cover.jpg"
         assert kwargs["headers"] == HEADERS.copy()
-        assert kwargs["timeout"] == (5, REQUEST_TIMEOUT)
+        assert kwargs["timeout"] == REQUEST_TIMEOUT, (
+            "無 fallback 的呼叫端（自家 9 源）必須維持單值 30 秒——"
+            "縮成 (5, 30) 會讓慢速連線的使用者從『30 秒後成功』變成『5 秒失敗』"
+        )
 
     @patch("core.organizer.requests.get")
     def test_download_image_connect_timeout_is_short(self, mock_get, tmp_path):
-        """mutation 錨點：connect 逾時必須是短的 tuple，不是單一 REQUEST_TIMEOUT。"""
+        """mutation 錨點：**有代理可退時**，原址那一次的 connect 逾時必須是短的 tuple。
+
+        短逾時的收益只存在於「失敗了還有第二條路」的情境（被牆的使用者只付第一張的等待）；
+        成本（慢速連線被提前判死）不該落在沒有第二條路的人身上——所以它綁 fallback，
+        不是全域（Codex PR review P2）。
+        """
         from core.organizer import CONNECT_TIMEOUT, REQUEST_TIMEOUT
 
         mock_get.return_value = _ok_resp()
-        download_image("http://example.com/cover.jpg", str(tmp_path / "c.jpg"))
+        download_image(
+            "http://example.com/cover.jpg",
+            str(tmp_path / "c.jpg"),
+            fallback_url="http://mt.example/v1/images/primary/MGS/N-1?url=c",
+        )
         timeout = mock_get.call_args.kwargs["timeout"]
         assert timeout == (CONNECT_TIMEOUT, REQUEST_TIMEOUT)
         assert CONNECT_TIMEOUT == 5
         assert REQUEST_TIMEOUT == 30
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_no_fallback_keeps_long_connect_timeout(self, mock_get, tmp_path):
+        """AC-5 的另一半：**沒有**代理可退時，connect 逾時維持改動前的單值 30 秒。
+
+        使用者流程：只用 JavBus／JAVDB 這些內建來源的人，連線慢但 TCP 接得起來
+        （手機熱點、遠端 CDN）→ 若被縮成 5 秒，本來抓得到的封面會變成抓不到，
+        而且沒有任何退路可以救。
+        """
+        from core.organizer import REQUEST_TIMEOUT
+
+        mock_get.return_value = _ok_resp()
+        download_image("http://example.com/cover.jpg", str(tmp_path / "c2.jpg"))
+        assert mock_get.call_args.kwargs["timeout"] == REQUEST_TIMEOUT
 
     @patch("core.organizer.requests.get")
     def test_download_image_no_fallback_connect_timeout_returns_false(self, mock_get, tmp_path):
@@ -5354,3 +5385,145 @@ class TestT4bOrganizeFallback:
             assert mg.call_count == 3
         finally:
             self._clear_failed_hosts()
+
+
+# ============ TASK-126 Codex PR review P2-1：preview_* 傳得過去，但不得持久化 ============
+#
+# 113c-T3b 立的規矩逐字是「preview_* **不能落磁碟**」；當時用「連傳都不傳」達成它。
+# 126 把兩件事分開：**傳遞是必要的**（搜尋後按「產生」是最常走的入庫路徑，後端不重新搜尋，
+# 不傳等於被牆的使用者永遠拿不到代理退路），**不落磁碟仍然是不變式**——由這個 class 直接驗。
+#
+# 這是把守衛從「代理指標」（有沒有被傳）換成「真正的不變式」（有沒有被寫下去）。
+
+class TestT6PreviewNotPersisted:
+    """preview_* 進得了 POST metadata，但不得出現在 NFO 或任何落磁碟的產物裡。"""
+
+    def _clear_failed_hosts(self):
+        import core.organizer as org
+        with org._failed_hosts_lock:
+            org._failed_hosts.clear()
+
+    _PROXY = 'http://mt.example/v1/images/primary/MGS/ABC-777?url=https%3A%2F%2Fcdn%2Fc.jpg'
+
+    def _metadata(self):
+        return {
+            'number': 'ABC-777', 'title': 'T', 'actors': ['A'], 'tags': ['t1'],
+            'date': '2024-01-01', 'maker': 'M', 'director': 'D', 'series': 'S',
+            'label': 'L', 'duration': 120, 'url': 'https://example/detail',
+            'cover': 'https://cdn/c.jpg',
+            'sample_images': ['https://cdn/s1.jpg'],
+            'preview_cover_url': self._PROXY,
+            'preview_sample_images': [self._PROXY + '&i=1'],
+        }
+
+    def test_preview_urls_never_appear_in_generated_nfo(self, tmp_path):
+        """**核心不變式**：NFO 的內容裡不得出現任何 preview／metatube 網址。
+
+        使用者流程：使用者按「產生」入庫 → 那個 .nfo 會活很久（Jellyfin 讀它、
+        換機器也跟著走）。若代理網址被寫進去，等 metatube 換 IP 之後那就是一串
+        永遠連不到的死字串躺在使用者的檔案裡。
+        """
+        self._clear_failed_hosts()
+        try:
+            src = tmp_path / 'ABC-777.mp4'
+            src.write_bytes(b'v' * 100)
+            config = {'output_dir': str(tmp_path / 'out'), 'create_folder': True,
+                      'download_cover': True, 'create_nfo': True,
+                      'download_sample_images': True}
+            with patch('core.organizer.requests.get',
+                       return_value=self._resp_ok()):
+                result = organize_file(str(src), self._metadata(), config)
+
+            nfo_path = result.get('nfo_path')
+            assert nfo_path and os.path.exists(nfo_path), 'NFO 應該有產生，否則這條驗不到東西'
+            content = open(nfo_path, encoding='utf-8').read()
+            for needle in ('preview_cover_url', 'preview_sample_images',
+                           'mt.example', '/v1/images/'):
+                assert needle not in content, (
+                    f'NFO 裡出現了 {needle!r} —— preview_* 只對顯示有意義、'
+                    f'會隨 metatube 連線狀態失效，寫進 NFO 等於留下一串會死掉的字串'
+                )
+        finally:
+            self._clear_failed_hosts()
+
+    def test_preview_urls_never_appear_in_any_written_file(self, tmp_path):
+        """更寬的一道：整個輸出資料夾裡的**任何文字檔**都不得含代理網址。
+
+        比只驗 NFO 多守住「日後有人新增別的 sidecar 產物」的情況。
+        """
+        self._clear_failed_hosts()
+        try:
+            src = tmp_path / 'ABC-777.mp4'
+            src.write_bytes(b'v' * 100)
+            config = {'output_dir': str(tmp_path / 'out'), 'create_folder': True,
+                      'download_cover': True, 'create_nfo': True,
+                      'download_sample_images': True}
+            with patch('core.organizer.requests.get',
+                       return_value=self._resp_ok()):
+                result = organize_file(str(src), self._metadata(), config)
+
+            # ⚠️ organize_file 的產出落在**來源檔旁邊**（`src.parent/<folder>/`），
+            # **不是** `output_dir` 底下。初版掃 `out/` 掃到一個空資料夾 ⇒ 假綠。
+            # （Opus 自驗 mutation 時抓到：往 NFO 注入代理網址後這支竟然沒紅。）
+            scan_root = Path(result['new_folder'])
+            assert scan_root.exists(), '沒有產出資料夾就代表這條什麼都沒驗到'
+            assert any(scan_root.rglob('*.nfo')), '沒有 NFO 就代表這條什麼都沒驗到'
+
+            offenders = []
+            for p in scan_root.rglob('*'):
+                if not p.is_file():
+                    continue
+                try:
+                    text = p.read_text(encoding='utf-8')
+                except (UnicodeDecodeError, OSError):
+                    continue  # 圖片等二進位檔不看
+                if 'mt.example' in text or '/v1/images/' in text:
+                    offenders.append(str(p))
+            assert offenders == [], f'這些落磁碟的檔案含有代理網址：{offenders}'
+        finally:
+            self._clear_failed_hosts()
+
+    def test_db_schema_has_no_preview_columns(self, tmp_path):
+        """結構面的第二道：**真的建一個 DB，用 PRAGMA 問它的欄位**。
+
+        日後若有人真的加了 preview 欄位進 videos 表，這裡會紅，
+        提醒他先想清楚「這串會隨 metatube 位址失效的網址，為什麼要落 DB」。
+
+        **為什麼是 PRAGMA 而不是掃 `connection.py` 的原始碼**（Codex PR review 第二輪 P3）：
+        初版是「原始碼裡不得出現這兩個字串」——那是**代理指標**，不是不變式。
+        它有兩個毛病：① 依 CLAUDE.md「Lint 守衛規則」，純字串存在性檢查不該進 pytest；
+        ② **會假紅**——有人在 `connection.py` 寫一句「`preview_cover_url` 刻意不存 DB」
+        的註解，或把欄位清單重構成別的形狀，守衛就無故變紅，而 schema 根本沒變。
+        改問真正的 schema 之後，它驗的是**行為**（`init_db()` 建出來的表長什麼樣），
+        註解與重構都影響不到它。
+        """
+        import sqlite3
+
+        from core.database.connection import init_db
+
+        db_path = tmp_path / 'schema_probe.db'
+        init_db(db_path)
+        with sqlite3.connect(str(db_path)) as conn:
+            tables = [
+                r[0] for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            ]
+            assert 'videos' in tables, 'init_db() 沒有建出 videos 表，這條什麼都沒驗到'
+            offenders = {}
+            for table in tables:
+                cols = [r[1] for r in conn.execute(f'PRAGMA table_info("{table}")')]
+                hits = [c for c in cols if 'preview' in c.lower()]
+                if hits:
+                    offenders[table] = hits
+
+        assert offenders == {}, (
+            f'DB schema 出現了 preview 欄位：{offenders} —— 那串網址綁著 metatube '
+            f'當下的位址，存進 DB 之後就是一筆會過期的資料（換 IP／換 port 就死）'
+        )
+
+    def _resp_ok(self):
+        m = MagicMock()
+        m.status_code = 200
+        m.content = b'IMG' + b'\x00' * 2000
+        return m

--- a/tests/unit/test_organizer.py
+++ b/tests/unit/test_organizer.py
@@ -7,7 +7,8 @@ import json
 import os
 import pytest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+import requests
 from PIL import Image
 
 from core.organizer import _detect_suffixes, format_string, organize_file, crop_to_poster, generate_nfo, extract_chinese_title, download_image, truncate_to_chars, truncate_title, _detect_vr_cluster, _is_multipart_kw, _poster_window_ratio, generate_jellyfin_images
@@ -2229,6 +2230,359 @@ class TestDownloadImage:
 
         assert result is False
         assert not save_path.exists()
+
+
+# ============ download_image() fallback / host memory (TASK-126-T4a) ============
+
+_BIG_JPEG = b"x" * 1001
+
+
+def _ok_resp(content=_BIG_JPEG):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = content
+    return resp
+
+
+def _status_resp(code):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.content = b""
+    return resp
+
+
+class TestDownloadImageFallback:
+    """TASK-126-T4a：原址優先、短 connect 逾時、失敗 host 記憶。"""
+
+    @pytest.fixture(autouse=True)
+    def _clear_host_failure_memory(self):
+        import core.organizer as org
+        mem = getattr(org, "_failed_hosts", None)
+        lock = getattr(org, "_failed_hosts_lock", None)
+        if mem is not None and lock is not None:
+            with lock:
+                mem.clear()
+        yield
+        if mem is not None and lock is not None:
+            with lock:
+                mem.clear()
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_no_fallback_success_preserves_args(self, mock_get, tmp_path):
+        """邊界 1：無 fallback、原址成功；除 timeout 外參數與改動前相同。"""
+        from core.organizer import HEADERS, REQUEST_TIMEOUT
+
+        mock_get.return_value = _ok_resp()
+        save_path = tmp_path / "cover.jpg"
+        result = download_image("http://example.com/cover.jpg", str(save_path))
+
+        assert result is True
+        assert save_path.read_bytes() == _BIG_JPEG
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        assert args[0] == "http://example.com/cover.jpg"
+        assert kwargs["headers"] == HEADERS.copy()
+        assert kwargs["timeout"] == (5, REQUEST_TIMEOUT)
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_connect_timeout_is_short(self, mock_get, tmp_path):
+        """mutation 錨點：connect 逾時必須是短的 tuple，不是單一 REQUEST_TIMEOUT。"""
+        from core.organizer import CONNECT_TIMEOUT, REQUEST_TIMEOUT
+
+        mock_get.return_value = _ok_resp()
+        download_image("http://example.com/cover.jpg", str(tmp_path / "c.jpg"))
+        timeout = mock_get.call_args.kwargs["timeout"]
+        assert timeout == (CONNECT_TIMEOUT, REQUEST_TIMEOUT)
+        assert CONNECT_TIMEOUT == 5
+        assert REQUEST_TIMEOUT == 30
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_no_fallback_connect_timeout_returns_false(self, mock_get, tmp_path):
+        """邊界 2：無 fallback、原址 ConnectTimeout → False（行為不變）。"""
+        mock_get.side_effect = requests.exceptions.ConnectTimeout("connect timed out")
+        result = download_image("http://example.com/cover.jpg", str(tmp_path / "c.jpg"))
+        assert result is False
+        mock_get.assert_called_once()
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_fallback_on_connect_timeout(self, mock_get, tmp_path):
+        """邊界 3：有 fallback、原址 ConnectTimeout → 改試 fallback 並存檔。"""
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("connect timed out"),
+            _ok_resp(b"y" * 1001),
+        ]
+        save_path = tmp_path / "cover.jpg"
+        result = download_image(
+            "http://example.com/cover.jpg",
+            str(save_path),
+            fallback_url="http://proxy.example/cover.jpg",
+        )
+        assert result is True
+        assert save_path.read_bytes() == b"y" * 1001
+        assert mock_get.call_count == 2
+        assert mock_get.call_args_list[0].args[0] == "http://example.com/cover.jpg"
+        assert mock_get.call_args_list[1].args[0] == "http://proxy.example/cover.jpg"
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_primary_success_skips_fallback(self, mock_get, tmp_path):
+        """邊界 4：有 fallback、原址成功 → 不呼叫 fallback。"""
+        mock_get.return_value = _ok_resp()
+        result = download_image(
+            "http://example.com/cover.jpg",
+            str(tmp_path / "c.jpg"),
+            fallback_url="http://proxy.example/cover.jpg",
+        )
+        assert result is True
+        mock_get.assert_called_once()
+        assert mock_get.call_args.args[0] == "http://example.com/cover.jpg"
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_failed_host_skips_primary_on_subsequent(self, mock_get, tmp_path):
+        """邊界 5：同一 key 連續 3 張，第 1 張 ConnectTimeout 後第 2/3 張不試原址。"""
+        primary = "http://blocked.example/a.jpg"
+        proxy = "http://proxy.example/a.jpg"
+        responses = [
+            requests.exceptions.ConnectTimeout("t"),
+            _ok_resp(b"a" * 1001),
+            _ok_resp(b"b" * 1001),
+            _ok_resp(b"c" * 1001),
+        ]
+        mock_get.side_effect = responses
+
+        assert download_image(primary, str(tmp_path / "1.jpg"), fallback_url=proxy) is True
+        assert download_image(
+            "http://blocked.example/b.jpg", str(tmp_path / "2.jpg"), fallback_url="http://proxy.example/b.jpg"
+        ) is True
+        assert download_image(
+            "http://blocked.example/c.jpg", str(tmp_path / "3.jpg"), fallback_url="http://proxy.example/c.jpg"
+        ) is True
+
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://blocked.example/a.jpg",
+            "http://proxy.example/a.jpg",
+            "http://proxy.example/b.jpg",
+            "http://proxy.example/c.jpg",
+        ]
+        assert mock_get.call_count == 4
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_read_timeout_does_not_poison_host(self, mock_get, tmp_path):
+        """邊界 6 ＋ mutation 錨點：ReadTimeout 走 fallback，但不進記憶。"""
+        mock_get.side_effect = [
+            requests.exceptions.ReadTimeout("read timed out"),
+            _ok_resp(b"f" * 1001),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://slow.example/a.jpg",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/a.jpg",
+        ) is True
+        assert download_image(
+            "http://slow.example/b.jpg",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://proxy.example/b.jpg",
+        ) is True
+
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://slow.example/a.jpg",
+            "http://proxy.example/a.jpg",
+            "http://slow.example/b.jpg",
+        ]
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_http_error_does_not_poison_host(self, mock_get, tmp_path):
+        """邊界 7：原址 404/500 走 fallback、不進記憶。"""
+        mock_get.side_effect = [
+            _status_resp(404),
+            _ok_resp(b"f" * 1001),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://err.example/a.jpg",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/a.jpg",
+        ) is True
+        assert download_image(
+            "http://err.example/b.jpg",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://proxy.example/b.jpg",
+        ) is True
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://err.example/a.jpg",
+            "http://proxy.example/a.jpg",
+            "http://err.example/b.jpg",
+        ]
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_small_content_does_not_poison_host(self, mock_get, tmp_path):
+        """邊界 8：200 但 content ≤1000 走 fallback、不進記憶。"""
+        mock_get.side_effect = [
+            _ok_resp(b"tiny"),
+            _ok_resp(b"f" * 1001),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://small.example/a.jpg",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/a.jpg",
+        ) is True
+        assert download_image(
+            "http://small.example/b.jpg",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://proxy.example/b.jpg",
+        ) is True
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://small.example/a.jpg",
+            "http://proxy.example/a.jpg",
+            "http://small.example/b.jpg",
+        ]
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_scheme_differs_keeps_primary(self, mock_get, tmp_path):
+        """邊界 9：http 失敗後 https 同 host 仍先試原址（三元組 key）。"""
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("t"),
+            _ok_resp(b"f" * 1001),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://h.example/x",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/x",
+        ) is True
+        assert download_image(
+            "https://h.example/y",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://proxy.example/y",
+        ) is True
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://h.example/x",
+            "http://proxy.example/x",
+            "https://h.example/y",
+        ]
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_port_differs_keeps_primary(self, mock_get, tmp_path):
+        """邊界 10：:8080 失敗後預設 port 仍先試原址。"""
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("t"),
+            _ok_resp(b"f" * 1001),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://h.example:8080/x",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/x",
+        ) is True
+        assert download_image(
+            "http://h.example/y",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://proxy.example/y",
+        ) is True
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://h.example:8080/x",
+            "http://proxy.example/x",
+            "http://h.example/y",
+        ]
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_ttl_expiry_restores_primary(self, mock_get, tmp_path, monkeypatch):
+        """邊界 11：TTL 過期後回到原址優先（注入時鐘，不得 sleep）。"""
+        import core.organizer as org
+
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(org, "_now", lambda: clock["t"])
+
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("t"),
+            _ok_resp(b"f" * 1001),
+            _ok_resp(b"p" * 1001),
+        ]
+        assert download_image(
+            "http://ttl.example/a.jpg",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/a.jpg",
+        ) is True
+
+        clock["t"] = 1000.0 + org._HOST_FAILURE_TTL + 1
+
+        assert download_image(
+            "http://ttl.example/b.jpg",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://proxy.example/b.jpg",
+        ) is True
+
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://ttl.example/a.jpg",
+            "http://proxy.example/a.jpg",
+            "http://ttl.example/b.jpg",
+        ]
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_empty_url_ignores_fallback(self, mock_get, tmp_path):
+        """邊界 12：url 空、fallback 非空 → False，不走代理。"""
+        result = download_image(
+            "",
+            str(tmp_path / "c.jpg"),
+            fallback_url="http://proxy.example/cover.jpg",
+        )
+        assert result is False
+        mock_get.assert_not_called()
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_both_fail_returns_false(self, mock_get, tmp_path):
+        """邊界 13：原址與 fallback 都失敗 → False，不拋例外。"""
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("t1"),
+            requests.exceptions.ConnectTimeout("t2"),
+        ]
+        result = download_image(
+            "http://example.com/cover.jpg",
+            str(tmp_path / "c.jpg"),
+            fallback_url="http://proxy.example/cover.jpg",
+        )
+        assert result is False
+        assert mock_get.call_count == 2
+
+    @patch("core.organizer.requests.get")
+    def test_download_image_fallback_connect_timeout_is_recorded(self, mock_get, tmp_path):
+        """邊界 14：fallback 也 ConnectTimeout → fallback host 進記憶。"""
+        import core.organizer as org
+
+        mock_get.side_effect = [
+            requests.exceptions.ConnectTimeout("primary"),
+            requests.exceptions.ConnectTimeout("fallback"),
+            _ok_resp(b"z" * 1001),
+        ]
+        assert download_image(
+            "http://primary.example/a.jpg",
+            str(tmp_path / "1.jpg"),
+            fallback_url="http://proxy.example/a.jpg",
+        ) is False
+
+        # proxy host 已進記憶：下次以它當原址時應跳過，直接走它的 fallback
+        assert download_image(
+            "http://proxy.example/b.jpg",
+            str(tmp_path / "2.jpg"),
+            fallback_url="http://other.example/b.jpg",
+        ) is True
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert urls == [
+            "http://primary.example/a.jpg",
+            "http://proxy.example/a.jpg",
+            "http://other.example/b.jpg",
+        ]
+        key = ("http", "proxy.example", 80)
+        with org._failed_hosts_lock:
+            assert key in org._failed_hosts
 
 
 # ============ generate_nfo() 新欄位測試 (T5b) ============

--- a/tests/unit/test_readonly_producer.py
+++ b/tests/unit/test_readonly_producer.py
@@ -6377,6 +6377,9 @@ class TestNfoToProducerMeta:
             'number', 'title', 'original_title', 'actors', 'tags', 'date',
             'maker', 'director', 'series', 'label', 'duration', 'url',
             '_summary', '_rating', 'cover', 'sample_images',
+            # TASK-126-T4b（CD-126-2）：本地 NFO 沒有代理可言，但這兩個鍵必須存在——
+            # 否則下游 `.get()` 的預設值會散落在四個地方。值恆為空。
+            'preview_cover_url', 'preview_sample_images',
         }
         assert meta['number'] == 'ABC-123'
         assert meta['title'] == 'My Title'
@@ -7626,3 +7629,215 @@ class TestEnrichOneReadonlyEntryPoint:
             "readonly preserve gate — Table 2 #8, opposite of Table 1 #6's "
             "non-readonly .jpg-family-only rule"
         )
+
+
+# ============ TASK-126-T4b：代理網址走到 readonly 的下載點 ============
+#
+# 本 task 的整個風險是「函式對了但值沒走到」——那種缺口在單測層是**綠的**
+# （T4a 的 283 條照樣全過）。所以這幾條一律從 `_write_movie_assets` 這個
+# **caller 入口**打進去，不是直接呼叫 `download_image`。
+#
+# mock 目標是**使用端 binding**（`core.readonly_producer.requests` 底下的
+# `core.organizer.requests.get`）——`download_image` 是
+# `from core.organizer import download_image` 進來的（BE-TEST-01）。
+
+from unittest.mock import patch as _t4b_patch
+
+from core.readonly_producer import _write_movie_assets, resolve_ingest_plan
+
+_T4B_DIRECT = b'DIRECT' + b'\x00' * 2000
+_T4B_PROXY = b'PROXY' + b'\x00' * 2000
+
+
+class _T4bReadonlyBase:
+    """每支測試前後清 process 級失敗記憶（T4a review：它不分呼叫端，會跨測試污染）。"""
+
+    def _clear_failed_hosts(self):
+        import core.organizer as org
+        with org._failed_hosts_lock:
+            org._failed_hosts.clear()
+
+    def _resp(self, content):
+        m = MagicMock()
+        m.status_code = 200
+        m.content = content
+        return m
+
+    def _fake_get(self, proxy_host='mt.example'):
+        """原址一律 ConnectTimeout，代理一律成功。"""
+        import requests as _rq
+
+        def _side(url, **kwargs):
+            if proxy_host in url:
+                return self._resp(_T4B_PROXY)
+            raise _rq.exceptions.ConnectTimeout('blocked')
+        return _side
+
+
+class TestT4bReadonlySamplesOnlyFallback(_T4bReadonlyBase):
+    """邊界 3：readonly samples_only（補劇照）入口 → 原址不通時走代理。"""
+
+    def test_samples_only_uses_preview_fallback(self, tmp_path):
+        self._clear_failed_hosts()
+        try:
+            meta = {
+                'sample_images': ['https://cdn.blocked/s1.jpg', 'https://cdn.blocked/s2.jpg'],
+                'preview_sample_images': [
+                    'http://mt.example/v1/images/primary/MGS/N-1?url=s1',
+                    'http://mt.example/v1/images/primary/MGS/N-1?url=s2',
+                ],
+            }
+            movie_dir = str(tmp_path / 'movie')
+            with _t4b_patch('core.organizer.requests.get', side_effect=self._fake_get()):
+                out = _write_movie_assets(
+                    movie_dir=movie_dir, meta=meta, format_data={}, source_fs_path='',
+                    config={}, cover_strategy=('none',), assets_mode='samples_only',
+                )
+            assert len(out['sample_fs']) == 2, '兩張劇照都應該經由代理落地'
+            for p in out['sample_fs']:
+                assert open(p, 'rb').read() == _T4B_PROXY
+        finally:
+            self._clear_failed_hosts()
+
+    def test_samples_only_no_preview_keeps_todays_behaviour(self, tmp_path):
+        """邊界 9（AC-5）：沒有 preview → 原址失敗就是失敗，行為與 branch 前相同。"""
+        self._clear_failed_hosts()
+        try:
+            meta = {'sample_images': ['https://cdn.blocked/s1.jpg'], 'preview_sample_images': []}
+            movie_dir = str(tmp_path / 'movie')
+            with _t4b_patch('core.organizer.requests.get', side_effect=self._fake_get()) as mg:
+                out = _write_movie_assets(
+                    movie_dir=movie_dir, meta=meta, format_data={}, source_fs_path='',
+                    config={}, cover_strategy=('none',), assets_mode='samples_only',
+                )
+            assert out['sample_fs'] == []
+            # 只打了原址一次，沒有第二次嘗試
+            assert mg.call_count == 1
+            assert 'fallback_url' not in mg.call_args.kwargs
+        finally:
+            self._clear_failed_hosts()
+
+    def test_short_preview_does_not_truncate(self, tmp_path):
+        """邊界 8：preview 比 sample 短 → 缺的格當 '' ，**不得少下載**。"""
+        self._clear_failed_hosts()
+        try:
+            meta = {
+                'sample_images': ['https://cdn.ok/s1.jpg', 'https://cdn.ok/s2.jpg', 'https://cdn.ok/s3.jpg'],
+                'preview_sample_images': ['http://mt.example/v1/images/primary/MGS/N-1?url=s1'],
+            }
+            movie_dir = str(tmp_path / 'movie')
+            with _t4b_patch('core.organizer.requests.get', return_value=self._resp(_T4B_DIRECT)) as mg:
+                out = _write_movie_assets(
+                    movie_dir=movie_dir, meta=meta, format_data={}, source_fs_path='',
+                    config={}, cover_strategy=('none',), assets_mode='samples_only',
+                )
+            assert len(out['sample_fs']) == 3, 'zip 截斷會讓這裡變成 1'
+            assert mg.call_count == 3
+        finally:
+            self._clear_failed_hosts()
+
+
+class TestT4bReadonlyFullCoverFallback(_T4bReadonlyBase):
+    """邊界 2：readonly full 模式封面 → CD-126-9（fallback 從 meta 取，不動 tuple）。"""
+
+    def test_full_cover_uses_preview_fallback_from_meta(self, tmp_path):
+        self._clear_failed_hosts()
+        try:
+            meta = {
+                'number': 'N-1', 'title': 'T', 'actors': [], 'tags': [],
+                'sample_images': [], 'preview_sample_images': [],
+                'preview_cover_url': 'http://mt.example/v1/images/primary/MGS/N-1?url=cover',
+            }
+            movie_dir = str(tmp_path / 'movie')
+            with _t4b_patch('core.organizer.requests.get', side_effect=self._fake_get()):
+                out = _write_movie_assets(
+                    movie_dir=movie_dir, meta=meta, format_data={'number': 'N-1'},
+                    source_fs_path=str(tmp_path / 'src.mp4'), config={},
+                    cover_strategy=('download', 'https://cdn.blocked/cover.jpg'),
+                    assets_mode='full',
+                )
+            assert out.get('has_cover') is True or out.get('cover_fs'), '封面應經由代理落地'
+        finally:
+            self._clear_failed_hosts()
+
+
+class TestT4bLengthContract:
+    """邊界 7 / D4：full 模式清空 sample_images 時，preview 必須同步清空。"""
+
+    def test_resolve_ingest_plan_clears_preview_in_lockstep(self, tmp_path):
+        src = tmp_path / 'ABC-123.mp4'
+        src.write_bytes(b'x' * 10)
+        scraper_data = {
+            'number': 'ABC-123', 'title': 'T', 'cover': 'https://cdn/c.jpg',
+            'sample_images': ['https://cdn/s1.jpg', 'https://cdn/s2.jpg'],
+            'preview_sample_images': ['http://mt/p1', 'http://mt/p2'],
+            'preview_cover_url': 'http://mt/pc',
+        }
+        meta, _strategy = resolve_ingest_plan(
+            str(src), 'ABC-123', {}, action='rescrape', scraper_data=scraper_data,
+        )
+        assert meta is not None
+        assert meta['sample_images'] == []
+        assert meta['preview_sample_images'] == [], (
+            '等長契約：清空 sample_images 卻留著 preview → 兩者長度不等 → '
+            '下游逐張配對時圖片對到別張（靜默錯位，比破圖難查）'
+        )
+
+
+# ============ TASK-126-T4b review MAJOR-2：readonly full 模式的劇照分支 ============
+#
+# 初版只測了 full 模式的**封面**，而且那支的 meta 是 `sample_images: []`（劇照迴圈根本不會跑）。
+# review 在沙盒把 full 分支的 preview 傳遞整段拔掉，335 條照樣全綠 ⇒ 這個下載點沒人守。
+
+class TestT4bReadonlyFullSamplesFallback(_T4bReadonlyBase):
+
+    def test_full_mode_extrafanart_uses_preview_fallback(self, tmp_path):
+        """使用者用放大鏡全量重刮一部片（full 模式）→ 原址被牆 → 劇照經代理落地。"""
+        self._clear_failed_hosts()
+        try:
+            meta = {
+                'number': 'N-2', 'title': 'T', 'actors': [], 'tags': [],
+                'sample_images': ['https://cdn.blocked/s1.jpg', 'https://cdn.blocked/s2.jpg'],
+                'preview_sample_images': [
+                    'http://mt.example/v1/images/primary/MGS/N-2?url=s1',
+                    'http://mt.example/v1/images/primary/MGS/N-2?url=s2',
+                ],
+            }
+            movie_dir = str(tmp_path / 'movie')
+            with _t4b_patch('core.organizer.requests.get', side_effect=self._fake_get()):
+                out = _write_movie_assets(
+                    movie_dir=movie_dir, meta=meta, format_data={'number': 'N-2'},
+                    source_fs_path=str(tmp_path / 'src.mp4'),
+                    config={'download_sample_images': True},
+                    cover_strategy=('none',), assets_mode='full',
+                )
+            assert len(out.get('sample_fs') or []) == 2, (
+                'full 模式的劇照分支若沒接上 preview，被牆的使用者重刮一次會拿到 0 張劇照，'
+                '而且沒有任何錯誤訊息'
+            )
+            for p in out['sample_fs']:
+                assert open(p, 'rb').read() == _T4B_PROXY
+        finally:
+            self._clear_failed_hosts()
+
+    def test_full_mode_extrafanart_short_preview_does_not_truncate(self, tmp_path):
+        """邊界 8 在 full 模式也成立：preview 比 sample 短，不得少下載。"""
+        self._clear_failed_hosts()
+        try:
+            meta = {
+                'number': 'N-3', 'title': 'T', 'actors': [], 'tags': [],
+                'sample_images': ['https://cdn.ok/s1.jpg', 'https://cdn.ok/s2.jpg', 'https://cdn.ok/s3.jpg'],
+                'preview_sample_images': ['http://mt.example/v1/images/primary/MGS/N-3?url=s1'],
+            }
+            movie_dir = str(tmp_path / 'movie')
+            with _t4b_patch('core.organizer.requests.get', return_value=self._resp(_T4B_DIRECT)) as mg:
+                out = _write_movie_assets(
+                    movie_dir=movie_dir, meta=meta, format_data={'number': 'N-3'},
+                    source_fs_path=str(tmp_path / 'src.mp4'),
+                    config={'download_sample_images': True},
+                    cover_strategy=('none',), assets_mode='full',
+                )
+            assert len(out.get('sample_fs') or []) == 3, 'zip 截斷會讓這裡變成 1'
+            assert mg.call_count == 3
+        finally:
+            self._clear_failed_hosts()

--- a/tests/unit/test_source_merger.py
+++ b/tests/unit/test_source_merger.py
@@ -334,6 +334,43 @@ def test_merge_preview_sample_images_follows_same_winner():
     assert merged.preview_sample_images == []
 
 
+def test_merge_preview_sample_images_positive_copies_winner_previews():
+    """邊界 8b（**正向**）：勝出候選自己帶非空 preview_sample_images → merged 必須拿到那組值。
+
+    Pre-merge mutation 自驗抓到的洞（`source_merger.py:139` SURVIVED）＋ SA-pre-6 獨立指到同一處：
+    邊界 8 的斷言是 `preview_sample_images == []`，而該案例的勝出候選 preview 本來就是 `[]`——
+    把那行賦值整個刪掉，值會從 text_source 沿用下來、**也是 `[]`**，測試照樣綠。
+    封面那組有這支對稱的正向鎖（test_preview_cover_url_follows_cover_winner_when_metatube），
+    劇照這組沒有。
+
+    使用者流程：來源順序把 metatube 排第一 → 搜到一片、metatube 有劇照 → 若日後有人
+    改壞這行，燈箱的劇照代理網址整組消失、退回冷門圖床 403 破圖，而測試全綠沒人發現。
+    """
+    previews = [
+        "http://mt:8080/v1/images/primary/FANZA/X?url=s1",
+        "http://mt:8080/v1/images/primary/FANZA/X?url=s2",
+    ]
+    javbus = _v("javbus", title="JB Title", sample_images=[], preview_sample_images=[])
+    metatube = _v(
+        "metatube:FANZA",
+        title="",
+        sample_images=["http://mt/s1.jpg", "http://mt/s2.jpg"],
+        preview_sample_images=previews,
+    )
+    merged = merge_results(
+        {"javbus": javbus, "metatube:FANZA": metatube},
+        user_order=["javbus", "metatube:FANZA"],
+    )
+    # javbus 是 text_source（整包贏）但沒有劇照 → 劇照勝出候選是 metatube
+    assert merged.sample_images == ["http://mt/s1.jpg", "http://mt/s2.jpg"]
+    assert merged.preview_sample_images == previews, (
+        "勝出候選帶非空 preview_sample_images 時，merged 必須取到該值（同源綁定的正向半邊）"
+    )
+    assert len(merged.preview_sample_images) == len(merged.sample_images), (
+        "CD-126-2 等長契約"
+    )
+
+
 def test_merge_preview_sample_images_cleared_when_no_sample_winner():
     """邊界 9：無任何候選有 sample_images，但 text_source 有 preview_sample_images
     → preview_sample_images 明確清空為 []，不得從 text_source 漏出。"""

--- a/tests/unit/test_source_merger.py
+++ b/tests/unit/test_source_merger.py
@@ -305,3 +305,50 @@ def test_preview_cover_url_cleared_when_no_candidate_has_cover():
     assert merged.preview_cover_url == "", (
         "沒有任何候選有封面時 preview 必須清空，不得從 text_source 漏出"
     )
+
+
+# ---------------------------------------------------------------------------
+# preview_sample_images 同源綁定（TASK-126-T2, CD-126-2／CD-113c-12 形狀）
+# ---------------------------------------------------------------------------
+
+def test_merge_preview_sample_images_follows_same_winner():
+    """邊界 8：候選 A 有 sample_images（無 preview）、候選 B 有 sample＋preview，
+    A 排前 → 兩欄都取 A（含 A 的空 preview），不得從 B 漏過來。"""
+    a = _v(
+        "javbus",
+        title="JB Title",
+        sample_images=["http://javbus/s1.jpg"],
+        preview_sample_images=[],
+    )
+    b = _v(
+        "metatube:FANZA",
+        title="",
+        sample_images=["http://mt/s1.jpg"],
+        preview_sample_images=["http://mt:8080/v1/images/primary/FANZA/X?url=s1"],
+    )
+    merged = merge_results(
+        {"javbus": a, "metatube:FANZA": b},
+        user_order=["javbus", "metatube:FANZA"],
+    )
+    assert merged.sample_images == ["http://javbus/s1.jpg"]
+    assert merged.preview_sample_images == []
+
+
+def test_merge_preview_sample_images_cleared_when_no_sample_winner():
+    """邊界 9：無任何候選有 sample_images，但 text_source 有 preview_sample_images
+    → preview_sample_images 明確清空為 []，不得從 text_source 漏出。"""
+    leaky = _v(
+        "metatube:FANZA",
+        title="MT Title",
+        sample_images=[],
+        preview_sample_images=["http://mt:8080/v1/images/primary/FANZA/X?url=s1"],
+    )
+    other = _v("javbus", title="", sample_images=[], preview_sample_images=[])
+    merged = merge_results(
+        {"metatube:FANZA": leaky, "javbus": other},
+        user_order=["metatube:FANZA", "javbus"],
+    )
+    assert merged.sample_images == []
+    assert merged.preview_sample_images == [], (
+        "沒有任何候選有劇照時 preview_sample_images 必須清空，不得從 text_source 漏出"
+    )

--- a/web/routers/capabilities.py
+++ b/web/routers/capabilities.py
@@ -1431,6 +1431,65 @@ def _capabilities_auth_fields(
     return curl_auth, network_auth, agent_instructions
 
 
+def _build_image_display(curl_auth: str) -> dict:
+    """`GET /api/capabilities` 的 image_display 區塊。
+
+    從 `get_capabilities()` 抽出來的原因是函式規模棘輪（`scripts/py_function_size_lint.py`，
+    上限 200 行）——加了 metatube preview_* 的食譜之後剛好推爆。抽法照該檔既有的
+    `_build_tools(base, curl_auth)` 模式，內容逐字元不變。
+    """
+    return {
+        "description": "如何在對話流程中向用戶展示搜尋結果的封面 / 劇照圖片",
+        "problem": "搜尋結果的 cover 和 sample_images 是遠端 URL。AI agent 直接 curl 遠端 URL 會被 Cloudflare / 防盜鏈擋掉（回傳 HTML 而非圖片）。",
+        "solution": "透過 /api/proxy-image 下載圖片到本地，再依 agent 形態用本地絕對路徑嵌入。",
+        "steps": [
+            "1. 搜尋取得 cover / sample_images URL",
+            "1b. 若同筆結果有 preview_cover_url / preview_sample_images（metatube 來源），"
+            "改用 preview_cover_url || cover、preview_sample_images[i] || sample_images[i]",
+            f"2. curl {curl_auth}-o <local_path> '<base_url>/api/proxy-image?url=<remote_url>' 下載到本地",
+            "3. 依 agent 形態嵌入（見 agents 區塊）：對話氣泡內嵌 / artifact 面板 / 純路徑文字",
+        ],
+        "rules": [
+            "禁止直接 curl 遠端圖片 URL — 一定會被擋",
+            "一律透過 /api/proxy-image 代理下載",
+            "metatube 來源優先用 preview_* 欄位：/api/proxy-image 的網域白名單只收錄常見圖床，"
+            "metatube 接的冷門 provider 圖床不在名單內會回 403。preview_* 走使用者自己的 "
+            "metatube 伺服器（在動態白名單內），是同一張圖的可達副本。空字串代表該格沒有代理，"
+            "退回原始網址即可（用 || 不要用 ??）",
+            "下載到本地後用絕對路徑顯示（不要用遠端 URL 嵌入）",
+        ],
+        "agents": {
+            "codex_app": {
+                "description": "Codex App（OpenAI 桌面應用）— 對話氣泡可直接內嵌圖片",
+                "mechanism": "inline_markdown",
+                "temp_dir": "C:/Codex/tmp/openaver-images/",
+                "display_format": "![SONE-205 cover](C:/Codex/tmp/openaver-images/SONE-205-cover.jpg)",
+                "naming": "<number>-cover.jpg 或 <number>-sample-<N>.jpg",
+                "note": "路徑不可含空格。OpenAver 的番號與檔名不含空格，可安全使用。",
+            },
+            "antigravity": {
+                "description": "Google Antigravity 2.0（桌面 app）— 對話氣泡不渲染圖片，必須透過右側 artifact 面板（Markdown 富文本）嵌入",
+                "mechanism": "artifact_markdown",
+                "artifact_dir_hint": "<appDataDir>/brain/<conversation-id>/  例：C:/Users/<user>/.gemini/antigravity/brain/<conv-id>/。實際路徑請從 runtime 取得當前對話的 artifact 目錄，不要寫死 conv-id",
+                "display_format": "![SONE-205 cover](<artifact_dir>/SONE-205-cover.jpg)",
+                "rules": [
+                    "圖片下載到 artifact 目錄內（或其子目錄）才能被 artifact 引用",
+                    "Markdown 路徑用絕對路徑 + 正斜線（Windows 也用 / 不用 \\）",
+                    "用 ![]() 不能用 []()，前綴 ! 才會渲染為圖片",
+                    "圖片不在對話氣泡顯示，而是右側 artifact 面板",
+                ],
+                "carousel_syntax": "多張圖可用 carousel 區塊：````carousel 開頭 + 每張 ![](path) 之間用 <!-- slide --> 分隔 + ```` 結尾（實測可用，官方文件未列）",
+            },
+            "terminal_cli": {
+                "description": "終端機型 agent（Claude Code / Codex CLI / Gemini CLI 等）— 終端不渲染圖片",
+                "mechanism": "path_text",
+                "display_format": "下載完成後在訊息中提供絕對路徑供用戶手動開啟（檔案總管 / Preview / Quick Look 等）",
+                "note": "若 agent host 環境支援開檔指令，可主動呼叫 open / xdg-open / start 等",
+            },
+        },
+    }
+
+
 @router.get("/capabilities")
 async def get_capabilities(request: Request):
     base = str(request.base_url).rstrip("/")
@@ -1470,50 +1529,7 @@ async def get_capabilities(request: Request):
             "note": "本地/區網服務，不上公網",
         },
         "agent_instructions": agent_instructions,
-        "image_display": {
-            "description": "如何在對話流程中向用戶展示搜尋結果的封面 / 劇照圖片",
-            "problem": "搜尋結果的 cover 和 sample_images 是遠端 URL。AI agent 直接 curl 遠端 URL 會被 Cloudflare / 防盜鏈擋掉（回傳 HTML 而非圖片）。",
-            "solution": "透過 /api/proxy-image 下載圖片到本地，再依 agent 形態用本地絕對路徑嵌入。",
-            "steps": [
-                "1. 搜尋取得 cover / sample_images URL",
-                f"2. curl {curl_auth}-o <local_path> '<base_url>/api/proxy-image?url=<remote_url>' 下載到本地",
-                "3. 依 agent 形態嵌入（見 agents 區塊）：對話氣泡內嵌 / artifact 面板 / 純路徑文字",
-            ],
-            "rules": [
-                "禁止直接 curl 遠端圖片 URL — 一定會被擋",
-                "一律透過 /api/proxy-image 代理下載",
-                "下載到本地後用絕對路徑顯示（不要用遠端 URL 嵌入）",
-            ],
-            "agents": {
-                "codex_app": {
-                    "description": "Codex App（OpenAI 桌面應用）— 對話氣泡可直接內嵌圖片",
-                    "mechanism": "inline_markdown",
-                    "temp_dir": "C:/Codex/tmp/openaver-images/",
-                    "display_format": "![SONE-205 cover](C:/Codex/tmp/openaver-images/SONE-205-cover.jpg)",
-                    "naming": "<number>-cover.jpg 或 <number>-sample-<N>.jpg",
-                    "note": "路徑不可含空格。OpenAver 的番號與檔名不含空格，可安全使用。",
-                },
-                "antigravity": {
-                    "description": "Google Antigravity 2.0（桌面 app）— 對話氣泡不渲染圖片，必須透過右側 artifact 面板（Markdown 富文本）嵌入",
-                    "mechanism": "artifact_markdown",
-                    "artifact_dir_hint": "<appDataDir>/brain/<conversation-id>/  例：C:/Users/<user>/.gemini/antigravity/brain/<conv-id>/。實際路徑請從 runtime 取得當前對話的 artifact 目錄，不要寫死 conv-id",
-                    "display_format": "![SONE-205 cover](<artifact_dir>/SONE-205-cover.jpg)",
-                    "rules": [
-                        "圖片下載到 artifact 目錄內（或其子目錄）才能被 artifact 引用",
-                        "Markdown 路徑用絕對路徑 + 正斜線（Windows 也用 / 不用 \\）",
-                        "用 ![]() 不能用 []()，前綴 ! 才會渲染為圖片",
-                        "圖片不在對話氣泡顯示，而是右側 artifact 面板",
-                    ],
-                    "carousel_syntax": "多張圖可用 carousel 區塊：````carousel 開頭 + 每張 ![](path) 之間用 <!-- slide --> 分隔 + ```` 結尾（實測可用，官方文件未列）",
-                },
-                "terminal_cli": {
-                    "description": "終端機型 agent（Claude Code / Codex CLI / Gemini CLI 等）— 終端不渲染圖片",
-                    "mechanism": "path_text",
-                    "display_format": "下載完成後在訊息中提供絕對路徑供用戶手動開啟（檔案總管 / Preview / Quick Look 等）",
-                    "note": "若 agent host 環境支援開檔指令，可主動呼叫 open / xdg-open / start 等",
-                },
-            },
-        },
+        "image_display": _build_image_display(curl_auth),
         "error_format": {
             "structure": {"success": False, "error": "string — 錯誤描述"},
             "http_codes": {

--- a/web/static/js/pages/search/__tests__/build-organize-metadata.test.mjs
+++ b/web/static/js/pages/search/__tests__/build-organize-metadata.test.mjs
@@ -69,46 +69,64 @@ test('buildOrganizeMetadata: date 缺席 → 無 date key（不再正規化為�
   assert.deepEqual(buildOrganizeMetadata(file), { number: 'ABC-001' });
 });
 
-// TASK-113c-T3b DoD-4：preview_cover_url 只對顯示有意義（會隨 metatube 連線狀態失效），
-// 不可被 buildOrganizeMetadata 送進 /api/scrape-single 落磁碟（不接受「反正後端只讀 cover」
-// 當理由——那是 fail-open by accident，card 明文）。
-test('buildOrganizeMetadata: 剝除 preview_cover_url，不送 /api/scrape-single', () => {
+// TASK-126（Codex PR review P2）：這兩支從「驗**不傳遞**」翻成「驗**傳遞**」。
+//
+// 113c-T3b 立的規矩逐字是「preview_* **不能落磁碟**」，剝除只是當時達成它的手段。
+// 兩件事分開之後：不變式（不落磁碟）由 `tests/unit/test_organizer.py::TestT6PreviewNotPersisted`
+// 直接驗證產出的 NFO 與 DB；而傳遞是**必要的**——搜尋後按「產生」是最常走的入庫路徑，
+// 後端不會重新搜尋，不傳等於被牆的使用者永遠拿不到代理退路（spec §3.2 的承諾）。
+//
+// ⚠️ 這兩支測試的**方向被刻意翻面了**。若日後有人想改回剝除，請先讀
+// `feature/126-metatube-image-proxy/CODEX-ROUND1-FIXES.md`。
+
+test('buildOrganizeMetadata: preview_cover_url 必須傳給 /api/scrape-single（下載端的代理退路）', () => {
   const file = {
     searchResults: [{
       number: 'ABC-001',
       cover: 'http://example/cover.jpg',
-      preview_cover_url: 'http://mt:8080/v1/images/primary/FANZA/ABC-001?url=x',
-    }],
-  };
-
-  const result = buildOrganizeMetadata(file);
-  assert.deepEqual(result, { number: 'ABC-001', cover: 'http://example/cover.jpg' });
-  assert.ok(!('preview_cover_url' in result), 'preview_cover_url 不應出現在送出的 metadata');
-});
-
-// TASK-126-T3 D4：preview_sample_images 同 preview_cover_url——只對顯示有意義
-// （會隨 metatube 連線狀態失效），不可被 buildOrganizeMetadata 送進 /api/scrape-single
-// 落磁碟（不接受「反正後端只讀 sample_images」當理由——那是 fail-open by accident）。
-test('buildOrganizeMetadata strips preview_sample_images', () => {
-  const file = {
-    searchResults: [{
-      number: 'ABC-001',
-      sample_images: ['http://example/s1.jpg', 'http://example/s2.jpg'],
-      preview_sample_images: [
-        'http://mt:8080/v1/images/primary/MGS/ABC-001?url=s1',
-        '',
-      ],
       preview_cover_url: 'http://mt:8080/v1/images/primary/MGS/ABC-001?url=c',
     }],
   };
 
   const result = buildOrganizeMetadata(file);
-  assert.deepEqual(result, {
-    number: 'ABC-001',
-    sample_images: ['http://example/s1.jpg', 'http://example/s2.jpg'],
-  });
-  assert.ok(!('preview_sample_images' in result), 'preview_sample_images 不應出現在送出的 metadata');
-  assert.ok(!('preview_cover_url' in result), 'preview_cover_url 不應出現在送出的 metadata');
+  assert.equal(
+    result.preview_cover_url,
+    'http://mt:8080/v1/images/primary/MGS/ABC-001?url=c',
+    '剝掉它 → 被牆的使用者按「產生」永遠拿不到封面，而且沒有錯誤訊息',
+  );
+  assert.equal(result.cover, 'http://example/cover.jpg', '原址必須一併保留（原址優先）');
+});
+
+test('buildOrganizeMetadata: preview_sample_images 必須傳給 /api/scrape-single', () => {
+  const file = {
+    searchResults: [{
+      number: 'ABC-001',
+      sample_images: ['http://example/s1.jpg', 'http://example/s2.jpg'],
+      preview_sample_images: ['http://mt:8080/v1/images/primary/MGS/ABC-001?url=s1', ''],
+      preview_cover_url: 'http://mt:8080/v1/images/primary/MGS/ABC-001?url=c',
+    }],
+  };
+
+  const result = buildOrganizeMetadata(file);
+  assert.deepEqual(
+    result.preview_sample_images,
+    ['http://mt:8080/v1/images/primary/MGS/ABC-001?url=s1', ''],
+    '逐張傳遞，含空字串那一格（空＝這格沒有代理，落回原址）',
+  );
+  assert.deepEqual(result.sample_images, ['http://example/s1.jpg', 'http://example/s2.jpg']);
+});
+
+test('buildOrganizeMetadata: 仍然只送選中的那個候選，不混到別的候選', () => {
+  const file = {
+    selectedCandidateIndex: 1,
+    searchResults: [
+      { number: 'WRONG-000', cover: 'http://example/wrong.jpg' },
+      { number: 'ABC-001', cover: 'http://example/right.jpg', preview_cover_url: 'http://mt:8080/p' },
+    ],
+  };
+  const result = buildOrganizeMetadata(file);
+  assert.equal(result.number, 'ABC-001');
+  assert.equal(result.preview_cover_url, 'http://mt:8080/p');
 });
 
 test('loadMore: listMode="file" → 立即回傳 null、不呼叫 fetch（CD-106-5 P1-#2 順修 pre-existing bug）', async () => {

--- a/web/static/js/pages/search/__tests__/build-organize-metadata.test.mjs
+++ b/web/static/js/pages/search/__tests__/build-organize-metadata.test.mjs
@@ -86,6 +86,31 @@ test('buildOrganizeMetadata: 剝除 preview_cover_url，不送 /api/scrape-singl
   assert.ok(!('preview_cover_url' in result), 'preview_cover_url 不應出現在送出的 metadata');
 });
 
+// TASK-126-T3 D4：preview_sample_images 同 preview_cover_url——只對顯示有意義
+// （會隨 metatube 連線狀態失效），不可被 buildOrganizeMetadata 送進 /api/scrape-single
+// 落磁碟（不接受「反正後端只讀 sample_images」當理由——那是 fail-open by accident）。
+test('buildOrganizeMetadata strips preview_sample_images', () => {
+  const file = {
+    searchResults: [{
+      number: 'ABC-001',
+      sample_images: ['http://example/s1.jpg', 'http://example/s2.jpg'],
+      preview_sample_images: [
+        'http://mt:8080/v1/images/primary/MGS/ABC-001?url=s1',
+        '',
+      ],
+      preview_cover_url: 'http://mt:8080/v1/images/primary/MGS/ABC-001?url=c',
+    }],
+  };
+
+  const result = buildOrganizeMetadata(file);
+  assert.deepEqual(result, {
+    number: 'ABC-001',
+    sample_images: ['http://example/s1.jpg', 'http://example/s2.jpg'],
+  });
+  assert.ok(!('preview_sample_images' in result), 'preview_sample_images 不應出現在送出的 metadata');
+  assert.ok(!('preview_cover_url' in result), 'preview_cover_url 不應出現在送出的 metadata');
+});
+
 test('loadMore: listMode="file" → 立即回傳 null、不呼叫 fetch（CD-106-5 P1-#2 順修 pre-existing bug）', async () => {
   let fetchCalls = 0;
   globalThis.fetch = async () => { fetchCalls++; return { ok: true, json: async () => ({}) }; };

--- a/web/static/js/pages/search/state/batch.js
+++ b/web/static/js/pages/search/state/batch.js
@@ -41,9 +41,10 @@ async function translateBatchHelper(titles) {
 // TASK-113c-T3b: preview_cover_url 只對顯示有意義（會隨 metatube 連線狀態失效），
 // 不能落磁碟。剝除後才送 /api/scrape-single——不接受「反正後端只讀 cover」當理由，
 // 那是 fail-open by accident（card 明文）。
+// TASK-126-T3 D4：preview_sample_images 同理——只對顯示有意義，對稱剝除。
 export function buildOrganizeMetadata(file) {
     const cand = file.searchResults[file.selectedCandidateIndex ?? 0];
-    const { preview_cover_url, ...metadata } = { ...cand };
+    const { preview_cover_url, preview_sample_images, ...metadata } = { ...cand };
     return metadata;
 }
 

--- a/web/static/js/pages/search/state/batch.js
+++ b/web/static/js/pages/search/state/batch.js
@@ -38,14 +38,26 @@ async function translateBatchHelper(titles) {
 // T7: date 隨候選 raw 直通，不再正規化——picker 產生的已是合法 YYYY-MM-DD、scraper 契約
 // 亦 YYYY-MM-DD（models.py:20），且新設計中有日期走唯讀 raw span、無日期才出 picker，
 // 唯讀 span 顯示即整理送出值（顯示＝整理一致）。cand 為 undefined 時 `{...undefined}` → {} 安全。
-// TASK-113c-T3b: preview_cover_url 只對顯示有意義（會隨 metatube 連線狀態失效），
-// 不能落磁碟。剝除後才送 /api/scrape-single——不接受「反正後端只讀 cover」當理由，
-// 那是 fail-open by accident（card 明文）。
-// TASK-126-T3 D4：preview_sample_images 同理——只對顯示有意義，對稱剝除。
+// TASK-113c-T3b 立的規矩逐字是「**不能落磁碟**」，剝除只是當時**達成**它的手段
+// （0.13.6 當下後端根本不讀 preview_*，連傳都不傳是最省的防線）。
+//
+// TASK-126（Codex PR review P2）把這兩件事分開：
+//   「不落磁碟」＝ 不變式（**仍然成立且有守衛**：preview_* 進不了 NFO——generate_nfo()
+//                 是具名參數；也進不了 DB——videos 表沒有這兩個欄位。
+//                 由 tests/unit/test_organizer.py 的 TestT6PreviewNotPersisted 釘住）
+//   「不傳遞」  ＝ 手段（**已不再需要**：後端現在有一個**刻意的**讀取點——
+//                 organize_file() 拿它當 download_image 的 fallback_url，
+//                 用完就丟。那不是 fail-open by accident，是有名字、有測試的用途）
+//
+// 為什麼一定要傳：搜尋後按「產生」是**最常走的入庫路徑**，而它的 metadata 由前端提供、
+// 後端不會重新搜尋（web/routers/scraper.py）。不傳的話，被牆的使用者明明剛剛用 metatube
+// 搜到了資料，按下產生卻因為原址 timeout 而拿不到封面與劇照——得改按「補齊資料」才行。
+// 那違反 spec §3.2 對「存檔到片庫那一步」的承諾。
+//
+// ⚠️ 安全面沒有變大：`cover` / `sample_images` 本來就是前端可控且未經白名單的值
+// （下載端沒有白名單，spec §1.2），preview_* 沒有新增任何攻擊面。
 export function buildOrganizeMetadata(file) {
-    const cand = file.searchResults[file.selectedCandidateIndex ?? 0];
-    const { preview_cover_url, preview_sample_images, ...metadata } = { ...cand };
-    return metadata;
+    return { ...file.searchResults[file.selectedCandidateIndex ?? 0] };
 }
 
 export function searchStateBatch() {

--- a/web/templates/search.html
+++ b/web/templates/search.html
@@ -86,9 +86,10 @@
                 <div class="lb-header">
                     <div class="lb-title" x-text="currentLightboxVideo()?.title || '-'"></div>
                     <!-- T8: Sample Gallery 入口按鈕 -->
+                    <!-- FE-JS-01: preview || raw 的 || 刻意；''＝這格無代理，必須落回原址，不准改 ?? -->
                     <button class="sg-open-btn"
                             x-show="(currentLightboxVideo()?.sample_images || []).length > 0"
-                            @click="openSampleGallery((currentLightboxVideo()?.sample_images || []).map(url => '/api/proxy-image?url=' + encodeURIComponent(url)), 0)"
+                            @click="openSampleGallery((currentLightboxVideo()?.sample_images || []).map((url, i) => '/api/proxy-image?url=' + encodeURIComponent(currentLightboxVideo()?.preview_sample_images?.[i] || url)), 0)"
                             x-text="t('search.gallery.sample_prefix') + ' (' + (currentLightboxVideo()?.sample_images || []).length + ')'">
                     </button>
                 </div>
@@ -454,11 +455,13 @@
                          x-show="displayMode === 'detail' && (current().sample_images || []).length > 0"
                          x-cloak>
                         <template x-for="(url, idx) in (current().sample_images || [])" :key="url">
+                            <!-- FE-JS-01: preview || raw 的 || 刻意；''＝這格無代理，必須落回原址，不准改 ?? -->
                             <button class="sample-thumb-btn"
-                                    @click="openSampleGallery((current().sample_images || []).map(u => '/api/proxy-image?url=' + encodeURIComponent(u)), idx)"
+                                    @click="openSampleGallery((current().sample_images || []).map((u, i) => '/api/proxy-image?url=' + encodeURIComponent(current().preview_sample_images?.[i] || u)), idx)"
                                     :class="{ 'sample-thumb-active': sampleGalleryOpen && sampleGalleryIndex === idx }"
                                     :title="t('search.grid.sample_prefix') + ' ' + (idx + 1)">
-                                <img :src="`/api/proxy-image?url=${encodeURIComponent(url)}`"
+                                <!-- FE-JS-01: preview || raw 的 || 刻意；''＝這格無代理，必須落回原址，不准改 ?? -->
+                                <img :src="`/api/proxy-image?url=${encodeURIComponent(current().preview_sample_images?.[idx] || url)}`"
                                      :alt="t('search.grid.sample_prefix') + ' ' + (idx + 1)"
                                      loading="lazy"
                                      class="sample-thumb-img">


### PR DESCRIPTION
**儀式強度：T2** — 理由：不動影片檔搬移邏輯（`organize_file` 的 `shutil.move` 零改動）⇒ 非 T1；但 `_failed_hosts` 是 module-level 共享狀態、判斷失準會**靜默影響整批**圖片下載，且 `fallback_url` 讓**前端可控的 URL** 進到**無白名單**的後端外連（`download_image` 從來沒有白名單）——安全邊界固定 ≥T2。

> **刻意沒做**（T2 明文豁免，不是漏做）：Stage 1 兩台 reviewer、push 前 red-team、owner 主持 e2e、每支新測試逐一 mutation。

---

## 這支解決的問題

使用者把 metatube 設成來源之後，**資料走 metatube，圖片卻走本機直連**——第 3 步和第 4 步之間換了執行者，metatube 那端的網路能力（proxy、境外機房）第 4 步一點都用不到。

四格裡有三格是破的，而且破的原因各不相同：

| | 封面顯示 | 封面下載 | 劇照顯示 | 劇照下載 |
|---|---|---|---|---|
| **沒被牆**（owner） | ✅ 0.13.6 修好 | ✅ 直連 | ❌ **403** | ✅ 直連 |
| **被牆**（貢獻者） | ✅ 同上 | ❌ timeout | ❌ 403 ＋ 連不到 | ❌ **timeout** |

**「那把網域加進白名單不就好了」——那是打地鼠**：metatube 接 30+ provider，站方會換 CDN，名單越長這道 SSRF 防線越沒意義。改走代理是把 N 個網域收斂成 1 個（使用者自己那台 metatube，已在動態白名單內且帶 path 前綴約束）。**這是本 branch 對 owner 的實質收益**，不是「幫中國使用者」。

## 承接外部貢獻

第一顆 commit `0c00f047` 是 @sheepzacks 的 [PR #151](https://github.com/slive777/OpenAver/pull/151)，**原封不動保留**（本 branch rebase 到他的 commit 之上，SHA 未改）。

他做到的：劇照逐張多產一份代理 URL、下載端改走代理。
本 branch **翻掉他的一半**：他把 `cover_url` **覆蓋**成代理 URL，原始網址從此在系統裡消失——那讓 `cover-fallback.js` 的破圖救援（啟動條件是 `preview !== cover`）變成**死碼**，機制還在、測試還綠（實跑 158 條全過），但永遠不會啟動。對他無感（原址對他本來就是死的），對 owner 是實打實的退步。

**存檔改為原址優先**：實測 metatube 的 `/v1/images/` 會重新編碼 JPEG（+3% 體積、尺寸不變＝一代 lossy），所以只在直連真的取不到時才用它。

## 已接受的 residual

1. **這條備援只對「圖片網址是 metatube 給的」那些片有效。** 來源順序讓 javdb／javbus 贏得封面時，那張圖沒有代理副本可退——自家 9 個 scraper 的圖片路徑本次一個位元組都沒動（spec §0 的範圍宣告）。
2. **偶發網路抖動 → 同圖床 5 分鐘內存的是重壓副本。** 失敗記憶是 process 級 × TTL 300s × **記錄端不分呼叫方**（自家 9 源的連線失敗也會記進去），而消費端只有帶 fallback 的呼叫。所以抖一下之後，同一個圖床的封面與劇照會直接跳過直連，沒有提示也不會自動重存。肉眼幾乎看不出來，要換掉只能重刮。
   > spec §6 residual 4 原本寫「對沒被牆的使用者實質為零」——**那句不成立，已更正**。設計不改（TTL 與 process 級是 CD-126-5／5c 拍過板的取捨，且改機制正是停損規則①要避免的 fix-forward）。
3. **失敗記憶只短路 primary，從不短路 fallback。** metatube 自己掛掉時每張圖仍付一次完整逾時。但**改動前也是同樣的牆鐘時間**（原本就是每張 30s 打不通的原址），非回歸，屬未取的優化。
4. **劇照沒有 error-time 救援**（封面有）。本 branch 不新增，維持今天的行為。
5. **被牆路徑我們驗不了。** 證據來自貢獻者的對照實驗，不是我們的真機驗證。
6. **依賴 metatube 的內部路由行為。** `?url=` 覆寫 primary 路由是讀原始碼推出來的，不是文件化的公開 API。0.13.6 起封面已依賴它；本 branch 把爆炸半徑從「封面破圖」擴大到「所有圖片破圖」——備胎機制（功能 C）正是這條的緩衝。

### 範圍變更留痕：0.13.6 的「剝除」被移除

`buildOrganizeMetadata()` 原本會剝掉 `preview_cover_url` / `preview_sample_images` 再送 `/api/scrape-single`。**本 branch 移除了它**（Codex PR review P2-1 ＋ owner 同日三次裁決）。

0.13.6 立的不變式是「代理網址**不落磁碟**」，剝除只是當時採用的**手段**；手段擋掉的同時也擋掉了整理／改名時的圖片救援。改由 `TestT6PreviewNotPersisted` 直接斷言真不變式：NFO 內容與 `new_folder` 下**所有**文字檔都不含代理 URL，外加 `PRAGMA table_info` 掃 `init_db()` 產出的真 SQLite 全部欄位。

**使用者流程**：使用者在搜尋頁按「產生」→ 被牆時封面與劇照現在也拿得到，不必改按「補齊資料」。
**安全面零增量**：`metadata['cover']` 今天就已經是前端可控且未過濾的值（spec §1.2），preview 欄位只是同一類值多兩個。

## Non-Goals（逐條查證通過）

`core/image_host_policy.py`、`_is_allowed_image_url`、`cover-fallback.js`、`showcase.html` 在 diff 中**零改動**——SSRF 防線既沒加寬也沒收窄、**無新增白名單網域**。失敗記憶只存 host key ＋ 到期時間、不存位元組（不違反「不做快取」）。

---

## Review 與驗證

### Codex PR review（兩輪，已修）
- **P2-1** 整理路徑拿不到備胎 → 見上方「範圍變更留痕」
- **P2-2** 短 connect timeout 波及所有來源 → 改條件式。**無備胎時逐字元維持 `timeout=REQUEST_TIMEOUT`**（AC-5）——短逾時的收益只存在於「失敗了還有第二條路」，成本卻會落在沒有第二條路的自家 9 源身上（從「30 秒後成功」變「5 秒失敗」）
- **P3** 字串守衛易假紅 → 改 `PRAGMA table_info`。實測：真加欄位→紅；只在 docstring 提到→綠（**舊寫法在後者假紅**，不是理論）

### Stage 2 review（Opus high，唯讀）六條，逐條查證後全部處置
| # | 處置 |
|---|---|
| P2-1 翻掉 owner 裁決沒留痕 | 事實半錯（owner 已親口推翻自己），**文件半對** → 三張 card 加更正 banner ＋ 本 PR body 留痕 |
| **P3-1 `_host_key()` 對非數字 port 拋 `ValueError`** | **採納，實際嚴重度高於 P3**（見下） |
| P3-2 spec 的下載呼叫點清單漏 organize 兩處 | 採納，補齊為 6 個並標明「以此為盤點基準」 |
| P3-3 residual 4 措辭不成立 | 採納，**只改措辭不改設計** |
| P3-4 capabilities 食譜還在叫 agent 用原始 `sample_images` | 採納，補 step 1b ＋ preview_* 規則 |
| P3-5 `cover_strategy[1] == meta['cover']` 隱含耦合 | **採納文件、拒絕 runtime guard**（先寫了 assert，撞到一支合法測試；assert 會在唯讀產出跑到一半崩掉，比它要防的「封面錯一張」更糟） |

**P3-1 的使用者流程**：刮到一部片，來源站給的封面網址剛好長成 `http://host:abc/x.jpg` → 按「產生」→ **影片檔已經被搬到新資料夾了、NFO 沒寫**，畫面回「整理失敗」→ 使用者得自己去收拾半成品。改動前這種髒網址只會讓封面抓不到，整理照樣完成——**本 branch 引入的回歸**。實測 `urlparse().port` 拋 `ValueError`、`skip_primary` 那行不在任何 try 內、`shutil.move` 在 `:1219` 而封面下載在 `:1244`。

### Mutation 自驗 11/11（跨四輪）——抓到一條真的洞

`core/source_merger.py:139` 的賦值刪成 `pass`，**測試照樣全綠**。既有測試名叫 `follows_same_winner`，但斷言 `preview_sample_images == []`，而勝出候選的 preview **剛好就是 `[]`**——刪掉賦值會從 `text_source` 沿用下來、也是 `[]`。封面那組有正向鎖，劇照這組只有負向案例。**SA-pre-6 用完全不同的方法（讀測試對稱性）獨立指到同一處。** 已補正向鎖。

另補 `enricher.py:564`（`external_manager != "off"` 的 `_write_cover` wiring）——Jellyfin／Emby／Kodi 使用者走的那條路先前無人驗過。

### 契約真理表 `download_image()`

| # | url | fallback | host 近期失敗 | 行為 | 測試 |
|---|---|---|---|---|---|
| 1 | 空 | 任意 | — | 直接 False，不碰 fallback | `..._empty_url_ignores_fallback` |
| 2 | 有 | 無 | — | 原址 1 次，`timeout=30`（**非** tuple） | `..._no_fallback_keeps_long_connect_timeout` |
| 3 | 有 | 無 | — | 原址失敗 → 直接 False | `..._no_fallback_connect_timeout_returns_false` |
| 4 | 有 | 有 | 否 | 原址 `(5,30)` → 成功則不呼叫 fallback | `..._connect_timeout_is_short` / `..._primary_success_skips_fallback` |
| 5 | 有 | 有 | 否 | 原址失敗 → fallback（`timeout=30`） | `..._fallback_on_connect_timeout` |
| 6 | 有 | 有 | **是** | 跳過原址，直接 fallback | `..._failed_host_skips_primary_on_subsequent` |
| 7 | 髒 port | 有 | — | `_host_key`→None，照常兩次、**不得拋例外** | `..._malformed_port_does_not_raise` |

「什麼才算失敗」：`ConnectionError`（含 `ConnectTimeout`／`SSLError`）✅；`ReadTimeout`（**不是** ConnectionError 子類）❌；HTTP 非 200 ❌；200 但 ≤1000 bytes ❌；fallback 那次的 connect 失敗 ✅。**七列 ＋ 五列全部有具名測試，無空格。**

---

## 閘

| 閘 | 結果 |
|---|---|
| pytest（排除 smoke/e2e） | **6991 → 7048 passed / 1 skipped** |
| npm test | **1187 → 1189**（+3 −1，一支剝除測試被正向測試取代） |
| `npm run lint` | EXIT 0 |
| `ruff check .` / `lint-imports` / `py_function_size_lint` | 綠 / 1 kept 0 broken / PASS |
| 來源金絲雀 | **12 源全綠**（影片 8 ＋ 女優 4，無 skip 無 fail） |
| 敏感掃描 ＋ 打包完整性 | CLEAN |
| CI parity（749 追蹤檔的乾淨樹） | 三閘全綠 |
| /simplify | **skip**（針對性 bugfix ＋ 守衛 patch，已過 Codex ×2 ＋ Stage 2） |

**守衛總量三桶棘輪**：12,121 → **12,147**（+26，全在 `static_guard_lint.mjs`）。三條 anchored `required-string` rule 取代原本一條 `count: 3`——單一 count 是**下限**且不剝註解，沙盒實證「刪一個綁定 ＋ 在註解裡補回指紋」可以維持全綠。

**函式規模豁免基準調高兩條**（`organize_file` 359→366、`_write_movie_assets` 218→235）：都是 T4b 的功能碼長大，理由與 backlog 寫進 `py_function_size_lint.py`。那個「有備胎才傳 `fallback_url`」的 4 行形狀在 7 處重複，抽 helper 可同時消掉兩條增量——但會讓既有測試的 `patch('core.enricher.download_image')` 攔不到（BE-TEST-01 是 patch 消費端綁定），屬「要連測試策略一起改」的動作，**不該在 pre-merge 尾聲順手做**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
