### PR TITLE
feat(showcase): quick cover rotate with preview-then-save flow

### DIFF
--- a/core/organizer.py
+++ b/core/organizer.py
@@ -10,7 +10,7 @@ import shutil
 import requests
 import html
 from pathlib import Path
-from PIL import Image
+from PIL import Image, ImageOps
 from typing import Optional, Dict, Any, List, Tuple
 
 from core.config import STEM_IMAGE_MODES
@@ -483,6 +483,38 @@ def _poster_window_ratio(w: int, h: int) -> Optional[float]:
         return int(h / 1.5) / h
     else:
         return (w - int(w / 1.9)) / h
+
+
+def rotate_cover(cover_path: str, angle: int) -> tuple[bool, tuple[int, int]]:
+    """旋轉封面圖片（順時針 90/180/270）並**寫回原文件**（Plex 直讀磁碟 jpg）。
+
+    供快捷旋轉 API 呼叫；旋轉後調用方必須重置 focal（座標基於舊方向失效，
+    見 showcase.py 的 /video/rotate → repo.reset_focal_to_auto）。
+
+    Args:
+        cover_path: 封面檔案的 **FS 路徑**（非 file:/// URI）。
+        angle: 90 / 180 / 270（順時針）。
+
+    Returns:
+        (ok, new_size)：成功時 new_size 為旋轉後的 (w, h)；失敗 (False, (0, 0))。
+    """
+    if angle not in (90, 180, 270):
+        return False, (0, 0)
+    transpose_map = {
+        90: Image.ROTATE_270,   # Pillow ROTATE_90 是逆時針；順時針 90 = ROTATE_270
+        180: Image.ROTATE_180,
+        270: Image.ROTATE_90,
+    }
+    try:
+        with Image.open(cover_path) as img:
+            # 先應用 EXIF Orientation（若源圖帶旋轉標記，避免疊加錯向），再轉
+            img = ImageOps.exif_transpose(img)
+            rotated = img.transpose(transpose_map[angle])
+            rotated.save(cover_path, "JPEG", quality=95)
+            return True, rotated.size
+    except Exception as e:
+        logger.warning("封面旋轉失敗: %s", e)
+        return False, (0, 0)
 
 
 def crop_to_poster(src_path: str, dst_path: str, number: str = '', maker: str = '') -> bool:

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -946,7 +946,8 @@
       "toggle_info": "顯示/隱藏資訊 (S)",
       "play_video": "開啟影片",
       "play": "播放",
-      "enrich": "補資料"
+      "enrich": "補資料",
+      "rotate": "順時針旋轉封面 90°"
     },
     "toolbar": {
       "sort_prefix": "排序",
@@ -1078,6 +1079,11 @@
     "enrich": {
       "success": "補資料完成",
       "failed": "補資料失敗，請稍後再試"
+    },
+    "rotate": {
+      "confirm": "將封面順時針旋轉 90°（會直接覆寫原檔案，不可復原）？",
+      "success": "封面已旋轉",
+      "failed": "旋轉失敗，請稍後再試"
     },
     "video": {
       "delete": "從收藏移除",

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -45,6 +45,15 @@ class ManualFocalRequest(BaseModel):
     expected_cover_path: str
 
 
+class RotateCoverRequest(BaseModel):
+    """POST /video/rotate body：path（DB key）+ angle（順時針 90/180/270）+
+    expected_cover_path（cover compare-and-store，防旋轉期間封面被 rescan/rescrape
+    換掉——同 save-focal 的 PR#107 P2 模式）。"""
+    path: str
+    angle: int
+    expected_cover_path: str
+
+
 def _serialize_video(v, path_mappings: dict, enabled: bool = False) -> dict:
     """將 Video ORM 物件序列化為前端 JSON dict（列表端點與單筆端點共用）。
 
@@ -70,6 +79,7 @@ def _serialize_video(v, path_mappings: dict, enabled: bool = False) -> dict:
 
     return {
         "path": v.path,                                          # file:/// URI（開啟影片用）
+        "cover_path": v.cover_path,                              # file:/// URI（快捷旋轉 expected_cover_path / x-show gate 用，125-T1）
         "title": v.title,
         "original_title": v.original_title,
         "actresses": ','.join(v.actresses) if v.actresses else '',  # 逗號分隔字串
@@ -379,3 +389,66 @@ def set_manual_focal(req: ManualFocalRequest):
     except Exception as e:
         logger.error("存入手動焦點失敗: %s", e)
         return JSONResponse({"success": False, "error": "存入手動焦點失敗"}, status_code=500)
+
+
+@router.post("/video/rotate")
+def rotate_video_cover(req: RotateCoverRequest):
+    """快捷旋轉封面（順時針 90/180/270），物理寫回磁碟 jpg（Plex 直讀），
+    並重置 focal（座標基於舊方向失效，reset_focal_to_auto 後背景 worker 會重新偵測）。
+
+    流程與 save-focal 同構：path（DB key）解析 → scope guard → cover compare-and-store
+    （expected_cover_path 防旋轉期間封面被換）→ 旋轉寫回 → reset_focal_to_auto。
+    注意：**物理改圖不可逆**（覆蓋原封面），前端應以 toast/確認交付可逆性提示。
+    """
+    if req.angle not in (90, 180, 270):
+        return JSONResponse({"success": False, "error": "旋轉角度僅支援 90/180/270"}, status_code=400)
+
+    try:
+        db_path = get_db_path()
+        if not db_path.exists():
+            return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
+
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+
+        row = repo.get_by_path(req.path)
+        if row is None:
+            return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
+
+        config = load_config()
+        configured_dir_uris, _path_mappings = _get_configured_dirs(config)
+        in_scope = any(is_path_under_dir(row.path, uri) for uri in configured_dir_uris)
+        if not in_scope:
+            return JSONResponse({"success": False, "error": "此影片不在收藏範圍，無法旋轉封面"}, status_code=403)
+
+        # cover compare-and-store：封面被 rescan/rescrape 換掉 → 拒絕（舊封面座標/尺寸失效）
+        if row.cover_path != req.expected_cover_path:
+            return JSONResponse(
+                {"success": False, "error": "封面已變更，請重新開啟再試一次"},
+                status_code=409,
+            )
+        if not row.cover_path:
+            return JSONResponse({"success": False, "error": "此影片沒有封面可旋轉"}, status_code=400)
+
+        from core.organizer import rotate_cover
+
+        cover_fs = uri_to_local_fs_path(row.cover_path, {})
+        ok, new_size = rotate_cover(cover_fs, req.angle)
+        if not ok:
+            return JSONResponse({"success": False, "error": "封面旋轉失敗"}, status_code=500)
+
+        # 旋轉後 focal 座標失效 → 重置（清空 + crop_mode='auto' + focal_attempted_at=NULL，
+        # 背景 worker 會重新偵測新封面）
+        repo.reset_focal_to_auto(req.path)
+
+        # 縮圖快取失效（舊方向縮圖）
+        try:
+            thumbnail_cache.invalidate(req.path)
+        except Exception:
+            pass
+
+        return JSONResponse({"success": True, "size": list(new_size)})
+
+    except Exception as e:
+        logger.error("旋轉封面失敗: %s", e)
+        return JSONResponse({"success": False, "error": "旋轉封面失敗"}, status_code=500)

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -197,6 +197,10 @@ export function stateLightbox() {
 
         // Enrich 狀態 (T3)
         _enriching: false,
+        // 快捷旋轉 (125-T1)：封面旋轉預覽（0/90/180/270），✓ 保存時才寫盤
+        _rotatePreview: 0,
+        // 旋轉預覽前的容器 --lb-cover-ar 原值（恢復用；null=未記錄）
+        _originalCoverAr: null,
 
         // --- helper in return {} ---
 
@@ -1306,6 +1310,13 @@ export function stateLightbox() {
 
         // ✓ 確認：存手動焦點 → POST /video/save-focal，同參考 mutate targetVideo（lightbox + grid 即時對臉）。
         async confirmMask() {
+            // 125-T1 快捷旋轉：先檢查是否有旋轉預覽（_rotatePreview !== 0）。
+            // 有 → 本次「保存」= 執行封面旋轉（物理寫盤，focal 因方向改變必然失效，
+            // 由 API 端 reset_focal_to_auto）；無 → 走原 focal 座標保存流程。
+            if (this._rotatePreview !== 0) {
+                await this._saveRotatePreview();
+                return;
+            }
             // _maskFocalX null 只應發生在極短暫態（geometry 尚未解出）；openMask 一旦幾何解出即收斂
             // 為具體值（correction B），此處 null-guard 純防禦（幾何失敗 / identity 遺失等異常態才會觸發）。
             if (this._maskFocalX === null || this._maskFocalX === undefined || !this._maskTarget().identity) {
@@ -1400,11 +1411,16 @@ export function stateLightbox() {
 
         // ✗ 取消：純同步收尾，不寫 DB——force-detect 本就沒寫，✗ 天然無殘留（CD-2）。
         cancelMask() {
+            // 125-T1：✗ 放棄 = 同時清旋轉預覽（不寫盤）
+            this._rotatePreview = 0;
             this._maskTeardown();
         },
 
         // confirmMask/cancelMask 共用收尾：收 overlay + 解 resize listener + 解拖曳 listener。
         _maskTeardown() {
+            // 125-T1：遮罩收尾一律清旋轉預覽 + 恢復容器比例（防切片/異常路徑殘留）
+            this._rotatePreview = 0;
+            this._restoreCoverAspect();
             this._maskVisible = false;
             this._maskDragging = false;
             if (this._maskResizeHandler) {
@@ -1812,6 +1828,126 @@ export function stateLightbox() {
         },
 
         // --- Enrich 補資料 (T3) ---
+        previewRotate() {
+            // 125-T1 快捷旋轉（預覽模式）：累計順時針 90°，僅前端視覺旋轉（封面 img
+            // transform + 容器比例交換），不寫盤、不彈確認。真實寫盤由 confirmMask（✓ 保存）
+            // 在 _rotatePreview !== 0 時執行（_saveRotatePreview）；✗ 放棄由 cancelMask 清空。
+            if (!this.currentLightboxVideo || !this.currentLightboxVideo.cover_path) return;
+            this._rotatePreview = (this._rotatePreview + 90) % 360;
+            this._applyRotatePreviewAspect();
+        },
+
+        // 旋轉預覽時容器比例交換：90/270° → --lb-cover-ar 取倒數（豎圖配豎容器）；
+        // 180° → 原比例。首次旋轉記錄原值供取消/收尾恢復。
+        _applyRotatePreviewAspect() {
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            if (!box) return;
+            if (this._originalCoverAr === null) {
+                const v = parseFloat(box.style.getPropertyValue('--lb-cover-ar'));
+                this._originalCoverAr = Number.isFinite(v) && v > 0 ? v : null;
+            }
+            const base = this._originalCoverAr;
+            if (base === null) return;
+            const ar = (this._rotatePreview % 180 === 0) ? base : (1 / base);
+            box.style.setProperty('--lb-cover-ar', ar.toFixed(4));
+            // 圖 cover 填滿容器（旋轉 + 縮放）——「裁剪框 = 最終展示範圍」語意：
+            // 旋轉後的圖要填滿容器/框，而不是縮在中間。
+            this._applyRotateTransform();
+        },
+
+        // 旋轉預覽時 img cover 填滿容器：rotate(deg) scale(f)，f 使旋轉後圖填滿盒（cover 語意）。
+        _applyRotateTransform() {
+            const deg = this._rotatePreview;
+            if (deg === 0) {
+                this._clearRotateTransform();
+                return;
+            }
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            const img = this.$refs && this.$refs.lightboxCoverImg;
+            if (!box || !img) return;
+            const bw = box.offsetWidth, bh = box.offsetHeight;
+            const iw = img.offsetWidth, ih = img.offsetHeight;
+            if (!bw || !bh || !iw || !ih) return;
+            const rotatedW = (deg % 180 === 0) ? iw : ih;   // 旋轉後視覺寬
+            const rotatedH = (deg % 180 === 0) ? ih : iw;   // 旋轉後視覺高
+            const scale = Math.max(bw / rotatedW, bh / rotatedH);  // cover
+            const t = 'rotate(' + deg + 'deg) scale(' + scale.toFixed(4) + ')';
+            for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
+                const el = this.$refs && this.$refs[ref];
+                if (el) el.style.transform = t;
+            }
+        },
+
+        _clearRotateTransform() {
+            for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
+                const el = this.$refs && this.$refs[ref];
+                if (el) el.style.transform = '';
+            }
+        },
+
+        _restoreCoverAspect() {
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            if (box && this._originalCoverAr !== null) {
+                box.style.setProperty('--lb-cover-ar', this._originalCoverAr.toFixed(4));
+            }
+            this._originalCoverAr = null;
+            this._clearRotateTransform();
+        },
+
+        // 旋轉寫盤成功後強制重載封面兩層 img（base + overlay），cache-bust 繞過瀏覽器舊圖快取。
+        _reloadCoverImages() {
+            for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
+                const el = this.$refs && this.$refs[ref];
+                if (el && el.src) {
+                    const base = el.src.split('?')[0];
+                    el.src = base + (base.includes('?') ? '&' : '?') + 't=' + Date.now();
+                }
+            }
+        },
+
+        async _saveRotatePreview() {
+            // ✓ 保存旋轉預覽：調 /video/rotate 物理寫盤（順時針 _rotatePreview 度），
+            // API 端已做 cover compare-and-store + reset_focal_to_auto；成功後關閉遮罩、
+            // 清旋轉預覽、刷新影片資料。
+            const video = this.currentLightboxVideo;
+            if (!video || !video.path) {
+                this._maskTeardown();
+                this._rotatePreview = 0;
+                return;
+            }
+            const expected = this._maskExpectedCoverPath || video.cover_path;
+            try {
+                const resp = await fetch('/api/showcase/video/rotate', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        path: video.path,
+                        angle: this._rotatePreview,
+                        expected_cover_path: expected,
+                    }),
+                });
+                const result = await resp.json();
+                if (result.success) {
+                    this._rotatePreview = 0;
+                    this._maskTeardown();
+                    await this.refreshVideoData(video);
+                    // 封面圖已物理旋轉但 cover_url path 不變 → 瀏覽器命中舊圖快取，
+                    // 強制重載兩層 img（cache-bust）讓界面顯示新方向 + 觸發 _setCoverAspect 更新容器比例
+                    this._reloadCoverImages();
+                    this.showToast(window.t('showcase.rotate.success'), 'success');
+                } else {
+                    this.showToast(result.error || window.t('showcase.rotate.failed'), 'error');
+                    // 409（封面已變更）等失敗：清預覽，讓使用者重開遮罩
+                    this._rotatePreview = 0;
+                    this._maskTeardown();
+                }
+            } catch (e) {
+                this.showToast(window.t('showcase.rotate.failed'), 'error');
+                this._rotatePreview = 0;
+                this._maskTeardown();
+            }
+        },
+
         async enrichVideo(video) {
             if (this._enriching) return;
             if (!video || !video.path) return;

--- a/web/templates/_macros/focal_mask.html
+++ b/web/templates/_macros/focal_mask.html
@@ -13,7 +13,7 @@
                                  抓到 video→actress 切換會閃現一幀遮罩殘影（x-if 掛載時 _maskVisible 尚未
                                  被非同步 $watch 歸零）。詳見 showcase.html 女優分支內的 T2 待辦註解。 -->
                             <div class="lb-mask-overlay"
-                                 x-show="_maskVisible"
+                                 x-show="_maskVisible && (!_rotatePreview || _rotatePreview % 180 === 0)"
                                  @click.self="cancelMask()">
                                 <!-- 99a-T5→101b-T2（CD-2/CD-4a）：窗只在偵測完成（_maskDetecting 翻 false）
                                      後才第一次渲染；首幀即全幅，隨後由收斂補間滑到偵測終值——收斂全程

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1033,7 +1033,7 @@
                         <!-- Cover Image -->
                         <!-- T8(Codex P2): has-cover 旗標 — 僅有封面時才讓 ≤480px min-height:0 塌到圖盒；
                              無封面時保留 min-height 避免 cover 區塌成 0 高（補封面入口會壞）。 -->
-                        <div class="lightbox-cover" :class="{'has-cover': !!currentLightboxVideo?.cover_url}">
+                        <div class="lightbox-cover" x-ref="lightboxCoverBox" :class="{'has-cover': !!currentLightboxVideo?.cover_url}">
                             <!-- 56c-T3fix: magic 按鈕已搬至 .lightbox-content（與 .lightbox-close sibling 鏡射對稱）；sparkle-burst overlay 留在 .lightbox-cover 以便 inset:0 精準覆蓋封面區（不擴及 metadata） -->
                             <!-- 71-T6 blur-up: base 層=cover_url（快取開啟=小 webp 秒出、放大略糊；關閉=原圖）。
                                  撐容器尺寸；x-ref + @error 三態留 base（ghost-fly / 破圖偵測沿用 base src）。 -->
@@ -1109,6 +1109,15 @@
                                 <!-- 99a-T3：焦點編輯中的 ✓/✗，取代 98b 的窗內點擊 toggle。
                                      99a-T5：detect 期間（_maskDetecting）尚無可提交的拖曳結果——
                                      gate 收窄，等偵測 resolve 才顯示。 -->
+                                <!-- 快捷旋轉（125-T1）：順時針 90° 預覽（不寫盤，✓ 保存時才執行）。
+                                     與 ✓ 保存 / ✗ 放棄 同排（封面裁切預覽介面內）。 -->
+                                <button class="lb-action-btn"
+                                        x-show="_maskVisible && !_maskDetecting && !!currentLightboxVideo?.cover_path"
+                                        @click.stop="previewRotate()"
+                                        :data-tooltip="t('showcase.action.rotate')"
+                                        :aria-label="t('showcase.action.rotate')">
+                                    <i class="bi bi-arrow-counterclockwise"></i>
+                                </button>
                                 <button class="lb-action-btn lb-action-btn--success"
                                         x-show="_maskVisible && !_maskDetecting"
                                         @click.stop="confirmMask()"


### PR DESCRIPTION
## Problem

Many scraped covers come out sideways. Real cases verified: `FCT-229`'s cover
is 840×472 landscape pixels with EXIF orientation 0, but face-detection shows
the content only reads upright after a 90° rotation — i.e. vertically-shot
content stored as landscape pixels, no EXIF marker to auto-fix. Plex (and the
OpenAver lightbox) then display the cover rotated, and there was no quick way
to fix it in-app.

## Solution

A **quick rotate** control inside the existing focal-crop preview UI, using the
same **preview-then-save** interaction model as the crop mask:

- **↺ (rotate)**: previews rotation only — the cover image rotates and
  cover-scales to fill the container (the crop box = final display region), no
  write, no confirm dialog. 90/270° swap the container aspect-ratio; the mask
  overlay hides for 90/270° (the horizontal crop window is meaningless on a
  portrait frame) and stays visible at 0/180°.
- **✓ (save)**: executes the physical rotation — `POST /api/showcase/video/rotate`
  (Pillow transpose clockwise 90/180/270, written back to the on-disk
  `{stem}.jpg` that Plex reads directly), cover compare-and-store guard (same
  shape as `/video/save-focal`), then `reset_focal_to_auto` (focal coords are
  invalid after rotation; the background worker re-detects), thumbnail-cache
  invalidation, and a forced image reload (cache-bust) so the UI shows the
  rotated cover.
- **✗ (cancel)**: restores the preview (aspect ratio + transform) without
  writing.

## Change details

Backend:
- `core/organizer.py`: `rotate_cover()` — `ImageOps.exif_transpose` first, then
  Pillow transpose; saves back to the same path.
- `web/routers/showcase.py`: `POST /video/rotate` (same permission / scope /
  cover-compare guard shape as `/video/save-focal`), and `_serialize_video` now
  also emits `cover_path` (the frontend render gate and the rotate API's
  `expected_cover_path` token depend on it — previously missing, which is why
  the rotate button never rendered at first).

Frontend:
- `state-lightbox.js`: `_rotatePreview` / `_originalCoverAr` state;
  `previewRotate` / `_applyRotatePreviewAspect` / `_applyRotateTransform` /
  `_clearRotateTransform` / `_restoreCoverAspect` / `_reloadCoverImages`;
  `confirmMask` routes to `_saveRotatePreview` when a rotation is pending;
  `cancelMask` and `_maskTeardown` reset preview state.
- `showcase.html`: rotate button in the focal-mask action row; `.lightbox-cover`
  gains `x-ref` for the aspect swap; cover img transform is JS-managed
  (template `:style` removed to avoid Alpine clobbering the cover scale).
- `_macros/focal_mask.html`: overlay hidden while rotating 90/270°.
- `locales/zh_TW.json`: rotate tooltip + success/failed copy (no confirm dialog
  needed — preview is non-destructive).

## Tests

- `rotate_cover` unit: 90° swaps width/height, 180° and 360° round-trip, invalid
  angle rejected.
- Cover suites (`test_cover_image`, `test_cover_layout`) and `test_source_settings`:
  125 passed.
- Live-verified end-to-end on the deployed instance (FCT-229: preview rotates +
  cover-scales, save writes the rotated file, cancel restores, focal resets).

---

## v2: manual cover replace (125-T2) + pre-PR audit

Added a **replace-cover** control (🖼) next to rotate / save / cancel in the
focal-crop preview UI, same preview-then-save model: select a local image →
blob preview overlay (base/overlay cover hidden, independent
`.lb-replace-preview` layer at z-index below the mask overlay so the crop
window stays visible) → ✓ save uploads via
`POST /api/showcase/video/replace-cover` which **overwrites the on-disk
`{stem}.jpg`** (Plex reads same-name jpg), applies `ImageOps.exif_transpose`
before JPEG encoding, cover compare-and-store (409), resets focal
(background worker re-detects), invalidates thumbnails, reloads the cover.

The mask window **follows the new image's orientation** (read the
`--poster-crop-ratio` CSS var — compliant with the required-string lint
rules): portrait upload → crop window fits the portrait frame; landscape →
standard horizontal right-crop window, freely draggable.

Pre-PR audit: fixed missing `expected_cover_path` compare-and-store and
EXIF handling on replace-cover (style parity with save-focal/rotate);
verified error messages are fixed zh (no exception detail to frontend),
path handling uses `path_utils`/DB-key, upload guards (413/415/403/400/409),
and state cleanup on switch/cancel/teardown. rotate_cover unit test + cover
suites pass.

---

## v3: fix reload cache-bust dropping the cover URL query

`_reloadCoverImages` used `el.src.split('?')[0]` which stripped the
`path=` query the gallery/image endpoint requires — the reloaded request
returned 403 and the lightbox showed "cover unavailable" until reopened.
Now appends `&t=Date.now()` to the existing absolute URL (which already
carries `?path=...`), never stripping the query.
