### PR TITLE
fix(sources): remove metatube availability gate from fan-out routing

### DIFF
--- a/core/source_settings.py
+++ b/core/source_settings.py
@@ -23,15 +23,19 @@ def get_enabled_source_ids(
 ) -> list[str]:
     """回傳 Runtime Auto Pool 的來源 id 清單（依 order 升冪）。
 
-    Runtime Auto Pool 過濾公式（design §2.2）：
+    Runtime Auto Pool 過濾公式（design §2.2，metatube gate 已移除）：
         enabled is True AND manual_only is not True
-        AND (type != 'metatube' OR available)
 
-    - builtin（與所有非 metatube type）**bypass** availability gate（永遠視為 available）。
-    - `availability_map=None`（B1 default）= 不 gate，等同全 available（含 metatube）。
-    - populated map：`type == 'metatube'` 的 source 僅在 `map[id] is True` 時保留；
-      id 不在 map 或值為 False → 排除。
-    - 斷線的 metatube provider 仍占 cap 槽（cap basis），但**不**出現在本回傳結果。
+    - builtin（與所有非 metatube type）bypass availability gate（永遠視為 available）。
+    - **metatube availability gate 已移除**（feature/metatube-no-availability-gate）：
+      metatube server 每次 search 都對所有 provider 並發廣播、且無失敗快取
+      （engine/movie.go searchMovieAll）；本地 availability 過濾在國內網路環境下
+      會因一次臨時超時誤傷可用源並**永久擱置**（mark_failed 無 TTL，需手動
+      「測試」才恢復）。metatube 源每次刮削都應照常試驗——與 server 端
+      「以試驗為準」的設計一致。
+    - `availability_map` 參數**保留**（簽名相容既有呼叫方），但**不再影響**
+      enabled metatube 源是否進入 fan-out；UI 的灰膠囊顯示
+      （metatube_state.availability_map()）仍正常運作。
 
     空 / 缺失 `sources` 段 → 回 `[]`（graceful）。malformed 條目以 `.get()` 防禦。
     """
@@ -49,10 +53,6 @@ def get_enabled_source_ids(
             continue
         if s.get('manual_only') is True:
             continue
-        # availability gate：非 metatype bypass；metatube 需 map 允許。
-        if s.get('type') == 'metatube':
-            if availability_map is not None and availability_map.get(s.get('id'), False) is not True:
-                continue
         included.append(s)
 
     included.sort(key=lambda s: s.get('order', 0))

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -286,7 +286,7 @@
       "mt_connected_status": "✓ 已連線",
       "mt_edit_btn": "編輯",
       "mt_disconnect_btn": "中斷",
-      "mt_connected_tier_hint": "連線後所有 provider 預設停留在下方清單（未進入 Active Row），由你手動加入。連線後會自動測試所有 provider，連不到的會灰化並標示常見原因，可手動「重新測試」。",
+      "mt_connected_tier_hint": "連線後所有 provider 預設停留在下方清單（未進入 Active Row），由你手動加入。連線後會自動測試所有 provider，連不到的會灰化並標示常見原因，可手動「重新測試」。測試狀態不會自動更新，僅供參考——加入 Active Row 後刮削仍會照常試驗所有已啟用的 metatube 源。",
       "mt_provider_list_header": "Provider 清單",
       "mt_provider_list_expand_aria": "展開 Provider 清單",
       "mt_provider_list_collapse_aria": "收合 Provider 清單",

--- a/tests/unit/test_source_settings.py
+++ b/tests/unit/test_source_settings.py
@@ -72,16 +72,24 @@ def test_availability_none_includes_all_enabled_incl_metatube(monkeypatch):
     assert source_settings.get_enabled_source_ids(None) == ['dmm', 'mt1']
 
 
-def test_populated_map_excludes_unavailable_metatube_keeps_builtin(monkeypatch):
+def test_populated_map_keeps_unavailable_metatube_gate_removed(monkeypatch):
+    """availability gate 已移除（feature/metatube-no-availability-gate）：
+    map 標記不可用（或不在 map）的 enabled metatube 源**仍**進入 fan-out。
+
+    理由：metatube server 每次 search 都並發廣播所有 provider 且無失敗快取
+    （engine/movie.go searchMovieAll）；本地 availability 過濾在國內網路環境下
+    會因一次臨時超時誤傷可用源並永久擱置（mark_failed 無 TTL），需手動「測試」
+    才恢復。metatube 源每次刮削照常試驗，與 server 端設計一致。builtin 照舊 bypass。
+    """
     _patch_config(monkeypatch, {
         'sources': [
             {'id': 'dmm', 'type': 'builtin', 'enabled': True, 'order': 0, 'manual_only': False},
             {'id': 'mt1', 'type': 'metatube', 'enabled': True, 'order': 1, 'manual_only': False},
         ]
     })
-    # mt1 absent from map -> excluded; builtin dmm bypasses gate even though absent.
-    assert source_settings.get_enabled_source_ids({'mt1': False}) == ['dmm']
-    assert source_settings.get_enabled_source_ids({}) == ['dmm']
+    # map 標記 False / 空 map → metatube 照常保留；builtin 亦保留。
+    assert source_settings.get_enabled_source_ids({'mt1': False}) == ['dmm', 'mt1']
+    assert source_settings.get_enabled_source_ids({}) == ['dmm', 'mt1']
 
 
 def test_populated_map_keeps_available_metatube(monkeypatch):

--- a/web/templates/_rescrape_modal.html
+++ b/web/templates/_rescrape_modal.html
@@ -83,7 +83,11 @@
                     :aria-disabled="s.available ? 'false' : 'true'"
                     :title="!s.available ? t('showcase.rescrape.offline_tooltip') : ''"
                     :disabled="rescrapeLoadingSource !== null && rescrapeLoadingSource !== s.id"
-                    @click="s.available ? rescrapeWithSource(s.id) : null">
+                    @click="rescrapeWithSource(s.id)">
+              {# 灰化（data-enabled/aria-disabled/title）僅為資訊性展示——可用性探測是
+                 連線/手動測試時的快照（feature/metatube-no-availability-gate：測試狀態
+                 不會自動更新，僅供參考），且 metatube server 每次 search 都並發廣播所有
+                 provider、無失敗快取。不可用的源照樣可選，刮削時照常試驗。 #}
               <span class="pill-spin" x-show="rescrapeLoadingSource === s.id"></span>
               <i class="bi bi-slash-circle slash-icn" x-show="rescrapeLoadingSource !== s.id" aria-hidden="true"></i>
               {# 品牌名（display_name_raw → display_name_key fallback；不走 i18n，CD-62-12） #}


### PR DESCRIPTION
## Problem

OpenAver keeps a **local availability cache** for metatube providers:

- Probed only at connect / manual "test" / startup reconnect (`probe_all`)
- A single probe timeout **or a single scrape failure** calls `mark_failed(source_id)`
- `get_enabled_source_ids(availability_map=...)` then **hard-excludes** "unavailable"
  providers from every fan-out scrape
- The rescrape modal (manual scrape source picker) additionally hard-blocked
  probe-greyed metatube providers: `@click="s.available ? rescrapeWithSource(s.id) : null"`

Under mainland-China network conditions a provider is routinely reachable one
moment and times out the next. The result: a single transient timeout
**permanently shelves an otherwise-usable provider** (`mark_failed` has no TTL)
until the user manually clicks "test" in settings — and even then, the manual
scrape picker refuses to select the greyed source.

The metatube server itself is designed **"probe every time"**: `searchMovieAll`
broadcasts to ALL movie providers concurrently on every search, with **no failure
cache** (`engine/movie.go` in metatube-sdk-go — a provider's failure is recorded
in that one response but never skips it on subsequent searches). The Plex
metatube plugin inherits this by delegating search to the server. OpenAver's
local availability gate is the **only layer that caches failures**, and it
contradicts the server contract.

## Change (4 parts)

**1. Remove the availability gate from fan-out routing** (`core/source_settings.py`):
`get_enabled_source_ids()` no longer gates metatube sources on `availability_map`.
Enabled metatube sources always enter fan-out and are tested on every scrape.
The parameter is kept for signature compatibility; `mark_failed`/`availability_map`
still drive the UI grey-capsule display but never block scraping.

**2. Manual scrape picker (rescrape modal) no longer blocks greyed metatube
sources** (`web/templates/_rescrape_modal.html`): metatube pills now always call
`rescrapeWithSource(s.id)` instead of `s.available ? rescrapeWithSource(s.id) : null`.
Greyed display (`data-enabled` / `aria-disabled` / offline `title` / classes)
is kept **purely informational** — display logic untouched, only the click
interaction is unblocked.

**3. Settings "add metatube provider"** (`promoteMetatube`): verified it already
allows promoting a probe-failed provider (warning toast only, never blocked) —
no logic change needed.

**4. i18n (zh_TW)** (`locales/zh_TW.json`): extend the metatube connection hint
to state the probe status is a **non-auto-updating snapshot for reference only** —
greyed-out providers can still be selected and scraping still tests every enabled
metatube source.

## Tests

- `test_source_settings`: updated `test_populated_map_excludes_unavailable_metatube_keeps_builtin`
  → `test_populated_map_keeps_unavailable_metatube_gate_removed` (asserts both
  map-False and empty-map keep the metatube source). Gate-related suites green
  (`test_source_settings`, `test_scraper_routing`, `test_pipeline_routing`,
  `test_metatube_state`); two pre-existing `TestApiEchoStrip` errors are an
  unrelated starlette/httpx fixture issue.
- `locales/zh_TW.json` JSON validity checked.
- Rescrape modal change is a template-only Alpine expression simplification
  (removes the `available` guard); greyed display bindings unchanged.
