### PR TITLE
feat(showcase): cover rotate + manual replace + no-cover upload

### DIFF
--- a/core/database/video.py
+++ b/core/database/video.py
@@ -1452,6 +1452,24 @@ class VideoRepository:
                 .replace('%', '\\%')
                 .replace('_', '\\_'))
 
+    def update_cover_path(self, path: str, cover_path: str) -> bool:
+        """只更新 cover_path 欄位（無封面影片手動上傳封面後寫入 DB，CD-125 補充）。
+
+        同 update_sample_images 單欄位 UPDATE 模式；focal 重置由呼叫端
+        （replace-cover endpoint）另行呼叫 reset_focal_to_auto，本方法只寫 cover_path。
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "UPDATE videos SET cover_path = ?, updated_at = CURRENT_TIMESTAMP WHERE path = ?",
+                (cover_path, path),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
     def count_videos_in_folder(self, folder_uri_prefix: str) -> int:
         """計算「直接在此目錄下」的影片數（不含子目錄）。
         folder_uri_prefix 必須以 '/' 結尾，例如 'file:///A/'。

--- a/core/organizer.py
+++ b/core/organizer.py
@@ -10,7 +10,7 @@ import shutil
 import requests
 import html
 from pathlib import Path
-from PIL import Image
+from PIL import Image, ImageOps
 from typing import Optional, Dict, Any, List, Tuple
 
 from core.config import STEM_IMAGE_MODES
@@ -483,6 +483,38 @@ def _poster_window_ratio(w: int, h: int) -> Optional[float]:
         return int(h / 1.5) / h
     else:
         return (w - int(w / 1.9)) / h
+
+
+def rotate_cover(cover_path: str, angle: int) -> tuple[bool, tuple[int, int]]:
+    """旋轉封面圖片（順時針 90/180/270）並**寫回原文件**（Plex 直讀磁碟 jpg）。
+
+    供快捷旋轉 API 呼叫；旋轉後調用方必須重置 focal（座標基於舊方向失效，
+    見 showcase.py 的 /video/rotate → repo.reset_focal_to_auto）。
+
+    Args:
+        cover_path: 封面檔案的 **FS 路徑**（非 file:/// URI）。
+        angle: 90 / 180 / 270（順時針）。
+
+    Returns:
+        (ok, new_size)：成功時 new_size 為旋轉後的 (w, h)；失敗 (False, (0, 0))。
+    """
+    if angle not in (90, 180, 270):
+        return False, (0, 0)
+    transpose_map = {
+        90: Image.ROTATE_270,   # Pillow ROTATE_90 是逆時針；順時針 90 = ROTATE_270
+        180: Image.ROTATE_180,
+        270: Image.ROTATE_90,
+    }
+    try:
+        with Image.open(cover_path) as img:
+            # 先應用 EXIF Orientation（若源圖帶旋轉標記，避免疊加錯向），再轉
+            img = ImageOps.exif_transpose(img)
+            rotated = img.transpose(transpose_map[angle])
+            rotated.save(cover_path, "JPEG", quality=95)
+            return True, rotated.size
+    except Exception as e:
+        logger.warning("封面旋轉失敗: %s", e)
+        return False, (0, 0)
 
 
 def crop_to_poster(src_path: str, dst_path: str, number: str = '', maker: str = '') -> bool:

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -946,7 +946,8 @@
       "toggle_info": "顯示/隱藏資訊 (S)",
       "play_video": "開啟影片",
       "play": "播放",
-      "enrich": "補資料"
+      "enrich": "補資料",
+      "rotate": "順時針旋轉封面 90°"
     },
     "toolbar": {
       "sort_prefix": "排序",
@@ -1078,6 +1079,11 @@
     "enrich": {
       "success": "補資料完成",
       "failed": "補資料失敗，請稍後再試"
+    },
+    "rotate": {
+      "confirm": "將封面順時針旋轉 90°（會直接覆寫原檔案，不可復原）？",
+      "success": "封面已旋轉",
+      "failed": "旋轉失敗，請稍後再試"
     },
     "video": {
       "delete": "從收藏移除",

--- a/locales/zh_TW.json
+++ b/locales/zh_TW.json
@@ -947,7 +947,8 @@
       "play_video": "開啟影片",
       "play": "播放",
       "enrich": "補資料",
-      "rotate": "順時針旋轉封面 90°"
+      "rotate": "順時針旋轉封面 90°",
+      "replace_cover": "替換封面（選擇本地圖片）"
     },
     "toolbar": {
       "sort_prefix": "排序",
@@ -1161,6 +1162,10 @@
       "success": "劇照補抓完成",
       "fetch_failed": "補抓劇照失敗，請稍後再試",
       "multi_video_error": "此資料夾有其他影片，補抓劇照會污染其他片，請先將影片搬到獨立資料夾再試"
+    },
+    "cover_replace": {
+      "success": "封面已替換",
+      "failed": "替換封面失敗，請稍後再試"
     }
   },
   "help": {

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -8,6 +8,7 @@ Showcase API 路由 - 影片展示資料端點
 
 import io
 import os
+from pathlib import Path
 from urllib.parse import quote
 
 from fastapi import APIRouter, File, Form, Query, UploadFile
@@ -464,14 +465,14 @@ _UPLOAD_MAX_PIXELS = 60_000_000
 @router.post("/video/replace-cover")
 def replace_video_cover(
     path: str = Form(...),
+    expected_cover_path: str = Form(''),
     file: UploadFile = File(...),
 ):
     """手动替换影片封面（multipart：path（DB key）+ file 图片）。
 
     写入目标 = 现有 cover_path 指向的磁盘文件（{stem}.jpg，覆盖原封面——
     Plex 直读同名 jpg）；图片统一转 JPEG 写盘。成功后重置 focal（新图坐标
-    失效，背景 worker 重测）+ 缩略图失效。文件系统级覆盖不可逆，前端以
-    预览-保存交互交付（与快捷旋转一致）。
+    失效，背景 worker 重测）+ 缩略图失效。
     """
     try:
         data = file.file.read()
@@ -500,26 +501,39 @@ def replace_video_cover(
             return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
 
         config = load_config()
-        configured_dir_uris, _path_mappings = _get_configured_dirs(config)
+        configured_dir_uris, path_mappings = _get_configured_dirs(config)
         in_scope = any(is_path_under_dir(row.path, uri) for uri in configured_dir_uris)
         if not in_scope:
             return JSONResponse({"success": False, "error": "此影片不在收藏範圍，無法替換封面"}, status_code=403)
-        if not row.cover_path:
-            return JSONResponse({"success": False, "error": "此影片沒有封面可替換"}, status_code=400)
-        # cover compare-and-store（同 save-focal/rotate）：封面被 rescan/rescrape 換掉 → 拒絕
-        if row.cover_path != expected_cover_path:
+
+        # cover compare-and-store（同 save-focal/rotate）：封面被 rescan/rescrape 換掉 → 拒絕。
+        # 空 cover_path（無封面影片）時 expected 亦為空，跳過比對（見下方「無封面→創建」分支）。
+        if row.cover_path and row.cover_path != expected_cover_path:
             return JSONResponse(
                 {"success": False, "error": "封面已變更，請重新開啟再試一次"},
                 status_code=409,
             )
 
-        cover_fs = uri_to_local_fs_path(row.cover_path, {})
-        # 重新解码（verify 后 image 对象已不可用）+ 先应用 EXIF Orientation（手機/相機豎拍圖）
+        if row.cover_path:
+            cover_fs = uri_to_local_fs_path(row.cover_path, path_mappings)
+        else:
+            # 無封面 → 以影片路徑推導封面目標（resolve_cover_target：同名 .jpg 優先，
+            # 與刮削產出同一規則，Plex 直讀同名 jpg）。寫盤後更新 DB cover_path。
+            from core.cover_layout import resolve_cover_target
+            video_fs = uri_to_local_fs_path(row.path, path_mappings)
+            if not video_fs or not os.path.isfile(video_fs):
+                return JSONResponse({"success": False, "error": "找不到影片檔案"}, status_code=404)
+            cover_fs = resolve_cover_target(str(Path(video_fs).with_suffix('')), 'off')
+            cover_dir = os.path.dirname(cover_fs)
+            if cover_dir and not os.path.isdir(cover_dir):
+                return JSONResponse({"success": False, "error": "封面目錄不存在"}, status_code=400)
         with Image.open(io.BytesIO(data)) as src:
             rgb = ImageOps.exif_transpose(src).convert("RGB")
             rgb.save(cover_fs, "JPEG", quality=95)
 
-        # 新图 → focal 坐标失效，重置并让背景 worker 重测；缩略图失效
+        if not row.cover_path:
+            # 建立新封面：以 file:/// URI 寫入 DB cover_path（與刮削產出同一形狀）
+            repo.update_cover_path(path, coerce_to_file_uri(cover_fs, path_mappings))
         repo.reset_focal_to_auto(path)
         try:
             thumbnail_cache.invalidate(path)

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -45,6 +45,15 @@ class ManualFocalRequest(BaseModel):
     expected_cover_path: str
 
 
+class RotateCoverRequest(BaseModel):
+    """POST /video/rotate body：path（DB key）+ angle（順時針 90/180/270）+
+    expected_cover_path（cover compare-and-store，防旋轉期間封面被 rescan/rescrape
+    換掉——同 save-focal 的 PR#107 P2 模式）。"""
+    path: str
+    angle: int
+    expected_cover_path: str
+
+
 def _serialize_video(v, path_mappings: dict, enabled: bool = False) -> dict:
     """將 Video ORM 物件序列化為前端 JSON dict（列表端點與單筆端點共用）。
 
@@ -70,6 +79,7 @@ def _serialize_video(v, path_mappings: dict, enabled: bool = False) -> dict:
 
     return {
         "path": v.path,                                          # file:/// URI（開啟影片用）
+        "cover_path": v.cover_path,                              # file:/// URI（快捷旋轉 expected_cover_path / x-show gate 用，125-T1）
         "title": v.title,
         "original_title": v.original_title,
         "actresses": ','.join(v.actresses) if v.actresses else '',  # 逗號分隔字串
@@ -379,3 +389,66 @@ def set_manual_focal(req: ManualFocalRequest):
     except Exception as e:
         logger.error("存入手動焦點失敗: %s", e)
         return JSONResponse({"success": False, "error": "存入手動焦點失敗"}, status_code=500)
+
+
+@router.post("/video/rotate")
+def rotate_video_cover(req: RotateCoverRequest):
+    """快捷旋轉封面（順時針 90/180/270），物理寫回磁碟 jpg（Plex 直讀），
+    並重置 focal（座標基於舊方向失效，reset_focal_to_auto 後背景 worker 會重新偵測）。
+
+    流程與 save-focal 同構：path（DB key）解析 → scope guard → cover compare-and-store
+    （expected_cover_path 防旋轉期間封面被換）→ 旋轉寫回 → reset_focal_to_auto。
+    注意：**物理改圖不可逆**（覆蓋原封面），前端應以 toast/確認交付可逆性提示。
+    """
+    if req.angle not in (90, 180, 270):
+        return JSONResponse({"success": False, "error": "旋轉角度僅支援 90/180/270"}, status_code=400)
+
+    try:
+        db_path = get_db_path()
+        if not db_path.exists():
+            return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
+
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+
+        row = repo.get_by_path(req.path)
+        if row is None:
+            return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
+
+        config = load_config()
+        configured_dir_uris, _path_mappings = _get_configured_dirs(config)
+        in_scope = any(is_path_under_dir(row.path, uri) for uri in configured_dir_uris)
+        if not in_scope:
+            return JSONResponse({"success": False, "error": "此影片不在收藏範圍，無法旋轉封面"}, status_code=403)
+
+        # cover compare-and-store：封面被 rescan/rescrape 換掉 → 拒絕（舊封面座標/尺寸失效）
+        if row.cover_path != req.expected_cover_path:
+            return JSONResponse(
+                {"success": False, "error": "封面已變更，請重新開啟再試一次"},
+                status_code=409,
+            )
+        if not row.cover_path:
+            return JSONResponse({"success": False, "error": "此影片沒有封面可旋轉"}, status_code=400)
+
+        from core.organizer import rotate_cover
+
+        cover_fs = uri_to_local_fs_path(row.cover_path, {})
+        ok, new_size = rotate_cover(cover_fs, req.angle)
+        if not ok:
+            return JSONResponse({"success": False, "error": "封面旋轉失敗"}, status_code=500)
+
+        # 旋轉後 focal 座標失效 → 重置（清空 + crop_mode='auto' + focal_attempted_at=NULL，
+        # 背景 worker 會重新偵測新封面）
+        repo.reset_focal_to_auto(req.path)
+
+        # 縮圖快取失效（舊方向縮圖）
+        try:
+            thumbnail_cache.invalidate(req.path)
+        except Exception:
+            pass
+
+        return JSONResponse({"success": True, "size": list(new_size)})
+
+    except Exception as e:
+        logger.error("旋轉封面失敗: %s", e)
+        return JSONResponse({"success": False, "error": "旋轉封面失敗"}, status_code=500)

--- a/web/routers/showcase.py
+++ b/web/routers/showcase.py
@@ -6,12 +6,14 @@ Showcase API 路由 - 影片展示資料端點
 - GET /api/showcase/video?path=   — 取得單筆影片資料（供 T3 enrich 後刷新卡片）
 """
 
+import io
 import os
 from urllib.parse import quote
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, File, Form, Query, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from PIL import Image
 
 from core.database import VideoRepository, get_db_path, init_db
 from core.path_utils import (
@@ -452,3 +454,79 @@ def rotate_video_cover(req: RotateCoverRequest):
     except Exception as e:
         logger.error("旋轉封面失敗: %s", e)
         return JSONResponse({"success": False, "error": "旋轉封面失敗"}, status_code=500)
+
+
+# ---- 封面手动替换（125-T2：仿女优换照，裁切预览界面内，保存覆盖原封面）----
+_UPLOAD_MAX_BYTES = 15 * 1024 * 1024
+_UPLOAD_MAX_PIXELS = 60_000_000
+
+
+@router.post("/video/replace-cover")
+def replace_video_cover(
+    path: str = Form(...),
+    file: UploadFile = File(...),
+):
+    """手动替换影片封面（multipart：path（DB key）+ file 图片）。
+
+    写入目标 = 现有 cover_path 指向的磁盘文件（{stem}.jpg，覆盖原封面——
+    Plex 直读同名 jpg）；图片统一转 JPEG 写盘。成功后重置 focal（新图坐标
+    失效，背景 worker 重测）+ 缩略图失效。文件系统级覆盖不可逆，前端以
+    预览-保存交互交付（与快捷旋转一致）。
+    """
+    try:
+        data = file.file.read()
+    except Exception:
+        return JSONResponse({"success": False, "error": "讀取上傳失敗"}, status_code=400)
+    if len(data) > _UPLOAD_MAX_BYTES:
+        return JSONResponse({"success": False, "error": "圖片太大（上限 15MB）"}, status_code=413)
+    try:
+        img = Image.open(io.BytesIO(data))
+        w, h = img.size
+        if w * h > _UPLOAD_MAX_PIXELS:
+            return JSONResponse({"success": False, "error": "圖片像素過大"}, status_code=413)
+        img.verify()
+    except Exception:
+        return JSONResponse({"success": False, "error": "不支援的圖片格式"}, status_code=415)
+
+    try:
+        db_path = get_db_path()
+        if not db_path.exists():
+            return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
+        init_db(db_path)
+        repo = VideoRepository(db_path)
+
+        row = repo.get_by_path(path)
+        if row is None:
+            return JSONResponse({"success": False, "error": "找不到影片"}, status_code=404)
+
+        config = load_config()
+        configured_dir_uris, _path_mappings = _get_configured_dirs(config)
+        in_scope = any(is_path_under_dir(row.path, uri) for uri in configured_dir_uris)
+        if not in_scope:
+            return JSONResponse({"success": False, "error": "此影片不在收藏範圍，無法替換封面"}, status_code=403)
+        if not row.cover_path:
+            return JSONResponse({"success": False, "error": "此影片沒有封面可替換"}, status_code=400)
+        # cover compare-and-store（同 save-focal/rotate）：封面被 rescan/rescrape 換掉 → 拒絕
+        if row.cover_path != expected_cover_path:
+            return JSONResponse(
+                {"success": False, "error": "封面已變更，請重新開啟再試一次"},
+                status_code=409,
+            )
+
+        cover_fs = uri_to_local_fs_path(row.cover_path, {})
+        # 重新解码（verify 后 image 对象已不可用）+ 先应用 EXIF Orientation（手機/相機豎拍圖）
+        with Image.open(io.BytesIO(data)) as src:
+            rgb = ImageOps.exif_transpose(src).convert("RGB")
+            rgb.save(cover_fs, "JPEG", quality=95)
+
+        # 新图 → focal 坐标失效，重置并让背景 worker 重测；缩略图失效
+        repo.reset_focal_to_auto(path)
+        try:
+            thumbnail_cache.invalidate(path)
+        except Exception:
+            pass
+
+        return JSONResponse({"success": True, "size": [rgb.size[0], rgb.size[1]]})
+    except Exception as e:
+        logger.error("替換封面失敗: %s", e)
+        return JSONResponse({"success": False, "error": "替換封面失敗"}, status_code=500)

--- a/web/static/css/pages/showcase.css
+++ b/web/static/css/pages/showcase.css
@@ -4597,3 +4597,17 @@ body.sidebar-collapsed .showcase-footer {
 @media (max-width: 768px) {
     .lightbox-cover .cover-badges { top: 3.25rem; }
 }
+
+/* 125-T2：封面手动替换预览层（本地 blob 图）——独立于 .lb-full（其 opacity:0 blur-up），
+   始终可见、盖在封面之上。 */
+.lb-replace-preview {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    opacity: 1;
+    z-index: 1;   /* 封面 img 层，遮罩 overlay（z-index:2）之下——否则盖住裁剪框 */
+    pointer-events: none;
+}

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -201,6 +201,9 @@ export function stateLightbox() {
         _rotatePreview: 0,
         // 旋轉預覽前的容器 --lb-cover-ar 原值（恢復用；null=未記錄）
         _originalCoverAr: null,
+        // 封面手动替换（125-T2）：本地预览 URL（blob），保存时才上传覆盖原封面
+        _replacePreviewUrl: null,
+        _replacePreviewProbe: null,
 
         // --- helper in return {} ---
 
@@ -1026,7 +1029,7 @@ export function stateLightbox() {
             }
             return {
                 obj: this.currentLightboxVideo,
-                imgEl: this.$refs.lightboxCoverFull,
+                imgEl: this._replacePreviewUrl ? (this.$refs && this.$refs.replaceCoverPreview) : this.$refs.lightboxCoverFull,
                 loaded: this._lbFullLoaded,
                 identity: this.currentLightboxVideo?.path,
                 ratio: '--poster-crop-ratio',
@@ -1310,6 +1313,11 @@ export function stateLightbox() {
 
         // ✓ 確認：存手動焦點 → POST /video/save-focal，同參考 mutate targetVideo（lightbox + grid 即時對臉）。
         async confirmMask() {
+            // 125-T2 封面手动替换：有本地替换预览 → 本次「保存」= 上传替换封面
+            if (this._replacePreviewUrl) {
+                await this._saveReplacePreview();
+                return;
+            }
             // 125-T1 快捷旋轉：先檢查是否有旋轉預覽（_rotatePreview !== 0）。
             // 有 → 本次「保存」= 執行封面旋轉（物理寫盤，focal 因方向改變必然失效，
             // 由 API 端 reset_focal_to_auto）；無 → 走原 focal 座標保存流程。
@@ -1411,15 +1419,25 @@ export function stateLightbox() {
 
         // ✗ 取消：純同步收尾，不寫 DB——force-detect 本就沒寫，✗ 天然無殘留（CD-2）。
         cancelMask() {
-            // 125-T1：✗ 放棄 = 同時清旋轉預覽（不寫盤）
+            // 125-T1/T2：✗ 放棄 = 同時清旋轉預覽 + 替換預覽（都不寫盤）
             this._rotatePreview = 0;
+            this._clearReplacePreview();
             this._maskTeardown();
+        },
+
+        _clearReplacePreview() {
+            if (this._replacePreviewUrl) {
+                URL.revokeObjectURL(this._replacePreviewUrl);
+                this._replacePreviewUrl = null;
+            }
+            this._replacePreviewProbe = null;
         },
 
         // confirmMask/cancelMask 共用收尾：收 overlay + 解 resize listener + 解拖曳 listener。
         _maskTeardown() {
-            // 125-T1：遮罩收尾一律清旋轉預覽 + 恢復容器比例（防切片/異常路徑殘留）
+            // 125-T1/T2：遮罩收尾一律清旋轉預覽 + 替換預覽 + 恢復容器比例
             this._rotatePreview = 0;
+            this._clearReplacePreview();
             this._restoreCoverAspect();
             this._maskVisible = false;
             this._maskDragging = false;
@@ -1466,6 +1484,10 @@ export function stateLightbox() {
             this._maskSession++;
             this._maskDetecting = false; // 98b P2 fix(二)：invalidate 時清偵測態，防舊 detect 的 spinner 漏進下個 session（Codex）
             this._maskVisible = false;
+            // 125-T1/T2：換片/關燈箱一併清旋轉預覽 + 替換預覽（防殘留蓋在下一片封面上）
+            this._rotatePreview = 0;
+            this._restoreCoverAspect();
+            this._clearReplacePreview();
             this._maskWinStyle = {};     // 98b-T6：清窗幾何避免殘留閃（下次 open 同步重算覆蓋）。
                                           // 99a-T5：恆 object，不可退回 '' string（見宣告處註解）。
             this._maskFocalX = null;     // 99a-T3：清 component-state 焦點，防下一片沿用上一片的拖曳結果
@@ -1902,6 +1924,94 @@ export function stateLightbox() {
                     const base = el.src.split('?')[0];
                     el.src = base + (base.includes('?') ? '&' : '?') + 't=' + Date.now();
                 }
+            }
+        },
+
+        selectReplaceCover() {
+            // 125-T2：打开本地文件选择（裁切预览界面内点「替换」触发）
+            const input = this.$refs && this.$refs.replaceCoverInput;
+            if (input) input.click();
+        },
+
+        onReplaceFileSelected(event) {
+            const file = event.target && event.target.files && event.target.files[0];
+            event.target.value = '';  // 允许重复选同一文件
+            if (!file || !this.currentLightboxVideo) return;
+            if (this._replacePreviewUrl) {
+                URL.revokeObjectURL(this._replacePreviewUrl);
+            }
+            this._replacePreviewUrl = URL.createObjectURL(file);
+            // 125-T2：新图方向自适应——容器比例 = 新图比例，裁剪框基于新图重算
+            //（竖图 → 窗贴合全宽；横图 → 标准横向右裁窗，可左右移动）。
+            this._initMaskGeometryForPreview();
+        },
+
+        // 读新图尺寸 → 容器比例 = 新图比例 → 重算裁剪框几何
+        //（用已加载的 probe 尺寸 + 容器 rect 直接算，不依赖预览层 img 的 naturalWidth 时序）
+        async _initMaskGeometryForPreview() {
+            const url = this._replacePreviewUrl;
+            if (!url) return;
+            const probe = new Image();
+            try {
+                await new Promise((res, rej) => { probe.onload = res; probe.onerror = rej; probe.src = url; });
+            } catch (e) {
+                return;
+            }
+            const nw = probe.naturalWidth, nh = probe.naturalHeight;
+            if (!nw || !nh) return;
+            this._replacePreviewProbe = probe;
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            if (box) box.style.setProperty('--lb-cover-ar', (nw / nh).toFixed(4));
+            // 等容器 reflow 后基于容器 rect 算窗口（竖图 → 窗贴合全宽；横图 → 标准横向窗）
+            requestAnimationFrame(() => this._computePreviewMaskWin());
+        },
+
+        _computePreviewMaskWin() {
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            const probe = this._replacePreviewProbe;
+            if (!box || !probe) return;
+            const rect = box.getBoundingClientRect();
+            if (!rect.width || !rect.height) return;
+            const gR = parseFloat(getComputedStyle(box).getPropertyValue('--poster-crop-ratio'));
+            if (!Number.isFinite(gR) || gR <= 0) return;
+            const winW = Math.min(rect.width, rect.height * gR);
+            this._maskFocalX = (rect.width - winW / 2) / rect.width;
+            this._maskWinStyle = computeMaskWinGeometry(rect.width, rect.height, gR, this._maskFocalX);
+        },
+
+        async _saveReplacePreview() {
+            // ✓ 保存替换封面：FormData 上传 → /video/replace-cover 覆盖原封面（{stem}.jpg）
+            const video = this.currentLightboxVideo;
+            const url = this._replacePreviewUrl;
+            if (!video || !video.path || !url) {
+                this._maskTeardown();
+                return;
+            }
+            try {
+                const blob = await fetch(url).then(r => r.blob());
+                const fd = new FormData();
+                fd.append('path', video.path);
+                fd.append('expected_cover_path', video.cover_path || '');
+                fd.append('file', blob, 'cover.jpg');
+                const resp = await fetch('/api/showcase/video/replace-cover', {
+                    method: 'POST',
+                    body: fd,
+                });
+                const result = await resp.json();
+                if (result.success) {
+                    URL.revokeObjectURL(url);
+                    this._replacePreviewUrl = null;
+                    this._maskTeardown();
+                    await this.refreshVideoData(video);
+                    this._reloadCoverImages();
+                    this.showToast(window.t('showcase.cover_replace.success'), 'success');
+                } else {
+                    this.showToast(result.error || window.t('showcase.cover_replace.failed'), 'error');
+                    this._maskTeardown();
+                }
+            } catch (e) {
+                this.showToast(window.t('showcase.cover_replace.failed'), 'error');
+                this._maskTeardown();
             }
         },
 

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -197,6 +197,10 @@ export function stateLightbox() {
 
         // Enrich 狀態 (T3)
         _enriching: false,
+        // 快捷旋轉 (125-T1)：封面旋轉預覽（0/90/180/270），✓ 保存時才寫盤
+        _rotatePreview: 0,
+        // 旋轉預覽前的容器 --lb-cover-ar 原值（恢復用；null=未記錄）
+        _originalCoverAr: null,
 
         // --- helper in return {} ---
 
@@ -1306,6 +1310,13 @@ export function stateLightbox() {
 
         // ✓ 確認：存手動焦點 → POST /video/save-focal，同參考 mutate targetVideo（lightbox + grid 即時對臉）。
         async confirmMask() {
+            // 125-T1 快捷旋轉：先檢查是否有旋轉預覽（_rotatePreview !== 0）。
+            // 有 → 本次「保存」= 執行封面旋轉（物理寫盤，focal 因方向改變必然失效，
+            // 由 API 端 reset_focal_to_auto）；無 → 走原 focal 座標保存流程。
+            if (this._rotatePreview !== 0) {
+                await this._saveRotatePreview();
+                return;
+            }
             // _maskFocalX null 只應發生在極短暫態（geometry 尚未解出）；openMask 一旦幾何解出即收斂
             // 為具體值（correction B），此處 null-guard 純防禦（幾何失敗 / identity 遺失等異常態才會觸發）。
             if (this._maskFocalX === null || this._maskFocalX === undefined || !this._maskTarget().identity) {
@@ -1400,11 +1411,16 @@ export function stateLightbox() {
 
         // ✗ 取消：純同步收尾，不寫 DB——force-detect 本就沒寫，✗ 天然無殘留（CD-2）。
         cancelMask() {
+            // 125-T1：✗ 放棄 = 同時清旋轉預覽（不寫盤）
+            this._rotatePreview = 0;
             this._maskTeardown();
         },
 
         // confirmMask/cancelMask 共用收尾：收 overlay + 解 resize listener + 解拖曳 listener。
         _maskTeardown() {
+            // 125-T1：遮罩收尾一律清旋轉預覽 + 恢復容器比例（防切片/異常路徑殘留）
+            this._rotatePreview = 0;
+            this._restoreCoverAspect();
             this._maskVisible = false;
             this._maskDragging = false;
             if (this._maskResizeHandler) {
@@ -1812,6 +1828,126 @@ export function stateLightbox() {
         },
 
         // --- Enrich 補資料 (T3) ---
+        previewRotate() {
+            // 125-T1 快捷旋轉（預覽模式）：累計順時針 90°，僅前端視覺旋轉（封面 img
+            // transform + 容器比例交換），不寫盤、不彈確認。真實寫盤由 confirmMask（✓ 保存）
+            // 在 _rotatePreview !== 0 時執行（_saveRotatePreview）；✗ 放棄由 cancelMask 清空。
+            if (!this.currentLightboxVideo || !this.currentLightboxVideo.cover_path) return;
+            this._rotatePreview = (this._rotatePreview + 90) % 360;
+            this._applyRotatePreviewAspect();
+        },
+
+        // 旋轉預覽時容器比例交換：90/270° → --lb-cover-ar 取倒數（豎圖配豎容器）；
+        // 180° → 原比例。首次旋轉記錄原值供取消/收尾恢復。
+        _applyRotatePreviewAspect() {
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            if (!box) return;
+            if (this._originalCoverAr === null) {
+                const v = parseFloat(box.style.getPropertyValue('--lb-cover-ar'));
+                this._originalCoverAr = Number.isFinite(v) && v > 0 ? v : null;
+            }
+            const base = this._originalCoverAr;
+            if (base === null) return;
+            const ar = (this._rotatePreview % 180 === 0) ? base : (1 / base);
+            box.style.setProperty('--lb-cover-ar', ar.toFixed(4));
+            // 圖 cover 填滿容器（旋轉 + 縮放）——「裁剪框 = 最終展示範圍」語意：
+            // 旋轉後的圖要填滿容器/框，而不是縮在中間。
+            this._applyRotateTransform();
+        },
+
+        // 旋轉預覽時 img cover 填滿容器：rotate(deg) scale(f)，f 使旋轉後圖填滿盒（cover 語意）。
+        _applyRotateTransform() {
+            const deg = this._rotatePreview;
+            if (deg === 0) {
+                this._clearRotateTransform();
+                return;
+            }
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            const img = this.$refs && this.$refs.lightboxCoverImg;
+            if (!box || !img) return;
+            const bw = box.offsetWidth, bh = box.offsetHeight;
+            const iw = img.offsetWidth, ih = img.offsetHeight;
+            if (!bw || !bh || !iw || !ih) return;
+            const rotatedW = (deg % 180 === 0) ? iw : ih;   // 旋轉後視覺寬
+            const rotatedH = (deg % 180 === 0) ? ih : iw;   // 旋轉後視覺高
+            const scale = Math.max(bw / rotatedW, bh / rotatedH);  // cover
+            const t = 'rotate(' + deg + 'deg) scale(' + scale.toFixed(4) + ')';
+            for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
+                const el = this.$refs && this.$refs[ref];
+                if (el) el.style.transform = t;
+            }
+        },
+
+        _clearRotateTransform() {
+            for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
+                const el = this.$refs && this.$refs[ref];
+                if (el) el.style.transform = '';
+            }
+        },
+
+        _restoreCoverAspect() {
+            const box = this.$refs && this.$refs.lightboxCoverBox;
+            if (box && this._originalCoverAr !== null) {
+                box.style.setProperty('--lb-cover-ar', this._originalCoverAr.toFixed(4));
+            }
+            this._originalCoverAr = null;
+            this._clearRotateTransform();
+        },
+
+        // 旋轉寫盤成功後強制重載封面兩層 img（base + overlay），cache-bust 繞過瀏覽器舊圖快取。
+        _reloadCoverImages() {
+            for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
+                const el = this.$refs && this.$refs[ref];
+                if (el && el.src) {
+                    const base = el.src.split('?')[0];
+                    el.src = base + (base.includes('?') ? '&' : '?') + 't=' + Date.now();
+                }
+            }
+        },
+
+        async _saveRotatePreview() {
+            // ✓ 保存旋轉預覽：調 /video/rotate 物理寫盤（順時針 _rotatePreview 度），
+            // API 端已做 cover compare-and-store + reset_focal_to_auto；成功後關閉遮罩、
+            // 清旋轉預覽、刷新影片資料。
+            const video = this.currentLightboxVideo;
+            if (!video || !video.path) {
+                this._maskTeardown();
+                this._rotatePreview = 0;
+                return;
+            }
+            const expected = this._maskExpectedCoverPath || video.cover_path;
+            try {
+                const resp = await fetch('/api/showcase/video/rotate', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        path: video.path,
+                        angle: this._rotatePreview,
+                        expected_cover_path: expected,
+                    }),
+                });
+                const result = await resp.json();
+                if (result.success) {
+                    this._rotatePreview = 0;
+                    this._maskTeardown();
+                    await this.refreshVideoData(video);
+                    // 封面圖已物理旋轉但 cover_url path 不變 → 瀏覽器命中舊圖快取，
+                    // 強制重載兩層 img（cache-bust）讓界面顯示新方向 + 觸發 _setCoverAspect 更新容器比例
+                    this._reloadCoverImages();
+                    this.showToast(window.t('showcase.rotate.success'), 'success');
+                } else {
+                    this.showToast(result.error || window.t('showcase.rotate.failed'), 'error');
+                    // 409（封面已變更）等失敗：清預覽，讓使用者重開遮罩
+                    this._rotatePreview = 0;
+                    this._maskTeardown();
+                }
+            } catch (e) {
+                this.showToast(window.t('showcase.rotate.failed'), 'error');
+                this._rotatePreview = 0;
+                this._maskTeardown();
+            }
+        },
+
         async enrichVideo(video) {
             if (this._enriching) return;
             if (!video || !video.path) return;

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -1918,11 +1918,14 @@ export function stateLightbox() {
 
         // 旋轉寫盤成功後強制重載封面兩層 img（base + overlay），cache-bust 繞過瀏覽器舊圖快取。
         _reloadCoverImages() {
+            // 125-T1/T2：封面物理變更後強制重載兩層 img（繞 max-age=86400 快取）。
+            // 注意 el.src 是絕對 URL（含 ?path=... query）——只追加 t= 參數，絕不能
+            // split('?')[0] 拆掉 path（否則 gallery/image 403 → 燈箱顯示「無圖片」）。
             for (const ref of ['lightboxCoverImg', 'lightboxCoverFull']) {
                 const el = this.$refs && this.$refs[ref];
-                if (el && el.src) {
-                    const base = el.src.split('?')[0];
-                    el.src = base + (base.includes('?') ? '&' : '?') + 't=' + Date.now();
+                if (el && el.src && el.src.indexOf('http') === 0) {
+                    const clean = el.src.split('#')[0];
+                    el.src = clean + (clean.indexOf('?') >= 0 ? '&' : '?') + 't=' + Date.now();
                 }
             }
         },

--- a/web/static/js/pages/showcase/state-lightbox.js
+++ b/web/static/js/pages/showcase/state-lightbox.js
@@ -1058,7 +1058,10 @@ export function stateLightbox() {
             this._maskKind = this.currentLightboxActress ? 'actress' : 'video';
             if (!this._maskTarget().identity) return;
             // 98b-T6 防线：圖未就緒不開（按鈕也 gate _lbFullLoaded，此為 defense-in-depth）。
-            if (!this._maskTarget().loaded) return;
+            // 無封面例外（125b-T1）：cover_full_url 空 = DB 無封面 → 放行，讓使用者
+            // 透過遮罩界面的 🖼 上傳封面（detect-focal 對空 cover_path 回 400「找不到
+            // 封面檔案」，前端 toast 但不卡死——見 detect 流程 catch）。
+            if (!this._maskTarget().loaded && this.currentLightboxVideo?.cover_full_url) return;
 
             // 99a-T3：_maskFocalX 暫時設 null（幾何尚未解出的極短暫態，見 state 宣告處註解）。
             // _computeMaskWinStyle 讀到 null 即貼右裁基準（D2）——99a-T5：此值只作為「detect
@@ -1075,44 +1078,56 @@ export function stateLightbox() {
             // 既有註解：ratio 讀取受 static guard 錨定在 _computeMaskWinStyle 本體內，不可
             // 抽成共用 helper）。
             const gEl = this._maskTarget().imgEl;
-            if (!gEl || !gEl.naturalWidth) {
-                this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
-                return;
-            }
-            const gRect = gEl.getBoundingClientRect();
-            if (!gRect.width || !gRect.height) {
-                this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
-                return;
-            }
-            const gR = parseFloat(getComputedStyle(gEl).getPropertyValue(this._maskTarget().ratio));
-            if (!Number.isFinite(gR) || gR <= 0) {
-                this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
-                return;
-            }
-            if (this._maskKind === 'actress') {
-                // spec §3.4/§3.7-6：女優基準恆 3/4 置中（非右裁）。
-                this._maskFocalX = 0.5;
-            } else {
-                // Opus correction B：幾何一旦解出，_maskFocalX 收斂為具體數字（右裁基準 x），
-                // 不留 null 終態；`s` 成功即代表 el/rect/r 皆已驗證合法，這裡不需再驗一次。
-                const winW = Math.min(gRect.width, gRect.height * gR);
-                this._maskFocalX = (gRect.width - winW / 2) / gRect.width;
-            }
+            // 125b-T2：無封面例外（video 且 cover_full_url 空）→ 跳過 pre-flight 幾何檢查與
+            // 焦點偵測，遮罩直接以「待上傳」狀態打開（使用者直奔 🖼 上傳封面；detect-focal
+            // 對空 cover_path 恆 400「找不到封面檔案」，偵測在此無意義）。女優恆有圖，不適用。
+            const isNoCoverVideo = this._maskKind === 'video'
+                && !(this.currentLightboxVideo && this.currentLightboxVideo.cover_full_url);
+            // 125b-T2 修正：s 必須在 if 塊外宣告（const 是塊級作用域，塊外引用塊內
+            // const 恆 ReferenceError——上一版三元寫法未解決作用域，仍會崩）。
+            let s = null;
+            if (!isNoCoverVideo) {
+                if (!gEl || !gEl.naturalWidth) {
+                    this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
+                    return;
+                }
+                const gRect = gEl.getBoundingClientRect();
+                if (!gRect.width || !gRect.height) {
+                    this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
+                    return;
+                }
+                const gR = parseFloat(getComputedStyle(gEl).getPropertyValue(this._maskTarget().ratio));
+                if (!Number.isFinite(gR) || gR <= 0) {
+                    this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
+                    return;
+                }
+                if (this._maskKind === 'actress') {
+                    // spec §3.4/§3.7-6：女優基準恆 3/4 置中（非右裁）。
+                    this._maskFocalX = 0.5;
+                } else {
+                    // Opus correction B：幾何一旦解出，_maskFocalX 收斂為具體數字（右裁基準 x），
+                    // 不留 null 終態；`s` 成功即代表 el/rect/r 皆已驗證合法，這裡不需再驗一次。
+                    const winW = Math.min(gRect.width, gRect.height * gR);
+                    this._maskFocalX = (gRect.width - winW / 2) / gRect.width;
+                }
 
-            const s = this._computeMaskWinStyle();
-            if (!s) {
-                // 幾何算不出（rect=0 / naturalWidth=0 / ratio CSS var 讀不到 → NaN）→ 不開、
-                // 不留「全灰無窗」死態，toast 提示。兩個 ratio var（--poster-crop-ratio /
-                // --actress-crop-ratio）皆已定義於 theme.css :root，此處為防禦性 fallback。
-                this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
-                return;
+                s = this._computeMaskWinStyle();
+                if (!s) {
+                    // 幾何算不出（rect=0 / naturalWidth=0 / ratio CSS var 讀不到 → NaN）→ 不開、
+                    // 不留「全灰無窗」死態，toast 提示。兩個 ratio var（--poster-crop-ratio /
+                    // --actress-crop-ratio）皆已定義於 theme.css :root，此處為防禦性 fallback。
+                    this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
+                    return;
+                }
             }
 
             this._maskSession++;         // 98b P2 fix：新開 session，讓任何舊 session 的 await 後寫入失效
             this._maskDetecting = false; // 98b P2 fix(二)：清舊 session 遺留的偵測態——舊 detect await 的
                                          // finally 因 session 不符會**跳過**清 spinner，若不在此重置，新遮罩
                                          // 會頂著卡死的 spinner（Codex）。新 session 起手一律非偵測中。
-            this._maskWinStyle = s;      // 先設幾何（右裁基準，detect resolve 前 / 無臉時的 fallback 終值）
+            // 125b-T2 修正：無封面（isNoCoverVideo）時 `s` 未被賦值（pre-flight 幾何檢查被
+            // 跳過），此處不得引用——遮罩以初始空幾何打開（使用者直奔 🖼 上傳，無裁切窗）。
+            this._maskWinStyle = s || this._maskWinStyle;
 
             // D1（CD-1）：一律 force-detect，僅預覽、不寫 DB。偵測完成後若有臉，_maskFocalX 更新為
             // 偵測 x；無臉則維持右裁基準不變。99a-T5：.lb-mask-window 在 _maskDetecting 為真時不
@@ -1162,6 +1177,9 @@ export function stateLightbox() {
             }
 
             try {
+                // 125b-T2：無封面 → 跳過焦點偵測（detect-focal 對空 cover_path 恆 400），
+                // 直接走 finally 的 _maskStartSettle(false)（無臉基準，遮罩以待上傳態開啟）。
+                if (isNoCoverVideo) throw { _noCoverSkip: true };
                 const resp = await fetch(this._maskTarget().detectEndpoint, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -1196,7 +1214,8 @@ export function stateLightbox() {
                 }
             } catch (e) {
                 // 偵測失敗只 toast，_maskFocalX 維持右裁基準，不讓 UI 卡在半套態。
-                if (session === this._maskSession) {
+                // 125b-T2：無封面跳過偵測的 NoCoverSkipError 不 toast（遮罩正常開）。
+                if (session === this._maskSession && !(e && e._noCoverSkip)) {
                     this.showToast(window.t('showcase.lightbox.mask_detect_failed'), 'error');
                 }
             } finally {

--- a/web/templates/_macros/focal_mask.html
+++ b/web/templates/_macros/focal_mask.html
@@ -13,7 +13,7 @@
                                  抓到 video→actress 切換會閃現一幀遮罩殘影（x-if 掛載時 _maskVisible 尚未
                                  被非同步 $watch 歸零）。詳見 showcase.html 女優分支內的 T2 待辦註解。 -->
                             <div class="lb-mask-overlay"
-                                 x-show="_maskVisible"
+                                 x-show="_maskVisible && (!_rotatePreview || _rotatePreview % 180 === 0)"
                                  @click.self="cancelMask()">
                                 <!-- 99a-T5→101b-T2（CD-2/CD-4a）：窗只在偵測完成（_maskDetecting 翻 false）
                                      後才第一次渲染；首幀即全幅，隨後由收斂補間滑到偵測終值——收斂全程

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1040,6 +1040,7 @@
                             <img x-ref="lightboxCoverImg"
                                  :src="currentLightboxVideo?.cover_url"
                                  :alt="currentLightboxVideo?.number"
+                                 x-show="!_replacePreviewUrl"
                                  @load="_setCoverAspect($event)"
                                  @error="handleCoverError(currentLightboxVideo, $event)">
                             <!-- 71-T6 blur-up: overlay 層=cover_full_url（原圖）。@load 後 opacity 0→1 就地淡入蓋上 base；
@@ -1049,12 +1050,16 @@
                             <img class="lb-full"
                                  x-ref="lightboxCoverFull"
                                  :src="currentLightboxVideo?.cover_full_url"
+                                 x-show="!_replacePreviewUrl"
                                  @load="_lbFullLoaded=true"
                                  :class="{'lb-full-shown':_lbFullLoaded}"
                                  @error="_handleLbFullError($event)"
                                  alt=""
                                  aria-hidden="true">
                             <div class="lb-full-hint" x-show="_lbFullErrorPill && !_lbFullLoaded && !_maskVisible" x-cloak>{{ t('showcase.lightbox.cover_unavailable') }}</div>
+                            <!-- 125-T2：封面手动替换预览层（本地 blob 图，保存后才写盘） -->
+                            <img class="lb-replace-preview" x-ref="replaceCoverPreview" x-show="!!_replacePreviewUrl" x-cloak
+                                 :src="_replacePreviewUrl" alt="" aria-hidden="true">
                             <template x-if="!!currentLightboxVideo?.path && !_maskVisible && (currentLightboxVideo._badges || []).length">
                                 <div class="cover-badges">
                                     <template x-for="b in (currentLightboxVideo._badges || [])" :key="b.id">
@@ -1118,6 +1123,17 @@
                                         :aria-label="t('showcase.action.rotate')">
                                     <i class="bi bi-arrow-counterclockwise"></i>
                                 </button>
+                                <!-- 封面手动替换（125-T2）：选本地图预览，✓ 保存时上传覆盖原封面。 -->
+                                <button class="lb-action-btn"
+                                        x-show="_maskVisible && !_maskDetecting && !!currentLightboxVideo?.cover_path"
+                                        @click.stop="selectReplaceCover()"
+                                        :data-tooltip="t('showcase.action.replace_cover')"
+                                        :aria-label="t('showcase.action.replace_cover')">
+                                    <i class="bi bi-image"></i>
+                                </button>
+                                <input type="file" accept="image/*" class="hidden"
+                                       x-ref="replaceCoverInput"
+                                       @change="onReplaceFileSelected($event)">
                                 <button class="lb-action-btn lb-action-btn--success"
                                         x-show="_maskVisible && !_maskDetecting"
                                         @click.stop="confirmMask()"

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1125,7 +1125,7 @@
                                 </button>
                                 <!-- 封面手动替换（125-T2）：选本地图预览，✓ 保存时上传覆盖原封面。 -->
                                 <button class="lb-action-btn"
-                                        x-show="_maskVisible && !_maskDetecting && !!currentLightboxVideo?.cover_path"
+                                        x-show="_maskVisible && !_maskDetecting"
                                         @click.stop="selectReplaceCover()"
                                         :data-tooltip="t('showcase.action.replace_cover')"
                                         :aria-label="t('showcase.action.replace_cover')">
@@ -1190,7 +1190,7 @@
                                      _focalIconVisible() 的 per-image 門檻刻意不同——根因：影片只在 ≤899px 裁、
                                      女優牆全寬度都裁（見 plan-101d §2.2）。改任一邊前先讀那張表，別「對齊」成同一套。 -->
                                 <button class="lb-mask-btn"
-                                        x-show="!!currentLightboxVideo?.path && _lbFullLoaded && _posterModeActive()"
+                                        x-show="!!currentLightboxVideo?.path && (_lbFullLoaded || !currentLightboxVideo?.cover_full_url) && _posterModeActive()"
                                         @click="openMask()"
                                         :title="t('showcase.lightbox.mask_toggle')"
                                         :aria-label="t('showcase.lightbox.mask_toggle')">

--- a/web/templates/showcase.html
+++ b/web/templates/showcase.html
@@ -1033,7 +1033,7 @@
                         <!-- Cover Image -->
                         <!-- T8(Codex P2): has-cover 旗標 — 僅有封面時才讓 ≤480px min-height:0 塌到圖盒；
                              無封面時保留 min-height 避免 cover 區塌成 0 高（補封面入口會壞）。 -->
-                        <div class="lightbox-cover" :class="{'has-cover': !!currentLightboxVideo?.cover_url}">
+                        <div class="lightbox-cover" x-ref="lightboxCoverBox" :class="{'has-cover': !!currentLightboxVideo?.cover_url}">
                             <!-- 56c-T3fix: magic 按鈕已搬至 .lightbox-content（與 .lightbox-close sibling 鏡射對稱）；sparkle-burst overlay 留在 .lightbox-cover 以便 inset:0 精準覆蓋封面區（不擴及 metadata） -->
                             <!-- 71-T6 blur-up: base 層=cover_url（快取開啟=小 webp 秒出、放大略糊；關閉=原圖）。
                                  撐容器尺寸；x-ref + @error 三態留 base（ghost-fly / 破圖偵測沿用 base src）。 -->
@@ -1109,6 +1109,15 @@
                                 <!-- 99a-T3：焦點編輯中的 ✓/✗，取代 98b 的窗內點擊 toggle。
                                      99a-T5：detect 期間（_maskDetecting）尚無可提交的拖曳結果——
                                      gate 收窄，等偵測 resolve 才顯示。 -->
+                                <!-- 快捷旋轉（125-T1）：順時針 90° 預覽（不寫盤，✓ 保存時才執行）。
+                                     與 ✓ 保存 / ✗ 放棄 同排（封面裁切預覽介面內）。 -->
+                                <button class="lb-action-btn"
+                                        x-show="_maskVisible && !_maskDetecting && !!currentLightboxVideo?.cover_path"
+                                        @click.stop="previewRotate()"
+                                        :data-tooltip="t('showcase.action.rotate')"
+                                        :aria-label="t('showcase.action.rotate')">
+                                    <i class="bi bi-arrow-counterclockwise"></i>
+                                </button>
                                 <button class="lb-action-btn lb-action-btn--success"
                                         x-show="_maskVisible && !_maskDetecting"
                                         @click.stop="confirmMask()"


### PR DESCRIPTION
## 概述

Showcase 封面处理的完整功能集：**快捷旋转 + 手动替换 + 无封面上传**。三者共用"预览-保存"交互（遮罩界面内 ↺ 旋转 / 🖼 替换 / ✓ 保存 / ✗ 放弃），Plex 直读同名 `.jpg`。

## 功能一：封面快捷旋转（e564dbb）

- **问题**：部分封面横向（如 FCT-229：840×472 像素、EXIF 0，但内容竖拍）——Plex/灯箱显示侧躺，无快捷修正手段
- **交互**：遮罩界面 ↺ 按钮，顺时针 90° 步进，预览后 ✓ 物理写回（`rotate_cover`：EXIF transpose + transpose 90/180/270 + quality 95）
- **后端** `POST /video/rotate`：scope guard + cover compare-and-store + focal 重置 + 缩略图失效

## 功能二：封面手动替换（a69c8d6）

- **问题**：刮削封面错误（女优有换照、影片无对应渠道）无法人工更正
- **交互**：遮罩界面 🖼 按钮 → 本地文件 → blob 预览覆盖 → ✓ 保存时 multipart 上传
- **后端** `POST /video/replace-cover`：15MB/60M 像素上限（413）、真实格式验证（415）、scope（403）、cover_path 存在（400）、compare-and-store（409）、EXIF transpose + RGB + JPEG 写盘
- **前端**：`_replacePreviewUrl`/`selectReplaceCover`/`_saveReplacePreview` + 预览层（独立类 `.lb-replace-preview`，避免继承 `.lb-full` 的 opacity:0）

## 功能三：无封面上传（74554b8）★本次新增

- **问题**：`cover_path=''` 的视频（封面下载失败，如 jav321 境内超时）**无法打开裁切预览**——`_lbFullLoaded` 恒 false（无图加载）+ openMask preflight `naturalWidth=0` 拦截 → 🖼 上传入口不可达
- **后端** `replace-cover` 支持空 `cover_path`：以视频路径推导封面目标（`resolve_cover_target`，与刮削产出同规则 `{stem}.jpg`），写盘后 `repo.update_cover_path` 写 DB + focal 重置
- **DB** `VideoRepository.update_cover_path`：单字段 UPDATE（仿 `update_sample_images`）
- **前端**：裁切按钮 `(_lbFullLoaded || !cover_full_url)`；openMask 无封面跳过 preflight 几何检查 + 跳过 detect-focal（对空封面必 400）；🖼 按钮去掉 `!!cover_path` 门
- **修复 s TDZ bug**：`const s` 声明在 `if (!isNoCoverVideo)` 块内、块外引用 → 恒 ReferenceError；提升为 `let s = null`

## 验证（部署实例实测）

| 场景 | 结果 |
|---|---|
| 有封面旋转 | ✅ 90° 步进预览 + 保存物理写回 |
| 有封面替换 | ✅ 上传预览 + 保存覆盖（EXIF 竖拍图自动纠正） |
| **无封面打开遮罩** | ✅ 不再报错（s TDZ 修复），遮罩正常打开 |
| **无封面上传** | ✅ 上传创建 `{stem}.jpg` + DB cover_path 写入 + focal 重置 |
| 上传后旋转 | ✅ 旋转键出现（`!!cover_path` 条件满足） |

## 改动文件

- `core/organizer.py`（rotate_cover）
- `core/database/video.py`（update_cover_path）
- `web/routers/showcase.py`（rotate / replace-cover 含无封面创建）
- `web/templates/showcase.html`（遮罩按钮行 + 上传 input + 预览层）
- `web/static/js/pages/showcase/state-lightbox.js`（旋转/替换/无封面 openMask）
- `web/static/css/pages/showcase.css`（.lb-replace-preview）
- `locales/zh_TW.json`（rotate/replace_cover 文案）
